### PR TITLE
chore(ts-sdk): stop the generated API docs drifting

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -94,7 +94,42 @@ jobs:
             fi
           } >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Validate TypeDoc
+      # Replaces `docs:validate`, which used --emit none and so never rendered
+      # pages — meaning it could not see the strip or its guard in
+      # typedoc-plugin.mjs. MUST stay after "Build all": docs output depends on
+      # the gitignored babylon-tbv-rust-wasm/dist.
+      - name: Check generated API docs are current
+        shell: bash
         run: |
-          cd packages/babylon-ts-sdk
-          pnpm docs:validate
+          set -o pipefail
+          pnpm --filter @babylonlabs-io/ts-sdk run docs:clean
+
+          # --porcelain, not `git diff`: a file for a newly added module would be
+          # untracked and so invisible to a diff.
+          if [ -z "$(git status --porcelain -- packages/babylon-ts-sdk/docs/api)" ]; then
+            echo "Generated API docs are up to date."
+            exit 0
+          fi
+
+          {
+            echo "## Generated API docs are stale"
+            echo ""
+            echo "The public API changed but \`docs/api/\` was not regenerated. Run:"
+            echo ""
+            echo '```'
+            echo "pnpm --filter @babylonlabs-io/ts-sdk run docs:clean"
+            echo '```'
+            echo ""
+            echo "and commit the result. Diff CI produced:"
+            echo ""
+            echo '```diff'
+            git status --porcelain -- packages/babylon-ts-sdk/docs/api
+            echo ""
+            # sed, not `head -400`: head would SIGPIPE git diff and abort the
+            # step under `set -e -o pipefail`, before the error annotation.
+            git diff -- packages/babylon-ts-sdk/docs/api | sed -n '1,400p'
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          echo "::error::Generated API docs are stale — run: pnpm --filter @babylonlabs-io/ts-sdk run docs:clean"
+          exit 1

--- a/packages/babylon-ts-sdk/docs/api/README.md
+++ b/packages/babylon-ts-sdk/docs/api/README.md
@@ -25,7 +25,7 @@
 
 ---
 
-# @babylonlabs-io/ts-sdk v0.1.2
+# @babylonlabs-io/ts-sdk
 
 ## Modules
 

--- a/packages/babylon-ts-sdk/docs/api/clients.md
+++ b/packages/babylon-ts-sdk/docs/api/clients.md
@@ -11,7 +11,7 @@ at registration — signing-critical values must not come from the indexer mirro
 
 ### ViemOperationKeyReader
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/operation-key-reader.ts:66](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/operation-key-reader.ts#L66)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/operation-key-reader.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/operation-key-reader.ts)
 
 Reads RFC-006 operation keys and payout scripts.
 
@@ -33,7 +33,7 @@ const keys = await reader.getCurrentOperationKeys(query);
 new ViemOperationKeyReader(publicClient, contracts): ViemOperationKeyReader;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/operation-key-reader.ts:67](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/operation-key-reader.ts#L67)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/operation-key-reader.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/operation-key-reader.ts)
 
 ###### Parameters
 
@@ -55,7 +55,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/operation-key-read
 getCurrentOperationKeys(query): Promise<RawOperationKeys>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/operation-key-reader.ts:87](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/operation-key-reader.ts#L87)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/operation-key-reader.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/operation-key-reader.ts)
 
 Resolve every participant's *current* operation key.
 
@@ -83,7 +83,7 @@ fallback, so an operator that never rotated yields its registration key.
 getOperationKeysAtEpochs(query, epochs): Promise<RawOperationKeys>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/operation-key-reader.ts:114](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/operation-key-reader.ts#L114)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/operation-key-reader.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/operation-key-reader.ts)
 
 Resolve every participant's operation key bonded at a vault's frozen
 epochs. Used for every existing-vault path (resume, payout, refund).
@@ -112,7 +112,7 @@ epochs. Used for every existing-vault path (resume, payout, refund).
 getPayoutScriptsAtEpochs(query, epochs): Promise<RawPayoutScripts>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/operation-key-reader.ts:155](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/operation-key-reader.ts#L155)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/operation-key-reader.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/operation-key-reader.ts)
 
 Resolve the VP's commission payout script and each keeper's payout script
 at a vault's frozen epochs.
@@ -144,7 +144,7 @@ script.
 
 ### ViemProtocolParamsReader
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/protocol-params-reader.ts:126](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/protocol-params-reader.ts#L126)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/protocol-params-reader.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/protocol-params-reader.ts)
 
 Concrete protocol params reader using viem.
 
@@ -170,7 +170,7 @@ const config = await reader.getPegInConfiguration();
 new ViemProtocolParamsReader(publicClient, contractAddress): ViemProtocolParamsReader;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/protocol-params-reader.ts:127](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/protocol-params-reader.ts#L127)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/protocol-params-reader.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/protocol-params-reader.ts)
 
 ###### Parameters
 
@@ -192,7 +192,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/protocol-params-re
 getTBVProtocolParams(): Promise<TBVProtocolParams>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/protocol-params-reader.ts:132](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/protocol-params-reader.ts#L132)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/protocol-params-reader.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/protocol-params-reader.ts)
 
 ###### Returns
 
@@ -208,7 +208,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/protocol-params-re
 getLatestOffchainParams(): Promise<VersionedOffchainParams>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/protocol-params-reader.ts:144](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/protocol-params-reader.ts#L144)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/protocol-params-reader.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/protocol-params-reader.ts)
 
 ###### Returns
 
@@ -224,7 +224,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/protocol-params-re
 getOffchainParamsByVersion(version): Promise<VersionedOffchainParams>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/protocol-params-reader.ts:156](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/protocol-params-reader.ts#L156)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/protocol-params-reader.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/protocol-params-reader.ts)
 
 ###### Parameters
 
@@ -246,7 +246,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/protocol-params-re
 getLatestOffchainParamsVersion(): Promise<number>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/protocol-params-reader.ts:171](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/protocol-params-reader.ts#L171)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/protocol-params-reader.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/protocol-params-reader.ts)
 
 ###### Returns
 
@@ -262,7 +262,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/protocol-params-re
 getTimelockPeginByVersion(version): Promise<number>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/protocol-params-reader.ts:182](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/protocol-params-reader.ts#L182)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/protocol-params-reader.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/protocol-params-reader.ts)
 
 ###### Parameters
 
@@ -284,7 +284,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/protocol-params-re
 getPegInConfiguration(): Promise<PegInConfiguration>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/protocol-params-reader.ts:194](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/protocol-params-reader.ts#L194)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/protocol-params-reader.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/protocol-params-reader.ts)
 
 Read TBV protocol params, latest offchain params, and the latest version
 label atomically via multicall. The version is paired with the params so
@@ -306,7 +306,7 @@ under version N+1.
 fetchAllOffchainParams(onSkippedVersion?): Promise<AllOffchainParamsData>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/protocol-params-reader.ts:255](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/protocol-params-reader.ts#L255)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/protocol-params-reader.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/protocol-params-reader.ts)
 
 Fetch every historical offchain params version in a single multicall.
 Iterates 1..latestVersion and calls `getOffchainParamsByVersion` for each.
@@ -335,7 +335,7 @@ optional observer invoked once per skipped
 
 ### ViemVaultKeeperReader
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/signer-set-reader.ts:37](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/signer-set-reader.ts#L37)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/signer-set-reader.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/signer-set-reader.ts)
 
 Reads vault keepers from the ApplicationRegistry contract.
 
@@ -357,7 +357,7 @@ const keepers = await reader.getCurrentVaultKeepers(appEntryPoint);
 new ViemVaultKeeperReader(publicClient, contractAddress): ViemVaultKeeperReader;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/signer-set-reader.ts:38](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/signer-set-reader.ts#L38)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/signer-set-reader.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/signer-set-reader.ts)
 
 ###### Parameters
 
@@ -379,7 +379,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/signer-set-reader.
 getVaultKeepersByVersion(appEntryPoint, version): Promise<AddressBTCKeyPair[]>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/signer-set-reader.ts:43](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/signer-set-reader.ts#L43)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/signer-set-reader.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/signer-set-reader.ts)
 
 ###### Parameters
 
@@ -405,7 +405,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/signer-set-reader.
 getCurrentVaultKeepers(appEntryPoint): Promise<AddressBTCKeyPair[]>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/signer-set-reader.ts:57](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/signer-set-reader.ts#L57)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/signer-set-reader.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/signer-set-reader.ts)
 
 ###### Parameters
 
@@ -427,7 +427,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/signer-set-reader.
 getCurrentVaultKeepersVersion(appEntryPoint): Promise<number>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/signer-set-reader.ts:70](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/signer-set-reader.ts#L70)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/signer-set-reader.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/signer-set-reader.ts)
 
 ###### Parameters
 
@@ -447,7 +447,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/signer-set-reader.
 
 ### ViemUniversalChallengerReader
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/signer-set-reader.ts:93](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/signer-set-reader.ts#L93)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/signer-set-reader.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/signer-set-reader.ts)
 
 Reads universal challengers from the ProtocolParams contract.
 
@@ -469,7 +469,7 @@ const challengers = await reader.getCurrentUniversalChallengers();
 new ViemUniversalChallengerReader(publicClient, contractAddress): ViemUniversalChallengerReader;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/signer-set-reader.ts:94](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/signer-set-reader.ts#L94)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/signer-set-reader.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/signer-set-reader.ts)
 
 ###### Parameters
 
@@ -491,7 +491,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/signer-set-reader.
 getUniversalChallengersByVersion(version): Promise<AddressBTCKeyPair[]>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/signer-set-reader.ts:99](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/signer-set-reader.ts#L99)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/signer-set-reader.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/signer-set-reader.ts)
 
 ###### Parameters
 
@@ -513,7 +513,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/signer-set-reader.
 getCurrentUniversalChallengers(): Promise<AddressBTCKeyPair[]>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/signer-set-reader.ts:112](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/signer-set-reader.ts#L112)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/signer-set-reader.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/signer-set-reader.ts)
 
 ###### Returns
 
@@ -529,7 +529,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/signer-set-reader.
 getLatestUniversalChallengersVersion(): Promise<number>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/signer-set-reader.ts:122](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/signer-set-reader.ts#L122)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/signer-set-reader.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/signer-set-reader.ts)
 
 ###### Returns
 
@@ -543,7 +543,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/signer-set-reader.
 
 ### ViemVaultRegistryReader
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/vault-registry-reader.ts:147](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/vault-registry-reader.ts#L147)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/vault-registry-reader.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/vault-registry-reader.ts)
 
 Concrete vault registry reader using viem.
 
@@ -565,7 +565,7 @@ const data = await reader.getVaultData(vaultId);
 new ViemVaultRegistryReader(publicClient, contractAddress): ViemVaultRegistryReader;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/vault-registry-reader.ts:148](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/vault-registry-reader.ts#L148)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/vault-registry-reader.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/vault-registry-reader.ts)
 
 ###### Parameters
 
@@ -587,7 +587,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/vault-registry-rea
 getVaultProviderGenesisBtcPubKey(vpAddress): Promise<OnChainBtcPubkey>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/vault-registry-reader.ts:176](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/vault-registry-reader.ts#L176)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/vault-registry-reader.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/vault-registry-reader.ts)
 
 Read the VP's **genesis** (registration) x-only BTC pubkey — the key bonded
 at version 0, which never moves when the operator rotates.
@@ -631,7 +631,7 @@ the brand. Returns 64-char lowercase hex without the `0x` prefix.
 getCurrentVaultProviderOperationBtcKey(vpAddress): Promise<OnChainBtcPubkey>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/vault-registry-reader.ts:202](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/vault-registry-reader.ts#L202)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/vault-registry-reader.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/vault-registry-reader.ts)
 
 Read a vault provider's *current* RFC-006 operation BTC key.
 
@@ -663,16 +663,22 @@ the current key rather than any vault's frozen epoch.
 getVaultKeyEpochs(vaultId): Promise<KeyEpochs>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/vault-registry-reader.ts:227](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/vault-registry-reader.ts#L227)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/vault-registry-reader.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/vault-registry-reader.ts)
 
 Read a vault's frozen RFC-006 operation-key epochs.
 
 Reads `getBtcVaultProtocolInfo` through the **extended** ABI, which is only
-valid against an RFC-006 registry: against one that predates RFC-006 this
-call does not fail for a populated vault, it silently returns three words
-of tail data as epochs. Nothing here can detect that, so the guarantee is a
-deployment one — every network this ships to has the RFC-006 getters, and
-mainnet is a fresh RFC-006 deploy. See `BTCVaultRegistryKeyEpochs.abi.ts`.
+valid against an RFC-006 registry: against one whose `BTCVaultProtocolInfo`
+struct is not extended this call does not fail for a populated vault, it
+silently returns three words of tail data as epochs. Nothing here can detect
+that, so the guarantee is a deployment one — every network this ships to has
+the RFC-006 getters, and mainnet is a fresh RFC-006 deploy.
+
+A registry missing the operation-key getters entirely is the *safer* of the
+two cases: `resolveParticipantKeysAtEpochs` reverts downstream and these
+epochs never reach key resolution. See UINT64\_EXCLUSIVE\_UPPER\_BOUND
+for which state the range check actually guards, and
+`BTCVaultRegistryKeyEpochs.abi.ts` for the decode hazard.
 
 ###### Parameters
 
@@ -694,7 +700,7 @@ mainnet is a fresh RFC-006 deploy. See `BTCVaultRegistryKeyEpochs.abi.ts`.
 getVaultKeyEpochsBatch(vaultIds): Promise<KeyEpochs[]>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/vault-registry-reader.ts:238](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/vault-registry-reader.ts#L238)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/vault-registry-reader.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/vault-registry-reader.ts)
 
 [getVaultKeyEpochs](#getvaultkeyepochs) for many vaults in one multicall.
 
@@ -718,7 +724,7 @@ readonly `` `0x${string}` ``[]
 getVaultBasicInfo(vaultId): Promise<VaultBasicInfo>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/vault-registry-reader.ts:256](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/vault-registry-reader.ts#L256)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/vault-registry-reader.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/vault-registry-reader.ts)
 
 ###### Parameters
 
@@ -740,7 +746,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/vault-registry-rea
 getVaultProtocolInfo(vaultId): Promise<VaultProtocolInfo>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/vault-registry-reader.ts:267](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/vault-registry-reader.ts#L267)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/vault-registry-reader.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/vault-registry-reader.ts)
 
 ###### Parameters
 
@@ -762,7 +768,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/vault-registry-rea
 getProtocolInfoBatch(vaultIds): Promise<VaultProtocolInfo[]>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/vault-registry-reader.ts:278](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/vault-registry-reader.ts#L278)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/vault-registry-reader.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/vault-registry-reader.ts)
 
 ###### Parameters
 
@@ -784,7 +790,7 @@ readonly `` `0x${string}` ``[]
 getPegInFee(vaultProvider): Promise<bigint>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/vault-registry-reader.ts:311](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/vault-registry-reader.ts#L311)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/vault-registry-reader.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/vault-registry-reader.ts)
 
 Read the protocol pegin fee (in wei) for a given vault provider.
 Mirrors the `getPegInFee(address)` view on BTCVaultRegistry.
@@ -809,7 +815,7 @@ Mirrors the `getPegInFee(address)` view on BTCVaultRegistry.
 getVaultProviderCommission(vaultProvider): Promise<number>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/vault-registry-reader.ts:327](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/vault-registry-reader.ts#L327)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/vault-registry-reader.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/vault-registry-reader.ts)
 
 Read a vault provider's current commission in basis points from
 BTCVaultRegistry. The contract enforces `commissionBps < 10000`, so the
@@ -837,7 +843,7 @@ trusted.
 getVaultData(vaultId): Promise<VaultData>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/vault-registry-reader.ts:346](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/vault-registry-reader.ts#L346)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/vault-registry-reader.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/vault-registry-reader.ts)
 
 ###### Parameters
 
@@ -859,7 +865,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/vault-registry-rea
 getOffchainParamsVersionsByVaultIds(vaultIds): Promise<number[]>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/vault-registry-reader.ts:388](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/vault-registry-reader.ts#L388)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/vault-registry-reader.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/vault-registry-reader.ts)
 
 Read `offchainParamsVersion` for many vaults in a single multicall.
 Reads only `getBtcVaultProtocolInfo` (one read per vault), so an N-vault
@@ -883,7 +889,7 @@ readonly `` `0x${string}` ``[]
 
 ### VaultProviderRpcClient
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts:79](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts#L79)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts)
 
 Concrete VP RPC client implementing all service interfaces.
 
@@ -908,7 +914,7 @@ const status = await client.getPeginStatus({ pegin_txid: "abc..." });
 new VaultProviderRpcClient(baseUrl, options?): VaultProviderRpcClient;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts:84](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts#L84)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts)
 
 ###### Parameters
 
@@ -932,7 +938,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts:
 requestDepositorPresignTransactions(params, signal?): Promise<RequestDepositorPresignTransactionsResponse>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts:102](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts#L102)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts)
 
 Request the payout/claim/assert transactions that the depositor
 needs to pre-sign before the vault can be activated on Bitcoin.
@@ -961,7 +967,7 @@ needs to pre-sign before the vault can be activated on Bitcoin.
 submitDepositorPresignatures(params, signal?): Promise<void>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts:118](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts#L118)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts)
 
 Submit the depositor's pre-signatures for the payout transactions
 and the depositor-as-claimer graph.
@@ -990,7 +996,7 @@ and the depositor-as-claimer graph.
 submitDepositorWotsKey(params, signal?): Promise<void>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts:134](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts#L134)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts)
 
 Submit the depositor's WOTS public key to the vault provider.
 Called after the pegin is finalized on Ethereum, when the VP is in
@@ -1020,7 +1026,7 @@ Called after the pegin is finalized on Ethereum, when the VP is in
 requestDepositorClaimerArtifacts(params, signal?): Promise<RequestDepositorClaimerArtifactsResponse>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts:149](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts#L149)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts)
 
 Request the BaBe DecryptorArtifacts needed for the depositor to
 independently evaluate garbled circuits during a challenge.
@@ -1049,7 +1055,7 @@ independently evaluate garbled circuits during a challenge.
 getPeginStatus(params, signal?): Promise<GetPeginStatusResponse>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts:162](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts#L162)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts)
 
 Get the current pegin status from the vault provider daemon.
 
@@ -1077,7 +1083,7 @@ Get the current pegin status from the vault provider daemon.
 batchGetPeginStatus(params, signal?): Promise<BatchGetPeginStatusResponse>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts:180](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts#L180)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts)
 
 Get pegin status for many txids in one round trip. Per-result envelope
 isolates per-pegin failures from the overall RPC. Caller must chunk
@@ -1103,7 +1109,7 @@ inputs at `VP_BATCH_MAX_SIZE`.
 batchGetPegoutStatus(params, signal?): Promise<BatchGetPegoutStatusResponse>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts:196](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts#L196)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts)
 
 Get pegout status for many txids in one round trip. Same per-result
 envelope semantics as `batchGetPeginStatus`.
@@ -1126,7 +1132,7 @@ envelope semantics as `batchGetPeginStatus`.
 
 ### ServerIdentityError
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/serverIdentity.ts:80](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/serverIdentity.ts#L80)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/serverIdentity.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/serverIdentity.ts)
 
 #### Extends
 
@@ -1140,7 +1146,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/se
 new ServerIdentityError(message, reason): ServerIdentityError;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/serverIdentity.ts:81](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/serverIdentity.ts#L81)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/serverIdentity.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/serverIdentity.ts)
 
 ###### Parameters
 
@@ -1179,13 +1185,13 @@ readonly reason:
   | "signature_verification_failed";
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/serverIdentity.ts:83](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/serverIdentity.ts#L83)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/serverIdentity.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/serverIdentity.ts)
 
 ***
 
 ### VpTokenRegistry
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/tokenRegistry.ts:31](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/tokenRegistry.ts#L31)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/tokenRegistry.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/tokenRegistry.ts)
 
 #### Accessors
 
@@ -1197,7 +1203,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/to
 get size(): number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/tokenRegistry.ts:110](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/tokenRegistry.ts#L110)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/tokenRegistry.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/tokenRegistry.ts)
 
 ###### Returns
 
@@ -1223,7 +1229,7 @@ new VpTokenRegistry(): VpTokenRegistry;
 getOrCreate(input): VpTokenProvider;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/tokenRegistry.ts:40](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/tokenRegistry.ts#L40)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/tokenRegistry.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/tokenRegistry.ts)
 
 Return the cached `VpTokenProvider` for `peginTxid` if one exists
 with matching `authAnchorHex` and `pinnedServerPubkey`, otherwise
@@ -1246,7 +1252,7 @@ silent overwrite would mask derivation drift or VP pubkey rotation.
 peek(peginTxid): VpTokenProvider | undefined;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/tokenRegistry.ts:87](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/tokenRegistry.ts#L87)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/tokenRegistry.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/tokenRegistry.ts)
 
 Return the cached provider, or `undefined` if none.
 
@@ -1266,7 +1272,7 @@ Return the cached provider, or `undefined` if none.
 release(peginTxid): void;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/tokenRegistry.ts:96](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/tokenRegistry.ts#L96)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/tokenRegistry.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/tokenRegistry.ts)
 
 Evict the entry for `peginTxid`. Idempotent. Called on terminal
 paths — activation success, user-cancel, or component unmount —
@@ -1286,7 +1292,7 @@ so `authAnchorHex` doesn't outlive the deposit session.
 
 ### JsonRpcError
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts:94](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts#L94)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts)
 
 #### Extends
 
@@ -1304,7 +1310,7 @@ new JsonRpcError(
    data?): JsonRpcError;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts:95](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts#L95)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts)
 
 ###### Parameters
 
@@ -1346,7 +1352,7 @@ Error.constructor
 code: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts:96](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts#L96)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts)
 
 ##### source
 
@@ -1354,7 +1360,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rp
 source: JsonRpcErrorSource = "local";
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts:99](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts#L99)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts)
 
 "wire" for server-returned envelopes; "local" for SDK-side failures.
 
@@ -1364,7 +1370,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rp
 optional data: unknown;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts:101](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts#L101)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts)
 
 Structured data from the server `error.data` field, if any.
 
@@ -1372,7 +1378,7 @@ Structured data from the server `error.data` field, if any.
 
 ### JsonRpcClient
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts:215](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts#L215)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts)
 
 Generic JSON-RPC 2.0 HTTP client with safe retry policy.
 
@@ -1384,7 +1390,7 @@ Generic JSON-RPC 2.0 HTTP client with safe retry policy.
 new JsonRpcClient(config): JsonRpcClient;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts:226](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts#L226)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts)
 
 ###### Parameters
 
@@ -1407,7 +1413,7 @@ call<TParams, TResult>(
 signal?): Promise<TResult>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts:272](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts#L272)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts)
 
 Make a JSON-RPC request with optional retry for safe methods.
 
@@ -1464,7 +1470,7 @@ callRaw<TParams>(
 signal?): Promise<Response>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts:397](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts#L397)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts)
 
 Make a JSON-RPC request returning the raw Response (unparsed body).
 
@@ -1505,7 +1511,7 @@ large downloads must read the body themselves and re-invoke
 getBaseUrl(): string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts:534](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts#L534)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts)
 
 ###### Returns
 
@@ -1515,7 +1521,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rp
 
 ### VpResponseValidationError
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/validators.ts:48](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/validators.ts#L48)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/validators.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/validators.ts)
 
 Thrown when a VP RPC response fails runtime validation.
 
@@ -1534,7 +1540,7 @@ Thrown when a VP RPC response fails runtime validation.
 new VpResponseValidationError(detail): VpResponseValidationError;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/validators.ts:51](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/validators.ts#L51)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/validators.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/validators.ts)
 
 ###### Parameters
 
@@ -1560,13 +1566,13 @@ Error.constructor
 readonly detail: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/validators.ts:49](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/validators.ts#L49)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/validators.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/validators.ts)
 
 ## Interfaces
 
 ### ProtocolAddresses
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/contract-address-resolver.ts:15](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/contract-address-resolver.ts#L15)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/contract-address-resolver.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/contract-address-resolver.ts)
 
 #### Properties
 
@@ -1576,7 +1582,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/contract-address-r
 protocolParams: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/contract-address-resolver.ts:17](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/contract-address-resolver.ts#L17)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/contract-address-resolver.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/contract-address-resolver.ts)
 
 Address of the ProtocolParams contract
 
@@ -1586,7 +1592,7 @@ Address of the ProtocolParams contract
 applicationRegistry: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/contract-address-resolver.ts:19](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/contract-address-resolver.ts#L19)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/contract-address-resolver.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/contract-address-resolver.ts)
 
 Address of the ApplicationRegistry contract
 
@@ -1594,7 +1600,7 @@ Address of the ApplicationRegistry contract
 
 ### OperationKeyContracts
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/operation-key-reader.ts:22](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/operation-key-reader.ts#L22)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/operation-key-reader.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/operation-key-reader.ts)
 
 Addresses of the three registries an operation-key resolution spans.
 
@@ -1606,7 +1612,7 @@ Addresses of the three registries an operation-key resolution spans.
 btcVaultRegistry: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/operation-key-reader.ts:23](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/operation-key-reader.ts#L23)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/operation-key-reader.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/operation-key-reader.ts)
 
 ##### applicationRegistry
 
@@ -1614,7 +1620,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/operation-key-read
 applicationRegistry: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/operation-key-reader.ts:24](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/operation-key-reader.ts#L24)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/operation-key-reader.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/operation-key-reader.ts)
 
 ##### protocolParams
 
@@ -1622,13 +1628,13 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/operation-key-read
 protocolParams: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/operation-key-reader.ts:25](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/operation-key-reader.ts#L25)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/operation-key-reader.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/operation-key-reader.ts)
 
 ***
 
 ### VaultBasicInfo
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:50](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L50)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 Basic vault info from BTCVaultRegistry.getBtcVaultBasicInfo
 
@@ -1640,7 +1646,7 @@ Basic vault info from BTCVaultRegistry.getBtcVaultBasicInfo
 depositor: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:51](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L51)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 ##### depositorBtcPubKey
 
@@ -1648,7 +1654,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:51](../..
 depositorBtcPubKey: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:52](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L52)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 ##### amount
 
@@ -1656,7 +1662,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:52](../..
 amount: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:53](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L53)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 ##### vaultProvider
 
@@ -1664,7 +1670,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:53](../..
 vaultProvider: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:54](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L54)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 ##### status
 
@@ -1672,7 +1678,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:54](../..
 status: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:55](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L55)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 ##### applicationEntryPoint
 
@@ -1680,7 +1686,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:55](../..
 applicationEntryPoint: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:56](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L56)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 ##### createdAt
 
@@ -1688,13 +1694,13 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:56](../..
 createdAt: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:57](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L57)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 ***
 
 ### VaultProtocolInfo
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:61](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L61)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 Protocol info from BTCVaultRegistry.getBtcVaultProtocolInfo
 
@@ -1706,7 +1712,7 @@ Protocol info from BTCVaultRegistry.getBtcVaultProtocolInfo
 depositorSignedPeginTx: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:62](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L62)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 ##### universalChallengersVersion
 
@@ -1714,7 +1720,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:62](../..
 universalChallengersVersion: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:63](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L63)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 ##### appVaultKeepersVersion
 
@@ -1722,7 +1728,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:63](../..
 appVaultKeepersVersion: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:64](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L64)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 ##### offchainParamsVersion
 
@@ -1730,7 +1736,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:64](../..
 offchainParamsVersion: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:65](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L65)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 ##### verifiedAt
 
@@ -1738,7 +1744,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:65](../..
 verifiedAt: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:66](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L66)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 ##### depositorWotsPkHash
 
@@ -1746,7 +1752,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:66](../..
 depositorWotsPkHash: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:67](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L67)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 ##### hashlock
 
@@ -1754,7 +1760,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:67](../..
 hashlock: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:68](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L68)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 ##### htlcVout
 
@@ -1762,7 +1768,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:68](../..
 htlcVout: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:69](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L69)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 ##### depositorPopSignature
 
@@ -1770,7 +1776,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:69](../..
 depositorPopSignature: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:70](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L70)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 ##### prePeginTxHash
 
@@ -1778,7 +1784,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:70](../..
 prePeginTxHash: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:71](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L71)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 ##### vaultProviderCommissionBps
 
@@ -1786,7 +1792,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:71](../..
 vaultProviderCommissionBps: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:72](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L72)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 ##### claimExpiredUntil
 
@@ -1794,7 +1800,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:72](../..
 claimExpiredUntil: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:74](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L74)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 Block deadline (uint256) for depositor reclaim. TODO(#1690): wire to refund flow.
 
@@ -1804,7 +1810,7 @@ Block deadline (uint256) for depositor reclaim. TODO(#1690): wire to refund flow
 vaultCoreVersion: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:76](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L76)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 Vault core version (uint16) stamped at registration. VP-side gating only — see #1690.
 
@@ -1812,7 +1818,7 @@ Vault core version (uint16) stamped at registration. VP-side gating only — see
 
 ### VaultData
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:80](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L80)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 Combined vault data (basic + protocol)
 
@@ -1824,7 +1830,7 @@ Combined vault data (basic + protocol)
 basic: VaultBasicInfo;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:81](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L81)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 ##### protocol
 
@@ -1832,13 +1838,13 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:81](../..
 protocol: VaultProtocolInfo;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:82](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L82)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 ***
 
 ### KeyEpochs
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:101](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L101)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 RFC-006 operation-key epochs a vault froze at `submitPeginRequest`.
 
@@ -1863,7 +1869,7 @@ read is quarantined to its own ABI.
 vpKeyEpoch: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:102](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L102)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 ##### appKeeperKeyEpoch
 
@@ -1871,7 +1877,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:102](../.
 appKeeperKeyEpoch: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:103](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L103)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 ##### ucKeyEpoch
 
@@ -1879,13 +1885,13 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:103](../.
 ucKeyEpoch: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:104](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L104)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 ***
 
 ### VaultRegistryReader
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:108](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L108)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 Interface for reading vault data from the BTCVaultRegistry contract.
 
@@ -1897,7 +1903,7 @@ Interface for reading vault data from the BTCVaultRegistry contract.
 getVaultBasicInfo(vaultId): Promise<VaultBasicInfo>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:109](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L109)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 ###### Parameters
 
@@ -1915,7 +1921,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:109](../.
 getVaultProtocolInfo(vaultId): Promise<VaultProtocolInfo>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:110](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L110)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 ###### Parameters
 
@@ -1933,7 +1939,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:110](../.
 getProtocolInfoBatch(vaultIds): Promise<VaultProtocolInfo[]>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:111](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L111)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 ###### Parameters
 
@@ -1951,7 +1957,7 @@ readonly `` `0x${string}` ``[]
 getVaultData(vaultId): Promise<VaultData>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:112](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L112)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 ###### Parameters
 
@@ -1969,7 +1975,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:112](../.
 getVaultProviderGenesisBtcPubKey(vpAddress): Promise<OnChainBtcPubkey>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:124](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L124)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 Read a vault provider's *genesis* (registration) BTC key — the key bonded
 at version 0, which never moves when the operator rotates.
@@ -1997,7 +2003,7 @@ RFC-006 registry — as does every caller.
 getPegInFee(vaultProvider): Promise<bigint>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:128](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L128)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 Read the protocol pegin fee (in wei) for a given vault provider.
 
@@ -2017,7 +2023,7 @@ Read the protocol pegin fee (in wei) for a given vault provider.
 getVaultProviderCommission(vaultProvider): Promise<number>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:135](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L135)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 Read a vault provider's current commission in basis points.
 
@@ -2040,7 +2046,7 @@ value signals a wrong contract address or ABI drift, not a real rate.
 getOffchainParamsVersionsByVaultIds(vaultIds): Promise<number[]>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:141](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L141)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 Read `offchainParamsVersion` for many vaults in a single multicall.
 Returns versions in the same order as the input. Throws if any vault
@@ -2062,15 +2068,17 @@ readonly `` `0x${string}` ``[]
 getVaultKeyEpochs(vaultId): Promise<KeyEpochs>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:153](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L153)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 Read a vault's frozen RFC-006 key epochs.
 
-Uses the extended `getBtcVaultProtocolInfo` ABI. Against a registry that
-predates RFC-006 this returns silent garbage for a populated vault rather
-than throwing, so it must only be called against an RFC-006 registry —
-a deployment invariant, not something this call can detect. See
-`BTCVaultRegistryKeyEpochs.abi.ts`.
+Uses the extended `getBtcVaultProtocolInfo` ABI. Against a registry whose
+`BTCVaultProtocolInfo` struct is not extended this returns silent garbage
+for a populated vault rather than throwing, so it must only be called
+against an RFC-006 registry — a deployment invariant, not something this
+call can detect. A registry missing the operation-key getters altogether is
+the safer case: key resolution reverts downstream and these epochs are never
+used. See `BTCVaultRegistryKeyEpochs.abi.ts`.
 
 ###### Parameters
 
@@ -2088,7 +2096,7 @@ a deployment invariant, not something this call can detect. See
 getVaultKeyEpochsBatch(vaultIds): Promise<KeyEpochs[]>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:155](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L155)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 [getVaultKeyEpochs](#getvaultkeyepochs) for many vaults in one multicall.
 
@@ -2108,7 +2116,7 @@ readonly `` `0x${string}` ``[]
 getCurrentVaultProviderOperationBtcKey(vpAddress): Promise<OnChainBtcPubkey>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:161](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L161)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 Read a vault provider's *current* RFC-006 operation BTC key — the key its
 server signs auth tokens with. Falls back to the registration key when the
@@ -2128,7 +2136,7 @@ provider has never rotated.
 
 ### TBVProtocolParams
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:177](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L177)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 TBV protocol parameters from the ProtocolParams contract.
 Matches Solidity struct `IProtocolParams.TBVProtocolParams` exactly.
@@ -2144,7 +2152,7 @@ uint8 uses number (bounded, max 255).
 minimumPegInAmount: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:178](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L178)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 ##### maxPegInAmount
 
@@ -2152,7 +2160,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:178](../.
 maxPegInAmount: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:179](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L179)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 ##### pegInAckTimeout
 
@@ -2160,7 +2168,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:179](../.
 pegInAckTimeout: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:180](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L180)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 ##### pegInActivationTimeout
 
@@ -2168,7 +2176,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:180](../.
 pegInActivationTimeout: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:181](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L181)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 ##### maxHtlcOutputCount
 
@@ -2176,7 +2184,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:181](../.
 maxHtlcOutputCount: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:182](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L182)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 ##### expiredPegInGraceBlocks
 
@@ -2184,7 +2192,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:182](../.
 expiredPegInGraceBlocks: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:188](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L188)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 Number of blocks added to the activation deadline as a grace window
 during which a depositor may still reclaim an expired pegin via the
@@ -2194,7 +2202,7 @@ HTLC preimage. Source: `IProtocolParams.TBVProtocolParams.expiredPegInGraceBlock
 
 ### VersionedOffchainParams
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:198](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L198)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 Versioned offchain parameters from the ProtocolParams contract.
 Matches Solidity struct `IProtocolParams.VersionedOffchainParams` exactly.
@@ -2210,7 +2218,7 @@ number for: uint8/uint16/uint32 fields (bounded, safe for JS arithmetic).
 timelockAssert: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:199](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L199)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 ##### timelockChallengeAssert
 
@@ -2218,7 +2226,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:199](../.
 timelockChallengeAssert: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:200](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L200)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 ##### securityCouncilKeys
 
@@ -2226,7 +2234,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:200](../.
 securityCouncilKeys: `0x${string}`[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:201](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L201)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 ##### councilQuorum
 
@@ -2234,7 +2242,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:201](../.
 councilQuorum: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:202](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L202)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 ##### feeRate
 
@@ -2242,7 +2250,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:202](../.
 feeRate: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:203](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L203)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 ##### babeTotalInstances
 
@@ -2250,7 +2258,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:203](../.
 babeTotalInstances: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:204](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L204)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 ##### babeInstancesToFinalize
 
@@ -2258,7 +2266,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:204](../.
 babeInstancesToFinalize: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:205](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L205)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 ##### minVpCommissionBps
 
@@ -2266,7 +2274,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:205](../.
 minVpCommissionBps: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:206](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L206)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 ##### tRefund
 
@@ -2274,7 +2282,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:206](../.
 tRefund: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:207](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L207)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 ##### tStale
 
@@ -2282,7 +2290,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:207](../.
 tStale: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:208](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L208)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 ##### minPeginFeeRate
 
@@ -2290,7 +2298,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:208](../.
 minPeginFeeRate: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:209](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L209)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 ##### proverCircuitVersion
 
@@ -2298,7 +2306,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:209](../.
 proverCircuitVersion: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:210](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L210)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 ##### minPrepeginDepth
 
@@ -2306,13 +2314,13 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:210](../.
 minPrepeginDepth: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:211](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L211)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 ***
 
 ### PegInConfiguration
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:218](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L218)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 Combined peg-in configuration read atomically via multicall.
 Prevents TOCTOU inconsistency if governance updates params between reads.
@@ -2325,7 +2333,7 @@ Prevents TOCTOU inconsistency if governance updates params between reads.
 minimumPegInAmount: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:219](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L219)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 ##### maxPegInAmount
 
@@ -2333,7 +2341,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:219](../.
 maxPegInAmount: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:220](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L220)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 ##### pegInAckTimeout
 
@@ -2341,7 +2349,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:220](../.
 pegInAckTimeout: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:221](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L221)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 ##### pegInActivationTimeout
 
@@ -2349,7 +2357,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:221](../.
 pegInActivationTimeout: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:222](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L222)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 ##### maxHtlcOutputCount
 
@@ -2357,7 +2365,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:222](../.
 maxHtlcOutputCount: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:223](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L223)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 ##### expiredPegInGraceBlocks
 
@@ -2365,7 +2373,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:223](../.
 expiredPegInGraceBlocks: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:224](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L224)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 ##### timelockPegin
 
@@ -2373,7 +2381,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:224](../.
 timelockPegin: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:225](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L225)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 ##### timelockRefund
 
@@ -2381,7 +2389,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:225](../.
 timelockRefund: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:226](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L226)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 ##### minVpCommissionBps
 
@@ -2389,7 +2397,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:226](../.
 minVpCommissionBps: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:227](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L227)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 ##### offchainParams
 
@@ -2397,7 +2405,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:227](../.
 offchainParams: VersionedOffchainParams;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:228](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L228)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 ##### offchainParamsVersion
 
@@ -2405,7 +2413,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:228](../.
 offchainParamsVersion: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:235](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L235)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 Version label paired atomically with `offchainParams`.
 Read in the same multicall as the params struct so that, if a parameter
@@ -2418,7 +2426,7 @@ the version label stay consistent.
 activeVaultCoreVersion: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:243](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L243)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 Currently-active vault core (tx-graph) version
 (`ProtocolParams.activeVaultCoreVersion()`, uint16 ≥ 1). Stamped onto
@@ -2430,7 +2438,7 @@ can't land between reading the params and reading the version.
 
 ### AllOffchainParamsData
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:252](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L252)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 All offchain params snapshots indexed by version, plus the latest version
 number known when the snapshot was taken. Used by consumers that need to
@@ -2445,7 +2453,7 @@ to an older version).
 byVersion: Map<number, VersionedOffchainParams>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:253](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L253)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 ##### latestVersion
 
@@ -2453,13 +2461,13 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:253](../.
 latestVersion: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:254](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L254)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 ***
 
 ### ProtocolParamsReader
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:268](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L268)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 Interface for reading protocol parameters from the ProtocolParams contract.
 
@@ -2471,7 +2479,7 @@ Interface for reading protocol parameters from the ProtocolParams contract.
 getTBVProtocolParams(): Promise<TBVProtocolParams>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:269](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L269)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 ###### Returns
 
@@ -2483,7 +2491,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:269](../.
 getOffchainParamsByVersion(version): Promise<VersionedOffchainParams>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:270](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L270)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 ###### Parameters
 
@@ -2501,7 +2509,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:270](../.
 getLatestOffchainParams(): Promise<VersionedOffchainParams>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:271](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L271)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 ###### Returns
 
@@ -2513,7 +2521,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:271](../.
 getLatestOffchainParamsVersion(): Promise<number>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:272](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L272)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 ###### Returns
 
@@ -2525,7 +2533,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:272](../.
 getTimelockPeginByVersion(version): Promise<number>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:273](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L273)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 ###### Parameters
 
@@ -2543,7 +2551,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:273](../.
 getPegInConfiguration(): Promise<PegInConfiguration>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:274](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L274)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 ###### Returns
 
@@ -2555,7 +2563,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:274](../.
 fetchAllOffchainParams(onSkippedVersion?): Promise<AllOffchainParamsData>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:275](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L275)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 ###### Parameters
 
@@ -2571,7 +2579,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:275](../.
 
 ### AddressBTCKeyPair
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:288](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L288)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 Matches Solidity struct `BTCVaultTypes.AddressBTCKeyPair` exactly.
 Used for vault keepers and universal challengers.
@@ -2584,7 +2592,7 @@ Used for vault keepers and universal challengers.
 ethAddress: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:289](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L289)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 ##### btcPubKey
 
@@ -2592,13 +2600,13 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:289](../.
 btcPubKey: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:290](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L290)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 ***
 
 ### VaultKeeperReader
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:294](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L294)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 Interface for reading vault keepers from the ApplicationRegistry contract.
 
@@ -2610,7 +2618,7 @@ Interface for reading vault keepers from the ApplicationRegistry contract.
 getVaultKeepersByVersion(appEntryPoint, version): Promise<AddressBTCKeyPair[]>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:295](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L295)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 ###### Parameters
 
@@ -2632,7 +2640,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:295](../.
 getCurrentVaultKeepers(appEntryPoint): Promise<AddressBTCKeyPair[]>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:299](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L299)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 ###### Parameters
 
@@ -2650,7 +2658,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:299](../.
 getCurrentVaultKeepersVersion(appEntryPoint): Promise<number>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:300](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L300)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 ###### Parameters
 
@@ -2666,7 +2674,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:300](../.
 
 ### UniversalChallengerReader
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:304](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L304)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 Interface for reading universal challengers from the ProtocolParams contract.
 
@@ -2678,7 +2686,7 @@ Interface for reading universal challengers from the ProtocolParams contract.
 getUniversalChallengersByVersion(version): Promise<AddressBTCKeyPair[]>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:305](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L305)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 ###### Parameters
 
@@ -2696,7 +2704,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:305](../.
 getCurrentUniversalChallengers(): Promise<AddressBTCKeyPair[]>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:308](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L308)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 ###### Returns
 
@@ -2708,7 +2716,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:308](../.
 getLatestUniversalChallengersVersion(): Promise<number>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:309](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L309)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 ###### Returns
 
@@ -2718,7 +2726,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:309](../.
 
 ### OperationKeyQuery
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:327](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L327)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 The participants whose operation keys are being resolved, and the roster
 they are resolved against.
@@ -2738,7 +2746,7 @@ was later dropped from the roster no longer has a current entry for.
 vaultProviderEthAddress: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:328](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L328)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 ##### vaultProviderGenesisBtcPubkey
 
@@ -2746,7 +2754,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:328](../.
 vaultProviderGenesisBtcPubkey: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:338](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L338)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 The VP's genesis (registration) key, from
 [VaultRegistryReader.getVaultProviderGenesisBtcPubKey](#getvaultprovidergenesisbtcpubkey).
@@ -2762,7 +2770,7 @@ it is what the indexer hint is compared against, and what makes the VP's
 applicationEntryPoint: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:339](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L339)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 ##### vaultKeepers
 
@@ -2770,7 +2778,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:339](../.
 vaultKeepers: readonly AddressBTCKeyPair[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:341](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L341)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 Keeper roster at the membership version being resolved against.
 
@@ -2780,7 +2788,7 @@ Keeper roster at the membership version being resolved against.
 universalChallengers: readonly AddressBTCKeyPair[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:343](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L343)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 Challenger roster at the membership version being resolved against.
 
@@ -2788,7 +2796,7 @@ Challenger roster at the membership version being resolved against.
 
 ### RawOperationKeys
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:347](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L347)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 Raw registry-returned operation keys, index-aligned with the query rosters.
 
@@ -2800,7 +2808,7 @@ Raw registry-returned operation keys, index-aligned with the query rosters.
 vaultProvider: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:348](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L348)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 ##### vaultKeepers
 
@@ -2808,7 +2816,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:348](../.
 vaultKeepers: `0x${string}`[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:349](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L349)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 ##### universalChallengers
 
@@ -2816,13 +2824,13 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:349](../.
 universalChallengers: `0x${string}`[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:350](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L350)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 ***
 
 ### RawPayoutScripts
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:358](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L358)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 Registry-returned payout scriptPubKeys, index-aligned with the query
 rosters. `universalChallengers` has no counterpart: a UC is never a claimer,
@@ -2836,7 +2844,7 @@ so it has no payout script.
 vaultProvider: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:359](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L359)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 ##### vaultKeepers
 
@@ -2844,13 +2852,13 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:359](../.
 vaultKeepers: `0x${string}`[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:360](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L360)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 ***
 
 ### OperationKeyReader
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:372](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L372)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 Reads RFC-006 operation keys and payout scripts across all three registries
 (BTCVaultRegistry, ApplicationRegistry, ProtocolParams).
@@ -2868,7 +2876,7 @@ builds a lock no counterparty agrees with.
 getCurrentOperationKeys(query): Promise<RawOperationKeys>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:380](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L380)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 Resolve every participant's *current* operation key.
 
@@ -2892,7 +2900,7 @@ fallback, so an operator that never rotated yields its registration key.
 getOperationKeysAtEpochs(query, epochs): Promise<RawOperationKeys>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:385](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L385)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 Resolve every participant's operation key bonded at a vault's frozen
 epochs. Used for every existing-vault path (resume, payout, refund).
@@ -2917,7 +2925,7 @@ epochs. Used for every existing-vault path (resume, payout, refund).
 getPayoutScriptsAtEpochs(query, epochs): Promise<RawPayoutScripts>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:398](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L398)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 Resolve the VP's commission payout script and each keeper's payout script
 at a vault's frozen epochs.
@@ -2945,7 +2953,7 @@ script.
 
 ### AddressTx
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts:431](../../packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts#L431)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts)
 
 Transaction summary from address transactions endpoint.
 
@@ -2957,7 +2965,7 @@ Transaction summary from address transactions endpoint.
 txid: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts:432](../../packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts#L432)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts)
 
 ##### status
 
@@ -2965,7 +2973,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts:
 status: object;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts:433](../../packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts#L433)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts)
 
 ###### confirmed
 
@@ -2983,7 +2991,7 @@ optional block_height: number;
 
 ### MempoolUTXO
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts:12](../../packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts#L12)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts)
 
 UTXO information from mempool API.
 
@@ -2995,7 +3003,7 @@ UTXO information from mempool API.
 txid: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts:13](../../packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts#L13)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts)
 
 ##### vout
 
@@ -3003,7 +3011,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts:13](.
 vout: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts:14](../../packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts#L14)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts)
 
 ##### value
 
@@ -3011,7 +3019,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts:14](.
 value: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts:15](../../packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts#L15)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts)
 
 ##### scriptPubKey
 
@@ -3019,7 +3027,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts:15](.
 scriptPubKey: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts:16](../../packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts#L16)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts)
 
 ##### confirmed
 
@@ -3027,13 +3035,13 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts:16](.
 confirmed: boolean;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts:17](../../packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts#L17)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts)
 
 ***
 
 ### TxInput
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts:23](../../packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts#L23)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts)
 
 Transaction input from mempool API.
 
@@ -3045,7 +3053,7 @@ Transaction input from mempool API.
 txid: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts:24](../../packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts#L24)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts)
 
 ##### vout
 
@@ -3053,7 +3061,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts:24](.
 vout: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts:25](../../packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts#L25)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts)
 
 ##### prevout
 
@@ -3061,7 +3069,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts:25](.
 prevout: object;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts:26](../../packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts#L26)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts)
 
 ###### scriptpubkey
 
@@ -3099,7 +3107,7 @@ value: number;
 scriptsig: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts:33](../../packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts#L33)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts)
 
 ##### scriptsig\_asm
 
@@ -3107,7 +3115,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts:33](.
 scriptsig_asm: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts:34](../../packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts#L34)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts)
 
 ##### witness
 
@@ -3115,7 +3123,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts:34](.
 witness: string[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts:35](../../packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts#L35)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts)
 
 ##### is\_coinbase
 
@@ -3123,7 +3131,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts:35](.
 is_coinbase: boolean;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts:36](../../packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts#L36)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts)
 
 ##### sequence
 
@@ -3131,13 +3139,13 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts:36](.
 sequence: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts:37](../../packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts#L37)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts)
 
 ***
 
 ### TxOutput
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts:43](../../packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts#L43)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts)
 
 Transaction output from mempool API.
 
@@ -3149,7 +3157,7 @@ Transaction output from mempool API.
 scriptpubkey: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts:44](../../packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts#L44)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts)
 
 ##### scriptpubkey\_asm
 
@@ -3157,7 +3165,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts:44](.
 scriptpubkey_asm: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts:45](../../packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts#L45)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts)
 
 ##### scriptpubkey\_type
 
@@ -3165,7 +3173,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts:45](.
 scriptpubkey_type: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts:46](../../packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts#L46)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts)
 
 ##### scriptpubkey\_address
 
@@ -3173,7 +3181,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts:46](.
 scriptpubkey_address: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts:47](../../packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts#L47)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts)
 
 ##### value
 
@@ -3181,13 +3189,13 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts:47](.
 value: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts:48](../../packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts#L48)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts)
 
 ***
 
 ### TxStatus
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts:54](../../packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts#L54)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts)
 
 Transaction status from mempool API.
 
@@ -3199,7 +3207,7 @@ Transaction status from mempool API.
 confirmed: boolean;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts:55](../../packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts#L55)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts)
 
 ##### block\_height?
 
@@ -3207,7 +3215,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts:55](.
 optional block_height: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts:56](../../packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts#L56)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts)
 
 ##### block\_hash?
 
@@ -3215,7 +3223,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts:56](.
 optional block_hash: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts:57](../../packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts#L57)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts)
 
 ##### block\_time?
 
@@ -3223,13 +3231,13 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts:57](.
 optional block_time: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts:58](../../packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts#L58)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts)
 
 ***
 
 ### OutspendStatus
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts:71](../../packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts#L71)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts)
 
 Spend status of a single transaction output, from the esplora-compatible
 `GET /tx/{txid}/outspend/{vout}` endpoint served by the mempool.space
@@ -3248,7 +3256,7 @@ serializes as `{ "spent": false }` (the optional fields use
 spent: boolean;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts:73](../../packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts#L73)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts)
 
 True when the output has been spent (mempool or a block).
 
@@ -3258,7 +3266,7 @@ True when the output has been spent (mempool or a block).
 optional txid: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts:75](../../packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts#L75)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts)
 
 Spending transaction id; present only when `spent`.
 
@@ -3268,7 +3276,7 @@ Spending transaction id; present only when `spent`.
 optional vin: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts:77](../../packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts#L77)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts)
 
 Input index within the spending tx; present only when `spent`.
 
@@ -3278,7 +3286,7 @@ Input index within the spending tx; present only when `spent`.
 optional status: TxStatus;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts:79](../../packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts#L79)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts)
 
 Confirmation status of the spending tx; present only when `spent`.
 
@@ -3286,7 +3294,7 @@ Confirmation status of the spending tx; present only when `spent`.
 
 ### TxInfo
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts:85](../../packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts#L85)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts)
 
 Full transaction info from mempool API.
 
@@ -3298,7 +3306,7 @@ Full transaction info from mempool API.
 txid: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts:86](../../packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts#L86)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts)
 
 ##### version
 
@@ -3306,7 +3314,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts:86](.
 version: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts:87](../../packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts#L87)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts)
 
 ##### locktime
 
@@ -3314,7 +3322,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts:87](.
 locktime: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts:88](../../packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts#L88)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts)
 
 ##### vin
 
@@ -3322,7 +3330,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts:88](.
 vin: TxInput[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts:89](../../packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts#L89)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts)
 
 ##### vout
 
@@ -3330,7 +3338,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts:89](.
 vout: TxOutput[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts:90](../../packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts#L90)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts)
 
 ##### size
 
@@ -3338,7 +3346,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts:90](.
 size: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts:91](../../packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts#L91)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts)
 
 ##### weight
 
@@ -3346,7 +3354,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts:91](.
 weight: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts:92](../../packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts#L92)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts)
 
 ##### fee
 
@@ -3354,7 +3362,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts:92](.
 fee: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts:93](../../packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts#L93)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts)
 
 ##### status
 
@@ -3362,13 +3370,13 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts:93](.
 status: TxStatus;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts:94](../../packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts#L94)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts)
 
 ***
 
 ### UtxoInfo
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts:102](../../packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts#L102)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts)
 
 UTXO info for a specific output (used for PSBT construction).
 
@@ -3382,7 +3390,7 @@ Only supports Taproot (P2TR) and native SegWit (P2WPKH, P2WSH) script types.
 txid: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts:103](../../packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts#L103)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts)
 
 ##### vout
 
@@ -3390,7 +3398,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts:103](
 vout: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts:104](../../packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts#L104)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts)
 
 ##### value
 
@@ -3398,7 +3406,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts:104](
 value: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts:105](../../packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts#L105)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts)
 
 ##### scriptPubKey
 
@@ -3406,13 +3414,13 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts:105](
 scriptPubKey: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts:106](../../packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts#L106)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts)
 
 ***
 
 ### NetworkFees
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts:114](../../packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts#L114)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts)
 
 Bitcoin network fee recommendations (sat/vbyte) from mempool.space API.
 
@@ -3428,7 +3436,7 @@ https://mempool.space/docs/api/rest#get-recommended-fees
 fastestFee: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts:116](../../packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts#L116)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts)
 
 Next block (~10 min)
 
@@ -3438,7 +3446,7 @@ Next block (~10 min)
 halfHourFee: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts:118](../../packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts#L118)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts)
 
 ~30 minutes
 
@@ -3448,7 +3456,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts:118](
 hourFee: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts:120](../../packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts#L120)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts)
 
 ~1 hour
 
@@ -3458,7 +3466,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts:120](
 economyFee: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts:122](../../packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts#L122)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts)
 
 Economy (no time guarantee)
 
@@ -3468,7 +3476,7 @@ Economy (no time guarantee)
 minimumFee: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts:124](../../packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts#L124)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/mempool/types.ts)
 
 Minimum network fee
 
@@ -3476,7 +3484,7 @@ Minimum network fee
 
 ### VaultProviderRpcClientOptions
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts:43](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts#L43)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts)
 
 #### Properties
 
@@ -3486,7 +3494,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts:
 optional timeout: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts:45](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts#L45)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts)
 
 Timeout in milliseconds per request (default: 60000)
 
@@ -3496,7 +3504,7 @@ Timeout in milliseconds per request (default: 60000)
 optional retries: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts:47](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts#L47)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts)
 
 Number of retry attempts for safe methods (default: 3)
 
@@ -3506,7 +3514,7 @@ Number of retry attempts for safe methods (default: 3)
 optional retryDelay: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts:49](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts#L49)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts)
 
 Initial retry delay in milliseconds (default: 1000)
 
@@ -3516,7 +3524,7 @@ Initial retry delay in milliseconds (default: 1000)
 optional retryableFor: (method) => boolean;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts:55](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts#L55)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts)
 
 Custom retry predicate. Default retries only the idempotent read
 methods: `getPeginStatus`, `batchGetPeginStatus`, `batchGetPegoutStatus`,
@@ -3538,7 +3546,7 @@ methods: `getPeginStatus`, `batchGetPeginStatus`, `batchGetPegoutStatus`,
 optional headers: Record<string, string>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts:57](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts#L57)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts)
 
 Custom headers.
 
@@ -3548,7 +3556,7 @@ Custom headers.
 optional tokenProvider: BearerTokenProvider;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts:63](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts#L63)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts)
 
 Per-request bearer-token source. A non-null return attaches
 `Authorization: Bearer <token>`; `null` skips auth. Wire a
@@ -3560,7 +3568,7 @@ VpTokenProvider for depositor-gated methods.
 optional maxResponseBytes: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts:65](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts#L65)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/api.ts)
 
 Maximum response body size, in bytes, for typed JSON-RPC calls
 
@@ -3568,7 +3576,7 @@ Maximum response body size, in bytes, for typed JSON-RPC calls
 
 ### AuthenticatedVpClientConfig
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/createAuthenticatedVpClient.ts:21](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/createAuthenticatedVpClient.ts#L21)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/createAuthenticatedVpClient.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/createAuthenticatedVpClient.ts)
 
 #### Properties
 
@@ -3578,7 +3586,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/cr
 baseUrl: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/createAuthenticatedVpClient.ts:23](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/createAuthenticatedVpClient.ts#L23)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/createAuthenticatedVpClient.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/createAuthenticatedVpClient.ts)
 
 Base URL of the VP RPC endpoint (already proxied if applicable).
 
@@ -3588,7 +3596,7 @@ Base URL of the VP RPC endpoint (already proxied if applicable).
 peginTxid: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/createAuthenticatedVpClient.ts:25](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/createAuthenticatedVpClient.ts#L25)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/createAuthenticatedVpClient.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/createAuthenticatedVpClient.ts)
 
 Per-vault depositor-signed PegIn tx id (registry cache key).
 
@@ -3598,7 +3606,7 @@ Per-vault depositor-signed PegIn tx id (registry cache key).
 authAnchorHex: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/createAuthenticatedVpClient.ts:27](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/createAuthenticatedVpClient.ts#L27)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/createAuthenticatedVpClient.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/createAuthenticatedVpClient.ts)
 
 Already-derived 32-byte auth-anchor preimage (64-char hex, no `0x`).
 
@@ -3608,7 +3616,7 @@ Already-derived 32-byte auth-anchor preimage (64-char hex, no `0x`).
 pinnedServerPubkey: OnChainBtcPubkey;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/createAuthenticatedVpClient.ts:29](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/createAuthenticatedVpClient.ts#L29)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/createAuthenticatedVpClient.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/createAuthenticatedVpClient.ts)
 
 On-chain VP pubkey, branded so it can only come from the registry reader.
 
@@ -3618,7 +3626,7 @@ On-chain VP pubkey, branded so it can only come from the registry reader.
 depositorBtcPubkey: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/createAuthenticatedVpClient.ts:34](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/createAuthenticatedVpClient.ts#L34)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/createAuthenticatedVpClient.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/createAuthenticatedVpClient.ts)
 
 Depositor BTC pubkey (x-only or compressed hex). Normalized to
 x-only and asserted against every issued token's CWT `aud` claim.
@@ -3629,7 +3637,7 @@ x-only and asserted against every issued token's CWT `aud` claim.
 optional options: VaultProviderRpcClientOptions;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/createAuthenticatedVpClient.ts:36](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/createAuthenticatedVpClient.ts#L36)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/createAuthenticatedVpClient.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/createAuthenticatedVpClient.ts)
 
 Optional outer-client tunables (timeout, retries, headers, etc.).
 
@@ -3637,7 +3645,7 @@ Optional outer-client tunables (timeout, retries, headers, etc.).
 
 ### PrimeVpAuthInput
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/primeVpAuth.ts:16](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/primeVpAuth.ts#L16)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/primeVpAuth.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/primeVpAuth.ts)
 
 #### Properties
 
@@ -3647,7 +3655,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/pr
 baseUrl: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/primeVpAuth.ts:17](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/primeVpAuth.ts#L17)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/primeVpAuth.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/primeVpAuth.ts)
 
 ##### peginTxid
 
@@ -3655,7 +3663,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/pr
 peginTxid: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/primeVpAuth.ts:18](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/primeVpAuth.ts#L18)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/primeVpAuth.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/primeVpAuth.ts)
 
 ##### authAnchorHex
 
@@ -3663,7 +3671,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/pr
 authAnchorHex: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/primeVpAuth.ts:19](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/primeVpAuth.ts#L19)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/primeVpAuth.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/primeVpAuth.ts)
 
 ##### pinnedServerPubkey
 
@@ -3671,7 +3679,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/pr
 pinnedServerPubkey: OnChainBtcPubkey;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/primeVpAuth.ts:20](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/primeVpAuth.ts#L20)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/primeVpAuth.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/primeVpAuth.ts)
 
 ##### depositorBtcPubkey
 
@@ -3679,7 +3687,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/pr
 depositorBtcPubkey: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/primeVpAuth.ts:25](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/primeVpAuth.ts#L25)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/primeVpAuth.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/primeVpAuth.ts)
 
 Depositor BTC pubkey (x-only or compressed hex). Normalized to
 x-only and asserted against every issued token's CWT `aud` claim.
@@ -3690,7 +3698,7 @@ x-only and asserted against every issued token's CWT `aud` claim.
 optional headers: Record<string, string>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/primeVpAuth.ts:27](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/primeVpAuth.ts#L27)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/primeVpAuth.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/primeVpAuth.ts)
 
 Optional headers forwarded to the inner token client (e.g. gateway auth).
 
@@ -3698,7 +3706,7 @@ Optional headers forwarded to the inner token client (e.g. gateway auth).
 
 ### ServerIdentityResponse
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/serverIdentity.ts:54](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/serverIdentity.ts#L54)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/serverIdentity.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/serverIdentity.ts)
 
 Wire representation from btc-vault's `ServerIdentityResponse`.
 
@@ -3710,7 +3718,7 @@ Wire representation from btc-vault's `ServerIdentityResponse`.
 server_pubkey: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/serverIdentity.ts:56](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/serverIdentity.ts#L56)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/serverIdentity.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/serverIdentity.ts)
 
 Hex-encoded x-only (32-byte) persistent server pubkey.
 
@@ -3720,7 +3728,7 @@ Hex-encoded x-only (32-byte) persistent server pubkey.
 ephemeral_pubkey: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/serverIdentity.ts:58](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/serverIdentity.ts#L58)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/serverIdentity.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/serverIdentity.ts)
 
 Hex-encoded compressed (33-byte) ephemeral token-signing pubkey.
 
@@ -3730,7 +3738,7 @@ Hex-encoded compressed (33-byte) ephemeral token-signing pubkey.
 expires_at: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/serverIdentity.ts:60](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/serverIdentity.ts#L60)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/serverIdentity.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/serverIdentity.ts)
 
 Unix timestamp at which the ephemeral key expires.
 
@@ -3740,7 +3748,7 @@ Unix timestamp at which the ephemeral key expires.
 signature: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/serverIdentity.ts:62](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/serverIdentity.ts#L62)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/serverIdentity.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/serverIdentity.ts)
 
 Hex-encoded 64-byte BIP-322 Schnorr signature.
 
@@ -3748,7 +3756,7 @@ Hex-encoded 64-byte BIP-322 Schnorr signature.
 
 ### VerifyServerIdentityInput
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/serverIdentity.ts:65](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/serverIdentity.ts#L65)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/serverIdentity.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/serverIdentity.ts)
 
 #### Properties
 
@@ -3758,7 +3766,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/se
 proof: ServerIdentityResponse;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/serverIdentity.ts:67](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/serverIdentity.ts#L67)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/serverIdentity.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/serverIdentity.ts)
 
 The proof returned by `auth_createDepositorToken`.
 
@@ -3768,7 +3776,7 @@ The proof returned by `auth_createDepositorToken`.
 pinnedServerPubkey: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/serverIdentity.ts:73](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/serverIdentity.ts#L73)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/serverIdentity.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/serverIdentity.ts)
 
 The x-only persistent server pubkey the FE expects (sourced from
 the on-chain `VaultProvider.btcPubKey` via the vault registry
@@ -3780,7 +3788,7 @@ reader). 64-char lowercase hex, no `0x` prefix.
 now: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/serverIdentity.ts:75](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/serverIdentity.ts#L75)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/serverIdentity.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/serverIdentity.ts)
 
 Current Unix timestamp in seconds. Injected for testability.
 
@@ -3790,7 +3798,7 @@ Current Unix timestamp in seconds. Injected for testability.
 optional maxLifetimeSecs: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/serverIdentity.ts:77](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/serverIdentity.ts#L77)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/serverIdentity.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/serverIdentity.ts)
 
 Cap on `proof.expires_at - now` (seconds). Defaults to DEFAULT\_MAX\_PROOF\_LIFETIME\_SECS.
 
@@ -3798,7 +3806,7 @@ Cap on `proof.expires_at - now` (seconds). Defaults to DEFAULT\_MAX\_PROOF\_LIFE
 
 ### VpTokenRegistryInput
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/tokenRegistry.ts:15](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/tokenRegistry.ts#L15)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/tokenRegistry.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/tokenRegistry.ts)
 
 #### Properties
 
@@ -3808,7 +3816,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/to
 client: JsonRpcClient;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/tokenRegistry.ts:16](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/tokenRegistry.ts#L16)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/tokenRegistry.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/tokenRegistry.ts)
 
 ##### peginTxid
 
@@ -3816,7 +3824,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/to
 peginTxid: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/tokenRegistry.ts:17](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/tokenRegistry.ts#L17)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/tokenRegistry.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/tokenRegistry.ts)
 
 ##### authAnchorHex
 
@@ -3824,7 +3832,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/to
 authAnchorHex: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/tokenRegistry.ts:18](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/tokenRegistry.ts#L18)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/tokenRegistry.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/tokenRegistry.ts)
 
 ##### pinnedServerPubkey
 
@@ -3832,7 +3840,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/to
 pinnedServerPubkey: OnChainBtcPubkey;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/tokenRegistry.ts:19](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/tokenRegistry.ts#L19)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/tokenRegistry.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/tokenRegistry.ts)
 
 ##### expectedAudienceXOnlyPubkey
 
@@ -3840,7 +3848,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/to
 expectedAudienceXOnlyPubkey: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/tokenRegistry.ts:21](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/tokenRegistry.ts#L21)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/tokenRegistry.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/tokenRegistry.ts)
 
 Depositor x-only pubkey (32-byte hex), asserted against each token's CWT `aud`.
 
@@ -3848,7 +3856,7 @@ Depositor x-only pubkey (32-byte hex), asserted against each token's CWT `aud`.
 
 ### BatchResultEntry
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/batchAttribution.ts:15](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/batchAttribution.ts#L15)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/batchAttribution.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/batchAttribution.ts)
 
 Per-item entry in a VP batch response.
 
@@ -3866,7 +3874,7 @@ Per-item entry in a VP batch response.
 pegin_txid: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/batchAttribution.ts:16](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/batchAttribution.ts#L16)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/batchAttribution.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/batchAttribution.ts)
 
 ##### result
 
@@ -3874,7 +3882,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/batchAt
 result: T | null;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/batchAttribution.ts:17](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/batchAttribution.ts#L17)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/batchAttribution.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/batchAttribution.ts)
 
 ##### error
 
@@ -3882,13 +3890,13 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/batchAt
 error: string | null;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/batchAttribution.ts:18](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/batchAttribution.ts#L18)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/batchAttribution.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/batchAttribution.ts)
 
 ***
 
 ### BatchPollByProviderOptions
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/batchPoll.ts:20](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/batchPoll.ts#L20)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/batchPoll.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/batchPoll.ts)
 
 #### Type Parameters
 
@@ -3908,7 +3916,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/batchPo
 items: TItem[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/batchPoll.ts:22](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/batchPoll.ts#L22)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/batchPoll.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/batchPoll.ts)
 
 Items to poll for this provider, e.g. `DepositToPoll[]`.
 
@@ -3918,7 +3926,7 @@ Items to poll for this provider, e.g. `DepositToPoll[]`.
 getTxid: (item) => string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/batchPoll.ts:24](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/batchPoll.ts#L24)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/batchPoll.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/batchPoll.ts)
 
 Extract the canonical txid for each item. Helper lowercases it.
 
@@ -3940,7 +3948,7 @@ batchCall: (txids) => Promise<{
 }>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/batchPoll.ts:29](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/batchPoll.ts#L29)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/batchPoll.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/batchPoll.ts)
 
 Per-chunk RPC call. Receives lowercased txids; returns the batch
 envelope. Caller wraps `rpcClient.batchGet*Status({ pegin_txids })`.
@@ -3963,7 +3971,7 @@ envelope. Caller wraps `rpcClient.batchGet*Status({ pegin_txids })`.
 onItem: (item, envelope) => void;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/batchPoll.ts:40](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/batchPoll.ts#L40)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/batchPoll.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/batchPoll.ts)
 
 Handle a per-item envelope. Exactly one of `result` / `error` is
 populated (validator invariant). Caller decides UI state, logging,
@@ -3992,7 +4000,7 @@ sent in the request, not whatever case/encoding the server echoed.
 onMissing: (item) => void;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/batchPoll.ts:42](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/batchPoll.ts#L42)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/batchPoll.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/batchPoll.ts)
 
 Server omitted this item from the response.
 
@@ -4012,7 +4020,7 @@ Server omitted this item from the response.
 onDuplicate: (item) => void;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/batchPoll.ts:44](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/batchPoll.ts#L44)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/batchPoll.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/batchPoll.ts)
 
 Server returned this item more than once. Caller picks UI state.
 
@@ -4032,7 +4040,7 @@ Server returned this item more than once. Caller picks UI state.
 optional onDuplicateBatch: (count) => void;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/batchPoll.ts:51](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/batchPoll.ts#L51)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/batchPoll.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/batchPoll.ts)
 
 Optional aggregate signal for an entire chunk where the server
 returned duplicates. Fires once per chunk (only if `count > 0`)
@@ -4055,7 +4063,7 @@ the count alongside the provider name.
 onWholeBatchError: (chunk, error) => void;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/batchPoll.ts:57](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/batchPoll.ts#L57)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/batchPoll.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/batchPoll.ts)
 
 The whole chunk's RPC call failed (transport or response
 validation). Receives the chunk and the error. Caller decides how
@@ -4081,7 +4089,7 @@ to project that onto per-item state.
 optional onUnexpected: (echoedTxids) => void;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/batchPoll.ts:64](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/batchPoll.ts#L64)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/batchPoll.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/batchPoll.ts)
 
 Server returned txids that were not in the request. Caller
 typically logs the count for observability — there's no recovery
@@ -4104,7 +4112,7 @@ defaults to no-op.
 optional batchSize: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/batchPoll.ts:70](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/batchPoll.ts#L70)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/batchPoll.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/batchPoll.ts)
 
 Maximum items per RPC call. Defaults to [VP\_BATCH\_MAX\_SIZE](#vp_batch_max_size).
 Exposed for tests so chunking can be exercised without 50+
@@ -4114,7 +4122,7 @@ fixtures.
 
 ### BearerTokenProvider
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts:44](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts#L44)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts)
 
 Injects bearer tokens into requests for auth-gated methods, and is
 notified when the server rejects a bearer so it can invalidate its cache.
@@ -4132,7 +4140,7 @@ request with no `Authorization` header.
 getToken(method): Promise<string | null>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts:49](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts#L49)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts)
 
 Return the bearer token to inject for `method`, or `null` if the
 method does not require auth.
@@ -4153,7 +4161,7 @@ method does not require auth.
 invalidate(): void;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts:54](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts#L54)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts)
 
 Drop the cached token. Next call to `getToken` must re-acquire.
 Called by the client on reactive-refresh-trigger responses.
@@ -4166,7 +4174,7 @@ Called by the client on reactive-refresh-trigger responses.
 
 ### JsonRpcClientConfig
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts:57](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts#L57)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts)
 
 #### Properties
 
@@ -4176,7 +4184,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rp
 baseUrl: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts:59](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts#L59)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts)
 
 Base URL of the RPC service
 
@@ -4186,7 +4194,7 @@ Base URL of the RPC service
 timeout: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts:61](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts#L61)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts)
 
 Timeout in milliseconds per request attempt
 
@@ -4196,7 +4204,7 @@ Timeout in milliseconds per request attempt
 optional headers: Record<string, string>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts:63](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts#L63)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts)
 
 Optional custom headers
 
@@ -4206,7 +4214,7 @@ Optional custom headers
 optional retries: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts:65](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts#L65)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts)
 
 Number of retry attempts for transient errors (default: 3)
 
@@ -4216,7 +4224,7 @@ Number of retry attempts for transient errors (default: 3)
 optional retryDelay: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts:67](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts#L67)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts)
 
 Initial retry delay in milliseconds (default: 1000)
 
@@ -4226,7 +4234,7 @@ Initial retry delay in milliseconds (default: 1000)
 optional maxResponseBytes: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts:73](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts#L73)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts)
 
 Maximum response body size, in bytes, for typed JSON-RPC calls.
 `callRaw` intentionally returns the unparsed Response and is not capped here.
@@ -4238,7 +4246,7 @@ Default: 2 MiB.
 optional retryableFor: (method) => boolean;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts:80](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts#L80)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts)
 
 Predicate that decides which methods retry on transient errors.
 Default retries only `getPeginStatus`, `batchGetPeginStatus`,
@@ -4261,7 +4269,7 @@ Write methods are not retried by default.
 optional tokenProvider: BearerTokenProvider;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts:88](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts#L88)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts)
 
 Per-request bearer-token source. A non-null return attaches
 `Authorization: Bearer <token>`; `null` skips auth. `call`
@@ -4273,7 +4281,7 @@ additionally retries once when the server rejects the bearer
 
 ### WotsConfig
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:136](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L136)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 WOTS configuration for a single block.
 Matches Rust `babe::wots::Config` serde format.
@@ -4286,7 +4294,7 @@ Matches Rust `babe::wots::Config` serde format.
 d: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:138](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L138)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 Digit bit-width (e.g. 4 → base-16 digits).
 
@@ -4296,7 +4304,7 @@ Digit bit-width (e.g. 4 → base-16 digits).
 n: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:140](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L140)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 Number of message digits in this block.
 
@@ -4306,7 +4314,7 @@ Number of message digits in this block.
 checksum_radix: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:142](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L142)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 Radix used for the checksum computation.
 
@@ -4314,7 +4322,7 @@ Radix used for the checksum computation.
 
 ### WotsBlockPublicKey
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:149](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L149)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 A single block of WOTS public keys.
 Chain values are arrays of byte values (matching Rust `[u8; 20]`).
@@ -4327,7 +4335,7 @@ Chain values are arrays of byte values (matching Rust `[u8; 20]`).
 config: WotsConfig;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:150](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L150)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ##### message\_terminals
 
@@ -4335,7 +4343,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.t
 message_terminals: number[][];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:151](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L151)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ##### checksum\_major\_terminal
 
@@ -4343,7 +4351,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.t
 checksum_major_terminal: number[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:152](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L152)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ##### checksum\_minor\_terminal
 
@@ -4351,13 +4359,13 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.t
 checksum_minor_terminal: number[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:153](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L153)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ***
 
 ### RequestDepositorPresignTransactionsParams
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:161](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L161)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 Params for requesting the payout/claim/assert transactions to pre-sign.
 
@@ -4369,7 +4377,7 @@ Params for requesting the payout/claim/assert transactions to pre-sign.
 pegin_txid: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:162](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L162)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ##### depositor\_pk
 
@@ -4377,13 +4385,13 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.t
 depositor_pk: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:163](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L163)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ***
 
 ### SubmitDepositorWotsKeyParams
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:167](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L167)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 Params for submitting the depositor's WOTS public key to the VP.
 
@@ -4395,7 +4403,7 @@ Params for submitting the depositor's WOTS public key to the VP.
 pegin_txid: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:168](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L168)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ##### depositor\_pk
 
@@ -4403,7 +4411,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.t
 depositor_pk: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:169](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L169)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ##### wots\_public\_keys
 
@@ -4411,13 +4419,13 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.t
 wots_public_keys: WotsBlockPublicKey[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:170](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L170)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ***
 
 ### DepositorPreSigsPerChallenger
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:174](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L174)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 Per-challenger signatures for the depositor-as-claimer flow.
 
@@ -4429,13 +4437,13 @@ Per-challenger signatures for the depositor-as-claimer flow.
 nopayout_signature: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:175](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L175)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ***
 
 ### DepositorAsClaimerPresignatures
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:179](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L179)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 Depositor-as-claimer pre-signatures (payout + per-challenger).
 
@@ -4447,7 +4455,7 @@ Depositor-as-claimer pre-signatures (payout + per-challenger).
 payout_signatures: ClaimerSignatures;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:180](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L180)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ##### per\_challenger
 
@@ -4455,13 +4463,13 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.t
 per_challenger: Record<string, DepositorPreSigsPerChallenger>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:181](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L181)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ***
 
 ### SubmitDepositorPresignaturesParams
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:185](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L185)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 Params for submitting depositor pre-signatures including claimer presignatures.
 
@@ -4473,7 +4481,7 @@ Params for submitting depositor pre-signatures including claimer presignatures.
 pegin_txid: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:186](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L186)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ##### depositor\_pk
 
@@ -4481,7 +4489,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.t
 depositor_pk: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:187](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L187)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ##### signatures
 
@@ -4489,7 +4497,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.t
 signatures: Record<string, ClaimerSignatures>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:188](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L188)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ##### depositor\_claimer\_presignatures
 
@@ -4497,13 +4505,13 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.t
 depositor_claimer_presignatures: DepositorAsClaimerPresignatures;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:189](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L189)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ***
 
 ### ClaimerSignatures
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:193](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L193)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 Payout signatures per claimer.
 
@@ -4515,13 +4523,13 @@ Payout signatures per claimer.
 payout_signature: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:194](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L194)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ***
 
 ### RequestDepositorClaimerArtifactsParams
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:198](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L198)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 Params for requesting BaBe DecryptorArtifacts from the VP.
 
@@ -4533,7 +4541,7 @@ Params for requesting BaBe DecryptorArtifacts from the VP.
 pegin_txid: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:199](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L199)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ##### depositor\_pk
 
@@ -4541,13 +4549,13 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.t
 depositor_pk: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:200](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L200)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ***
 
 ### TransactionData
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:213](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L213)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 A raw Bitcoin transaction with its hex encoding.
 
@@ -4559,13 +4567,13 @@ A raw Bitcoin transaction with its hex encoding.
 tx_hex: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:214](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L214)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ***
 
 ### ClaimerTransactions
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:218](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L218)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 Set of transactions the depositor must pre-sign for a single claimer.
 
@@ -4577,7 +4585,7 @@ Set of transactions the depositor must pre-sign for a single claimer.
 claimer_pubkey: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:219](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L219)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ##### claim\_tx
 
@@ -4585,7 +4593,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.t
 claim_tx: TransactionData;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:220](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L220)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ##### assert\_tx
 
@@ -4593,7 +4601,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.t
 assert_tx: TransactionData;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:221](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L221)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ##### payout\_tx
 
@@ -4601,7 +4609,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.t
 payout_tx: TransactionData;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:222](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L222)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ##### payout\_psbt
 
@@ -4609,13 +4617,13 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.t
 payout_psbt: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:223](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L223)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ***
 
 ### ChallengeAssertConnectorData
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:227](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L227)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 Per-segment connector data for ChallengeAssert inputs.
 
@@ -4627,7 +4635,7 @@ Per-segment connector data for ChallengeAssert inputs.
 wots_pks_json: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:228](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L228)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ##### gc\_wots\_keys\_json
 
@@ -4635,13 +4643,13 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.t
 gc_wots_keys_json: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:229](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L229)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ***
 
 ### PresignDataPerChallenger
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:233](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L233)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 Challenger-specific transactions and signing data for the depositor graph.
 
@@ -4653,7 +4661,7 @@ Challenger-specific transactions and signing data for the depositor graph.
 challenger_pubkey: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:234](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L234)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ##### challenge\_assert\_x\_tx
 
@@ -4661,7 +4669,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.t
 challenge_assert_x_tx: TransactionData;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:235](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L235)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ##### challenge\_assert\_y\_tx
 
@@ -4669,7 +4677,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.t
 challenge_assert_y_tx: TransactionData;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:236](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L236)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ##### nopayout\_tx
 
@@ -4677,7 +4685,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.t
 nopayout_tx: TransactionData;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:237](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L237)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ##### nopayout\_psbt
 
@@ -4685,7 +4693,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.t
 nopayout_psbt: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:238](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L238)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ##### challenge\_assert\_connectors
 
@@ -4693,7 +4701,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.t
 challenge_assert_connectors: ChallengeAssertConnectorData[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:239](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L239)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ##### output\_label\_hashes
 
@@ -4701,13 +4709,13 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.t
 output_label_hashes: string[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:240](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L240)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ***
 
 ### DepositorGraphTransactions
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:244](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L244)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 Depositor-as-claimer TxGraph transactions.
 
@@ -4719,7 +4727,7 @@ Depositor-as-claimer TxGraph transactions.
 claim_tx: TransactionData;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:245](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L245)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ##### assert\_tx
 
@@ -4727,7 +4735,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.t
 assert_tx: TransactionData;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:246](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L246)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ##### payout\_tx
 
@@ -4735,7 +4743,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.t
 payout_tx: TransactionData;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:247](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L247)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ##### payout\_psbt
 
@@ -4743,7 +4751,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.t
 payout_psbt: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:248](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L248)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ##### challenger\_presign\_data
 
@@ -4751,7 +4759,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.t
 challenger_presign_data: PresignDataPerChallenger[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:249](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L249)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ##### offchain\_params\_version
 
@@ -4759,13 +4767,13 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.t
 offchain_params_version: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:250](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L250)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ***
 
 ### RequestDepositorPresignTransactionsResponse
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:254](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L254)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 Response from `requestDepositorPresignTransactions`.
 
@@ -4777,7 +4785,7 @@ Response from `requestDepositorPresignTransactions`.
 txs: ClaimerTransactions[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:255](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L255)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ##### depositor\_graph
 
@@ -4785,13 +4793,13 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.t
 depositor_graph: DepositorGraphTransactions;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:256](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L256)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ***
 
 ### BaBeSessionData
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:260](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L260)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 BaBe garbled-circuit session data for a single challenger.
 
@@ -4803,13 +4811,13 @@ BaBe garbled-circuit session data for a single challenger.
 decryptor_artifacts_hex: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:261](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L261)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ***
 
 ### RequestDepositorClaimerArtifactsResponse
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:265](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L265)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 Response from `requestDepositorClaimerArtifacts`.
 
@@ -4821,7 +4829,7 @@ Response from `requestDepositorClaimerArtifacts`.
 tx_graph_json: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:266](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L266)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ##### verifying\_key\_hex
 
@@ -4829,7 +4837,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.t
 verifying_key_hex: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:267](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L267)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ##### babe\_sessions
 
@@ -4837,13 +4845,13 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.t
 babe_sessions: Record<string, BaBeSessionData>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:268](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L268)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ***
 
 ### ChallengerProgress
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:272](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L272)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 Progress tracker for a multi-challenger operation.
 
@@ -4859,7 +4867,7 @@ Progress tracker for a multi-challenger operation.
 total_challengers: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:273](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L273)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ##### completed\_challengers
 
@@ -4867,7 +4875,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.t
 completed_challengers: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:274](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L274)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ##### completed\_challenger\_pubkeys
 
@@ -4875,7 +4883,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.t
 completed_challenger_pubkeys: string[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:275](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L275)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ##### pending\_challenger\_pubkeys
 
@@ -4883,13 +4891,13 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.t
 pending_challenger_pubkeys: string[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:276](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L276)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ***
 
 ### PresigningProgress
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:283](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L283)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 Extended presigning progress with all 3 concurrent phases.
 
@@ -4905,7 +4913,7 @@ Extended presigning progress with all 3 concurrent phases.
 total_challengers: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:273](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L273)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ###### Inherited from
 
@@ -4917,7 +4925,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.t
 completed_challengers: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:274](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L274)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ###### Inherited from
 
@@ -4929,7 +4937,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.t
 completed_challenger_pubkeys: string[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:275](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L275)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ###### Inherited from
 
@@ -4941,7 +4949,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.t
 pending_challenger_pubkeys: string[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:276](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L276)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ###### Inherited from
 
@@ -4953,7 +4961,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.t
 optional depositor_graph_created: boolean;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:284](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L284)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ##### vk\_challenger\_presigning\_completed?
 
@@ -4961,7 +4969,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.t
 optional vk_challenger_presigning_completed: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:285](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L285)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ##### vk\_challenger\_presigning\_total?
 
@@ -4969,13 +4977,13 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.t
 optional vk_challenger_presigning_total: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:286](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L286)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ***
 
 ### PeginProgressDetails
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:290](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L290)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 Detailed progress breakdown for an in-progress pegin.
 
@@ -4987,7 +4995,7 @@ Detailed progress breakdown for an in-progress pegin.
 optional gc_data: ChallengerProgress;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:291](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L291)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ##### presigning?
 
@@ -4995,7 +5003,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.t
 optional presigning: PresigningProgress;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:292](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L292)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ##### ack\_collection?
 
@@ -5003,7 +5011,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.t
 optional ack_collection: ChallengerProgress;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:293](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L293)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ##### claimer\_graphs?
 
@@ -5011,13 +5019,13 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.t
 optional claimer_graphs: ClaimerGraphStatus[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:294](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L294)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ***
 
 ### ClaimerGraphStatus
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:298](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L298)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 Per-claimer graph status (challenger perspective).
 
@@ -5029,7 +5037,7 @@ Per-claimer graph status (challenger perspective).
 claimer_pubkey: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:299](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L299)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ##### presigned
 
@@ -5037,13 +5045,13 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.t
 presigned: boolean;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:300](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L300)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ***
 
 ### GetPeginStatusResponse
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:304](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L304)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 Response from `getPeginStatus`.
 
@@ -5055,7 +5063,7 @@ Response from `getPeginStatus`.
 pegin_txid: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:305](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L305)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ##### status
 
@@ -5063,7 +5071,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.t
 status: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:306](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L306)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ##### progress
 
@@ -5071,7 +5079,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.t
 progress: PeginProgressDetails;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:307](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L307)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ##### health\_info
 
@@ -5079,7 +5087,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.t
 health_info: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:308](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L308)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ##### last\_error?
 
@@ -5087,13 +5095,13 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.t
 optional last_error: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:309](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L309)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ***
 
 ### ClaimerPegoutStatus
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:320](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L320)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 Claimer-side pegout progress.
 Source: btc-vault crates/vaultd/src/rpc/server/pegout_status.rs ClaimerPegoutStatus.
@@ -5106,7 +5114,7 @@ Source: btc-vault crates/vaultd/src/rpc/server/pegout_status.rs ClaimerPegoutSta
 status: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:322](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L322)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 Wire string from PegoutStatus enum.
 
@@ -5116,7 +5124,7 @@ Wire string from PegoutStatus enum.
 failed: boolean;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:323](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L323)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ##### claim\_txid
 
@@ -5124,7 +5132,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.t
 claim_txid: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:324](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L324)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ##### claimer\_pubkey
 
@@ -5132,7 +5140,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.t
 claimer_pubkey: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:325](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L325)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ##### assert\_txid
 
@@ -5140,7 +5148,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.t
 assert_txid: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:326](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L326)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ##### created\_at
 
@@ -5148,7 +5156,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.t
 created_at: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:328](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L328)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 Unix epoch seconds.
 
@@ -5158,7 +5166,7 @@ Unix epoch seconds.
 updated_at: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:330](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L330)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 Unix epoch seconds.
 
@@ -5166,7 +5174,7 @@ Unix epoch seconds.
 
 ### ChallengerStatus
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:337](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L337)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 Challenger-side pegout progress.
 Source: btc-vault crates/vaultd/src/rpc/server/pegout_status.rs ChallengerStatus.
@@ -5179,7 +5187,7 @@ Source: btc-vault crates/vaultd/src/rpc/server/pegout_status.rs ChallengerStatus
 status: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:338](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L338)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ##### claim\_txid
 
@@ -5187,7 +5195,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.t
 claim_txid: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:339](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L339)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ##### claimer\_pubkey
 
@@ -5195,7 +5203,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.t
 claimer_pubkey: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:340](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L340)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ##### assert\_txid
 
@@ -5203,7 +5211,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.t
 assert_txid: string | null;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:341](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L341)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ##### challenge\_assert\_x\_txid
 
@@ -5211,7 +5219,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.t
 challenge_assert_x_txid: string | null;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:342](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L342)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ##### challenge\_assert\_y\_txid
 
@@ -5219,7 +5227,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.t
 challenge_assert_y_txid: string | null;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:343](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L343)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ##### nopayout\_txid
 
@@ -5227,7 +5235,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.t
 nopayout_txid: string | null;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:344](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L344)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ##### created\_at
 
@@ -5235,7 +5243,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.t
 created_at: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:345](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L345)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ##### updated\_at
 
@@ -5243,13 +5251,13 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.t
 updated_at: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:346](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L346)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ***
 
 ### GetPegoutStatusResponse
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:353](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L353)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 Pegout status response. Embedded by `batchGetPegoutStatus` per-result
 envelopes. Mirrors btc-vault `GetPegoutStatusResponse`.
@@ -5262,7 +5270,7 @@ envelopes. Mirrors btc-vault `GetPegoutStatusResponse`.
 pegin_txid: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:354](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L354)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ##### found
 
@@ -5270,7 +5278,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.t
 found: boolean;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:355](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L355)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ##### claimer
 
@@ -5278,7 +5286,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.t
 claimer: ClaimerPegoutStatus | null;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:356](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L356)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ##### challengers
 
@@ -5286,13 +5294,13 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.t
 challengers: ChallengerStatus[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:357](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L357)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ***
 
 ### BatchGetPeginStatusParams
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:365](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L365)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 Params for `batchGetPeginStatus`.
 
@@ -5304,7 +5312,7 @@ Params for `batchGetPeginStatus`.
 pegin_txids: string[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:367](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L367)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 Up to MAX_BATCH_SIZE (50) txids per call.
 
@@ -5312,7 +5320,7 @@ Up to MAX_BATCH_SIZE (50) txids per call.
 
 ### BatchPeginStatusResult
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:371](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L371)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 Per-pegin entry in a `batchGetPeginStatus` response.
 
@@ -5324,7 +5332,7 @@ Per-pegin entry in a `batchGetPeginStatus` response.
 pegin_txid: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:372](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L372)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ##### result
 
@@ -5332,7 +5340,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.t
 result: GetPeginStatusResponse | null;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:373](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L373)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ##### error
 
@@ -5340,13 +5348,13 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.t
 error: string | null;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:374](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L374)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ***
 
 ### BatchGetPeginStatusResponse
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:378](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L378)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 Response from `batchGetPeginStatus`. Results are returned in request order.
 
@@ -5358,13 +5366,13 @@ Response from `batchGetPeginStatus`. Results are returned in request order.
 results: BatchPeginStatusResult[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:379](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L379)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ***
 
 ### BatchGetPegoutStatusParams
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:383](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L383)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 Params for `batchGetPegoutStatus`.
 
@@ -5376,13 +5384,13 @@ Params for `batchGetPegoutStatus`.
 pegin_txids: string[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:384](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L384)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ***
 
 ### BatchPegoutStatusResult
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:388](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L388)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 Per-vault entry in a `batchGetPegoutStatus` response.
 
@@ -5394,7 +5402,7 @@ Per-vault entry in a `batchGetPegoutStatus` response.
 pegin_txid: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:389](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L389)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ##### result
 
@@ -5402,7 +5410,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.t
 result: GetPegoutStatusResponse | null;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:390](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L390)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ##### error
 
@@ -5410,13 +5418,13 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.t
 error: string | null;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:391](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L391)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ***
 
 ### BatchGetPegoutStatusResponse
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:395](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L395)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 Response from `batchGetPegoutStatus`. Results are returned in request order.
 
@@ -5428,7 +5436,7 @@ Response from `batchGetPegoutStatus`. Results are returned in request order.
 results: BatchPegoutStatusResult[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:396](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L396)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ## Type Aliases
 
@@ -5438,7 +5446,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.t
 type OnChainBtcPubkey = string & object;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:26](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L26)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 64-char lowercase hex (no `0x`) x-only BTC pubkey sourced from an on-chain
 registry. Minted only by `assertOnChainBtcPubkey`, which is the shared
@@ -5467,7 +5475,7 @@ frozen
 type OnSkippedOffchainParamsVersion = (version, error) => void;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:262](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L262)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 Optional observer invoked by `fetchAllOffchainParams` when a historical
 version fails validation. Called once per skipped version so callers can
@@ -5495,7 +5503,7 @@ log/telemeter without coupling the SDK to a specific logger.
 type JsonRpcErrorSource = "wire" | "local";
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts:92](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts#L92)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts)
 
 ***
 
@@ -5513,7 +5521,7 @@ type GetPeginStatusParams =
 };
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:204](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L204)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 Params for querying pegin status. Either pegin_txid or vault_id must be provided.
 
@@ -5525,7 +5533,7 @@ Params for querying pegin status. Either pegin_txid or vault_id must be provided
 type GcDataProgress = ChallengerProgress;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:279](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L279)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ***
 
@@ -5535,7 +5543,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.t
 type AckCollectionProgress = ChallengerProgress;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:280](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L280)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ## Functions
 
@@ -5545,7 +5553,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.t
 function resolveProtocolAddresses(publicClient, btcVaultRegistryAddress): Promise<ProtocolAddresses>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/contract-address-resolver.ts:31](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/contract-address-resolver.ts#L31)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/contract-address-resolver.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/contract-address-resolver.ts)
 
 Resolve ProtocolParams and ApplicationRegistry addresses from BTCVaultRegistry.
 
@@ -5577,7 +5585,7 @@ Resolved contract addresses
 function assertOnChainBtcPubkey(value, label): OnChainBtcPubkey;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/onChainBtcPubkey.ts:28](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/onChainBtcPubkey.ts#L28)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/onChainBtcPubkey.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/onChainBtcPubkey.ts)
 
 Validate a registry-returned `bytes32` as an x-only BTC pubkey and mint the
 brand. Checks length, hex form, and secp256k1 curve membership. Returns
@@ -5612,7 +5620,7 @@ with no bonded key surfaces as an error rather than a silent all-zero key.
 function validateOffchainParams(params): void;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/protocol-params-validation.ts:58](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/protocol-params-validation.ts#L58)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/protocol-params-validation.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/protocol-params-validation.ts)
 
 Validate offchain params consistency and bounds.
 
@@ -5638,7 +5646,7 @@ Error on invalid values to prevent constructing invalid Bitcoin scripts.
 function validateTBVProtocolParams(params): void;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/protocol-params-validation.ts:165](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/protocol-params-validation.ts#L165)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/protocol-params-validation.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/protocol-params-validation.ts)
 
 Validate TBV protocol params returned from the contract.
 
@@ -5664,7 +5672,7 @@ Error on invalid amounts or out-of-range bounded fields.
 function validatePegInConfiguration(config): void;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/protocol-params-validation.ts:223](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/protocol-params-validation.ts#L223)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/protocol-params-validation.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/protocol-params-validation.ts)
 
 Validate the full peg-in configuration after assembly.
 Checks both TBV params and offchain params consistency, and the
@@ -5690,7 +5698,7 @@ names).
 function pushTx(txHex, apiUrl): Promise<string>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts:175](../../packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts#L175)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts)
 
 Push a signed transaction to the Bitcoin network.
 
@@ -5726,7 +5734,7 @@ Error if broadcasting fails
 function getTxInfo(txid, apiUrl): Promise<TxInfo>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts:219](../../packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts#L219)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts)
 
 Get transaction information from mempool.
 
@@ -5758,7 +5766,7 @@ Transaction information
 function getTipHeight(apiUrl): Promise<number>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts:234](../../packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts#L234)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts)
 
 Get the current block tip height.
 
@@ -5794,7 +5802,7 @@ function getOutspend(
 apiUrl): Promise<OutspendStatus>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts:258](../../packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts#L258)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts)
 
 Get the spend status of a specific transaction output.
 
@@ -5837,7 +5845,7 @@ The output's spend status
 function getTxHex(txid, apiUrl): Promise<string>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts:278](../../packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts#L278)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts)
 
 Get the hex representation of a transaction.
 
@@ -5876,7 +5884,7 @@ function getUtxoInfo(
 apiUrl): Promise<UtxoInfo>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts:310](../../packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts#L310)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts)
 
 Get UTXO information for a specific transaction output.
 
@@ -5917,7 +5925,7 @@ UTXO information with value and scriptPubKey
 function getAddressUtxos(address, apiUrl): Promise<MempoolUTXO[]>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts:345](../../packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts#L345)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts)
 
 Get all UTXOs for a Bitcoin address.
 
@@ -5949,7 +5957,7 @@ Array of UTXOs sorted by value (largest first)
 function getMempoolApiUrl(network): string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts:422](../../packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts#L422)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts)
 
 Get the mempool API URL for a given network.
 
@@ -5975,7 +5983,7 @@ The mempool API URL
 function getAddressTxs(address, apiUrl): Promise<AddressTx[]>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts:449](../../packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts#L449)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts)
 
 Get recent transactions for a Bitcoin address.
 
@@ -6010,7 +6018,7 @@ Array of recent transactions
 function getNetworkFees(apiUrl): Promise<NetworkFees>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts:466](../../packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts#L466)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts)
 
 Fetches Bitcoin network fee recommendations from mempool.space API.
 
@@ -6044,7 +6052,7 @@ https://mempool.space/docs/api/rest#get-recommended-fees
 function createAuthenticatedVpClient(config): VaultProviderRpcClient;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/createAuthenticatedVpClient.ts:39](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/createAuthenticatedVpClient.ts#L39)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/createAuthenticatedVpClient.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/createAuthenticatedVpClient.ts)
 
 #### Parameters
 
@@ -6064,7 +6072,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/cr
 function primeVpTokenRegistry(input): void;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/primeVpAuth.ts:30](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/primeVpAuth.ts#L30)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/primeVpAuth.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/primeVpAuth.ts)
 
 #### Parameters
 
@@ -6084,7 +6092,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/pr
 function verifyServerIdentity(input): void;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/serverIdentity.ts:128](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/serverIdentity.ts#L128)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/serverIdentity.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/serverIdentity.ts)
 
 Verify a server identity proof against a pinned server pubkey.
 
@@ -6124,7 +6132,7 @@ ServerIdentityError on any validation failure.
 function batchPollByProvider<TItem, TResult>(options): Promise<void>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/batchPoll.ts:73](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/batchPoll.ts#L73)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/batchPoll.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/batchPoll.ts)
 
 #### Type Parameters
 
@@ -6154,7 +6162,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/batchPo
 function isAuthRejectedError(error): boolean;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts:195](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts#L195)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts)
 
 True when `error` is the vault provider rejecting our bearer token.
 
@@ -6190,7 +6198,7 @@ registry check and surfaces the same message.
 function validateRequestDepositorClaimerArtifactsResponse(response): asserts response is RequestDepositorClaimerArtifactsResponse;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/validators.ts:340](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/validators.ts#L340)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/validators.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/validators.ts)
 
 Validate a requestDepositorClaimerArtifacts response.
 
@@ -6208,7 +6216,7 @@ Validate a requestDepositorClaimerArtifacts response.
 
 ### OnChainBtcVaultStatus
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:41](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L41)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 Mirrors `IBTCVaultRegistry.BTCVaultStatus` in BTCVaultRegistry.sol exactly.
 Use this when consuming `status` from `getVaultBasicInfo` /
@@ -6228,7 +6236,7 @@ Expired(4) as LIQUIDATED.
 PENDING: 0;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:42](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L42)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 ##### VERIFIED
 
@@ -6236,7 +6244,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:42](../..
 VERIFIED: 1;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:43](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L43)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 ##### ACTIVE
 
@@ -6244,7 +6252,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:43](../..
 ACTIVE: 2;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:44](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L44)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 ##### REDEEMED
 
@@ -6252,7 +6260,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:44](../..
 REDEEMED: 3;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:45](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L45)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 ##### EXPIRED
 
@@ -6260,13 +6268,13 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:45](../..
 EXPIRED: 4;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts:46](../../packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts#L46)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
 ***
 
 ### DaemonStatus
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:38](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L38)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 Backend daemon status (vault provider database).
 Source: btc-vault crates/vaultd/src/workers/claimer/mod.rs PegInStatus enum
@@ -6298,7 +6306,7 @@ Branching / terminal states:
 PENDING_INGESTION: "PendingIngestion";
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:39](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L39)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ##### PENDING\_DEPOSITOR\_WOTS\_PK
 
@@ -6306,7 +6314,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.t
 PENDING_DEPOSITOR_WOTS_PK: "PendingDepositorWotsPK";
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:40](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L40)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ##### PENDING\_BABE\_SETUP
 
@@ -6314,7 +6322,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.t
 PENDING_BABE_SETUP: "PendingBabeSetup";
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:41](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L41)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ##### PENDING\_CHALLENGER\_PRESIGNING
 
@@ -6322,7 +6330,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.t
 PENDING_CHALLENGER_PRESIGNING: "PendingChallengerPresigning";
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:42](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L42)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ##### PENDING\_PEGIN\_SIGS\_AVAILABILITY
 
@@ -6330,7 +6338,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.t
 PENDING_PEGIN_SIGS_AVAILABILITY: "PendingPeginSigsAvailability";
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:43](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L43)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ##### PENDING\_PRE\_PEGIN\_CONFIRMATIONS
 
@@ -6338,7 +6346,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.t
 PENDING_PRE_PEGIN_CONFIRMATIONS: "PendingPrePegInConfirmations";
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:44](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L44)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ##### PENDING\_DEPOSITOR\_SIGNATURES
 
@@ -6346,7 +6354,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.t
 PENDING_DEPOSITOR_SIGNATURES: "PendingDepositorSignatures";
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:45](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L45)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ##### PENDING\_ACKS
 
@@ -6354,7 +6362,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.t
 PENDING_ACKS: "PendingACKs";
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:46](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L46)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ##### PENDING\_ACTIVATION
 
@@ -6362,7 +6370,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.t
 PENDING_ACTIVATION: "PendingActivation";
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:47](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L47)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ##### ACTIVATED\_PENDING\_BROADCAST
 
@@ -6370,7 +6378,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.t
 ACTIVATED_PENDING_BROADCAST: "ActivatedPendingBroadcast";
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:48](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L48)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ##### ACTIVATED
 
@@ -6378,7 +6386,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.t
 ACTIVATED: "Activated";
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:49](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L49)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ##### EXPIRED
 
@@ -6386,7 +6394,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.t
 EXPIRED: "Expired";
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:50](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L50)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ##### INGESTION\_REJECTED
 
@@ -6394,7 +6402,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.t
 INGESTION_REJECTED: "IngestionRejected";
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:51](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L51)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ##### INVALID\_SIG\_IN\_CONTRACT
 
@@ -6402,7 +6410,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.t
 INVALID_SIG_IN_CONTRACT: "InvalidSigInContract";
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:52](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L52)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ##### AML\_REJECTED
 
@@ -6410,7 +6418,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.t
 AML_REJECTED: "AmlRejected";
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:53](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L53)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ##### EXPIRED\_CLEANED\_UP
 
@@ -6418,7 +6426,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.t
 EXPIRED_CLEANED_UP: "ExpiredCleanedUp";
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:54](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L54)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ##### EXPIRED\_IN\_CLAIM
 
@@ -6426,13 +6434,13 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.t
 EXPIRED_IN_CLAIM: "ExpiredInClaim";
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:55](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L55)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ***
 
 ### RpcErrorCode
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:414](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L414)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 JSON-RPC error codes returned by the vault provider.
 Source: btc-vault `crates/vaultd/src/rpc/error.rs::RpcError::error_code`.
@@ -6445,7 +6453,7 @@ Source: btc-vault `crates/vaultd/src/rpc/error.rs::RpcError::error_code`.
 PEGIN_NOT_FOUND: 4001;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:415](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L415)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 ## Variables
 
@@ -6455,7 +6463,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.t
 const MEMPOOL_API_URLS: object;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts:130](../../packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts#L130)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts)
 
 Default mempool API URLs by network.
 
@@ -6487,7 +6495,7 @@ readonly signet: "https://mempool.space/signet/api" = "https://mempool.space/sig
 const vpTokenRegistry: VpTokenRegistryPublic;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/tokenRegistry.ts:126](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/tokenRegistry.ts#L126)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/tokenRegistry.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/tokenRegistry.ts)
 
 ***
 
@@ -6497,7 +6505,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/to
 const JSON_RPC_ERROR_CODES: object;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts:108](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts#L108)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts)
 
 #### Type Declaration
 
@@ -6553,7 +6561,7 @@ SDK client: response body exceeded the configured byte limit
 const AUTH_REJECTED_RPC_CODE: -32001 = -32001;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts:176](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts#L176)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/json-rpc-client.ts)
 
 JSON-RPC error code the vault provider returns for every bearer-token
 rejection: expired, not-yet-valid, missing bearer, invalid signature,
@@ -6575,7 +6583,7 @@ them — see [isAuthRejectedError](#isauthrejectederror).
 const PRE_DEPOSITOR_SIGNATURES_STATES: readonly DaemonStatus[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:66](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L66)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 States where the VP is still processing (no depositor action needed).
 Excludes PENDING_DEPOSITOR_WOTS_PK (requires depositor action).
@@ -6588,7 +6596,7 @@ Excludes PENDING_DEPOSITOR_WOTS_PK (requires depositor action).
 const VP_TRANSIENT_STATUSES: ReadonlySet<DaemonStatus>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:86](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L86)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 Statuses where no depositor action is needed (VP processing or already past
 depositor interaction). Excludes PENDING_INGESTION and PENDING_DEPOSITOR_WOTS_PK.
@@ -6601,7 +6609,7 @@ depositor interaction). Excludes PENDING_INGESTION and PENDING_DEPOSITOR_WOTS_PK
 const VP_TERMINAL_FAILURE_STATUSES: ReadonlySet<DaemonStatus>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:110](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L110)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 Terminal VP statuses that represent failure outcomes — polling should
 stop immediately with an error rather than wait for timeout.
@@ -6626,7 +6634,7 @@ VP_TERMINAL_FAILURE_STATUSES.has(status)`.
 const POST_WOTS_STATUSES: ReadonlySet<DaemonStatus>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:123](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L123)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 Statuses that come after WOTS key submission.
 If the VP is already in one of these states, the WOTS key was already
@@ -6640,7 +6648,7 @@ submitted and we can skip.
 const VP_BATCH_MAX_SIZE: 50 = 50;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts:404](../../packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts#L404)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/types.ts)
 
 Maximum number of items per batch call. Mirrors the server-side
 `MAX_BATCH_SIZE` in btc-vault (`crates/vaultd/src/rpc/server/vault_provider.rs:7`).

--- a/packages/babylon-ts-sdk/docs/api/deposit-terms.md
+++ b/packages/babylon-ts-sdk/docs/api/deposit-terms.md
@@ -12,7 +12,7 @@ wire-format concerns (TLV framing, SLIP-44, byte order) are provider-side.
 
 ### DepositTermsRejectedError
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTermsErrors.ts:17](../../packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTermsErrors.ts#L17)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTermsErrors.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTermsErrors.ts)
 
 SDK-owned typed rejection thrown when deposit terms fail pre-approval validation.
 
@@ -28,7 +28,7 @@ SDK-owned typed rejection thrown when deposit terms fail pre-approval validation
 new DepositTermsRejectedError(message, reason): DepositTermsRejectedError;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTermsErrors.ts:20](../../packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTermsErrors.ts#L20)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTermsErrors.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTermsErrors.ts)
 
 ###### Parameters
 
@@ -58,13 +58,13 @@ Error.constructor
 readonly reason: "device-envelope";
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTermsErrors.ts:18](../../packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTermsErrors.ts#L18)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTermsErrors.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTermsErrors.ts)
 
 ## Interfaces
 
 ### DepositTermsVaultGroup
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts:6](../../packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts#L6)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts)
 
 #### Properties
 
@@ -74,7 +74,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts:
 readonly htlcVout: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts:8](../../packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts#L8)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts)
 
 0-based; equals the group's position (groups are ascending by vout).
 
@@ -84,7 +84,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts:
 readonly vaultProviderBtcPubkey: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts:10](../../packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts#L10)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts)
 
 x-only hex (64 chars), as validated on-chain upstream.
 
@@ -94,7 +94,7 @@ x-only hex (64 chars), as validated on-chain upstream.
 readonly peginAmount: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts:12](../../packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts#L12)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts)
 
 sats
 
@@ -104,7 +104,7 @@ sats
 readonly commissionFee: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts:23](../../packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts#L23)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts)
 
 sats; the MAXIMUM commission the depositor accepts —
 floor(peginAmount * maxAcceptableCommissionBps / 10_000), the same
@@ -121,7 +121,7 @@ stamped commission may be lower. Display the quoted value in UI, not this.
 readonly depositorClaimValue: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts:25](../../packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts#L25)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts)
 
 sats; the same value for every vault.
 
@@ -131,7 +131,7 @@ sats; the same value for every vault.
 readonly peginMaxFee: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts:31](../../packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts#L31)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts)
 
 sats; the cap an approving wallet enforces on the PegIn tx fee. Equals
 the graph's exact (minimum) PegIn fee, which is deterministic — so the
@@ -141,7 +141,7 @@ cap is satisfied exact-by-construction.
 
 ### DepositTerms
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts:40](../../packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts#L40)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts)
 
 Field names follow btc-vault vocabulary (the protocol source of truth);
 a device-wire encoder maps them to its intent fields (e.g. the Ledger TLV:
@@ -156,7 +156,7 @@ timelockAssert -> payout_timelock, peginAmount -> vault_amount).
 vaultCoreVersion: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts:52](../../packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts#L52)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts)
 
 btc-vault tx-graph version (`vaultCoreVersion`) these terms describe —
 the vault's stamped on-chain version for resumes, the chain's
@@ -174,7 +174,7 @@ mis-validating the PSBTs later.
 protocolFeeRate: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts:58](../../packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts#L58)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts)
 
 sat/vB; the tx-graph fee rate (protocolFeeRate), NOT the mempool funding
 rate. Approving wallets bound each payout's fee against this rate —
@@ -186,7 +186,7 @@ pass the exact graph rate, not an inflated ceiling.
 timelockPegin: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts:60](../../packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts#L60)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts)
 
 Vault-UTXO CSV timelock (blocks).
 
@@ -196,7 +196,7 @@ Vault-UTXO CSV timelock (blocks).
 timelockAssert: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts:65](../../packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts#L65)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts)
 
 btc-vault `timelock_assert` (t2) — the CSV on Assert output 0. Its own
 param, though production derives it and `timelockPegin` from one value.
@@ -207,7 +207,7 @@ param, though production derives it and `timelockPegin` from one value.
 timelockRefund: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts:67](../../packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts#L67)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts)
 
 HTLC refund CSV timelock (blocks).
 
@@ -217,7 +217,7 @@ HTLC refund CSV timelock (blocks).
 prepeginTxid: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts:73](../../packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts#L73)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts)
 
 64-char hex in display order. A device-wire encoder may need the
 little-endian form — some hardware byte-compares it against
@@ -229,7 +229,7 @@ PSBT_IN_PREVIOUS_TXID rather than recomputing the txid.
 prepeginMaxFee: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts:75](../../packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts#L75)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts)
 
 sats; the funded Pre-PegIn fee (an approving wallet caps the signed fee at this).
 
@@ -239,7 +239,7 @@ sats; the funded Pre-PegIn fee (an approving wallet caps the signed fee at this)
 vaultKeeperBtcPubkeys: readonly string[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts:81](../../packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts#L81)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts)
 
 x-only hex. Sorted ascending by the upstream on-chain validation
 (validateOnChainParticipantKeys); the builder passes them through
@@ -251,7 +251,7 @@ unasserted — approving devices may reject unsorted lists at load.
 universalChallengerBtcPubkeys: readonly string[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts:88](../../packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts#L88)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts)
 
 x-only hex, sorted ascending upstream independently of vaultKeeperBtcPubkeys (same
 pass-through contract). Universal challengers only — the full graph
@@ -264,7 +264,7 @@ challengers).
 vaults: readonly DepositTermsVaultGroup[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts:90](../../packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts#L90)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts)
 
 Per-vault groups, ordered by ascending htlcVout.
 
@@ -272,7 +272,7 @@ Per-vault groups, ordered by ascending htlcVout.
 
 ### DepositTermsApprover
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts:107](../../packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts#L107)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts)
 
 Implemented only by depositor-approval wallets (e.g. a Ledger vault
 provider). Provider obligations:
@@ -295,7 +295,7 @@ re-approves after every derive and before the next terms-bound signature.
 approveDepositTerms(terms): Promise<void>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts:108](../../packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts#L108)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts)
 
 ###### Parameters
 
@@ -311,7 +311,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts:
 
 ### BuildDepositTermsInputs
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts:134](../../packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts#L134)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts)
 
 #### Properties
 
@@ -321,7 +321,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts:
 vaultCoreVersion: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts:136](../../packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts#L136)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts)
 
 btc-vault tx-graph version the graph is built under.
 
@@ -331,7 +331,7 @@ btc-vault tx-graph version the graph is built under.
 protocolFeeRate: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts:137](../../packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts#L137)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts)
 
 ##### timelockPegin
 
@@ -339,7 +339,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts:
 timelockPegin: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts:138](../../packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts#L138)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts)
 
 ##### timelockAssert
 
@@ -347,7 +347,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts:
 timelockAssert: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts:140](../../packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts#L140)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts)
 
 btc-vault `timelock_assert` (t2) — its own param; NOT derived from timelockPegin here.
 
@@ -357,7 +357,7 @@ btc-vault `timelock_assert` (t2) — its own param; NOT derived from timelockPeg
 timelockRefund: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts:141](../../packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts#L141)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts)
 
 ##### prepeginTxid
 
@@ -365,7 +365,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts:
 prepeginTxid: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts:142](../../packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts#L142)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts)
 
 ##### prepeginMaxFee
 
@@ -373,7 +373,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts:
 prepeginMaxFee: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts:143](../../packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts#L143)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts)
 
 ##### vaultProviderBtcPubkey
 
@@ -381,7 +381,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts:
 vaultProviderBtcPubkey: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts:144](../../packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts#L144)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts)
 
 ##### vaultKeeperBtcPubkeys
 
@@ -389,7 +389,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts:
 vaultKeeperBtcPubkeys: readonly string[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts:145](../../packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts#L145)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts)
 
 ##### universalChallengerBtcPubkeys
 
@@ -397,7 +397,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts:
 universalChallengerBtcPubkeys: readonly string[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts:146](../../packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts#L146)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts)
 
 ##### maxAcceptableCommissionBps
 
@@ -405,7 +405,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts:
 maxAcceptableCommissionBps: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts:148](../../packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts#L148)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts)
 
 Ceiling bps, not the quote — see [DepositTermsVaultGroup.commissionFee](#commissionfee).
 
@@ -415,7 +415,7 @@ Ceiling bps, not the quote — see [DepositTermsVaultGroup.commissionFee](#commi
 peginAmounts: readonly bigint[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts:149](../../packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts#L149)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts)
 
 ##### depositorClaimValue
 
@@ -423,7 +423,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts:
 depositorClaimValue: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts:150](../../packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts#L150)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts)
 
 ##### peginMaxFee
 
@@ -431,7 +431,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts:
 peginMaxFee: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts:151](../../packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts#L151)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts)
 
 ## Type Aliases
 
@@ -441,7 +441,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts:
 type DepositTermsRejectionReason = "device-envelope";
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTermsErrors.ts:14](../../packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTermsErrors.ts#L14)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTermsErrors.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTermsErrors.ts)
 
 Why the terms were rejected before approval.
 
@@ -453,7 +453,7 @@ Why the terms were rejected before approval.
 function buildDepositTerms(inputs): DepositTerms;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/buildDepositTerms.ts:19](../../packages/babylon-ts-sdk/src/tbv/core/deposit-terms/buildDepositTerms.ts#L19)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/buildDepositTerms.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/buildDepositTerms.ts)
 
 Project already-validated pegin inputs into protocol-level deposit terms.
 Not a second validator: keys arrive canonical and sorted from on-chain
@@ -477,7 +477,7 @@ validation, and non-negative sizing is already asserted by WASM output checks.
 function supportsDepositApproval(wallet): wallet is BitcoinWallet & DepositTermsApprover;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts:112](../../packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts#L112)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts)
 
 True when the wallet implements [DepositTermsApprover.approveDepositTerms](#approvedepositterms).
 
@@ -499,7 +499,7 @@ True when the wallet implements [DepositTermsApprover.approveDepositTerms](#appr
 function forwardDepositApproval(wallet): Partial<DepositTermsApprover>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts:126](../../packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts#L126)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts)
 
 Spreadable forward of `approveDepositTerms` for wallet-wrapper objects.
 Object spread drops prototype methods, so every `{...wallet}` wrapper site
@@ -523,7 +523,7 @@ must re-attach the capability explicitly: `...forwardDepositApproval(wallet)`.
 function isDepositTermsRejectedError(err): err is DepositTermsRejectedError;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTermsErrors.ts:35](../../packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTermsErrors.ts#L35)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTermsErrors.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTermsErrors.ts)
 
 Guard for app-side error mapping. Matches `instanceof` OR the documented
 `name` — providers and foreign realms throw structurally-conforming plain
@@ -547,6 +547,6 @@ errors that `instanceof` cannot see.
 const DEPOSIT_TERMS_REJECTED_ERROR_NAME: "DepositTermsRejectedError" = "DepositTermsRejectedError";
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTermsErrors.ts:11](../../packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTermsErrors.ts#L11)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTermsErrors.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTermsErrors.ts)
 
 The `name` value providers must set on envelope rejections (the wire contract).

--- a/packages/babylon-ts-sdk/docs/api/integrations/aave.md
+++ b/packages/babylon-ts-sdk/docs/api/integrations/aave.md
@@ -49,7 +49,7 @@ await walletClient.sendTransaction({ to: borrowTx.to, data: borrowTx.data });
 
 ### AssetDrawnRateRequest
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/hub.ts:12](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/hub.ts#L12)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/hub.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/hub.ts)
 
 Identifies one Hub asset to read the drawn rate for.
 
@@ -61,7 +61,7 @@ Identifies one Hub asset to read the drawn rate for.
 hub: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/hub.ts:14](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/hub.ts#L14)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/hub.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/hub.ts)
 
 Hub contract address (from the reserve's `hub` field).
 
@@ -71,7 +71,7 @@ Hub contract address (from the reserve's `hub` field).
 assetId: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/hub.ts:16](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/hub.ts#L16)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/hub.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/hub.ts)
 
 Asset identifier on that Hub (from the reserve's `assetId` field).
 
@@ -79,7 +79,7 @@ Asset identifier on that Hub (from the reserve's `assetId` field).
 
 ### AssetDrawnRateResult
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/hub.ts:19](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/hub.ts#L19)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/hub.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/hub.ts)
 
 #### Properties
 
@@ -89,7 +89,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/hub.ts:19
 hub: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/hub.ts:20](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/hub.ts#L20)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/hub.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/hub.ts)
 
 ##### assetId
 
@@ -97,7 +97,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/hub.ts:20
 assetId: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/hub.ts:21](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/hub.ts#L21)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/hub.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/hub.ts)
 
 ##### rateRay
 
@@ -105,7 +105,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/hub.ts:21
 rateRay: bigint | null;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/hub.ts:23](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/hub.ts#L23)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/hub.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/hub.ts)
 
 Annual borrow (drawn) rate in RAY (1e27 = 100%), or null on revert.
 
@@ -115,13 +115,13 @@ Annual borrow (drawn) rate in RAY (1e27 = 100%), or null on revert.
 error: Error | null;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/hub.ts:24](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/hub.ts#L24)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/hub.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/hub.ts)
 
 ***
 
 ### ReservePriceResult
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/oracle.ts:39](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/oracle.ts#L39)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/oracle.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/oracle.ts)
 
 #### Properties
 
@@ -131,7 +131,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/oracle.ts
 reserveId: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/oracle.ts:40](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/oracle.ts#L40)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/oracle.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/oracle.ts)
 
 ##### priceRaw
 
@@ -139,7 +139,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/oracle.ts
 priceRaw: bigint | null;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/oracle.ts:42](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/oracle.ts#L42)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/oracle.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/oracle.ts)
 
 Raw 1e8 base units, or null on revert.
 
@@ -149,13 +149,13 @@ Raw 1e8 base units, or null on revert.
 error: Error | null;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/oracle.ts:43](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/oracle.ts#L43)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/oracle.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/oracle.ts)
 
 ***
 
 ### AaveMarketPosition
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts:13](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts#L13)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts)
 
 Aave position structure from the contract.
 The adapter resolves the user's proxy and vaults from their address.
@@ -168,7 +168,7 @@ The adapter resolves the user's proxy and vaults from their address.
 proxyContract: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts:14](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts#L14)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts)
 
 ##### vaultIds
 
@@ -176,7 +176,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts:14](../.
 vaultIds: `0x${string}`[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts:15](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts#L15)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts)
 
 ##### totalCollateralBTC
 
@@ -184,7 +184,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts:15](../.
 totalCollateralBTC: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts:21](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts#L21)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts)
 
 Sum (in satoshis) of all vault amounts collateralised in this position.
 Mirrors `MarketPosition.totalCollateralBTC` returned by
@@ -194,7 +194,7 @@ Mirrors `MarketPosition.totalCollateralBTC` returned by
 
 ### AaveSpokeUserAccountData
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts:28](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts#L28)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts)
 
 User account data from the Spoke
 Contains aggregated position health data calculated by Aave using on-chain oracle prices.
@@ -207,7 +207,7 @@ Contains aggregated position health data calculated by Aave using on-chain oracl
 riskPremium: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts:30](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts#L30)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts)
 
 Risk premium
 
@@ -217,7 +217,7 @@ Risk premium
 avgCollateralFactor: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts:32](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts#L32)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts)
 
 Weighted average collateral factor in WAD (1e18 = 100%)
 
@@ -227,7 +227,7 @@ Weighted average collateral factor in WAD (1e18 = 100%)
 healthFactor: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts:34](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts#L34)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts)
 
 Health factor in WAD (1e18 = 1.00)
 
@@ -237,7 +237,7 @@ Health factor in WAD (1e18 = 1.00)
 totalCollateralValue: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts:36](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts#L36)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts)
 
 Total collateral value in base currency (1e26 = $1 USD)
 
@@ -247,7 +247,7 @@ Total collateral value in base currency (1e26 = $1 USD)
 totalDebtValueRay: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts:38](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts#L38)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts)
 
 Total debt value in base currency, scaled by RAY (1e35 = $1 USD)
 
@@ -257,7 +257,7 @@ Total debt value in base currency, scaled by RAY (1e35 = $1 USD)
 activeCollateralCount: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts:40](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts#L40)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts)
 
 Number of active collateral reserves
 
@@ -267,7 +267,7 @@ Number of active collateral reserves
 borrowCount: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts:42](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts#L42)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts)
 
 Number of borrowed reserves
 
@@ -275,7 +275,7 @@ Number of borrowed reserves
 
 ### AaveSpokeUserPosition
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts:48](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts#L48)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts)
 
 User position data from the Spoke
 
@@ -287,7 +287,7 @@ User position data from the Spoke
 drawnShares: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts:50](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts#L50)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts)
 
 Drawn debt shares
 
@@ -297,7 +297,7 @@ Drawn debt shares
 premiumShares: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts:52](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts#L52)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts)
 
 Premium shares (interest)
 
@@ -307,7 +307,7 @@ Premium shares (interest)
 premiumOffsetRay: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts:54](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts#L54)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts)
 
 Premium offset, expressed in asset units scaled by RAY (signed)
 
@@ -317,7 +317,7 @@ Premium offset, expressed in asset units scaled by RAY (signed)
 suppliedShares: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts:56](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts#L56)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts)
 
 Supplied collateral shares
 
@@ -327,7 +327,7 @@ Supplied collateral shares
 dynamicConfigKey: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts:58](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts#L58)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts)
 
 Dynamic config key
 
@@ -335,7 +335,7 @@ Dynamic config key
 
 ### TransactionParams
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts:65](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts#L65)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts)
 
 Transaction parameters for unsigned transactions
 Compatible with viem's transaction format
@@ -348,7 +348,7 @@ Compatible with viem's transaction format
 to: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts:67](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts#L67)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts)
 
 Contract address to call
 
@@ -358,7 +358,7 @@ Contract address to call
 data: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts:69](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts#L69)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts)
 
 Encoded function data
 
@@ -368,7 +368,7 @@ Encoded function data
 optional value: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts:71](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts#L71)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts)
 
 Value to send (optional, defaults to 0)
 
@@ -376,7 +376,7 @@ Value to send (optional, defaults to 0)
 
 ### PositionSizeParams
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts:78](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts#L78)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts)
 
 Position size parameters from the AaveIntegrationAdapter contract.
 Controls maximum BTC position size and vault count per user.
@@ -389,7 +389,7 @@ Controls maximum BTC position size and vault count per user.
 maxPositionBTC: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts:80](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts#L80)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts)
 
 Maximum BTC position size allowed (in satoshis)
 
@@ -399,7 +399,7 @@ Maximum BTC position size allowed (in satoshis)
 maxVaultsPerPosition: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts:82](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts#L82)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/types.ts)
 
 Maximum number of vaults per position
 
@@ -407,7 +407,7 @@ Maximum number of vaults per position
 
 ### CascadeVault
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/cascadeSimulation.ts:17](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/cascadeSimulation.ts#L17)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/cascadeSimulation.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/cascadeSimulation.ts)
 
 Minimal vault shape for cascade simulation.
 UI layers extend this with display fields (e.g. `name`).
@@ -420,7 +420,7 @@ UI layers extend this with display fields (e.g. `name`).
 id: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/cascadeSimulation.ts:18](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/cascadeSimulation.ts#L18)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/cascadeSimulation.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/cascadeSimulation.ts)
 
 ##### btc
 
@@ -428,13 +428,13 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/cascadeSimu
 btc: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/cascadeSimulation.ts:19](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/cascadeSimulation.ts#L19)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/cascadeSimulation.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/cascadeSimulation.ts)
 
 ***
 
 ### OptimalSplitParams
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/vaultSplit.ts:44](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/vaultSplit.ts#L44)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/vaultSplit.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/vaultSplit.ts)
 
 Parameters for computing the optimal vault split.
 
@@ -446,7 +446,7 @@ Parameters for computing the optimal vault split.
 totalBtc: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/vaultSplit.ts:46](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/vaultSplit.ts#L46)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/vaultSplit.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/vaultSplit.ts)
 
 Total deposit amount in satoshis
 
@@ -456,7 +456,7 @@ Total deposit amount in satoshis
 CF: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/vaultSplit.ts:48](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/vaultSplit.ts#L48)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/vaultSplit.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/vaultSplit.ts)
 
 Collateral factor (e.g. 0.75 for 75%)
 
@@ -466,7 +466,7 @@ Collateral factor (e.g. 0.75 for 75%)
 LB: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/vaultSplit.ts:50](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/vaultSplit.ts#L50)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/vaultSplit.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/vaultSplit.ts)
 
 Liquidation bonus (e.g. 1.05 for 5% bonus)
 
@@ -476,7 +476,7 @@ Liquidation bonus (e.g. 1.05 for 5% bonus)
 THF: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/vaultSplit.ts:52](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/vaultSplit.ts#L52)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/vaultSplit.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/vaultSplit.ts)
 
 Target health factor (e.g. 1.10)
 
@@ -486,7 +486,7 @@ Target health factor (e.g. 1.10)
 expectedHF: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/vaultSplit.ts:54](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/vaultSplit.ts#L54)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/vaultSplit.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/vaultSplit.ts)
 
 Expected health factor at liquidation (e.g. 0.95)
 
@@ -496,7 +496,7 @@ Expected health factor at liquidation (e.g. 0.95)
 safetyMargin: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/vaultSplit.ts:56](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/vaultSplit.ts#L56)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/vaultSplit.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/vaultSplit.ts)
 
 Safety margin multiplier for the sacrificial vault (e.g. 1.05 for 5% buffer)
 
@@ -504,7 +504,7 @@ Safety margin multiplier for the sacrificial vault (e.g. 1.05 for 5% buffer)
 
 ### OptimalSplitResult
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/vaultSplit.ts:62](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/vaultSplit.ts#L62)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/vaultSplit.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/vaultSplit.ts)
 
 Result of the optimal vault split computation.
 
@@ -516,7 +516,7 @@ Result of the optimal vault split computation.
 sacrificialVault: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/vaultSplit.ts:64](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/vaultSplit.ts#L64)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/vaultSplit.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/vaultSplit.ts)
 
 Sacrificial vault amount in satoshis (index 0, seized first)
 
@@ -526,7 +526,7 @@ Sacrificial vault amount in satoshis (index 0, seized first)
 protectedVault: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/vaultSplit.ts:66](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/vaultSplit.ts#L66)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/vaultSplit.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/vaultSplit.ts)
 
 Protected vault amount in satoshis (index 1, survives liquidation)
 
@@ -536,7 +536,7 @@ Protected vault amount in satoshis (index 1, survives liquidation)
 seizedFraction: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/vaultSplit.ts:68](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/vaultSplit.ts#L68)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/vaultSplit.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/vaultSplit.ts)
 
 Fraction of collateral that would be seized (0–1)
 
@@ -546,7 +546,7 @@ Fraction of collateral that would be seized (0–1)
 targetSeizureBtc: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/vaultSplit.ts:70](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/vaultSplit.ts#L70)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/vaultSplit.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/vaultSplit.ts)
 
 Raw target seizure amount in satoshis (before safety margin)
 
@@ -554,7 +554,7 @@ Raw target seizure amount in satoshis (before safety margin)
 
 ### MinDepositForSplitParams
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/vaultSplit.ts:76](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/vaultSplit.ts#L76)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/vaultSplit.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/vaultSplit.ts)
 
 Parameters for computing the minimum deposit required for a split.
 
@@ -566,7 +566,7 @@ Parameters for computing the minimum deposit required for a split.
 minPegin: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/vaultSplit.ts:78](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/vaultSplit.ts#L78)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/vaultSplit.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/vaultSplit.ts)
 
 Minimum peg-in amount in satoshis
 
@@ -576,7 +576,7 @@ Minimum peg-in amount in satoshis
 seizedFraction: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/vaultSplit.ts:80](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/vaultSplit.ts#L80)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/vaultSplit.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/vaultSplit.ts)
 
 Seized fraction (0–1), from computeOptimalSplit or computeSeizedFraction
 
@@ -586,7 +586,7 @@ Seized fraction (0–1), from computeOptimalSplit or computeSeizedFraction
 safetyMargin: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/vaultSplit.ts:82](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/vaultSplit.ts#L82)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/vaultSplit.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/vaultSplit.ts)
 
 Safety margin multiplier (e.g. 1.05)
 
@@ -598,7 +598,7 @@ Safety margin multiplier (e.g. 1.05)
 type HealthFactorStatus = "safe" | "warning" | "danger" | "no_debt";
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/healthFactor.ts:16](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/healthFactor.ts#L16)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/healthFactor.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/healthFactor.ts)
 
 ## Functions
 
@@ -608,7 +608,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/healthFacto
 function getAssetDrawnRatesSafe(publicClient, requests): Promise<AssetDrawnRateResult[]>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/hub.ts:38](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/hub.ts#L38)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/hub.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/hub.ts)
 
 Per-asset isolated read of `getAssetDrawnRate` for display lists (one bad
 asset ≠ whole list blank). One multicall round-trip instead of one
@@ -640,7 +640,7 @@ interest as `rate * dt / SECONDS_PER_YEAR`), i.e. an APR, not an APY.
 function getOracleAddress(publicClient, spokeAddress): Promise<`0x${string}`>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/oracle.ts:12](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/oracle.ts#L12)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/oracle.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/oracle.ts)
 
 `Spoke.ORACLE` is `immutable`; the result is safe to cache forever.
 
@@ -667,7 +667,7 @@ function getReservesPrices(
 reserveIds): Promise<bigint[]>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/oracle.ts:25](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/oracle.ts#L25)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/oracle.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/oracle.ts)
 
 Batch read; reverts the WHOLE batch on the first bad reserve.
 
@@ -698,7 +698,7 @@ function getReservesPricesSafe(
 reserveIds): Promise<ReservePriceResult[]>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/oracle.ts:54](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/oracle.ts#L54)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/oracle.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/oracle.ts)
 
 Per-reserve isolated read for display lists (one bad source ≠ whole list
 blank). One multicall round-trip instead of one `eth_call` per reserve:
@@ -734,7 +734,7 @@ function getPositionReserveTotalDebt(
 reserveId): Promise<bigint>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/positionProxy.ts:22](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/positionProxy.ts#L22)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/positionProxy.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/positionProxy.ts)
 
 Fee-inclusive total debt of the position held by `proxyContract` for
 `reserveId`: Spoke debt plus the adapter's uncollected interest fee
@@ -767,7 +767,7 @@ function getPosition(
 user): Promise<AaveMarketPosition | null>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/query.ts:27](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/query.ts#L27)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/query.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/query.ts)
 
 Get a position by user address.
 
@@ -809,7 +809,7 @@ Market position data or null if position doesn't exist
 function getPositionSizeParams(publicClient, contractAddress): Promise<PositionSizeParams>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/query.ts:69](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/query.ts#L69)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/query.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/query.ts)
 
 Get position size parameters from the adapter contract.
 
@@ -845,7 +845,7 @@ function getUserAccountData(
 userAddress): Promise<AaveSpokeUserAccountData>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/spoke.ts:115](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/spoke.ts#L115)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/spoke.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/spoke.ts)
 
 Get aggregated user account health data from AAVE spoke.
 
@@ -930,7 +930,7 @@ function getUserPositionAndAccountData(
 }>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/spoke.ts:136](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/spoke.ts#L136)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/spoke.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/spoke.ts)
 
 Read a user's position for one reserve and their aggregate account data in a
 single hard-fail multicall. Both reads are required for the live position
@@ -972,7 +972,7 @@ function getUserPosition(
 userAddress): Promise<AaveSpokeUserPosition>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/spoke.ts:183](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/spoke.ts#L183)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/spoke.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/spoke.ts)
 
 Get user position from the Spoke
 
@@ -1021,7 +1021,7 @@ function getUserTotalDebt(
 userAddress): Promise<bigint>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/spoke.ts:236](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/spoke.ts#L236)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/spoke.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/spoke.ts)
 
 Get user's exact total debt in a reserve (token units, not shares).
 
@@ -1097,7 +1097,7 @@ function getUserPositions(
 userAddress): Promise<(AaveSpokeUserPosition | null)[]>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/spoke.ts:260](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/spoke.ts#L260)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/spoke.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/spoke.ts)
 
 Probe `getUserPosition` for many reserves in a single multicall.
 
@@ -1138,7 +1138,7 @@ function getUserTotalDebts(
 userAddress): Promise<bigint[]>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/spoke.ts:290](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/spoke.ts#L290)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/spoke.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/spoke.ts)
 
 Read `getUserTotalDebt` for many reserves in a single multicall.
 
@@ -1177,7 +1177,7 @@ function getReserve(
 reserveId): Promise<ReserveResult>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/spoke.ts:350](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/spoke.ts#L350)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/spoke.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/spoke.ts)
 
 Get reserve data from the Core Spoke contract via the `getReserve` selector.
 
@@ -1220,7 +1220,7 @@ Reserve data including `dynamicConfigKey`
 function getTargetHealthFactor(publicClient, spokeAddress): Promise<bigint>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/spoke.ts:388](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/spoke.ts#L388)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/spoke.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/spoke.ts)
 
 Get the target health factor (THF) from the Core Spoke contract.
 
@@ -1257,7 +1257,7 @@ function getDynamicReserveConfig(
 dynamicConfigKey): Promise<DynamicReserveConfigResult>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/spoke.ts:413](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/spoke.ts#L413)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/spoke.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/spoke.ts)
 
 Get the dynamic reserve config from the Core Spoke contract.
 
@@ -1302,7 +1302,7 @@ Dynamic reserve config with collateralFactor (BPS), maxLiquidationBonus (BPS), l
 function buildReorderVaultsTx(contractAddress, permutedVaultIds): TransactionParams;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/transaction.ts:28](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/transaction.ts#L28)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/transaction.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/transaction.ts)
 
 Build transaction to reorder vaults for liquidation priority.
 
@@ -1338,7 +1338,7 @@ Unsigned transaction parameters
 function buildWithdrawCollateralsTx(contractAddress, vaultIds): TransactionParams;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/transaction.ts:54](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/transaction.ts#L54)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/transaction.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/transaction.ts)
 
 Build transaction to withdraw selected vaults from AAVE position.
 
@@ -1377,7 +1377,7 @@ function buildBorrowTx(
    receiver): TransactionParams;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/transaction.ts:120](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/transaction.ts#L120)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/transaction.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/transaction.ts)
 
 Build transaction to borrow assets against vBTC collateral.
 
@@ -1468,7 +1468,7 @@ function buildRepayTx(
    amount): TransactionParams;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/transaction.ts:187](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/transaction.ts#L187)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/transaction.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/transaction.ts)
 
 Build transaction to repay debt on AAVE position.
 
@@ -1554,7 +1554,7 @@ const hash = await walletClient.sendTransaction({
 function aaveValueToUsd(value): number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/aaveConversions.ts:21](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/aaveConversions.ts#L21)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/aaveConversions.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/aaveConversions.ts)
 
 Convert Aave base currency value to USD
 
@@ -1582,7 +1582,7 @@ Value in USD
 function aaveRayValueToUsd(value): number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/aaveConversions.ts:33](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/aaveConversions.ts#L33)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/aaveConversions.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/aaveConversions.ts)
 
 Convert Aave RAY-scaled base currency value to USD
 
@@ -1610,7 +1610,7 @@ Value in USD
 function wadToNumber(value): number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/aaveConversions.ts:45](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/aaveConversions.ts#L45)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/aaveConversions.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/aaveConversions.ts)
 
 Convert Aave WAD value to number
 
@@ -1641,7 +1641,7 @@ function getGroup1FromOrder<T>(
    seizureTol): T[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/cascadeSimulation.ts:35](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/cascadeSimulation.ts#L35)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/cascadeSimulation.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/cascadeSimulation.ts)
 
 Prefix walk: consume vaults front-to-back until target seizure is covered.
 Returns the vaults in the first liquidation group.
@@ -1686,7 +1686,7 @@ function simulateCascade<T>(
    expectedHF): object;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/cascadeSimulation.ts:93](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/cascadeSimulation.ts#L93)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/cascadeSimulation.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/cascadeSimulation.ts)
 
 Simulate full liquidation cascade with debt model.
 
@@ -1758,7 +1758,7 @@ btcAfterG1: number;
 function hasDebtFromPosition(position): boolean;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/debtUtils.ts:19](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/debtUtils.ts#L19)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/debtUtils.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/debtUtils.ts)
 
 Check if a position has any debt based on Spoke position data.
 
@@ -1788,7 +1788,7 @@ true if the position has any debt
 function getHealthFactorStatus(healthFactor, hasDebt): HealthFactorStatus;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/healthFactor.ts:25](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/healthFactor.ts#L25)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/healthFactor.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/healthFactor.ts)
 
 Determine health factor status for UI display
 
@@ -1820,7 +1820,7 @@ The status classification
 function getHealthFactorStatusFromValue(value): HealthFactorStatus;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/healthFactor.ts:43](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/healthFactor.ts#L43)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/healthFactor.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/healthFactor.ts)
 
 Get health factor status from a numeric value.
 Used for UI components that work with Infinity for no-debt scenarios.
@@ -1850,7 +1850,7 @@ function calculateHealthFactor(
    liquidationThresholdBps): number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/healthFactor.ts:91](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/healthFactor.ts#L91)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/healthFactor.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/healthFactor.ts)
 
 Calculate health factor for an AAVE position.
 
@@ -1930,7 +1930,7 @@ function computeOptimalOrder<T>(
    expectedHF): object;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/optimalOrder.ts:42](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/optimalOrder.ts#L42)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/optimalOrder.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/optimalOrder.ts)
 
 Main optimizer: bitmask DP over seized subsets.
 
@@ -2021,7 +2021,7 @@ function computeSeizedFractionDetailed(
    expectedHF): object;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/vaultSplit.ts:104](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/vaultSplit.ts#L104)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/vaultSplit.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/vaultSplit.ts)
 
 Compute the fraction of collateral that would be seized during liquidation,
 returning both the raw (unclamped) and clamped values.
@@ -2091,7 +2091,7 @@ function computeSeizedFraction(
    expectedHF): number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/vaultSplit.ts:142](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/vaultSplit.ts#L142)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/vaultSplit.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/vaultSplit.ts)
 
 Compute the fraction of collateral that would be seized during liquidation.
 
@@ -2135,7 +2135,7 @@ Seized fraction clamped to [0, 1]
 function computeOptimalSplit(params): OptimalSplitResult;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/vaultSplit.ts:176](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/vaultSplit.ts#L176)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/vaultSplit.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/vaultSplit.ts)
 
 Compute the optimal split between a sacrificial vault and a protected vault.
 
@@ -2181,7 +2181,7 @@ const result = computeOptimalSplit({
 function computeMinDepositForSplit(params): bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/vaultSplit.ts:253](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/vaultSplit.ts#L253)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/vaultSplit.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/vaultSplit.ts)
 
 Compute the minimum total deposit required for a 2-vault split.
 
@@ -2225,7 +2225,7 @@ const minDeposit = computeMinDepositForSplit({
 const AAVE_FUNCTION_NAMES: object;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/constants.ts:12](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/constants.ts#L12)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/constants.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/constants.ts)
 
 Aave contract function names
 Centralized constants for contract interactions
@@ -2272,7 +2272,7 @@ Reorder vault prefix ordering for liquidation priority
 const BPS_SCALE: 10000 = 10000;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/constants.ts:29](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/constants.ts#L29)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/constants.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/constants.ts)
 
 Full basis points scale (10000 BPS = 100%)
 
@@ -2287,7 +2287,7 @@ Example: 8000 BPS / 10000 = 0.80
 const AAVE_BASE_CURRENCY_DECIMALS: 26 = 26;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/constants.ts:37](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/constants.ts#L37)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/constants.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/constants.ts)
 
 Aave base currency decimals
 Account data values (collateral, debt) use 1e26 = $1 USD
@@ -2302,7 +2302,7 @@ Reference: ISpoke.sol UserAccountData
 const AAVE_BASE_CURRENCY_RAY_DECIMALS: 53 = 53;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/constants.ts:46](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/constants.ts#L46)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/constants.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/constants.ts)
 
 Aave RAY-scaled base currency decimals
 Debt values (totalDebtValueRay) use 1e53 = $1 USD
@@ -2318,7 +2318,7 @@ Reference: IAaveSpoke.sol UserAccountData.totalDebtValueRay
 const HEALTH_FACTOR_WARNING_THRESHOLD: 1.5 = 1.5;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/constants.ts:60](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/constants.ts#L60)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/constants.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/constants.ts)
 
 Health factor warning threshold
 Positions below this are considered at risk of liquidation
@@ -2331,7 +2331,7 @@ Positions below this are considered at risk of liquidation
 const MIN_HEALTH_FACTOR_FOR_BORROW: 1.05 = 1.05;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/constants.ts:66](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/constants.ts#L66)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/constants.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/constants.ts)
 
 Minimum health factor allowed for borrowing. Collateral factor doubles as the
 liquidation threshold here, so this floor is the only borrow→liquidation cushion.
@@ -2344,7 +2344,7 @@ liquidation threshold here, so this floor is the only borrow→liquidation cushi
 const FULL_REPAY_BUFFER_DIVISOR: 200n = 200n;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/constants.ts:78](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/constants.ts#L78)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/constants.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/constants.ts)
 
 Approval headroom for repay-all, sized against interest accrual between
 quoting the debt and transaction execution.
@@ -2363,7 +2363,7 @@ the user's balance, so a larger buffer never blocks a legitimate repay.
 const SEIZURE_TOL: 0.01 = 0.01;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/cascadeSimulation.ts:23](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/cascadeSimulation.ts#L23)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/cascadeSimulation.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/cascadeSimulation.ts)
 
 1% tolerance for prefix walk coverage — avoids cliff flip at boundary
 
@@ -2375,7 +2375,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/cascadeSimu
 const MAX_GROUPS: 20 = 20;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/cascadeSimulation.ts:26](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/cascadeSimulation.ts#L26)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/cascadeSimulation.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/cascadeSimulation.ts)
 
 Circuit breaker for group cascade loop
 
@@ -2387,7 +2387,7 @@ Circuit breaker for group cascade loop
 const MIN_DEBT_THRESHOLD: 0.01 = 0.01;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/cascadeSimulation.ts:29](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/cascadeSimulation.ts#L29)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/cascadeSimulation.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/cascadeSimulation.ts)
 
 Minimum debt threshold to continue cascade (avoids infinite loop on dust)
 
@@ -2399,7 +2399,7 @@ Minimum debt threshold to continue cascade (avoids infinite loop on dust)
 const MAX_DP_N: 17 = 17;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/optimalOrder.ts:24](../../packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/optimalOrder.ts#L24)
+Defined in: [packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/optimalOrder.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/optimalOrder.ts)
 
 Hard cap on vault count for the bitmask DP optimizer. 2^n memory + 3^n work
 blow up past this. For n > MAX_DP_N the optimizer falls back to a

--- a/packages/babylon-ts-sdk/docs/api/managers.md
+++ b/packages/babylon-ts-sdk/docs/api/managers.md
@@ -23,7 +23,7 @@ Optional exit after the CSV timelock expires: `buildAndBroadcastRefund()` (servi
 
 ### PayoutManager
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts:189](../../packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts#L189)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts)
 
 High-level manager for payout transaction signing.
 
@@ -56,7 +56,7 @@ manager and submit the signatures to the vault provider's RPC API.
 new PayoutManager(config): PayoutManager;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts:197](../../packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts#L197)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts)
 
 Creates a new PayoutManager instance.
 
@@ -80,7 +80,7 @@ Manager configuration including wallet
 signPayoutTransaction(params): Promise<PayoutSignatureResult>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts:223](../../packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts#L223)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts)
 
 Signs a Payout transaction and extracts the Schnorr signature.
 
@@ -126,7 +126,7 @@ Error if wallet operations fail or signature extraction fails
 getNetwork(): Network;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts:290](../../packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts#L290)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts)
 
 Gets the configured Bitcoin network.
 
@@ -142,7 +142,7 @@ The Bitcoin network (mainnet, testnet, signet, regtest)
 supportsBatchSigning(): boolean;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts:299](../../packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts#L299)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts)
 
 Checks if the wallet supports batch signing (signPsbts).
 
@@ -158,7 +158,7 @@ true if batch signing is supported
 signPayoutTransactionsBatch(transactions): Promise<object[]>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts:312](../../packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts#L312)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts)
 
 Batch signs multiple payout transactions (1 per claimer).
 This allows signing all transactions with a single wallet interaction.
@@ -189,7 +189,7 @@ Error if any signing operation fails
 
 ### PeginManager
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:674](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L674)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 #### Constructors
 
@@ -199,7 +199,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:674](
 new PeginManager(config): PeginManager;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:682](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L682)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 Creates a new PeginManager instance.
 
@@ -223,7 +223,7 @@ Manager configuration including wallets and contract addresses
 preparePegin(params): Promise<PreparePeginResult>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:696](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L696)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 Prepare a peg-in: sizing pass → vault-root derivation (one wallet
 popup) → per-vault WOTS / hashlock derivation → commit pass with
@@ -252,7 +252,7 @@ If the wallet rejects, insufficient funds, or an internal
 signAndBroadcast(params): Promise<string>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:1108](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L1108)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 Signs and broadcasts a funded peg-in transaction to the Bitcoin network.
 
@@ -288,7 +288,7 @@ Error if signing or broadcasting fails
 registerPeginOnChain(params): Promise<RegisterPeginResult>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:1259](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L1259)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 Registers a peg-in on Ethereum by calling the BTCVaultRegistry contract.
 
@@ -339,7 +339,7 @@ Error if contract simulation fails (e.g., invalid signature,
 registerPeginBatchOnChain(params): Promise<RegisterPeginBatchResult>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:1445](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L1445)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 Register multiple pegins on Ethereum in a single transaction.
 
@@ -367,7 +367,7 @@ Batch result with per-vault IDs and single ETH tx hash
 signProofOfPossession(): Promise<PopSignature>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:1765](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L1765)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 Sign a BIP-322 BTC Proof-of-Possession binding the connected BTC
 wallet to the connected ETH account for this chain and vault
@@ -384,7 +384,7 @@ every register call in the same session.
 getNetwork(): Network;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:1821](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L1821)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 Gets the configured Bitcoin network.
 
@@ -400,7 +400,7 @@ The Bitcoin network (mainnet, testnet, signet, regtest)
 getVaultContractAddress(): `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:1830](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L1830)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 Gets the configured BTCVaultRegistry contract address.
 
@@ -414,7 +414,7 @@ The Ethereum address of the BTCVaultRegistry contract
 
 ### SignInputOptions
 
-Defined in: [packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts:19](../../packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts#L19)
+Defined in: [packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts)
 
 Options for signing a specific input in a PSBT.
 
@@ -426,7 +426,7 @@ Options for signing a specific input in a PSBT.
 index: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts:21](../../packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts#L21)
+Defined in: [packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts)
 
 Input index to sign
 
@@ -436,7 +436,7 @@ Input index to sign
 optional address: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts:23](../../packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts#L23)
+Defined in: [packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts)
 
 Address for signing (optional)
 
@@ -446,7 +446,7 @@ Address for signing (optional)
 optional publicKey: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts:25](../../packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts#L25)
+Defined in: [packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts)
 
 Public key for signing (optional, hex string)
 
@@ -456,7 +456,7 @@ Public key for signing (optional, hex string)
 optional sighashTypes: number[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts:27](../../packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts#L27)
+Defined in: [packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts)
 
 Sighash types (optional)
 
@@ -466,7 +466,7 @@ Sighash types (optional)
 optional useTweakedSigner: boolean;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts:34](../../packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts#L34)
+Defined in: [packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts)
 
 Whether the wallet should sign with the tweaked (key-path) signer.
 Set `false` for Taproot script-path spends, where signing uses the
@@ -479,7 +479,7 @@ applies.
 optional disableTweakSigner: boolean;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts:45](../../packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts#L45)
+Defined in: [packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts)
 
 ###### Deprecated
 
@@ -496,7 +496,7 @@ convention and avoids the historical divergence in OKX's
 
 ### SignPsbtOptions
 
-Defined in: [packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts:51](../../packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts#L51)
+Defined in: [packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts)
 
 SignPsbt options for advanced signing scenarios.
 
@@ -508,7 +508,7 @@ SignPsbt options for advanced signing scenarios.
 optional autoFinalized: boolean;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts:53](../../packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts#L53)
+Defined in: [packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts)
 
 Whether to automatically finalize the PSBT after signing
 
@@ -518,7 +518,7 @@ Whether to automatically finalize the PSBT after signing
 optional signInputs: SignInputOptions[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts:59](../../packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts#L59)
+Defined in: [packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts)
 
 Specific inputs to sign.
 If not provided, wallet will attempt to sign all inputs it can.
@@ -530,7 +530,7 @@ Use this to restrict signing to specific inputs (e.g., only depositor's input).
 optional contracts: object[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts:61](../../packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts#L61)
+Defined in: [packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts)
 
 Contract information for the signing operation.
 
@@ -556,7 +556,7 @@ Contract parameters.
 optional action: object;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts:68](../../packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts#L68)
+Defined in: [packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts)
 
 Action metadata.
 
@@ -572,7 +572,7 @@ Action name for tracking.
 
 ### BitcoinWallet
 
-Defined in: [packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts:79](../../packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts#L79)
+Defined in: [packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts)
 
 This interface is designed to be compatible with @babylonlabs-io/wallet-connector's IBTCProvider
 
@@ -586,7 +586,7 @@ Supports Unisat, Ledger, OKX, OneKey, Keystone, and other Bitcoin wallets.
 getPublicKeyHex(): Promise<string>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts:89](../../packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts#L89)
+Defined in: [packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts)
 
 Returns the wallet's public key as a hex string.
 
@@ -606,7 +606,7 @@ consumers should strip the first byte to get x-only format.
 getAddress(): Promise<string>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts:94](../../packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts#L94)
+Defined in: [packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts)
 
 Returns the wallet's Bitcoin address.
 
@@ -620,7 +620,7 @@ Returns the wallet's Bitcoin address.
 signPsbt(psbtHex, options?): Promise<string>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts:103](../../packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts#L103)
+Defined in: [packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts)
 
 Signs a PSBT and returns the signed PSBT as hex.
 
@@ -652,7 +652,7 @@ If the PSBT is invalid or signing fails
 signPsbts(psbtsHexes, options?): Promise<string[]>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts:113](../../packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts#L113)
+Defined in: [packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts)
 
 Signs multiple PSBTs and returns the signed PSBTs as hex.
 This allows batch signing with a single wallet interaction.
@@ -685,7 +685,7 @@ If any PSBT is invalid or signing fails
 signMessage(message, type): Promise<string>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts:125](../../packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts#L125)
+Defined in: [packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts)
 
 Signs a message for authentication or proof of ownership.
 
@@ -715,7 +715,7 @@ Base64-encoded signature
 getNetwork(): Promise<BitcoinNetwork>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts:135](../../packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts#L135)
+Defined in: [packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts)
 
 Returns the Bitcoin network the wallet is connected to.
 
@@ -731,7 +731,7 @@ BitcoinNetwork enum value (MAINNET, TESTNET, SIGNET)
 deriveContextHash(appName, context): Promise<string>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts:144](../../packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts#L144)
+Defined in: [packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts)
 
 Derives a deterministic 32-byte value per
 `docs/specs/derive-context-hash.md` rev 1.0. Throws with code
@@ -757,7 +757,7 @@ Derives a deterministic 32-byte value per
 
 ### PayoutManagerConfig
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts:34](../../packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts#L34)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts)
 
 Configuration for the PayoutManager.
 
@@ -769,7 +769,7 @@ Configuration for the PayoutManager.
 network: Network;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts:38](../../packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts#L38)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts)
 
 Bitcoin network to use for transactions.
 
@@ -779,7 +779,7 @@ Bitcoin network to use for transactions.
 btcWallet: BitcoinWallet;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts:43](../../packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts#L43)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts)
 
 Bitcoin wallet for signing payout transactions.
 
@@ -787,7 +787,7 @@ Bitcoin wallet for signing payout transactions.
 
 ### SignPayoutParams
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts:139](../../packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts#L139)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts)
 
 Parameters for signing a Payout transaction.
 
@@ -806,7 +806,7 @@ Input 1 references the Assert transaction.
 vaultCoreVersion: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts:55](../../packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts#L55)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts)
 
 Vault core (tx-graph) version the vault was registered under — the
 vault's stamped on-chain `vaultCoreVersion`. Forwarded to
@@ -824,7 +824,7 @@ SignPayoutBaseParams.vaultCoreVersion
 peginTxHex: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts:61](../../packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts#L61)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts)
 
 Peg-in transaction hex.
 The original transaction that created the vault output being spent.
@@ -841,7 +841,7 @@ SignPayoutBaseParams.peginTxHex
 vaultProviderBtcPubkey: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts:66](../../packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts#L66)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts)
 
 Vault provider's BTC public key (x-only, 64-char hex).
 
@@ -857,7 +857,7 @@ SignPayoutBaseParams.vaultProviderBtcPubkey
 vaultKeeperBtcPubkeys: string[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts:71](../../packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts#L71)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts)
 
 Vault keeper BTC public keys (x-only, 64-char hex).
 
@@ -873,7 +873,7 @@ SignPayoutBaseParams.vaultKeeperBtcPubkeys
 universalChallengerBtcPubkeys: string[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts:76](../../packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts#L76)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts)
 
 Universal challenger BTC public keys (x-only, 64-char hex).
 
@@ -889,7 +889,7 @@ SignPayoutBaseParams.universalChallengerBtcPubkeys
 timelockPegin: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts:81](../../packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts#L81)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts)
 
 CSV timelock in blocks for the PegIn output.
 
@@ -905,7 +905,7 @@ SignPayoutBaseParams.timelockPegin
 timelockAssert: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts:83](../../packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts#L83)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts)
 
 btc-vault `timelock_assert`; payout input 1's sequence.
 
@@ -921,7 +921,7 @@ SignPayoutBaseParams.timelockAssert
 depositorBtcPubkey: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts:94](../../packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts#L94)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts)
 
 Depositor's BTC public key (x-only, 64-char hex). This MUST be the
 key registered on-chain for the vault — typically read from
@@ -943,7 +943,7 @@ SignPayoutBaseParams.depositorBtcPubkey
 registeredPayoutScriptPubKey: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts:101](../../packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts#L101)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts)
 
 The on-chain registered depositor payout scriptPubKey (hex, with or without 0x prefix).
 Used to validate that the VP-provided payout transaction actually pays to the
@@ -961,7 +961,7 @@ SignPayoutBaseParams.registeredPayoutScriptPubKey
 claimerBtcPubkey: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts:107](../../packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts#L107)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts)
 
 The claimer's x-only BTC public key for this payout (64-char hex, no prefix).
 Forwarded to [buildPayoutPsbt](primitives.md#buildpayoutpsbt) for per-role output validation.
@@ -978,7 +978,7 @@ SignPayoutBaseParams.claimerBtcPubkey
 commissionBps: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts:112](../../packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts#L112)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts)
 
 VP commission in basis points (`1..=9999`). Forwarded to [buildPayoutPsbt](primitives.md#buildpayoutpsbt).
 
@@ -994,7 +994,7 @@ SignPayoutBaseParams.commissionBps
 protocolFeeRate: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts:118](../../packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts#L118)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts)
 
 Version-locked tx-graph fee rate (sat/vB) the graph was built with.
 Forwarded to [buildPayoutPsbt](primitives.md#buildpayoutpsbt) for the fee band.
@@ -1011,7 +1011,7 @@ SignPayoutBaseParams.protocolFeeRate
 councilSize: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts:121](../../packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts#L121)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts)
 
 Security council member count; forwarded to the fee floor (see PayoutParams).
 
@@ -1027,7 +1027,7 @@ SignPayoutBaseParams.councilSize
 vkClaimerPayoutScriptPubKeys: Readonly<Record<string, string>>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts:128](../../packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts#L128)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts)
 
 RFC-006 resolved payout destinations, keyed by lowercased x-only operation
 pubkey. Forwarded verbatim to [buildPayoutPsbt](primitives.md#buildpayoutpsbt); every VK claimer
@@ -1045,7 +1045,7 @@ SignPayoutBaseParams.vkClaimerPayoutScriptPubKeys
 vpCommissionScriptPubKey: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts:130](../../packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts#L130)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts)
 
 RFC-006 VP commission destination. Forwarded to [buildPayoutPsbt](primitives.md#buildpayoutpsbt).
 
@@ -1061,7 +1061,7 @@ SignPayoutBaseParams.vpCommissionScriptPubKey
 payoutTxHex: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts:144](../../packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts#L144)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts)
 
 Payout transaction hex (unsigned).
 This is the transaction from the vault provider that needs depositor signature.
@@ -1072,7 +1072,7 @@ This is the transaction from the vault provider that needs depositor signature.
 assertTxHex: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts:150](../../packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts#L150)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts)
 
 Assert transaction hex.
 Payout input 1 references Assert output 0.
@@ -1081,7 +1081,7 @@ Payout input 1 references Assert output 0.
 
 ### PayoutSignatureResult
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts:156](../../packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts#L156)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts)
 
 Result of signing a payout transaction.
 
@@ -1093,7 +1093,7 @@ Result of signing a payout transaction.
 signature: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts:160](../../packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts#L160)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts)
 
 64-byte Schnorr signature (128 hex characters).
 
@@ -1103,7 +1103,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts:160]
 depositorBtcPubkey: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts:165](../../packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts#L165)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts)
 
 Depositor's BTC public key used for signing.
 
@@ -1111,7 +1111,7 @@ Depositor's BTC public key used for signing.
 
 ### PeginManagerConfig
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:165](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L165)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 Configuration for the PeginManager.
 
@@ -1123,7 +1123,7 @@ Configuration for the PeginManager.
 btcNetwork: Network;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:169](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L169)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 Bitcoin network to use for transactions.
 
@@ -1133,7 +1133,7 @@ Bitcoin network to use for transactions.
 btcWallet: BitcoinWallet;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:174](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L174)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 Bitcoin wallet for signing peg-in transactions.
 
@@ -1143,7 +1143,7 @@ Bitcoin wallet for signing peg-in transactions.
 ethWallet: object;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:180](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L180)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 Ethereum wallet for registering peg-in on-chain.
 Uses viem's WalletClient directly for proper gas estimation.
@@ -1154,7 +1154,7 @@ Uses viem's WalletClient directly for proper gas estimation.
 ethChain: Chain;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:186](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L186)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 Ethereum chain configuration.
 Required for proper gas estimation in contract calls.
@@ -1165,7 +1165,7 @@ Required for proper gas estimation in contract calls.
 publicClient: object;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:194](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L194)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 Public client used for read calls (`readContract`, `estimateGas`,
 `waitForTransactionReceipt`). Pass a client configured with the
@@ -1178,7 +1178,7 @@ application instead of viem's stock chain default.
 vaultContracts: object;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:199](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L199)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 Vault contract addresses.
 
@@ -1196,7 +1196,7 @@ BTCVaultRegistry contract address on Ethereum.
 mempoolApiUrl: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:211](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L211)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 Mempool API URL for fetching UTXO data and broadcasting transactions.
 Use MEMPOOL_API_URLS constant for standard mempool.space URLs, or provide
@@ -1206,7 +1206,7 @@ a custom URL if running your own mempool instance.
 
 ### PreparePeginParams
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:217](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L217)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 Parameters for the pegin flow (pre-pegin + pegin transactions).
 
@@ -1218,7 +1218,7 @@ Parameters for the pegin flow (pre-pegin + pegin transactions).
 vaultCoreVersion: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:224](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L224)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 Vault core (tx-graph) version to build — the contract's
 `ProtocolParams.activeVaultCoreVersion()` at build time. Stamped onto
@@ -1231,7 +1231,7 @@ constructs derives from this graph version.
 amounts: readonly bigint[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:231](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L231)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 Amounts to peg in per HTLC (in satoshis).
 Must have the same length as `hashlocks`.
@@ -1243,7 +1243,7 @@ For single deposits, pass a single-element array.
 vaultProviderBtcPubkey: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:237](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L237)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 Vault provider's BTC public key (x-only, 64-char hex).
 Can be provided with or without "0x" prefix (will be stripped automatically).
@@ -1254,7 +1254,7 @@ Can be provided with or without "0x" prefix (will be stripped automatically).
 commissionBps: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:244](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L244)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 VP commission quoted for this deposit (bps). Capped to the approval
 ceiling before it sizes the terms' commissionFee, so the user approves
@@ -1266,7 +1266,7 @@ the most the VP can take — not the quote.
 vaultKeeperBtcPubkeys: readonly string[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:250](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L250)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 Vault keeper BTC public keys (x-only, 64-char hex).
 Can be provided with or without "0x" prefix (will be stripped automatically).
@@ -1277,7 +1277,7 @@ Can be provided with or without "0x" prefix (will be stripped automatically).
 universalChallengerBtcPubkeys: readonly string[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:256](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L256)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 Universal challenger BTC public keys (x-only, 64-char hex).
 Can be provided with or without "0x" prefix (will be stripped automatically).
@@ -1288,7 +1288,7 @@ Can be provided with or without "0x" prefix (will be stripped automatically).
 timelockPegin: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:261](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L261)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 CSV timelock in blocks for the PegIn vault output.
 
@@ -1298,7 +1298,7 @@ CSV timelock in blocks for the PegIn vault output.
 timelockAssert: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:269](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L269)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 btc-vault `timelock_assert` (t2) — the Assert:0 payout-leaf CSV. Carried
 into DepositTerms as its own field. Production collapses the two: the SDK
@@ -1312,7 +1312,7 @@ derives timelockPegin from the same on-chain timelockAssert
 timelockRefund: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:274](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L274)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 CSV timelock in blocks for the Pre-PegIn HTLC refund path.
 
@@ -1322,7 +1322,7 @@ CSV timelock in blocks for the Pre-PegIn HTLC refund path.
 protocolFeeRate: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:280](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L280)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 TX-graph fee rate in sat/vB from the contract offchain params.
 Used by WASM to size the depositor claim value (graph transactions).
@@ -1333,7 +1333,7 @@ Used by WASM to size the depositor claim value (graph transactions).
 minPeginFeeRate: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:286](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L286)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 Minimum PegIn fee rate in sat/vB from the contract offchain params.
 Used by WASM to size the PegIn transaction fee.
@@ -1344,7 +1344,7 @@ Used by WASM to size the PegIn transaction fee.
 mempoolFeeRate: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:292](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L292)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 Mempool fee rate in sat/vB for funding the Pre-PegIn transaction.
 Used for UTXO selection and change calculation.
@@ -1355,7 +1355,7 @@ Used for UTXO selection and change calculation.
 councilQuorum: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:297](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L297)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 M in M-of-N council multisig (from contract params).
 
@@ -1365,7 +1365,7 @@ M in M-of-N council multisig (from contract params).
 councilSize: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:302](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L302)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 N in M-of-N council multisig (from contract params).
 
@@ -1375,7 +1375,7 @@ N in M-of-N council multisig (from contract params).
 availableUTXOs: readonly UTXO[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:307](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L307)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 Available UTXOs from the depositor's wallet for funding the Pre-PegIn transaction.
 
@@ -1385,7 +1385,7 @@ Available UTXOs from the depositor's wallet for funding the Pre-PegIn transactio
 changeAddress: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:312](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L312)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 Bitcoin address for receiving change from the Pre-PegIn transaction.
 
@@ -1393,7 +1393,7 @@ Bitcoin address for receiving change from the Pre-PegIn transaction.
 
 ### PerVaultPeginData
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:319](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L319)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 Per-vault PegIn data derived from a shared Pre-PegIn transaction
 
@@ -1405,7 +1405,7 @@ Per-vault PegIn data derived from a shared Pre-PegIn transaction
 htlcVout: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:321](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L321)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 Index of the HTLC output in the Pre-PegIn transaction (0, 1, 2, ...)
 
@@ -1415,7 +1415,7 @@ Index of the HTLC output in the Pre-PegIn transaction (0, 1, 2, ...)
 htlcValue: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:323](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L323)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 HTLC output value in satoshis
 
@@ -1425,7 +1425,7 @@ HTLC output value in satoshis
 peginTxHex: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:325](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L325)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 Depositor-signed PegIn transaction hex (for contract registration)
 
@@ -1435,7 +1435,7 @@ Depositor-signed PegIn transaction hex (for contract registration)
 peginTxid: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:327](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L327)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 PegIn transaction ID
 
@@ -1445,7 +1445,7 @@ PegIn transaction ID
 peginInputSignature: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:329](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L329)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 Depositor's Schnorr signature over PegIn input (HTLC leaf 0)
 
@@ -1455,7 +1455,7 @@ Depositor's Schnorr signature over PegIn input (HTLC leaf 0)
 vaultScriptPubKey: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:331](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L331)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 Vault output scriptPubKey hex
 
@@ -1463,7 +1463,7 @@ Vault output scriptPubKey hex
 
 ### PreparePeginTransaction
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:338](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L338)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 Broadcast-ready transaction output of [PeginManager.preparePegin](#preparepegin).
 Safe to log / persist — contains no sensitive material.
@@ -1476,7 +1476,7 @@ Safe to log / persist — contains no sensitive material.
 fundedPrePeginTxHex: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:344](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L344)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 Funded, pre-witness Pre-PegIn tx hex. Pass this for register calls'
 `unsignedPrePeginTx` — despite the contract-side name, the registry
@@ -1488,7 +1488,7 @@ stores the funded form so indexers can rebuild refund PSBTs.
 prePeginTxid: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:346](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L346)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 Funded Pre-PegIn transaction ID
 
@@ -1498,7 +1498,7 @@ Funded Pre-PegIn transaction ID
 perVault: PerVaultPeginData[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:348](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L348)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 Per-vault PegIn data — one entry per amount
 
@@ -1508,7 +1508,7 @@ Per-vault PegIn data — one entry per amount
 selectedUTXOs: UTXO[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:350](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L350)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 UTXOs selected to fund the Pre-PegIn transaction
 
@@ -1518,7 +1518,7 @@ UTXOs selected to fund the Pre-PegIn transaction
 fee: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:352](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L352)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 Transaction fee in satoshis
 
@@ -1528,7 +1528,7 @@ Transaction fee in satoshis
 changeAmount: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:354](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L354)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 Change amount in satoshis (if any)
 
@@ -1536,7 +1536,7 @@ Change amount in satoshis (if any)
 
 ### PreparePeginDerivedSecrets
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:362](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L362)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 Sensitive material derived from the wallet root. Do not log; do not
 persist beyond the activation flow. Strings are immutable in JS, so
@@ -1550,7 +1550,7 @@ lifetime is GC-only — secrets stay live until the result is dropped.
 perVaultWotsKeys: WotsBlockPublicKey[][];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:364](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L364)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 Per-vault WOTS block public keys (one array per vault).
 
@@ -1560,7 +1560,7 @@ Per-vault WOTS block public keys (one array per vault).
 wotsPkHashes: `0x${string}`[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:366](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L366)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 Per-vault keccak256 of WOTS keys, ready as `depositorWotsPkHash`.
 
@@ -1570,7 +1570,7 @@ Per-vault keccak256 of WOTS keys, ready as `depositorWotsPkHash`.
 htlcSecretHexes: string[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:371](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L371)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 Per-vault HTLC preimage hex (no 0x prefix). Re-derivable any time
 via `expandHashlockSecret(root, htlcVout)`; not persisted.
@@ -1581,7 +1581,7 @@ via `expandHashlockSecret(root, htlcVout)`; not persisted.
 authAnchorHex: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:382](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L382)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 Raw 32-byte auth-anchor preimage as 64-char lowercase hex (no `0x`).
 Sent to the VP via `auth_createDepositorToken` to obtain a bearer
@@ -1596,7 +1596,7 @@ not weaken the other derived secrets.
 
 ### PreparePeginResult
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:385](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L385)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 #### Properties
 
@@ -1606,7 +1606,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:385](
 transaction: PreparePeginTransaction;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:387](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L387)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 Broadcast-ready Pre-PegIn + per-vault PegIn txs. Safe to log.
 
@@ -1616,7 +1616,7 @@ Broadcast-ready Pre-PegIn + per-vault PegIn txs. Safe to log.
 depositorBtcPubkey: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:394](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L394)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 x-only depositor pubkey snapshot used end-to-end across sizing,
 vault-root derivation, and PSBT signing. Safe to persist; not
@@ -1629,7 +1629,7 @@ derived secrets and signed PSBTs reference the same identity.
 derivedSecrets: PreparePeginDerivedSecrets;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:396](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L396)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 Sensitive derived material — see [PreparePeginDerivedSecrets](#preparepeginderivedsecrets).
 
@@ -1639,7 +1639,7 @@ Sensitive derived material — see [PreparePeginDerivedSecrets](#preparepeginder
 depositTerms: DepositTerms;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:403](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L403)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 Protocol-level deposit terms for this Pre-PegIn. Always built, regardless
 of wallet capability — [supportsDepositApproval](deposit-terms.md#supportsdepositapproval) wallets get it via
@@ -1650,7 +1650,7 @@ reference.
 
 ### SignAndBroadcastParams
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:409](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L409)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 Parameters for signing and broadcasting a transaction.
 
@@ -1662,7 +1662,7 @@ Parameters for signing and broadcasting a transaction.
 fundedPrePeginTxHex: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:413](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L413)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 Funded Pre-PegIn transaction hex from preparePegin().
 
@@ -1672,7 +1672,7 @@ Funded Pre-PegIn transaction hex from preparePegin().
 depositorBtcPubkey: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:420](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L420)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 Depositor's BTC public key (x-only, 64-char hex).
 Can be provided with or without "0x" prefix.
@@ -1687,7 +1687,7 @@ optional localPrevouts: Record<string, {
 }>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:428](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L428)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 Optional pre-fetched prevout data for inputs not yet in the mempool.
 Key format: "txid:vout" (e.g. "abc123...def:0").
@@ -1698,7 +1698,7 @@ Useful for split transactions where outputs are unconfirmed.
 
 ### PopSignature
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:437](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L437)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 BIP-322 BTC Proof-of-Possession binding a depositor's BTC key to their
 Ethereum account. Produced by [PeginManager.signProofOfPossession](#signproofofpossession)
@@ -1713,7 +1713,7 @@ embedded identities are re-checked at register time.
 btcPopSignature: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:439](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L439)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 BIP-322 signature over the PoP message (0x-prefixed hex).
 
@@ -1723,7 +1723,7 @@ BIP-322 signature over the PoP message (0x-prefixed hex).
 depositorEthAddress: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:441](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L441)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 Ethereum address the PoP was signed for.
 
@@ -1733,7 +1733,7 @@ Ethereum address the PoP was signed for.
 depositorBtcPubkey: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:443](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L443)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 BTC x-only public key (64-char hex, no 0x prefix).
 
@@ -1741,7 +1741,7 @@ BTC x-only public key (64-char hex, no 0x prefix).
 
 ### RegisterPeginParams
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:449](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L449)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 Parameters for registering a peg-in on Ethereum.
 
@@ -1753,7 +1753,7 @@ Parameters for registering a peg-in on Ethereum.
 unsignedPrePeginTx: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:456](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L456)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 Funded, pre-witness Pre-PegIn tx hex — pass
 [PreparePeginTransaction.fundedPrePeginTxHex](#fundedprepegintxhex) from
@@ -1766,7 +1766,7 @@ is named `unsignedPrePeginTx` but it stores the funded form.
 depositorSignedPeginTx: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:461](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L461)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 Depositor-signed PegIn transaction hex (submitted to contract; vault ID derived from this).
 
@@ -1776,7 +1776,7 @@ Depositor-signed PegIn transaction hex (submitted to contract; vault ID derived 
 vaultProvider: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:466](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L466)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 Vault provider's Ethereum address.
 
@@ -1786,7 +1786,7 @@ Vault provider's Ethereum address.
 hashlock: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:471](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L471)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 SHA256 hashlock for HTLC activation (bytes32 hex with 0x prefix).
 
@@ -1796,7 +1796,7 @@ SHA256 hashlock for HTLC activation (bytes32 hex with 0x prefix).
 optional depositorPayoutBtcAddress: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:480](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L480)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 Depositor's BTC payout address (e.g. bc1p..., bc1q...).
 Converted to scriptPubKey internally via bitcoinjs-lib.
@@ -1810,7 +1810,7 @@ via `btcWallet.getAddress()`.
 depositorWotsPkHash: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:483](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L483)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 Keccak256 hash of the depositor's WOTS public key (bytes32)
 
@@ -1820,7 +1820,7 @@ Keccak256 hash of the depositor's WOTS public key (bytes32)
 popSignature: PopSignature;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:486](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L486)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 Proof of possession from [PeginManager.signProofOfPossession](#signproofofpossession).
 
@@ -1830,7 +1830,7 @@ Proof of possession from [PeginManager.signProofOfPossession](#signproofofposses
 htlcVout: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:493](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L493)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 Zero-based index of the HTLC output in the Pre-PegIn transaction that
 this PegIn spends. In a batch Pre-PegIn with N HTLC outputs, each vault
@@ -1842,7 +1842,7 @@ registration references a different htlcVout (0..N-1).
 optional quotedCommissionBps: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:500](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L500)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 Bounds the registration's maxAcceptableCommissionBps (#1691). REQUIRED
 when the wallet approved terms — the ceiling must anchor to the approved
@@ -1852,7 +1852,7 @@ quote. Optional otherwise; falls back to chain-current.
 
 ### RegisterPeginResult
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:506](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L506)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 Result of registering a peg-in on Ethereum.
 
@@ -1864,7 +1864,7 @@ Result of registering a peg-in on Ethereum.
 ethTxHash: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:510](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L510)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 Ethereum transaction hash for the peg-in registration.
 
@@ -1874,7 +1874,7 @@ Ethereum transaction hash for the peg-in registration.
 vaultId: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:516](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L516)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 Derived vault ID: keccak256(abi.encode(peginTxHash, depositor)).
 Used for contract reads/writes and indexer queries.
@@ -1885,7 +1885,7 @@ Used for contract reads/writes and indexer queries.
 peginTxHash: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:522](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L522)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 Raw Bitcoin pegin transaction hash (double-SHA256 of the signed pegin tx).
 Used for VP RPC operations which key on the BTC transaction ID.
@@ -1894,7 +1894,7 @@ Used for VP RPC operations which key on the BTC transaction ID.
 
 ### BatchPeginRequestItem
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:530](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L530)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 Single request in a batch pegin registration.
 All requests in a batch share the same vault provider, depositor BTC
@@ -1908,7 +1908,7 @@ pubkey, and Pre-PegIn transaction.
 depositorSignedPeginTx: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:532](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L532)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 Signed PegIn tx hex for this vault
 
@@ -1918,7 +1918,7 @@ Signed PegIn tx hex for this vault
 hashlock: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:534](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L534)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 SHA256 hashlock for HTLC activation (bytes32 hex)
 
@@ -1928,7 +1928,7 @@ SHA256 hashlock for HTLC activation (bytes32 hex)
 htlcVout: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:536](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L536)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 Zero-based HTLC output index in the Pre-PegIn tx (unique per request)
 
@@ -1938,7 +1938,7 @@ Zero-based HTLC output index in the Pre-PegIn tx (unique per request)
 depositorPayoutBtcAddress: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:538](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L538)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 Depositor's BTC payout address (required — funds are sent here on payout)
 
@@ -1948,7 +1948,7 @@ Depositor's BTC payout address (required — funds are sent here on payout)
 depositorWotsPkHash: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:540](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L540)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 Keccak256 hash of the depositor's WOTS public key (bytes32)
 
@@ -1956,7 +1956,7 @@ Keccak256 hash of the depositor's WOTS public key (bytes32)
 
 ### RegisterPeginBatchParams
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:546](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L546)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 Parameters for registerPeginBatchOnChain.
 
@@ -1968,7 +1968,7 @@ Parameters for registerPeginBatchOnChain.
 vaultProvider: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:548](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L548)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 Vault provider address (shared across all vaults in batch)
 
@@ -1978,7 +1978,7 @@ Vault provider address (shared across all vaults in batch)
 unsignedPrePeginTx: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:553](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L553)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 Funded, pre-witness Pre-PegIn tx hex — shared across every request in
 the batch. See [RegisterPeginParams.unsignedPrePeginTx](#unsignedprepegintx).
@@ -1989,7 +1989,7 @@ the batch. See [RegisterPeginParams.unsignedPrePeginTx](#unsignedprepegintx).
 requests: BatchPeginRequestItem[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:555](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L555)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 Individual pegin requests (one per vault)
 
@@ -1999,7 +1999,7 @@ Individual pegin requests (one per vault)
 popSignature: PopSignature;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:557](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L557)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 Proof of possession from [PeginManager.signProofOfPossession](#signproofofpossession).
 
@@ -2009,7 +2009,7 @@ Proof of possession from [PeginManager.signProofOfPossession](#signproofofposses
 optional quotedCommissionBps: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:559](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L559)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 See [RegisterPeginParams.quotedCommissionBps](#quotedcommissionbps).
 
@@ -2017,7 +2017,7 @@ See [RegisterPeginParams.quotedCommissionBps](#quotedcommissionbps).
 
 ### BatchPeginResultItem
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:565](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L565)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 Per-vault result from a batch pegin registration.
 
@@ -2029,7 +2029,7 @@ Per-vault result from a batch pegin registration.
 vaultId: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:567](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L567)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 Derived vault ID: keccak256(abi.encode(peginTxHash, depositor))
 
@@ -2039,7 +2039,7 @@ Derived vault ID: keccak256(abi.encode(peginTxHash, depositor))
 peginTxHash: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:569](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L569)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 Raw BTC pegin transaction hash
 
@@ -2047,7 +2047,7 @@ Raw BTC pegin transaction hash
 
 ### RegisterPeginBatchResult
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:575](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L575)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 Result of registering a batch of pegins on Ethereum in a single transaction.
 
@@ -2059,7 +2059,7 @@ Result of registering a batch of pegins on Ethereum in a single transaction.
 ethTxHash: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:577](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L577)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 Ethereum transaction hash
 
@@ -2069,7 +2069,7 @@ Ethereum transaction hash
 vaults: BatchPeginResultItem[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:579](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L579)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 Per-vault results (same order as input requests)
 
@@ -2077,7 +2077,7 @@ Per-vault results (same order as input requests)
 
 ### EstimateSubmitPeginRequestBatchGasParams
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:1900](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L1900)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 #### Properties
 
@@ -2087,7 +2087,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:1900]
 publicClient: object;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:1901](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L1901)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 ##### btcVaultRegistry
 
@@ -2095,7 +2095,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:1901]
 btcVaultRegistry: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:1902](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L1902)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 ##### depositorEthAddress
 
@@ -2103,7 +2103,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:1902]
 depositorEthAddress: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:1903](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L1903)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 ##### vaultProvider
 
@@ -2111,7 +2111,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:1903]
 vaultProvider: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:1904](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L1904)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 ##### batchSize
 
@@ -2119,7 +2119,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:1904]
 batchSize: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:1905](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L1905)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 ## Type Aliases
 
@@ -2129,7 +2129,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:1905]
 type BitcoinNetwork = "mainnet" | "testnet" | "signet";
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts:5](../../packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts#L5)
+Defined in: [packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts)
 
 Bitcoin network types.
 Using string literal union for maximum compatibility with wallet providers.
@@ -2142,7 +2142,7 @@ Using string literal union for maximum compatibility with wallet providers.
 function estimateSubmitPeginRequestBatchGas(params): Promise<bigint>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts:1925](../../packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts#L1925)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
 
 Estimate gas for a `submitPeginRequestBatch` call before the depositor has
 signed anything. Synthesizes calldata using representative dummy bytes for

--- a/packages/babylon-ts-sdk/docs/api/primitives.md
+++ b/packages/babylon-ts-sdk/docs/api/primitives.md
@@ -77,7 +77,7 @@ the managers module instead (PeginManager and PayoutManager).
 
 ### PsbtSubstitutionError
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/assertPsbtUnsignedTxMatches.ts:19](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/assertPsbtUnsignedTxMatches.ts#L19)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/assertPsbtUnsignedTxMatches.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/assertPsbtUnsignedTxMatches.ts)
 
 Thrown when a wallet-returned PSBT encodes a different unsigned
 transaction than the one the caller asked the wallet to sign.
@@ -94,7 +94,7 @@ transaction than the one the caller asked the wallet to sign.
 new PsbtSubstitutionError(detail): PsbtSubstitutionError;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/assertPsbtUnsignedTxMatches.ts:20](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/assertPsbtUnsignedTxMatches.ts#L20)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/assertPsbtUnsignedTxMatches.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/assertPsbtUnsignedTxMatches.ts)
 
 ###### Parameters
 
@@ -116,7 +116,7 @@ Error.constructor
 
 ### PeginP2aAnchorInfo
 
-Defined in: packages/babylon-tbv-rust-wasm/dist/types.d.ts:103
+Defined in: packages/babylon-tbv-rust-wasm/dist/types.d.ts
 
 A graph version's PegIn P2A (pay-to-anchor) output description, copied out
 of the WASM object into plain JS. v2: 240 sats at vout 2, script
@@ -131,7 +131,7 @@ of the WASM object into plain JS. v2: 240 sats at vout 2, script
 value: bigint;
 ```
 
-Defined in: packages/babylon-tbv-rust-wasm/dist/types.d.ts:105
+Defined in: packages/babylon-tbv-rust-wasm/dist/types.d.ts
 
 Anchor output value in satoshis (240 for v2)
 
@@ -141,7 +141,7 @@ Anchor output value in satoshis (240 for v2)
 vout: number;
 ```
 
-Defined in: packages/babylon-tbv-rust-wasm/dist/types.d.ts:107
+Defined in: packages/babylon-tbv-rust-wasm/dist/types.d.ts
 
 Anchor output index in the PegIn transaction (2 for v2)
 
@@ -151,7 +151,7 @@ Anchor output index in the PegIn transaction (2 for v2)
 scriptPubKey: string;
 ```
 
-Defined in: packages/babylon-tbv-rust-wasm/dist/types.d.ts:109
+Defined in: packages/babylon-tbv-rust-wasm/dist/types.d.ts
 
 Anchor scriptPubKey hex (`51024e73` for v2)
 
@@ -159,7 +159,7 @@ Anchor scriptPubKey hex (`51024e73` for v2)
 
 ### PayoutConnectorParams
 
-Defined in: packages/babylon-tbv-rust-wasm/dist/types.d.ts:159
+Defined in: packages/babylon-tbv-rust-wasm/dist/types.d.ts
 
 Parameters for creating a payout connector
 
@@ -171,7 +171,7 @@ Parameters for creating a payout connector
 txGraphVersion: number;
 ```
 
-Defined in: packages/babylon-tbv-rust-wasm/dist/types.d.ts:166
+Defined in: packages/babylon-tbv-rust-wasm/dist/types.d.ts
 
 Tx graph (vault-core) version selecting the builder inside the vault-wasm
 facade. Fresh deposits use the contract's `activeVaultCoreVersion()`;
@@ -184,7 +184,7 @@ closed on versions the shipped binary does not support.
 depositor: string;
 ```
 
-Defined in: packages/babylon-tbv-rust-wasm/dist/types.d.ts:168
+Defined in: packages/babylon-tbv-rust-wasm/dist/types.d.ts
 
 X-only public key of the depositor (hex encoded)
 
@@ -194,7 +194,7 @@ X-only public key of the depositor (hex encoded)
 vaultProvider: string;
 ```
 
-Defined in: packages/babylon-tbv-rust-wasm/dist/types.d.ts:170
+Defined in: packages/babylon-tbv-rust-wasm/dist/types.d.ts
 
 X-only public key of the vault provider (hex encoded)
 
@@ -204,7 +204,7 @@ X-only public key of the vault provider (hex encoded)
 vaultKeepers: string[];
 ```
 
-Defined in: packages/babylon-tbv-rust-wasm/dist/types.d.ts:172
+Defined in: packages/babylon-tbv-rust-wasm/dist/types.d.ts
 
 Array of x-only public keys of vault keepers (hex encoded)
 
@@ -214,7 +214,7 @@ Array of x-only public keys of vault keepers (hex encoded)
 universalChallengers: string[];
 ```
 
-Defined in: packages/babylon-tbv-rust-wasm/dist/types.d.ts:174
+Defined in: packages/babylon-tbv-rust-wasm/dist/types.d.ts
 
 Array of x-only public keys of universal challengers (hex encoded)
 
@@ -224,7 +224,7 @@ Array of x-only public keys of universal challengers (hex encoded)
 timelockPegin: number;
 ```
 
-Defined in: packages/babylon-tbv-rust-wasm/dist/types.d.ts:176
+Defined in: packages/babylon-tbv-rust-wasm/dist/types.d.ts
 
 CSV timelock in blocks for the PegIn output
 
@@ -232,7 +232,7 @@ CSV timelock in blocks for the PegIn output
 
 ### AssertPayoutNoPayoutConnectorParams
 
-Defined in: packages/babylon-tbv-rust-wasm/dist/types.d.ts:197
+Defined in: packages/babylon-tbv-rust-wasm/dist/types.d.ts
 
 Parameters for creating an Assert Payout/NoPayout connector.
 This connector generates scripts for the depositor's own graph (depositor-as-claimer).
@@ -245,7 +245,7 @@ This connector generates scripts for the depositor's own graph (depositor-as-cla
 txGraphVersion: number;
 ```
 
-Defined in: packages/babylon-tbv-rust-wasm/dist/types.d.ts:204
+Defined in: packages/babylon-tbv-rust-wasm/dist/types.d.ts
 
 Tx graph (vault-core) version selecting the builder inside the vault-wasm
 facade. Fresh deposits use the contract's `activeVaultCoreVersion()`;
@@ -258,7 +258,7 @@ closed on versions the shipped binary does not support.
 claimer: string;
 ```
 
-Defined in: packages/babylon-tbv-rust-wasm/dist/types.d.ts:206
+Defined in: packages/babylon-tbv-rust-wasm/dist/types.d.ts
 
 X-only public key of the claimer (depositor acting as claimer, hex encoded)
 
@@ -268,7 +268,7 @@ X-only public key of the claimer (depositor acting as claimer, hex encoded)
 localChallengers: string[];
 ```
 
-Defined in: packages/babylon-tbv-rust-wasm/dist/types.d.ts:208
+Defined in: packages/babylon-tbv-rust-wasm/dist/types.d.ts
 
 Array of x-only public keys of local challengers (hex encoded)
 
@@ -278,7 +278,7 @@ Array of x-only public keys of local challengers (hex encoded)
 universalChallengers: string[];
 ```
 
-Defined in: packages/babylon-tbv-rust-wasm/dist/types.d.ts:210
+Defined in: packages/babylon-tbv-rust-wasm/dist/types.d.ts
 
 Array of x-only public keys of universal challengers (hex encoded)
 
@@ -288,7 +288,7 @@ Array of x-only public keys of universal challengers (hex encoded)
 timelockAssert: number;
 ```
 
-Defined in: packages/babylon-tbv-rust-wasm/dist/types.d.ts:212
+Defined in: packages/babylon-tbv-rust-wasm/dist/types.d.ts
 
 CSV timelock in blocks for the Assert output
 
@@ -298,7 +298,7 @@ CSV timelock in blocks for the Assert output
 councilMembers: string[];
 ```
 
-Defined in: packages/babylon-tbv-rust-wasm/dist/types.d.ts:214
+Defined in: packages/babylon-tbv-rust-wasm/dist/types.d.ts
 
 Array of x-only public keys of security council members (hex encoded)
 
@@ -308,7 +308,7 @@ Array of x-only public keys of security council members (hex encoded)
 councilQuorum: number;
 ```
 
-Defined in: packages/babylon-tbv-rust-wasm/dist/types.d.ts:216
+Defined in: packages/babylon-tbv-rust-wasm/dist/types.d.ts
 
 Council quorum (M-of-N multisig threshold)
 
@@ -316,7 +316,7 @@ Council quorum (M-of-N multisig threshold)
 
 ### ChallengeAssertConnectorParams
 
-Defined in: packages/babylon-tbv-rust-wasm/dist/types.d.ts:240
+Defined in: packages/babylon-tbv-rust-wasm/dist/types.d.ts
 
 Parameters for creating a ChallengeAssert connector.
 This connector generates scripts for the ChallengeAssert transaction.
@@ -329,7 +329,7 @@ This connector generates scripts for the ChallengeAssert transaction.
 txGraphVersion: number;
 ```
 
-Defined in: packages/babylon-tbv-rust-wasm/dist/types.d.ts:247
+Defined in: packages/babylon-tbv-rust-wasm/dist/types.d.ts
 
 Tx graph (vault-core) version selecting the builder inside the vault-wasm
 facade. Fresh deposits use the contract's `activeVaultCoreVersion()`;
@@ -342,7 +342,7 @@ closed on versions the shipped binary does not support.
 claimer: string;
 ```
 
-Defined in: packages/babylon-tbv-rust-wasm/dist/types.d.ts:249
+Defined in: packages/babylon-tbv-rust-wasm/dist/types.d.ts
 
 X-only public key of the claimer (depositor acting as claimer, hex encoded)
 
@@ -352,7 +352,7 @@ X-only public key of the claimer (depositor acting as claimer, hex encoded)
 challenger: string;
 ```
 
-Defined in: packages/babylon-tbv-rust-wasm/dist/types.d.ts:251
+Defined in: packages/babylon-tbv-rust-wasm/dist/types.d.ts
 
 X-only public key of the challenger (hex encoded)
 
@@ -362,7 +362,7 @@ X-only public key of the challenger (hex encoded)
 claimerWotsKeysJson: string;
 ```
 
-Defined in: packages/babylon-tbv-rust-wasm/dist/types.d.ts:253
+Defined in: packages/babylon-tbv-rust-wasm/dist/types.d.ts
 
 JSON string of WOTS public keys (blocks 0-1) from VP
 
@@ -372,7 +372,7 @@ JSON string of WOTS public keys (blocks 0-1) from VP
 gcWotsKeysJson: string;
 ```
 
-Defined in: packages/babylon-tbv-rust-wasm/dist/types.d.ts:255
+Defined in: packages/babylon-tbv-rust-wasm/dist/types.d.ts
 
 JSON string of GC WOTS public keys (array of arrays) from VP
 
@@ -380,7 +380,7 @@ JSON string of GC WOTS public keys (array of arrays) from VP
 
 ### AssertPsbtUnsignedTxMatchesParams
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/assertPsbtUnsignedTxMatches.ts:28](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/assertPsbtUnsignedTxMatches.ts#L28)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/assertPsbtUnsignedTxMatches.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/assertPsbtUnsignedTxMatches.ts)
 
 #### Properties
 
@@ -390,7 +390,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/assertPsbtUnsi
 requestedPsbtHex: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/assertPsbtUnsignedTxMatches.ts:30](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/assertPsbtUnsignedTxMatches.ts#L30)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/assertPsbtUnsignedTxMatches.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/assertPsbtUnsignedTxMatches.ts)
 
 PSBT we built locally and asked the wallet to sign.
 
@@ -400,7 +400,7 @@ PSBT we built locally and asked the wallet to sign.
 returnedPsbtHex: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/assertPsbtUnsignedTxMatches.ts:32](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/assertPsbtUnsignedTxMatches.ts#L32)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/assertPsbtUnsignedTxMatches.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/assertPsbtUnsignedTxMatches.ts)
 
 PSBT the wallet returned after signing.
 
@@ -408,7 +408,7 @@ PSBT the wallet returned after signing.
 
 ### ChallengeAssertParams
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/challengeAssert.ts:33](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/challengeAssert.ts#L33)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/challengeAssert.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/challengeAssert.ts)
 
 Parameters for building a ChallengeAssert PSBT
 
@@ -420,7 +420,7 @@ Parameters for building a ChallengeAssert PSBT
 challengeAssertTxHex: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/challengeAssert.ts:35](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/challengeAssert.ts#L35)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/challengeAssert.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/challengeAssert.ts)
 
 ChallengeAssert transaction hex (unsigned)
 
@@ -430,7 +430,7 @@ ChallengeAssert transaction hex (unsigned)
 assertTxHex: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/challengeAssert.ts:37](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/challengeAssert.ts#L37)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/challengeAssert.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/challengeAssert.ts)
 
 Authoritative Assert transaction hex — every input must spend an Assert output
 
@@ -440,7 +440,7 @@ Authoritative Assert transaction hex — every input must spend an Assert output
 connectorParamsPerInput: ChallengeAssertConnectorParams[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/challengeAssert.ts:39](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/challengeAssert.ts#L39)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/challengeAssert.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/challengeAssert.ts)
 
 Per-input connector params (one per input/segment, determines the taproot script)
 
@@ -448,7 +448,7 @@ Per-input connector params (one per input/segment, determines the taproot script
 
 ### NoPayoutParams
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/noPayout.ts:32](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/noPayout.ts#L32)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/noPayout.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/noPayout.ts)
 
 Parameters for building a NoPayout PSBT
 
@@ -460,7 +460,7 @@ Parameters for building a NoPayout PSBT
 noPayoutTxHex: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/noPayout.ts:34](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/noPayout.ts#L34)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/noPayout.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/noPayout.ts)
 
 NoPayout transaction hex (unsigned) from VP
 
@@ -470,7 +470,7 @@ NoPayout transaction hex (unsigned) from VP
 challengerPubkey: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/noPayout.ts:36](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/noPayout.ts#L36)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/noPayout.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/noPayout.ts)
 
 Challenger's x-only public key (hex encoded)
 
@@ -480,7 +480,7 @@ Challenger's x-only public key (hex encoded)
 prevouts: object[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/noPayout.ts:38](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/noPayout.ts#L38)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/noPayout.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/noPayout.ts)
 
 Prevouts for all inputs [{script_pubkey, value}] from VP
 
@@ -502,7 +502,7 @@ value: number;
 connectorParams: AssertPayoutNoPayoutConnectorParams;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/noPayout.ts:40](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/noPayout.ts#L40)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/noPayout.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/noPayout.ts)
 
 Parameters for the Assert Payout/NoPayout connector
 
@@ -510,7 +510,7 @@ Parameters for the Assert Payout/NoPayout connector
 
 ### PayoutParams
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts:64](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts#L64)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts)
 
 Parameters for building an unsigned Payout PSBT
 
@@ -525,7 +525,7 @@ Input 1 references the Assert transaction.
 vaultCoreVersion: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts:70](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts#L70)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts)
 
 Vault core (tx-graph) version the vault was registered under — the
 vault's stamped on-chain `vaultCoreVersion`. Selects which graph's
@@ -537,7 +537,7 @@ payout connector scripts are derived.
 payoutTxHex: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts:76](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts#L76)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts)
 
 Payout transaction hex (unsigned)
 This is the transaction that needs to be signed by the depositor
@@ -548,7 +548,7 @@ This is the transaction that needs to be signed by the depositor
 assertTxHex: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts:82](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts#L82)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts)
 
 Assert transaction hex
 Payout input 1 references Assert output 0
@@ -559,7 +559,7 @@ Payout input 1 references Assert output 0
 peginTxHex: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts:88](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts#L88)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts)
 
 Peg-in transaction hex
 This transaction created the vault output that we're spending
@@ -570,7 +570,7 @@ This transaction created the vault output that we're spending
 depositorBtcPubkey: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts:93](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts#L93)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts)
 
 Depositor's BTC public key (x-only, 64-char hex without 0x prefix)
 
@@ -580,7 +580,7 @@ Depositor's BTC public key (x-only, 64-char hex without 0x prefix)
 vaultProviderBtcPubkey: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts:98](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts#L98)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts)
 
 Vault provider's BTC public key (x-only, 64-char hex)
 
@@ -590,7 +590,7 @@ Vault provider's BTC public key (x-only, 64-char hex)
 vaultKeeperBtcPubkeys: string[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts:103](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts#L103)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts)
 
 Vault keeper BTC public keys (x-only, 64-char hex)
 
@@ -600,7 +600,7 @@ Vault keeper BTC public keys (x-only, 64-char hex)
 universalChallengerBtcPubkeys: string[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts:108](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts#L108)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts)
 
 Universal challenger BTC public keys (x-only, 64-char hex)
 
@@ -610,7 +610,7 @@ Universal challenger BTC public keys (x-only, 64-char hex)
 timelockPegin: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts:114](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts#L114)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts)
 
 CSV timelock in blocks for the PegIn output (btc-vault `timelock_pegin`);
 payout input 0's sequence.
@@ -621,7 +621,7 @@ payout input 0's sequence.
 timelockAssert: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts:120](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts#L120)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts)
 
 CSV timelock in blocks on the Assert:0 payout leaf (btc-vault
 `timelock_assert`); payout input 1's sequence.
@@ -632,7 +632,7 @@ CSV timelock in blocks on the Assert:0 payout leaf (btc-vault
 network: Network;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts:125](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts#L125)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts)
 
 Bitcoin network
 
@@ -642,7 +642,7 @@ Bitcoin network
 claimerBtcPubkey: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts:131](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts#L131)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts)
 
 Claimer's x-only BTC public key (64-char hex, no prefix). Drives role
 inference (VP / depositor-as-claimer / VK-claimer) inside `buildPayoutPsbt`.
@@ -653,7 +653,7 @@ inference (VP / depositor-as-claimer / VK-claimer) inside `buildPayoutPsbt`.
 registeredPayoutScriptPubKey: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts:138](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts#L138)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts)
 
 On-chain registered depositor payout scriptPubKey (hex, 0x optional).
 Expected outs[0].script for VP- and depositor-claimer roles; unused for
@@ -665,7 +665,7 @@ VK-claimer (its outs[0].script is derived from `claimerBtcPubkey`).
 commissionBps: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts:145](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts#L145)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts)
 
 VP commission in basis points (`BTCVaultRegistry.vaultProviderCommissionBps`).
 Caps the VP-claimer outs[1].value. The protocol minimum is enforced
@@ -677,7 +677,7 @@ upstream; here only `0 <= bps < 10_000` is checked, for safe cap math.
 protocolFeeRate: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts:152](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts#L152)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts)
 
 Tx-graph fee rate (sat/vB) the graph was built with — the version-locked
 `offchainParams.feeRate` at the vault's stamped `offchainParamsVersion`,
@@ -689,7 +689,7 @@ NOT a live read. Anchors both ends of the fee band.
 councilSize: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts:161](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts#L161)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts)
 
 Security council member count from the locked offchain params version.
 Mirrors the upstream estimator's signature; at the current model pins the
@@ -703,7 +703,7 @@ pinned models.
 vkClaimerPayoutScriptPubKeys: Readonly<Record<string, string>>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts:178](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts#L178)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts)
 
 RFC-006. Expected `outs[0].script` per vault-keeper claimer, keyed by
 lowercased x-only **operation** pubkey (no `0x`), resolved from
@@ -725,7 +725,7 @@ it can be dropped.
 vpCommissionScriptPubKey: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts:186](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts#L186)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts)
 
 RFC-006. Expected `outs[1].script` for the VP-claimer commission output,
 from `BTCVaultRegistry.getPayoutScriptAtEpoch` at the vault's frozen
@@ -736,7 +736,7 @@ it — see acceptedPayoutScriptHexes.
 
 ### PayoutPsbtResult
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts:192](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts#L192)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts)
 
 Result of building an unsigned payout PSBT
 
@@ -748,7 +748,7 @@ Result of building an unsigned payout PSBT
 psbtHex: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts:196](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts#L196)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts)
 
 Unsigned PSBT hex ready for signing
 
@@ -756,7 +756,7 @@ Unsigned PSBT hex ready for signing
 
 ### PrePeginParams
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts:44](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts#L44)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts)
 
 Parameters for building an unfunded Pre-PegIn PSBT
 
@@ -768,7 +768,7 @@ Parameters for building an unfunded Pre-PegIn PSBT
 vaultCoreVersion: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts:51](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts#L51)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts)
 
 Vault core (tx-graph) version to build. Fresh deposits use the contract's
 `ProtocolParams.activeVaultCoreVersion()`; resumed vaults use their
@@ -781,7 +781,7 @@ versions it wasn't compiled with.
 depositorPubkey: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts:53](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts#L53)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts)
 
 Depositor's BTC public key (x-only, 64-char hex without 0x prefix)
 
@@ -791,7 +791,7 @@ Depositor's BTC public key (x-only, 64-char hex without 0x prefix)
 vaultProviderPubkey: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts:55](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts#L55)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts)
 
 Vault provider's BTC public key (x-only, 64-char hex)
 
@@ -801,7 +801,7 @@ Vault provider's BTC public key (x-only, 64-char hex)
 vaultKeeperPubkeys: string[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts:57](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts#L57)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts)
 
 Array of vault keeper BTC public keys (x-only, 64-char hex)
 
@@ -811,7 +811,7 @@ Array of vault keeper BTC public keys (x-only, 64-char hex)
 universalChallengerPubkeys: string[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts:59](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts#L59)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts)
 
 Array of universal challenger BTC public keys (x-only, 64-char hex)
 
@@ -821,7 +821,7 @@ Array of universal challenger BTC public keys (x-only, 64-char hex)
 hashlocks: readonly string[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts:61](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts#L61)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts)
 
 SHA256 hash commitment(s) (64 hex chars = 32 bytes each)
 
@@ -831,7 +831,7 @@ SHA256 hash commitment(s) (64 hex chars = 32 bytes each)
 timelockRefund: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts:63](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts#L63)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts)
 
 CSV timelock in blocks for the HTLC refund path
 
@@ -841,7 +841,7 @@ CSV timelock in blocks for the HTLC refund path
 pegInAmounts: readonly bigint[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts:65](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts#L65)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts)
 
 Amounts to peg in (satoshis), one per deposit
 
@@ -851,7 +851,7 @@ Amounts to peg in (satoshis), one per deposit
 feeRate: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts:67](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts#L67)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts)
 
 TX-graph fee rate in sat/vB from contract offchain params; sizes the depositor claim value
 
@@ -861,7 +861,7 @@ TX-graph fee rate in sat/vB from contract offchain params; sizes the depositor c
 minPeginFeeRate: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts:69](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts#L69)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts)
 
 Minimum PegIn fee rate in sat/vB from contract offchain params; sizes the PegIn tx fee
 
@@ -871,7 +871,7 @@ Minimum PegIn fee rate in sat/vB from contract offchain params; sizes the PegIn 
 numLocalChallengers: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts:71](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts#L71)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts)
 
 Number of local challengers (from contract params)
 
@@ -881,7 +881,7 @@ Number of local challengers (from contract params)
 councilQuorum: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts:73](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts#L73)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts)
 
 M in M-of-N council multisig (from contract params)
 
@@ -891,7 +891,7 @@ M in M-of-N council multisig (from contract params)
 councilSize: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts:75](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts#L75)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts)
 
 N in M-of-N council multisig (from contract params)
 
@@ -901,7 +901,7 @@ N in M-of-N council multisig (from contract params)
 network: Network;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts:77](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts#L77)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts)
 
 Bitcoin network
 
@@ -911,7 +911,7 @@ Bitcoin network
 optional authAnchorHash: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts:85](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts#L85)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts)
 
 Optional 32-byte `SHA256(auth_anchor)` commitment (64-char hex, no
 `0x` prefix). If provided, the Pre-PegIn tx will include an
@@ -923,7 +923,7 @@ Optional 32-byte `SHA256(auth_anchor)` commitment (64-char hex, no
 
 ### PrePeginPsbtResult
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts:99](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts#L99)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts)
 
 Result of building an unfunded Pre-PegIn transaction
 
@@ -935,7 +935,7 @@ Result of building an unfunded Pre-PegIn transaction
 psbtHex: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts:109](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts#L109)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts)
 
 Unfunded transaction hex (no inputs, HTLC outputs + optional
 auth-anchor OP_RETURN + CPFP anchor).
@@ -951,7 +951,7 @@ The caller is responsible for:
 totalOutputValue: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts:111](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts#L111)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts)
 
 Sum of all unfunded outputs — use this for UTXO selection
 
@@ -961,7 +961,7 @@ Sum of all unfunded outputs — use this for UTXO selection
 htlcValues: readonly bigint[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts:117](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts#L117)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts)
 
 HTLC output values in satoshis, one per deposit. Each includes
 peginAmount + depositorClaimValue + p2aAnchorValue + minPeginFee (the
@@ -973,7 +973,7 @@ anchor term is 0 for graph versions without a P2A anchor, 240 for v2).
 htlcScriptPubKeys: readonly string[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts:119](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts#L119)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts)
 
 HTLC output scriptPubKeys (hex encoded), one per deposit
 
@@ -983,7 +983,7 @@ HTLC output scriptPubKeys (hex encoded), one per deposit
 htlcAddresses: readonly string[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts:121](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts#L121)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts)
 
 HTLC Taproot addresses, one per deposit
 
@@ -993,7 +993,7 @@ HTLC Taproot addresses, one per deposit
 peginAmounts: readonly bigint[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts:123](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts#L123)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts)
 
 Pegin amounts in satoshis, one per deposit
 
@@ -1003,7 +1003,7 @@ Pegin amounts in satoshis, one per deposit
 depositorClaimValue: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts:125](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts#L125)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts)
 
 Depositor claim value computed by WASM from contract parameters
 
@@ -1013,7 +1013,7 @@ Depositor claim value computed by WASM from contract parameters
 authAnchorVout: number | null;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts:131](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts#L131)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts)
 
 Vout index of the auth-anchor `OP_RETURN` output if one was
 included (i.e. `authAnchorHash` was provided), or `null` if not.
@@ -1025,7 +1025,7 @@ Always equals `htlcValues.length` when present.
 minPeginFee: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts:137](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts#L137)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts)
 
 Minimum PegIn fee (sats), independently computed and asserted against
 `htlcValues`' implied reserve by assertWasmPeginSizing. Reuse
@@ -1035,7 +1035,7 @@ this instead of recomputing — it is already the cross-checked value.
 
 ### BuildPeginTxParams
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts:143](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts#L143)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts)
 
 Parameters for building the PegIn transaction from a funded Pre-PegIn tx
 
@@ -1047,7 +1047,7 @@ Parameters for building the PegIn transaction from a funded Pre-PegIn tx
 prePeginParams: PrePeginParams;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts:145](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts#L145)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts)
 
 Same PrePeginParams used to create the Pre-PegIn transaction
 
@@ -1057,7 +1057,7 @@ Same PrePeginParams used to create the Pre-PegIn transaction
 timelockPegin: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts:147](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts#L147)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts)
 
 CSV timelock in blocks for the PegIn vault output
 
@@ -1067,7 +1067,7 @@ CSV timelock in blocks for the PegIn vault output
 fundedPrePeginTxHex: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts:149](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts#L149)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts)
 
 Hex-encoded funded Pre-PegIn transaction
 
@@ -1077,7 +1077,7 @@ Hex-encoded funded Pre-PegIn transaction
 htlcVout: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts:151](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts#L151)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts)
 
 Index of the HTLC output to spend
 
@@ -1085,7 +1085,7 @@ Index of the HTLC output to spend
 
 ### PeginTxResult
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts:157](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts#L157)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts)
 
 Result of building the PegIn transaction
 
@@ -1097,7 +1097,7 @@ Result of building the PegIn transaction
 txHex: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts:163](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts#L163)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts)
 
 PegIn transaction hex. 1 input spending the HTLC; outputs are
 version-shaped: v1 = vault + depositor claim, v2 = vault + depositor
@@ -1109,7 +1109,7 @@ claim + P2A anchor at vout 2 (nVersion 3 / TRUC).
 txid: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts:165](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts#L165)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts)
 
 PegIn transaction ID
 
@@ -1119,7 +1119,7 @@ PegIn transaction ID
 vaultScriptPubKey: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts:167](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts#L167)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts)
 
 Vault output scriptPubKey (hex encoded)
 
@@ -1129,7 +1129,7 @@ Vault output scriptPubKey (hex encoded)
 vaultValue: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts:169](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts#L169)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts)
 
 Vault output value in satoshis
 
@@ -1137,7 +1137,7 @@ Vault output value in satoshis
 
 ### BuildPeginInputPsbtParams
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/peginInput.ts:32](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/peginInput.ts#L32)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/peginInput.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/peginInput.ts)
 
 Parameters for building the PegIn input PSBT
 
@@ -1149,7 +1149,7 @@ Parameters for building the PegIn input PSBT
 vaultCoreVersion: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/peginInput.ts:38](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/peginInput.ts#L38)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/peginInput.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/peginInput.ts)
 
 Vault core (tx-graph) version the Pre-PegIn was built with. Must match
 the version passed to buildPrePeginPsbt() so the HTLC connector scripts
@@ -1161,7 +1161,7 @@ are derived for the same graph.
 peginTxHex: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/peginInput.ts:43](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/peginInput.ts#L43)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/peginInput.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/peginInput.ts)
 
 PegIn transaction hex (1 input spending Pre-PegIn HTLC output 0).
 Returned by buildPeginTxFromFundedPrePegin().
@@ -1172,7 +1172,7 @@ Returned by buildPeginTxFromFundedPrePegin().
 fundedPrePeginTxHex: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/peginInput.ts:48](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/peginInput.ts#L48)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/peginInput.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/peginInput.ts)
 
 Funded Pre-PegIn transaction hex.
 Used to look up the HTLC output that the PegIn input spends.
@@ -1183,7 +1183,7 @@ Used to look up the HTLC output that the PegIn input spends.
 depositorPubkey: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/peginInput.ts:50](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/peginInput.ts#L50)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/peginInput.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/peginInput.ts)
 
 Depositor's BTC public key (x-only, 64-char hex)
 
@@ -1193,7 +1193,7 @@ Depositor's BTC public key (x-only, 64-char hex)
 vaultProviderPubkey: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/peginInput.ts:52](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/peginInput.ts#L52)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/peginInput.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/peginInput.ts)
 
 Vault provider's BTC public key (x-only, 64-char hex)
 
@@ -1203,7 +1203,7 @@ Vault provider's BTC public key (x-only, 64-char hex)
 vaultKeeperPubkeys: string[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/peginInput.ts:54](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/peginInput.ts#L54)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/peginInput.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/peginInput.ts)
 
 Vault keeper BTC public keys (x-only, 64-char hex)
 
@@ -1213,7 +1213,7 @@ Vault keeper BTC public keys (x-only, 64-char hex)
 universalChallengerPubkeys: string[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/peginInput.ts:56](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/peginInput.ts#L56)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/peginInput.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/peginInput.ts)
 
 Universal challenger BTC public keys (x-only, 64-char hex)
 
@@ -1223,7 +1223,7 @@ Universal challenger BTC public keys (x-only, 64-char hex)
 hashlock: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/peginInput.ts:58](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/peginInput.ts#L58)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/peginInput.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/peginInput.ts)
 
 SHA256 hash commitment (64 hex chars = 32 bytes)
 
@@ -1233,7 +1233,7 @@ SHA256 hash commitment (64 hex chars = 32 bytes)
 timelockRefund: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/peginInput.ts:60](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/peginInput.ts#L60)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/peginInput.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/peginInput.ts)
 
 CSV timelock in blocks for the HTLC refund path
 
@@ -1243,7 +1243,7 @@ CSV timelock in blocks for the HTLC refund path
 network: Network;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/peginInput.ts:62](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/peginInput.ts#L62)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/peginInput.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/peginInput.ts)
 
 Bitcoin network
 
@@ -1251,7 +1251,7 @@ Bitcoin network
 
 ### BuildPeginInputPsbtResult
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/peginInput.ts:68](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/peginInput.ts#L68)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/peginInput.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/peginInput.ts)
 
 Result of building the PegIn input PSBT
 
@@ -1263,7 +1263,7 @@ Result of building the PegIn input PSBT
 psbtHex: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/peginInput.ts:70](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/peginInput.ts#L70)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/peginInput.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/peginInput.ts)
 
 PSBT hex for the depositor to sign
 
@@ -1271,7 +1271,7 @@ PSBT hex for the depositor to sign
 
 ### BuildRefundPsbtParams
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/refund.ts:36](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/refund.ts#L36)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/refund.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/refund.ts)
 
 Parameters for building a refund PSBT
 
@@ -1283,7 +1283,7 @@ Parameters for building a refund PSBT
 prePeginParams: PrePeginParams;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/refund.ts:38](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/refund.ts#L38)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/refund.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/refund.ts)
 
 Same PrePeginParams used when the original Pre-PegIn tx was created
 
@@ -1293,7 +1293,7 @@ Same PrePeginParams used when the original Pre-PegIn tx was created
 fundedPrePeginTxHex: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/refund.ts:40](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/refund.ts#L40)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/refund.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/refund.ts)
 
 Funded Pre-PegIn transaction hex (the tx whose HTLC output is being refunded)
 
@@ -1303,7 +1303,7 @@ Funded Pre-PegIn transaction hex (the tx whose HTLC output is being refunded)
 htlcVout: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/refund.ts:42](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/refund.ts#L42)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/refund.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/refund.ts)
 
 Index of the HTLC output in the Pre-PegIn transaction
 
@@ -1313,7 +1313,7 @@ Index of the HTLC output in the Pre-PegIn transaction
 refundFee: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/refund.ts:44](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/refund.ts#L44)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/refund.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/refund.ts)
 
 Transaction fee in satoshis for the refund transaction
 
@@ -1323,7 +1323,7 @@ Transaction fee in satoshis for the refund transaction
 hashlock: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/refund.ts:46](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/refund.ts#L46)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/refund.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/refund.ts)
 
 SHA256 hash commitment for the HTLC (64 hex chars, no 0x prefix)
 
@@ -1331,7 +1331,7 @@ SHA256 hash commitment for the HTLC (64 hex chars, no 0x prefix)
 
 ### BuildRefundPsbtResult
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/refund.ts:52](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/refund.ts#L52)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/refund.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/refund.ts)
 
 Result of building a refund PSBT
 
@@ -1343,7 +1343,7 @@ Result of building a refund PSBT
 psbtHex: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/refund.ts:54](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/refund.ts#L54)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/refund.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/refund.ts)
 
 PSBT hex ready for depositor signing
 
@@ -1351,7 +1351,7 @@ PSBT hex ready for depositor signing
 
 ### VerifyScriptPathSchnorrSignatureParams
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/verifyScriptPathSchnorrSignature.ts:89](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/verifyScriptPathSchnorrSignature.ts#L89)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/verifyScriptPathSchnorrSignature.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/verifyScriptPathSchnorrSignature.ts)
 
 #### Properties
 
@@ -1361,7 +1361,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/verifyScriptPa
 requestedPsbtHex: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/verifyScriptPathSchnorrSignature.ts:95](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/verifyScriptPathSchnorrSignature.ts#L95)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/verifyScriptPathSchnorrSignature.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/verifyScriptPathSchnorrSignature.ts)
 
 Hex of the PSBT we built locally and sent to the wallet (the trusted
 source of prevout scripts/values and the leaf script). NOT the
@@ -1373,7 +1373,7 @@ wallet-returned PSBT.
 signatureHex: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/verifyScriptPathSchnorrSignature.ts:97](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/verifyScriptPathSchnorrSignature.ts#L97)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/verifyScriptPathSchnorrSignature.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/verifyScriptPathSchnorrSignature.ts)
 
 The 64-byte Schnorr signature extracted from the wallet's response (128 hex chars).
 
@@ -1383,7 +1383,7 @@ The 64-byte Schnorr signature extracted from the wallet's response (128 hex char
 signerXOnlyPubkeyHex: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/verifyScriptPathSchnorrSignature.ts:99](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/verifyScriptPathSchnorrSignature.ts#L99)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/verifyScriptPathSchnorrSignature.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/verifyScriptPathSchnorrSignature.ts)
 
 X-only public key (64 hex chars) the wallet signed the script-path leaf with.
 
@@ -1393,7 +1393,7 @@ X-only public key (64 hex chars) the wallet signed the script-path leaf with.
 inputIndex: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/verifyScriptPathSchnorrSignature.ts:101](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/verifyScriptPathSchnorrSignature.ts#L101)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/verifyScriptPathSchnorrSignature.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/verifyScriptPathSchnorrSignature.ts)
 
 Index of the input the signature is for.
 
@@ -1401,7 +1401,7 @@ Index of the input the signature is for.
 
 ### PayoutScriptParams
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/scripts/payout.ts:32](../../packages/babylon-ts-sdk/src/tbv/core/primitives/scripts/payout.ts#L32)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/scripts/payout.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/scripts/payout.ts)
 
 Parameters for creating a payout script.
 
@@ -1416,7 +1416,7 @@ the taproot script that controls how funds can be spent from the vault.
 vaultCoreVersion: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/scripts/payout.ts:38](../../packages/babylon-ts-sdk/src/tbv/core/primitives/scripts/payout.ts#L38)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/scripts/payout.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/scripts/payout.ts)
 
 Vault core (tx-graph) version the vault was registered under — the
 vault's stamped on-chain `vaultCoreVersion`. Selects which graph's
@@ -1428,7 +1428,7 @@ payout connector the WASM derives.
 depositor: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/scripts/payout.ts:46](../../packages/babylon-ts-sdk/src/tbv/core/primitives/scripts/payout.ts#L46)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/scripts/payout.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/scripts/payout.ts)
 
 Depositor's BTC public key (x-only, 64-char hex without 0x prefix).
 
@@ -1441,7 +1441,7 @@ payout transactions to authorize fund distribution.
 vaultProvider: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/scripts/payout.ts:54](../../packages/babylon-ts-sdk/src/tbv/core/primitives/scripts/payout.ts#L54)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/scripts/payout.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/scripts/payout.ts)
 
 Vault provider's BTC public key (x-only, 64-char hex without 0x prefix).
 
@@ -1454,7 +1454,7 @@ The service provider managing vault operations. Also referred to as
 vaultKeepers: string[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/scripts/payout.ts:61](../../packages/babylon-ts-sdk/src/tbv/core/primitives/scripts/payout.ts#L61)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/scripts/payout.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/scripts/payout.ts)
 
 Array of vault keeper BTC public keys (x-only, 64-char hex without 0x prefix).
 
@@ -1466,7 +1466,7 @@ Vault keepers participate in vault operations and script spending conditions.
 universalChallengers: string[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/scripts/payout.ts:68](../../packages/babylon-ts-sdk/src/tbv/core/primitives/scripts/payout.ts#L68)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/scripts/payout.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/scripts/payout.ts)
 
 Array of universal challenger BTC public keys (x-only, 64-char hex without 0x prefix).
 
@@ -1478,7 +1478,7 @@ These parties can challenge the vault under certain conditions.
 timelockPegin: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/scripts/payout.ts:73](../../packages/babylon-ts-sdk/src/tbv/core/primitives/scripts/payout.ts#L73)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/scripts/payout.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/scripts/payout.ts)
 
 CSV timelock in blocks for the PegIn output.
 
@@ -1488,7 +1488,7 @@ CSV timelock in blocks for the PegIn output.
 network: Network;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/scripts/payout.ts:81](../../packages/babylon-ts-sdk/src/tbv/core/primitives/scripts/payout.ts#L81)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/scripts/payout.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/scripts/payout.ts)
 
 Bitcoin network for script generation.
 
@@ -1499,7 +1499,7 @@ address encoding compatibility.
 
 ### PayoutScriptResult
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/scripts/payout.ts:90](../../packages/babylon-ts-sdk/src/tbv/core/primitives/scripts/payout.ts#L90)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/scripts/payout.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/scripts/payout.ts)
 
 Result of creating a payout script.
 
@@ -1514,7 +1514,7 @@ payout transactions from the vault.
 payoutScript: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/scripts/payout.ts:98](../../packages/babylon-ts-sdk/src/tbv/core/primitives/scripts/payout.ts#L98)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/scripts/payout.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/scripts/payout.ts)
 
 The payout script hex used in taproot script path spending.
 
@@ -1528,7 +1528,7 @@ tapLeafScript for PSBT signing.
 taprootScriptHash: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/scripts/payout.ts:106](../../packages/babylon-ts-sdk/src/tbv/core/primitives/scripts/payout.ts#L106)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/scripts/payout.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/scripts/payout.ts)
 
 The taproot script hash (leaf hash) for the payout script.
 
@@ -1541,7 +1541,7 @@ Required for computing the control block during script path spending.
 scriptPubKey: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/scripts/payout.ts:114](../../packages/babylon-ts-sdk/src/tbv/core/primitives/scripts/payout.ts#L114)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/scripts/payout.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/scripts/payout.ts)
 
 The full scriptPubKey for the vault output address.
 
@@ -1554,7 +1554,7 @@ used when creating the vault output in a peg-in transaction.
 address: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/scripts/payout.ts:122](../../packages/babylon-ts-sdk/src/tbv/core/primitives/scripts/payout.ts#L122)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/scripts/payout.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/scripts/payout.ts)
 
 The vault Bitcoin address derived from the script.
 
@@ -1567,7 +1567,7 @@ that can be used to receive funds into the vault.
 payoutControlBlock: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/scripts/payout.ts:130](../../packages/babylon-ts-sdk/src/tbv/core/primitives/scripts/payout.ts#L130)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/scripts/payout.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/scripts/payout.ts)
 
 Serialized control block for Taproot script path spend (hex encoded).
 
@@ -1578,7 +1578,7 @@ tapLeafScript when building payout PSBTs.
 
 ### WalletPubkeyValidationResult
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts:228](../../packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts#L228)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts)
 
 Result of validating a wallet public key against an expected depositor public key.
 
@@ -1590,7 +1590,7 @@ Result of validating a wallet public key against an expected depositor public ke
 walletPubkeyRaw: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts:230](../../packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts#L230)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts)
 
 Wallet's raw public key (as returned by wallet, may be compressed)
 
@@ -1600,7 +1600,7 @@ Wallet's raw public key (as returned by wallet, may be compressed)
 walletPubkeyXOnly: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts:232](../../packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts#L232)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts)
 
 Wallet's public key in x-only format (32 bytes, 64 hex chars)
 
@@ -1610,7 +1610,7 @@ Wallet's public key in x-only format (32 bytes, 64 hex chars)
 depositorPubkey: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts:234](../../packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts#L234)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts)
 
 The validated depositor public key (x-only format)
 
@@ -1622,7 +1622,7 @@ The validated depositor public key (x-only format)
 type Network = "bitcoin" | "testnet" | "regtest" | "signet";
 ```
 
-Defined in: packages/babylon-tbv-rust-wasm/dist/types.d.ts:4
+Defined in: packages/babylon-tbv-rust-wasm/dist/types.d.ts
 
 Bitcoin network types supported by the vault system
 
@@ -1634,7 +1634,7 @@ Bitcoin network types supported by the vault system
 type VaultId = `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/index.ts:106](../../packages/babylon-ts-sdk/src/tbv/core/primitives/index.ts#L106)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/index.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/index.ts)
 
 0x-prefixed bytes32, keccak256(abi.encode(peginTxHash, depositor)).
 On-chain vault identifier used by BTCVaultRegistry contract.
@@ -1656,7 +1656,7 @@ function computeMinClaimValue(
 feeRate): Promise<bigint>;
 ```
 
-Defined in: packages/babylon-tbv-rust-wasm/dist/index.d.ts:50
+Defined in: packages/babylon-tbv-rust-wasm/dist/index.d.ts
 
 Compute the minimum depositor claim value (PegIn output 1) in satoshis.
 
@@ -1705,7 +1705,7 @@ function computeMinPeginFee(
 minPeginFeeRate): Promise<bigint>;
 ```
 
-Defined in: packages/babylon-tbv-rust-wasm/dist/index.d.ts:61
+Defined in: packages/babylon-tbv-rust-wasm/dist/index.d.ts
 
 Compute the minimum PegIn (activation) transaction fee in satoshis.
 
@@ -1746,7 +1746,7 @@ prediction whose witness shape depends on the VK + UC signer count.
 function peginP2aAnchorOutput(txGraphVersion): Promise<PeginP2aAnchorInfo | null>;
 ```
 
-Defined in: packages/babylon-tbv-rust-wasm/dist/index.d.ts:82
+Defined in: packages/babylon-tbv-rust-wasm/dist/index.d.ts
 
 The PegIn transaction's P2A (pay-to-anchor) output for a graph version, or
 `null` when that version's PegIn carries no anchor (v1). The facade returns
@@ -1772,7 +1772,7 @@ script `51024e73`.
 function validatePeginP2aAnchor(txGraphVersion, txHex): Promise<void>;
 ```
 
-Defined in: packages/babylon-tbv-rust-wasm/dist/index.d.ts:89
+Defined in: packages/babylon-tbv-rust-wasm/dist/index.d.ts
 
 Validate a PegIn transaction's P2A anchor against a graph version's rules:
 v2 requires the exact anchor (240 sats, vout 2, P2A script) and v1 requires
@@ -1801,7 +1801,7 @@ checked as v1 fails closed, and vice versa.
 function supportedTxGraphVersions(): Promise<number[]>;
 ```
 
-Defined in: packages/babylon-tbv-rust-wasm/dist/index.d.ts:100
+Defined in: packages/babylon-tbv-rust-wasm/dist/index.d.ts
 
 Tx graph versions the shipped vault-wasm binary can build. Callers must
 preflight the required version (fresh: active; resume: stamped) against
@@ -1824,7 +1824,7 @@ byte-parity tests, not in a per-call version echo.
 function deriveVaultId(peginTxHash, depositor): Promise<string>;
 ```
 
-Defined in: packages/babylon-tbv-rust-wasm/dist/index.d.ts:126
+Defined in: packages/babylon-tbv-rust-wasm/dist/index.d.ts
 
 Derives the vault ID from a PegIn transaction hash and depositor ETH address.
 
@@ -1862,7 +1862,7 @@ function computeNumLocalChallengers(
    depositorPubkey): number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/challengers.ts:34](../../packages/babylon-ts-sdk/src/tbv/core/primitives/challengers.ts#L34)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/challengers.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/challengers.ts)
 
 Compute the number of local challengers for a vault.
 
@@ -1906,7 +1906,7 @@ Number of local challengers
 function assertPsbtUnsignedTxMatches(params): void;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/assertPsbtUnsignedTxMatches.ts:73](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/assertPsbtUnsignedTxMatches.ts#L73)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/assertPsbtUnsignedTxMatches.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/assertPsbtUnsignedTxMatches.ts)
 
 Compare two PSBTs and throw `PsbtSubstitutionError` unless they encode
 the same unsigned transaction (version, locktime, inputs, outputs).
@@ -1937,7 +1937,7 @@ Error if either PSBT cannot be parsed
 function buildChallengeAssertPsbt(params): Promise<string>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/challengeAssert.ts:58](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/challengeAssert.ts#L58)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/challengeAssert.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/challengeAssert.ts)
 
 Build unsigned ChallengeAssert PSBT.
 
@@ -1984,7 +1984,7 @@ If two inputs reference the same Assert output index
 function buildNoPayoutPsbt(params): Promise<string>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/noPayout.ts:52](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/noPayout.ts#L52)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/noPayout.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/noPayout.ts)
 
 Build unsigned NoPayout PSBT.
 
@@ -2013,7 +2013,7 @@ Unsigned PSBT hex ready for signing
 function buildPayoutPsbt(params): Promise<PayoutPsbtResult>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts:232](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts#L232)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts)
 
 Build unsigned Payout PSBT for depositor to sign.
 
@@ -2101,7 +2101,7 @@ function extractPayoutSignature(
    inputIndex): string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts:730](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts#L730)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts)
 
 Extract Schnorr signature from signed payout PSBT.
 
@@ -2155,7 +2155,7 @@ If the signature has an unexpected length
 function buildPrePeginPsbt(params): Promise<PrePeginPsbtResult>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts:183](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts#L183)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts)
 
 Build unfunded Pre-PegIn transaction using WASM.
 
@@ -2189,7 +2189,7 @@ If WASM initialization fails or parameters are invalid
 function buildPeginTxFromFundedPrePegin(params): Promise<PeginTxResult>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts:281](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts#L281)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts)
 
 Build the PegIn transaction from a funded Pre-PegIn transaction.
 
@@ -2222,7 +2222,7 @@ If WASM initialization fails or parameters are invalid
 function buildPeginInputPsbt(params): Promise<BuildPeginInputPsbtResult>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/peginInput.ts:92](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/peginInput.ts#L92)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/peginInput.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/peginInput.ts)
 
 Build PSBT for depositor to sign the PegIn transaction's HTLC leaf 0 input.
 
@@ -2270,7 +2270,7 @@ If Pre-PegIn tx output 0 is not found
 function extractPeginInputSignature(signedPsbtHex, depositorPubkey): string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/peginInput.ts:221](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/peginInput.ts#L221)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/peginInput.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/peginInput.ts)
 
 Extract the depositor's Schnorr signature from a signed PegIn input PSBT.
 
@@ -2314,7 +2314,7 @@ If no signature is found for the depositor's key
 function finalizePeginInputPsbt(signedPsbtHex): string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/peginInput.ts:272](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/peginInput.ts#L272)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/peginInput.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/peginInput.ts)
 
 Finalize a signed PegIn input PSBT and return the depositor-signed transaction hex.
 
@@ -2343,7 +2343,7 @@ Depositor-signed PegIn transaction hex with full taproot witness stack
 function buildRefundPsbt(params): Promise<BuildRefundPsbtResult>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/refund.ts:74](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/refund.ts#L74)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/refund.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/refund.ts)
 
 Build a PSBT for signing the refund transaction.
 
@@ -2386,7 +2386,7 @@ If the refund transaction does not have exactly 1 input
 function assertScriptPathSchnorrSignature(params): void;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/verifyScriptPathSchnorrSignature.ts:112](../../packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/verifyScriptPathSchnorrSignature.ts#L112)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/verifyScriptPathSchnorrSignature.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/verifyScriptPathSchnorrSignature.ts)
 
 Assert that `signatureHex` is a valid BIP-340 Schnorr signature by the
 `signerXOnlyPubkeyHex` key over the Taproot script-path sighash of
@@ -2415,7 +2415,7 @@ If the requested PSBT is malformed, lacks the prevout/leaf data needed
 function createPayoutScript(params): Promise<PayoutScriptResult>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/scripts/payout.ts:150](../../packages/babylon-ts-sdk/src/tbv/core/primitives/scripts/payout.ts#L150)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/scripts/payout.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/scripts/payout.ts)
 
 Create payout script and taproot information using WASM.
 
@@ -2455,7 +2455,7 @@ This script is used internally by [buildPayoutPsbt](#buildpayoutpsbt).
 function stripHexPrefix(hex): string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts:61](../../packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts#L61)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts)
 
 Strip "0x" prefix from hex string if present.
 
@@ -2484,7 +2484,7 @@ Hex string without "0x" prefix
 function ensureHexPrefix(hex): `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts:74](../../packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts#L74)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts)
 
 Ensure "0x" prefix on a hex string, returning viem's Hex type.
 
@@ -2513,7 +2513,7 @@ Hex string with or without "0x" prefix
 function hexToUint8Array(hex): Uint8Array;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts:87](../../packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts#L87)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts)
 
 Convert hex string to Uint8Array.
 
@@ -2543,7 +2543,7 @@ If hex is invalid
 function uint8ArrayToHex(bytes): string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts:105](../../packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts#L105)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts)
 
 Convert Uint8Array to hex string (without 0x prefix).
 
@@ -2569,7 +2569,7 @@ Hex string without 0x prefix
 function toXOnly(pubKey): Uint8Array;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts:133](../../packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts#L133)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts)
 
 Convert a 33-byte public key to 32-byte x-only format (removes first byte).
 
@@ -2598,7 +2598,7 @@ If the input is already 32 bytes, returns it unchanged.
 function processPublicKeyToXOnly(publicKeyHex): string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts:166](../../packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts#L166)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts)
 
 Process and convert a public key to x-only format (32 bytes hex).
 
@@ -2639,7 +2639,7 @@ If public key format is invalid or contains invalid hex characters
 function canonicalizeBtcPubkey(publicKeyHex): string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts:207](../../packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts#L207)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts)
 
 Normalize a public key to the one form two keys can be compared in:
 lowercase x-only hex, no `0x`.
@@ -2674,7 +2674,7 @@ If the key is not valid hex or has an unexpected length
 function isValidHex(hex): boolean;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts:220](../../packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts#L220)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts)
 
 Validate hex string format.
 
@@ -2703,7 +2703,7 @@ true if valid hex string
 function validateWalletPubkey(walletPubkeyRaw, expectedDepositorPubkey): WalletPubkeyValidationResult;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts:252](../../packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts#L252)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts)
 
 Validate that a wallet's public key matches the expected depositor public key.
 
@@ -2749,7 +2749,7 @@ If wallet pubkey doesn't match expected depositor pubkey
 function formatSatoshisToBtc(satoshis): string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts:285](../../packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts#L285)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts)
 
 Format satoshis as a human-readable BTC string with trailing zeros removed.
 
@@ -2771,7 +2771,7 @@ Format satoshis as a human-readable BTC string with trailing zeros removed.
 function deriveTaprootAddress(publicKeyHex, network): string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts:351](../../packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts#L351)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts)
 
 Derive a Taproot (P2TR) address from a public key.
 
@@ -2803,7 +2803,7 @@ Taproot address (bc1p... / tb1p... / bcrt1p...)
 function getSortedXOnlyPubkeys(pubkeys): string[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts:376](../../packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts#L376)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts)
 
 Strip `0x` prefixes and lex-sort an array of x-only public keys.
 
@@ -2832,7 +2832,7 @@ Lex-sorted array of pubkeys with `0x` prefix stripped
 function deriveBip86ScriptPubKeyHex(xOnlyPubkeyHex): string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts:396](../../packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts#L396)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts)
 
 Derive the BIP-86 P2TR scriptPubKey (`0x`-prefixed hex) from an x-only
 public key.
@@ -2871,7 +2871,7 @@ If `xOnlyPubkeyHex` is not exactly 64 hex chars after prefix stripping
 function deriveNativeSegwitAddress(publicKeyHex, network): string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts:421](../../packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts#L421)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts)
 
 Derive a Native SegWit (P2WPKH) address from a compressed public key.
 
@@ -2910,7 +2910,7 @@ function isAddressFromPublicKey(
    network): boolean;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts:459](../../packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts#L459)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts)
 
 Validate that a BTC address was derived from the given public key.
 
@@ -2958,7 +2958,7 @@ true if the address matches the public key
 function assertValidVaultCoreVersion(version, source): void;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/vaultCoreVersion.ts:29](../../packages/babylon-ts-sdk/src/tbv/core/primitives/vaultCoreVersion.ts#L29)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/vaultCoreVersion.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/vaultCoreVersion.ts)
 
 Assert a vault core version is a well-formed on-chain value: an integer in
 `[1, 65535]`. Mirrors the contract (`uint16`, setter rejects 0) and vaultd

--- a/packages/babylon-ts-sdk/docs/api/services.md
+++ b/packages/babylon-ts-sdk/docs/api/services.md
@@ -9,7 +9,7 @@ Callers own the wallet; services own the orchestration.
 
 ### ParticipantKeyDriftError
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegisteredParticipantKeys.ts:52](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegisteredParticipantKeys.ts#L52)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegisteredParticipantKeys.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegisteredParticipantKeys.ts)
 
 Participant operation keys drifted between building the Bitcoin artifacts
 and the vault freezing its epochs.
@@ -43,7 +43,7 @@ So: callers must keep the pending record when they catch this.
 new ParticipantKeyDriftError(message): ParticipantKeyDriftError;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegisteredParticipantKeys.ts:53](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegisteredParticipantKeys.ts#L53)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegisteredParticipantKeys.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegisteredParticipantKeys.ts)
 
 ###### Parameters
 
@@ -65,7 +65,7 @@ Error.constructor
 
 ### RegisteredVaultVersionMismatchError
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegisteredVaultVersions.ts:23](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegisteredVaultVersions.ts#L23)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegisteredVaultVersions.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegisteredVaultVersions.ts)
 
 #### Extends
 
@@ -79,7 +79,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegiste
 new RegisteredVaultVersionMismatchError(message): RegisteredVaultVersionMismatchError;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegisteredVaultVersions.ts:24](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegisteredVaultVersions.ts#L24)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegisteredVaultVersions.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegisteredVaultVersions.ts)
 
 ###### Parameters
 
@@ -101,7 +101,7 @@ Error.constructor
 
 ### BIP68NotMatureError
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/errors.ts:15](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/errors.ts#L15)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/errors.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/refund/errors.ts)
 
 Thrown when the broadcast transport rejects the refund tx because the CSV
 timelock has not yet matured (BIP68 non-final). Callers can surface a
@@ -120,7 +120,7 @@ available via [cause](#cause).
 new BIP68NotMatureError(vaultId, cause): BIP68NotMatureError;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/errors.ts:19](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/errors.ts#L19)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/errors.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/refund/errors.ts)
 
 ###### Parameters
 
@@ -150,7 +150,7 @@ Error.constructor
 readonly vaultId: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/errors.ts:16](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/errors.ts#L16)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/errors.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/refund/errors.ts)
 
 ##### cause
 
@@ -158,7 +158,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/errors.ts:16](
 readonly cause: Error;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/errors.ts:17](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/errors.ts#L17)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/errors.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/refund/errors.ts)
 
 ###### Overrides
 
@@ -170,7 +170,7 @@ Error.cause
 
 ### EthContractWriteCall
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVault.ts:58](../../packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVault.ts#L58)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVault.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVault.ts)
 
 A single ETH contract-write call. The SDK assembles these; the caller
 executes them via viem, wagmi, a wallet provider, or any other transport.
@@ -183,7 +183,7 @@ executes them via viem, wagmi, a wallet provider, or any other transport.
 address: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVault.ts:59](../../packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVault.ts#L59)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVault.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVault.ts)
 
 ##### abi
 
@@ -191,7 +191,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVa
 abi: Abi;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVault.ts:60](../../packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVault.ts#L60)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVault.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVault.ts)
 
 ##### functionName
 
@@ -199,7 +199,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVa
 functionName: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVault.ts:61](../../packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVault.ts#L61)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVault.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVault.ts)
 
 ##### args
 
@@ -207,13 +207,13 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVa
 args: readonly unknown[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVault.ts:62](../../packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVault.ts#L62)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVault.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVault.ts)
 
 ***
 
 ### EthContractWriteResult
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVault.ts:70](../../packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVault.ts#L70)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVault.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVault.ts)
 
 Minimum shape the SDK requires from any contract-write result. Callers may
 return richer objects (e.g. including the receipt) — the SDK propagates
@@ -227,13 +227,13 @@ them unchanged via the generic parameter on [EthContractWriter](#ethcontractwrit
 transactionHash: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVault.ts:71](../../packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVault.ts#L71)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVault.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVault.ts)
 
 ***
 
 ### ActivateVaultInput
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVault.ts:83](../../packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVault.ts#L83)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVault.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVault.ts)
 
 #### Type Parameters
 
@@ -249,7 +249,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVa
 btcVaultRegistryAddress: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVault.ts:87](../../packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVault.ts#L87)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVault.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVault.ts)
 
 BTCVaultRegistry contract address (env-specific).
 
@@ -259,7 +259,7 @@ BTCVaultRegistry contract address (env-specific).
 vaultId: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVault.ts:89](../../packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVault.ts#L89)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVault.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVault.ts)
 
 Vault ID (bytes32, 0x-prefixed).
 
@@ -269,7 +269,7 @@ Vault ID (bytes32, 0x-prefixed).
 secret: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVault.ts:94](../../packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVault.ts#L94)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVault.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVault.ts)
 
 HTLC secret preimage (bytes32). A missing `0x` prefix or an uppercase
 `0X` prefix is normalised before validation.
@@ -280,7 +280,7 @@ HTLC secret preimage (bytes32). A missing `0x` prefix or an uppercase
 optional hashlock: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVault.ts:99](../../packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVault.ts#L99)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVault.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVault.ts)
 
 Optional hashlock for client-side pre-validation. When provided, the SDK
 rejects before calling `writeContract` if `sha256(secret) != hashlock`.
@@ -291,7 +291,7 @@ rejects before calling `writeContract` if `sha256(secret) != hashlock`.
 activationMetadata: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVault.ts:106](../../packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVault.ts#L106)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVault.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVault.ts)
 
 Activation metadata passed through to the contract. Required to keep
 the "empty metadata" convention explicit at the call site — pass `"0x"`
@@ -304,7 +304,7 @@ string with an even number of hex chars.
 writeContract: EthContractWriter<R>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVault.ts:108](../../packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVault.ts#L108)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVault.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVault.ts)
 
 Caller-provided write callback — see [EthContractWriter](#ethcontractwriter).
 
@@ -314,7 +314,7 @@ Caller-provided write callback — see [EthContractWriter](#ethcontractwriter).
 optional signal: AbortSignal;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVault.ts:115](../../packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVault.ts#L115)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVault.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVault.ts)
 
 Optional abort signal. Checked before validation runs; since validation
 is fully synchronous, cancellation between validation and the write is
@@ -325,7 +325,7 @@ cancellation support for that window.
 
 ### ActivateVaultAndRedeemInput
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVault.ts:198](../../packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVault.ts#L198)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVault.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVault.ts)
 
 #### Type Parameters
 
@@ -341,7 +341,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVa
 btcVaultRegistryAddress: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVault.ts:202](../../packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVault.ts#L202)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVault.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVault.ts)
 
 BTCVaultRegistry contract address (env-specific).
 
@@ -351,7 +351,7 @@ BTCVaultRegistry contract address (env-specific).
 vaultId: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVault.ts:204](../../packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVault.ts#L204)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVault.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVault.ts)
 
 Vault ID (bytes32, 0x-prefixed).
 
@@ -361,7 +361,7 @@ Vault ID (bytes32, 0x-prefixed).
 secret: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVault.ts:209](../../packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVault.ts#L209)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVault.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVault.ts)
 
 HTLC secret preimage (bytes32). A missing `0x` prefix or an uppercase
 `0X` prefix is normalised before validation.
@@ -372,7 +372,7 @@ HTLC secret preimage (bytes32). A missing `0x` prefix or an uppercase
 optional hashlock: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVault.ts:214](../../packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVault.ts#L214)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVault.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVault.ts)
 
 Optional hashlock for client-side pre-validation. When provided, the SDK
 rejects before calling `writeContract` if `sha256(secret) != hashlock`.
@@ -383,7 +383,7 @@ rejects before calling `writeContract` if `sha256(secret) != hashlock`.
 writeContract: EthContractWriter<R>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVault.ts:216](../../packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVault.ts#L216)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVault.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVault.ts)
 
 Caller-provided write callback — see [EthContractWriter](#ethcontractwriter).
 
@@ -393,7 +393,7 @@ Caller-provided write callback — see [EthContractWriter](#ethcontractwriter).
 optional signal: AbortSignal;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVault.ts:223](../../packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVault.ts#L223)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVault.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVault.ts)
 
 Optional abort signal. Checked before validation runs; since validation
 is fully synchronous, cancellation between validation and the write is
@@ -404,7 +404,7 @@ cancellation support for that window.
 
 ### PeginStatusReader
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/interfaces.ts:21](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/interfaces.ts#L21)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/interfaces.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/interfaces.ts)
 
 Read-only VP operations needed by polling/status functions.
 
@@ -416,7 +416,7 @@ Read-only VP operations needed by polling/status functions.
 getPeginStatus(params, signal?): Promise<GetPeginStatusResponse>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/interfaces.ts:22](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/interfaces.ts#L22)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/interfaces.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/interfaces.ts)
 
 ###### Parameters
 
@@ -438,7 +438,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/interfaces.ts
 
 ### WotsKeySubmitter
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/interfaces.ts:29](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/interfaces.ts#L29)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/interfaces.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/interfaces.ts)
 
 Write VP operations for WOTS key submission.
 
@@ -450,7 +450,7 @@ Write VP operations for WOTS key submission.
 submitDepositorWotsKey(params, signal?): Promise<void>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/interfaces.ts:30](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/interfaces.ts#L30)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/interfaces.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/interfaces.ts)
 
 ###### Parameters
 
@@ -470,7 +470,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/interfaces.ts
 
 ### PresignClient
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/interfaces.ts:37](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/interfaces.ts#L37)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/interfaces.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/interfaces.ts)
 
 VP operations for the presign transaction flow.
 
@@ -482,7 +482,7 @@ VP operations for the presign transaction flow.
 requestDepositorPresignTransactions(params, signal?): Promise<RequestDepositorPresignTransactionsResponse>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/interfaces.ts:38](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/interfaces.ts#L38)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/interfaces.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/interfaces.ts)
 
 ###### Parameters
 
@@ -504,7 +504,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/interfaces.ts
 submitDepositorPresignatures(params, signal?): Promise<void>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/interfaces.ts:42](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/interfaces.ts#L42)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/interfaces.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/interfaces.ts)
 
 ###### Parameters
 
@@ -524,7 +524,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/interfaces.ts
 
 ### ClaimerArtifactsReader
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/interfaces.ts:49](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/interfaces.ts#L49)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/interfaces.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/interfaces.ts)
 
 VP operations for depositor-as-claimer artifacts (separate from payout signing).
 
@@ -536,7 +536,7 @@ VP operations for depositor-as-claimer artifacts (separate from payout signing).
 requestDepositorClaimerArtifacts(params, signal?): Promise<RequestDepositorClaimerArtifactsResponse>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/interfaces.ts:50](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/interfaces.ts#L50)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/interfaces.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/interfaces.ts)
 
 ###### Parameters
 
@@ -556,7 +556,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/interfaces.ts
 
 ### PeginProtocolState
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts:71](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts#L71)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts)
 
 Protocol-level peg-in state (framework-agnostic)
 
@@ -568,7 +568,7 @@ Protocol-level peg-in state (framework-agnostic)
 contractStatus: ContractStatus;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts:73](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts#L73)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts)
 
 Smart contract status (source of truth for on-chain state)
 
@@ -578,7 +578,7 @@ Smart contract status (source of truth for on-chain state)
 availableActions: PeginAction[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts:75](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts#L75)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts)
 
 Available user actions (empty array when no action is available)
 
@@ -586,7 +586,7 @@ Available user actions (empty array when no action is available)
 
 ### GetPeginProtocolStateOptions
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts:85](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts#L85)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts)
 
 Options for getPeginProtocolState function.
 
@@ -602,7 +602,7 @@ is NOT included — consumers handle that in their own layer.
 optional transactionsReady: boolean;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts:87](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts#L87)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts)
 
 Whether claim/payout transactions are ready from VP
 
@@ -612,7 +612,7 @@ Whether claim/payout transactions are ready from VP
 optional needsWotsKey: boolean;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts:89](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts#L89)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts)
 
 Whether the vault provider is waiting for the depositor's WOTS public key
 
@@ -622,7 +622,7 @@ Whether the vault provider is waiting for the depositor's WOTS public key
 optional pendingIngestion: boolean;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts:91](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts#L91)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts)
 
 Whether the vault provider hasn't ingested this peg-in yet
 
@@ -632,7 +632,7 @@ Whether the vault provider hasn't ingested this peg-in yet
 optional canRefund: boolean;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts:93](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts#L93)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts)
 
 Whether the depositor can refund the HTLC (Pre-PegIn tx available)
 
@@ -642,7 +642,7 @@ Whether the depositor can refund the HTLC (Pre-PegIn tx available)
 optional hasProviderTerminalFailure: boolean;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts:95](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts#L95)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts)
 
 Whether the vault provider reported a terminal failure
 
@@ -652,7 +652,7 @@ Whether the vault provider reported a terminal failure
 optional htlcSpentByPeginTx: boolean;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts:112](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts#L112)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts)
 
 VERIFIED only: the Pre-PegIn HTLC outpoint has been spent on Bitcoin BY
 THE PEGIN TRANSACTION while the vault is still Verified on Ethereum. The
@@ -673,7 +673,7 @@ returned.
 
 ### PayoutSigningContext
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts:40](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts#L40)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts)
 
 Context required for signing payout transactions.
 Caller builds this from on-chain data (contract queries, GraphQL, config).
@@ -686,7 +686,7 @@ Caller builds this from on-chain data (contract queries, GraphQL, config).
 vaultCoreVersion: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts:47](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts#L47)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts)
 
 Vault core (tx-graph) version the vault was registered under — the
 vault's stamped on-chain `vaultCoreVersion` from `BTCVaultRegistry`.
@@ -699,7 +699,7 @@ rebuilt with.
 peginTxHex: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts:49](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts#L49)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts)
 
 Raw pegin BTC transaction hex (for PSBT construction)
 
@@ -709,7 +709,7 @@ Raw pegin BTC transaction hex (for PSBT construction)
 vaultProviderBtcPubkey: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts:51](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts#L51)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts)
 
 Vault provider's BTC public key (x-only hex, no prefix)
 
@@ -719,7 +719,7 @@ Vault provider's BTC public key (x-only hex, no prefix)
 vaultKeeperBtcPubkeys: string[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts:53](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts#L53)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts)
 
 Sorted vault keeper BTC public keys (x-only hex, no prefix)
 
@@ -729,7 +729,7 @@ Sorted vault keeper BTC public keys (x-only hex, no prefix)
 universalChallengerBtcPubkeys: string[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts:55](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts#L55)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts)
 
 Sorted universal challenger BTC public keys (x-only hex, no prefix)
 
@@ -739,7 +739,7 @@ Sorted universal challenger BTC public keys (x-only hex, no prefix)
 depositorBtcPubkey: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts:57](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts#L57)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts)
 
 Depositor's BTC public key (x-only hex, no prefix)
 
@@ -749,7 +749,7 @@ Depositor's BTC public key (x-only hex, no prefix)
 timelockPegin: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts:59](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts#L59)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts)
 
 Pegin timelock from the locked offchain params version
 
@@ -759,7 +759,7 @@ Pegin timelock from the locked offchain params version
 timelockAssert: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts:66](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts#L66)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts)
 
 Assert CSV timelock from the locked offchain params version (blocks).
 Source: ProtocolParams contract via
@@ -772,7 +772,7 @@ Required for the depositor-graph NoPayout local rebuild.
 councilMembers: string[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts:73](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts#L73)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts)
 
 Security council member x-only public keys (hex, no prefix).
 Source: ProtocolParams contract via
@@ -785,7 +785,7 @@ Required for the depositor-graph NoPayout local rebuild.
 councilQuorum: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts:80](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts#L80)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts)
 
 M-of-N council quorum threshold.
 Source: ProtocolParams contract via
@@ -798,7 +798,7 @@ Required for the depositor-graph NoPayout local rebuild.
 network: Network;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts:82](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts#L82)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts)
 
 BTC network (Mainnet, Testnet, etc.)
 
@@ -808,7 +808,7 @@ BTC network (Mainnet, Testnet, etc.)
 registeredPayoutScriptPubKey: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts:84](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts#L84)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts)
 
 On-chain registered depositor payout scriptPubKey (hex)
 
@@ -818,7 +818,7 @@ On-chain registered depositor payout scriptPubKey (hex)
 commissionBps: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts:86](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts#L86)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts)
 
 VP commission (bps) from `BTCVaultRegistry`; caps the VP-claimer payout commission output.
 
@@ -828,7 +828,7 @@ VP commission (bps) from `BTCVaultRegistry`; caps the VP-claimer payout commissi
 protocolFeeRate: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts:92](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts#L92)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts)
 
 Tx-graph fee rate (sat/vB) from the locked offchain params version —
 `getOffchainParamsByVersion(...).feeRate`, the rate the VP built the
@@ -840,7 +840,7 @@ graph with. Bounds every payout's implicit fee (payout fee band).
 vkClaimerPayoutScriptPubKeys: Readonly<Record<string, string>>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts:98](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts#L98)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts)
 
 RFC-006 resolved keeper payout destinations at the vault's frozen
 `appKeeperKeyEpoch`, keyed by lowercased x-only operation pubkey.
@@ -851,7 +851,7 @@ RFC-006 resolved keeper payout destinations at the vault's frozen
 vpCommissionScriptPubKey: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts:103](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts#L103)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts)
 
 RFC-006 resolved VP commission destination at the vault's frozen
 `vpKeyEpoch`.
@@ -860,7 +860,7 @@ RFC-006 resolved VP commission destination at the vault's frozen
 
 ### RunDepositorPresignFlowParams
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts:106](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts#L106)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts)
 
 #### Properties
 
@@ -870,7 +870,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorP
 statusReader: PeginStatusReader;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts:108](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts#L108)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts)
 
 VP client implementing the status reader interface
 
@@ -880,7 +880,7 @@ VP client implementing the status reader interface
 presignClient: PresignClient;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts:110](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts#L110)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts)
 
 VP client implementing the presign transaction flow interface
 
@@ -890,7 +890,7 @@ VP client implementing the presign transaction flow interface
 btcWallet: BitcoinWallet;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts:112](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts#L112)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts)
 
 Bitcoin wallet for signing
 
@@ -900,7 +900,7 @@ Bitcoin wallet for signing
 peginTxid: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts:114](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts#L114)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts)
 
 BTC pegin transaction ID (unprefixed hex, 64 chars)
 
@@ -910,7 +910,7 @@ BTC pegin transaction ID (unprefixed hex, 64 chars)
 depositorPk: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts:116](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts#L116)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts)
 
 Depositor's x-only BTC public key (unprefixed hex, 64 chars)
 
@@ -920,7 +920,7 @@ Depositor's x-only BTC public key (unprefixed hex, 64 chars)
 signingContext: PayoutSigningContext;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts:118](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts#L118)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts)
 
 Signing context built from on-chain data
 
@@ -930,7 +930,7 @@ Signing context built from on-chain data
 optional depositTerms: DepositTerms;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts:123](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts#L123)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts)
 
 Required for approval-capable wallets; fresh flows thread
 PreparePeginResult.depositTerms. Resume-path rebuild is not wired yet.
@@ -941,7 +941,7 @@ PreparePeginResult.depositTerms. Resume-path rebuild is not wired yet.
 optional timeoutMs: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts:125](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts#L125)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts)
 
 Maximum polling timeout in milliseconds (default: 20 min)
 
@@ -951,7 +951,7 @@ Maximum polling timeout in milliseconds (default: 20 min)
 optional signal: AbortSignal;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts:127](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts#L127)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts)
 
 AbortSignal for cancellation
 
@@ -961,7 +961,7 @@ AbortSignal for cancellation
 optional onProgress: (completed, total) => void;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts:129](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts#L129)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts)
 
 Optional progress callback (completed claimers, total claimers)
 
@@ -983,7 +983,7 @@ Optional progress callback (completed claimers, total claimers)
 
 ### DepositorGraphSigningContext
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts:500](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts#L500)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts)
 
 Authoritative inputs required to construct the depositor's Payout AND every
 per-challenger NoPayout PSBT locally. Every field here must come from
@@ -998,7 +998,7 @@ directly into the Taproot sighash.
 vaultCoreVersion: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts:506](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts#L506)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts)
 
 Vault core (tx-graph) version the vault was registered under — the
 vault's stamped on-chain `vaultCoreVersion` from `BTCVaultRegistry`.
@@ -1010,7 +1010,7 @@ Selects which graph's connector scripts every PSBT is rebuilt with.
 peginTxHex: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts:508](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts#L508)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts)
 
 Raw pegin BTC transaction hex (provides the depositor's signed prevout)
 
@@ -1020,7 +1020,7 @@ Raw pegin BTC transaction hex (provides the depositor's signed prevout)
 depositorBtcPubkey: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts:510](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts#L510)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts)
 
 Depositor's BTC public key (x-only, 64-char hex, no 0x prefix)
 
@@ -1030,7 +1030,7 @@ Depositor's BTC public key (x-only, 64-char hex, no 0x prefix)
 vaultProviderBtcPubkey: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts:512](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts#L512)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts)
 
 Vault provider's BTC public key (x-only hex, no prefix)
 
@@ -1040,7 +1040,7 @@ Vault provider's BTC public key (x-only hex, no prefix)
 vaultKeeperBtcPubkeys: string[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts:514](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts#L514)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts)
 
 Sorted vault keeper BTC public keys (x-only hex, no prefix)
 
@@ -1050,7 +1050,7 @@ Sorted vault keeper BTC public keys (x-only hex, no prefix)
 universalChallengerBtcPubkeys: string[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts:516](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts#L516)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts)
 
 Sorted universal challenger BTC public keys (x-only hex, no prefix)
 
@@ -1060,7 +1060,7 @@ Sorted universal challenger BTC public keys (x-only hex, no prefix)
 timelockPegin: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts:518](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts#L518)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts)
 
 Pegin CSV timelock from the locked offchain params version (blocks)
 
@@ -1070,7 +1070,7 @@ Pegin CSV timelock from the locked offchain params version (blocks)
 protocolFeeRate: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts:523](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts#L523)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts)
 
 Tx-graph fee rate (sat/vB) from the locked offchain params version —
 bounds the depositor-claimer payout's implicit fee (payout fee band).
@@ -1081,7 +1081,7 @@ bounds the depositor-claimer payout's implicit fee (payout fee band).
 timelockAssert: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts:529](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts#L529)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts)
 
 Assert CSV timelock from the locked offchain params version (blocks).
 Sourced from the on-chain ProtocolParams contract via
@@ -1093,7 +1093,7 @@ Sourced from the on-chain ProtocolParams contract via
 councilMembers: string[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts:535](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts#L535)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts)
 
 Security council member x-only public keys (hex, no prefix). Sourced from
 the on-chain ProtocolParams contract via
@@ -1105,7 +1105,7 @@ the on-chain ProtocolParams contract via
 councilQuorum: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts:540](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts#L540)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts)
 
 M-of-N council quorum threshold. Sourced from the on-chain ProtocolParams
 contract via `ViemProtocolParamsReader.getOffchainParamsByVersion(...).councilQuorum`.
@@ -1116,7 +1116,7 @@ contract via `ViemProtocolParamsReader.getOffchainParamsByVersion(...).councilQu
 network: Network;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts:542](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts#L542)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts)
 
 BTC network (Mainnet, Testnet, etc.)
 
@@ -1126,7 +1126,7 @@ BTC network (Mainnet, Testnet, etc.)
 registeredPayoutScriptPubKey: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts:548](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts#L548)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts)
 
 On-chain registered depositor payout scriptPubKey (hex, with or without
 0x prefix). Used to assert the VP-advertised payout transaction pays to
@@ -1138,7 +1138,7 @@ the depositor's registered address before the wallet produces a signature.
 vkClaimerPayoutScriptPubKeys: Readonly<Record<string, string>>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts:555](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts#L555)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts)
 
 RFC-006 operator payout destinations. Forwarded to `buildPayoutPsbt` for
 shape completeness only: this graph is signed under the
@@ -1151,7 +1151,7 @@ neither the keeper map nor the VP commission destination.
 vpCommissionScriptPubKey: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts:557](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts#L557)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts)
 
 See [vkClaimerPayoutScriptPubKeys](#vkclaimerpayoutscriptpubkeys-1) — unused for this role.
 
@@ -1159,7 +1159,7 @@ See [vkClaimerPayoutScriptPubKeys](#vkclaimerpayoutscriptpubkeys-1) — unused f
 
 ### SignDepositorGraphParams
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts:560](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts#L560)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts)
 
 #### Properties
 
@@ -1169,7 +1169,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositor
 depositorGraph: DepositorGraphTransactions;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts:562](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts#L562)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts)
 
 The depositor graph from VP response
 
@@ -1179,7 +1179,7 @@ The depositor graph from VP response
 btcWallet: BitcoinWallet;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts:564](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts#L564)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts)
 
 Bitcoin wallet for signing
 
@@ -1189,7 +1189,7 @@ Bitcoin wallet for signing
 signingContext: DepositorGraphSigningContext;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts:566](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts#L566)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts)
 
 Authoritative inputs used to rebuild every PSBT locally
 
@@ -1197,7 +1197,7 @@ Authoritative inputs used to rebuild every PSBT locally
 
 ### SubmitWotsPublicKeyParams
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/submitWotsPublicKey.ts:30](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/submitWotsPublicKey.ts#L30)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/submitWotsPublicKey.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/submitWotsPublicKey.ts)
 
 #### Properties
 
@@ -1207,7 +1207,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/submitWotsPub
 statusReader: PeginStatusReader;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/submitWotsPublicKey.ts:32](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/submitWotsPublicKey.ts#L32)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/submitWotsPublicKey.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/submitWotsPublicKey.ts)
 
 VP client implementing the status reader interface
 
@@ -1217,7 +1217,7 @@ VP client implementing the status reader interface
 wotsSubmitter: WotsKeySubmitter;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/submitWotsPublicKey.ts:34](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/submitWotsPublicKey.ts#L34)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/submitWotsPublicKey.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/submitWotsPublicKey.ts)
 
 VP client implementing the WOTS key submission interface
 
@@ -1227,7 +1227,7 @@ VP client implementing the WOTS key submission interface
 peginTxid: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/submitWotsPublicKey.ts:36](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/submitWotsPublicKey.ts#L36)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/submitWotsPublicKey.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/submitWotsPublicKey.ts)
 
 BTC pegin transaction ID (unprefixed hex, 64 chars)
 
@@ -1237,7 +1237,7 @@ BTC pegin transaction ID (unprefixed hex, 64 chars)
 depositorPk: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/submitWotsPublicKey.ts:38](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/submitWotsPublicKey.ts#L38)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/submitWotsPublicKey.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/submitWotsPublicKey.ts)
 
 Depositor's x-only BTC public key (unprefixed hex, 64 chars)
 
@@ -1247,7 +1247,7 @@ Depositor's x-only BTC public key (unprefixed hex, 64 chars)
 wotsPublicKeys: WotsBlockPublicKey[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/submitWotsPublicKey.ts:40](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/submitWotsPublicKey.ts#L40)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/submitWotsPublicKey.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/submitWotsPublicKey.ts)
 
 Pre-derived WOTS block public keys (one per assert block)
 
@@ -1257,7 +1257,7 @@ Pre-derived WOTS block public keys (one per assert block)
 optional timeoutMs: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/submitWotsPublicKey.ts:42](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/submitWotsPublicKey.ts#L42)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/submitWotsPublicKey.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/submitWotsPublicKey.ts)
 
 Maximum time to wait for VP to be ready (default: 5 min)
 
@@ -1267,7 +1267,7 @@ Maximum time to wait for VP to be ready (default: 5 min)
 optional signal: AbortSignal;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/submitWotsPublicKey.ts:44](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/submitWotsPublicKey.ts#L44)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/submitWotsPublicKey.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/submitWotsPublicKey.ts)
 
 AbortSignal for cancellation
 
@@ -1275,7 +1275,7 @@ AbortSignal for cancellation
 
 ### ValidateOnChainParticipantKeysParams
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnChainParticipantKeys.ts:19](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnChainParticipantKeys.ts#L19)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnChainParticipantKeys.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnChainParticipantKeys.ts)
 
 #### Properties
 
@@ -1285,7 +1285,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnCha
 vaultRegistryReader: VaultRegistryReader;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnChainParticipantKeys.ts:20](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnChainParticipantKeys.ts#L20)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnChainParticipantKeys.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnChainParticipantKeys.ts)
 
 ##### vaultKeeperReader
 
@@ -1293,7 +1293,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnCha
 vaultKeeperReader: VaultKeeperReader;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnChainParticipantKeys.ts:21](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnChainParticipantKeys.ts#L21)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnChainParticipantKeys.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnChainParticipantKeys.ts)
 
 ##### universalChallengerReader
 
@@ -1301,7 +1301,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnCha
 universalChallengerReader: UniversalChallengerReader;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnChainParticipantKeys.ts:22](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnChainParticipantKeys.ts#L22)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnChainParticipantKeys.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnChainParticipantKeys.ts)
 
 ##### vaultProviderEthAddress
 
@@ -1309,7 +1309,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnCha
 vaultProviderEthAddress: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnChainParticipantKeys.ts:23](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnChainParticipantKeys.ts#L23)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnChainParticipantKeys.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnChainParticipantKeys.ts)
 
 ##### applicationEntryPoint
 
@@ -1317,7 +1317,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnCha
 applicationEntryPoint: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnChainParticipantKeys.ts:24](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnChainParticipantKeys.ts#L24)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnChainParticipantKeys.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnChainParticipantKeys.ts)
 
 ##### expectedVaultProviderBtcPubkey
 
@@ -1325,7 +1325,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnCha
 expectedVaultProviderBtcPubkey: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnChainParticipantKeys.ts:25](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnChainParticipantKeys.ts#L25)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnChainParticipantKeys.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnChainParticipantKeys.ts)
 
 ##### expectedVaultKeeperBtcPubkeys
 
@@ -1333,7 +1333,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnCha
 expectedVaultKeeperBtcPubkeys: string[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnChainParticipantKeys.ts:26](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnChainParticipantKeys.ts#L26)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnChainParticipantKeys.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnChainParticipantKeys.ts)
 
 ##### expectedUniversalChallengerBtcPubkeys
 
@@ -1341,7 +1341,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnCha
 expectedUniversalChallengerBtcPubkeys: string[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnChainParticipantKeys.ts:27](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnChainParticipantKeys.ts#L27)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnChainParticipantKeys.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnChainParticipantKeys.ts)
 
 ##### operationKeyReader
 
@@ -1349,7 +1349,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnCha
 operationKeyReader: OperationKeyReader;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnChainParticipantKeys.ts:32](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnChainParticipantKeys.ts#L32)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnChainParticipantKeys.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnChainParticipantKeys.ts)
 
 RFC-006. Participant keys are resolved to their *current operation* keys,
 and those are what the returned key fields carry.
@@ -1360,7 +1360,7 @@ and those are what the returned key fields carry.
 optional onIndexerServingOperationKeys: (message) => void;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnChainParticipantKeys.ts:38](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnChainParticipantKeys.ts#L38)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnChainParticipantKeys.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnChainParticipantKeys.ts)
 
 Optional observer for the case where the indexer hint matched the
 operation keys rather than the registration keys — i.e. the indexer is
@@ -1382,7 +1382,7 @@ ahead of us, not wrong. Called at most once.
 optional onIndexerHintsInconsistent: (message) => void;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnChainParticipantKeys.ts:47](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnChainParticipantKeys.ts#L47)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnChainParticipantKeys.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnChainParticipantKeys.ts)
 
 Optional observer for the case where the indexer is serving a half-applied
 view — one role explainable only by the registration keys, another only by
@@ -1405,7 +1405,7 @@ immediately before the throw.
 
 ### ValidatedOnChainParticipantKeys
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnChainParticipantKeys.ts:50](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnChainParticipantKeys.ts#L50)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnChainParticipantKeys.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnChainParticipantKeys.ts)
 
 #### Properties
 
@@ -1415,7 +1415,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnCha
 vaultProviderBtcPubkeyXOnly: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnChainParticipantKeys.ts:52](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnChainParticipantKeys.ts#L52)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnChainParticipantKeys.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnChainParticipantKeys.ts)
 
 The VP key to build with: its current operation key.
 
@@ -1425,7 +1425,7 @@ The VP key to build with: its current operation key.
 vaultKeeperBtcPubkeysSorted: string[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnChainParticipantKeys.ts:53](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnChainParticipantKeys.ts#L53)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnChainParticipantKeys.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnChainParticipantKeys.ts)
 
 ##### universalChallengerBtcPubkeysSorted
 
@@ -1433,7 +1433,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnCha
 universalChallengerBtcPubkeysSorted: string[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnChainParticipantKeys.ts:54](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnChainParticipantKeys.ts#L54)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnChainParticipantKeys.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnChainParticipantKeys.ts)
 
 ##### expectedAppVaultKeepersVersion
 
@@ -1441,7 +1441,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnCha
 expectedAppVaultKeepersVersion: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnChainParticipantKeys.ts:55](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnChainParticipantKeys.ts#L55)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnChainParticipantKeys.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnChainParticipantKeys.ts)
 
 ##### expectedUniversalChallengersVersion
 
@@ -1449,7 +1449,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnCha
 expectedUniversalChallengersVersion: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnChainParticipantKeys.ts:56](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnChainParticipantKeys.ts#L56)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnChainParticipantKeys.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnChainParticipantKeys.ts)
 
 ##### registrationKeys
 
@@ -1457,7 +1457,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnCha
 registrationKeys: object;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnChainParticipantKeys.ts:62](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnChainParticipantKeys.ts#L62)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnChainParticipantKeys.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnChainParticipantKeys.ts)
 
 The registration / roster keys, sorted. These are what indexer hints are
 compared against first, and they stay available for diagnostics after
@@ -1487,7 +1487,7 @@ universalChallengers: string[];
 participantKeys: ParticipantKeySet;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnChainParticipantKeys.ts:71](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnChainParticipantKeys.ts#L71)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnChainParticipantKeys.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnChainParticipantKeys.ts)
 
 The full resolution, including the admin↔key pairing. Feeds the
 post-registration read-after-mine verification.
@@ -1496,7 +1496,7 @@ post-registration read-after-mine verification.
 
 ### ValidationResult
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts:22](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts#L22)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts)
 
 #### Properties
 
@@ -1506,7 +1506,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts
 valid: boolean;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts:23](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts#L23)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts)
 
 ##### error?
 
@@ -1514,7 +1514,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts
 optional error: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts:24](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts#L24)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts)
 
 ##### warnings?
 
@@ -1522,13 +1522,13 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts
 optional warnings: string[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts:25](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts#L25)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts)
 
 ***
 
 ### DepositFormValidityParams
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts:31](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts#L31)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts)
 
 Parameters for checking if a deposit form is valid.
 
@@ -1540,7 +1540,7 @@ Parameters for checking if a deposit form is valid.
 amountSats: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts:33](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts#L33)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts)
 
 Deposit amount in satoshis
 
@@ -1550,7 +1550,7 @@ Deposit amount in satoshis
 minDeposit: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts:35](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts#L35)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts)
 
 Minimum deposit from protocol params
 
@@ -1560,7 +1560,7 @@ Minimum deposit from protocol params
 optional maxDeposit: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts:37](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts#L37)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts)
 
 Maximum deposit from protocol params (optional)
 
@@ -1570,7 +1570,7 @@ Maximum deposit from protocol params (optional)
 btcBalance: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts:39](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts#L39)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts)
 
 User's available BTC balance in satoshis
 
@@ -1580,7 +1580,7 @@ User's available BTC balance in satoshis
 optional estimatedFeeSats: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts:41](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts#L41)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts)
 
 Estimated transaction fee in satoshis
 
@@ -1590,7 +1590,7 @@ Estimated transaction fee in satoshis
 optional depositorClaimValue: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts:43](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts#L43)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts)
 
 Depositor claim value in satoshis (required output for challenge transactions)
 
@@ -1598,7 +1598,7 @@ Depositor claim value in satoshis (required output for challenge transactions)
 
 ### RemainingCapacityParams
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts:46](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts#L46)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts)
 
 #### Properties
 
@@ -1608,7 +1608,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts
 amount: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts:48](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts#L48)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts)
 
 Requested deposit amount in satoshis
 
@@ -1618,7 +1618,7 @@ Requested deposit amount in satoshis
 effectiveRemaining: bigint | null;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts:53](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts#L53)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts)
 
 Effective remaining capacity in satoshis (min of protocol-total and
 per-address remaining). `null` means no cap applies.
@@ -1627,7 +1627,7 @@ per-address remaining). `null` means no cap applies.
 
 ### MultiVaultDepositFlowInputs
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts:72](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts#L72)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts)
 
 Parameters for validating multi-vault deposit flow inputs.
 
@@ -1645,7 +1645,7 @@ responsibility and are NOT performed here.
 vaultAmounts: bigint[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts:73](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts#L73)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts)
 
 ##### confirmedUTXOs
 
@@ -1653,7 +1653,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts
 confirmedUTXOs: UtxoLike[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts:74](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts#L74)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts)
 
 ##### vaultProviderBtcPubkey
 
@@ -1661,7 +1661,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts
 vaultProviderBtcPubkey: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts:75](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts#L75)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts)
 
 ##### vaultKeeperBtcPubkeys
 
@@ -1669,7 +1669,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts
 vaultKeeperBtcPubkeys: string[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts:76](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts#L76)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts)
 
 ##### universalChallengerBtcPubkeys
 
@@ -1677,7 +1677,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts
 universalChallengerBtcPubkeys: string[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts:77](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts#L77)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts)
 
 ##### minDeposit
 
@@ -1685,7 +1685,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts
 minDeposit: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts:79](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts#L79)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts)
 
 Protocol minimum deposit per vault (satoshis)
 
@@ -1695,7 +1695,7 @@ Protocol minimum deposit per vault (satoshis)
 optional maxDeposit: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts:81](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts#L81)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts)
 
 Protocol maximum deposit per vault (satoshis)
 
@@ -1703,7 +1703,7 @@ Protocol maximum deposit per vault (satoshis)
 
 ### VerifyRegisteredParticipantKeysParams
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegisteredParticipantKeys.ts:70](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegisteredParticipantKeys.ts#L70)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegisteredParticipantKeys.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegisteredParticipantKeys.ts)
 
 #### Properties
 
@@ -1713,7 +1713,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegiste
 vaultRegistryReader: VaultRegistryReader;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegisteredParticipantKeys.ts:71](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegisteredParticipantKeys.ts#L71)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegisteredParticipantKeys.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegisteredParticipantKeys.ts)
 
 ##### operationKeyReader
 
@@ -1721,7 +1721,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegiste
 operationKeyReader: OperationKeyReader;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegisteredParticipantKeys.ts:72](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegisteredParticipantKeys.ts#L72)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegisteredParticipantKeys.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegisteredParticipantKeys.ts)
 
 ##### vaultIds
 
@@ -1729,7 +1729,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegiste
 vaultIds: readonly `0x${string}`[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegisteredParticipantKeys.ts:73](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegisteredParticipantKeys.ts#L73)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegisteredParticipantKeys.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegisteredParticipantKeys.ts)
 
 ##### expected
 
@@ -1737,7 +1737,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegiste
 expected: ParticipantKeySet;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegisteredParticipantKeys.ts:80](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegisteredParticipantKeys.ts#L80)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegisteredParticipantKeys.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegisteredParticipantKeys.ts)
 
 The exact key set the BTC artifacts were built with. Its `query` supplies
 the rosters to re-resolve against — deliberately reused rather than
@@ -1748,7 +1748,7 @@ roster that moved since the build cannot be misreported as a key drift.
 
 ### VerifyRegisteredVaultVersionsParams
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegisteredVaultVersions.ts:5](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegisteredVaultVersions.ts#L5)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegisteredVaultVersions.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegisteredVaultVersions.ts)
 
 #### Properties
 
@@ -1758,7 +1758,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegiste
 vaultRegistryReader: VaultRegistryReader;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegisteredVaultVersions.ts:6](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegisteredVaultVersions.ts#L6)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegisteredVaultVersions.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegisteredVaultVersions.ts)
 
 ##### vaultIds
 
@@ -1766,7 +1766,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegiste
 vaultIds: readonly `0x${string}`[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegisteredVaultVersions.ts:7](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegisteredVaultVersions.ts#L7)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegisteredVaultVersions.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegisteredVaultVersions.ts)
 
 ##### expectedOffchainParamsVersion
 
@@ -1774,7 +1774,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegiste
 expectedOffchainParamsVersion: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegisteredVaultVersions.ts:8](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegisteredVaultVersions.ts#L8)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegisteredVaultVersions.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegisteredVaultVersions.ts)
 
 ##### expectedAppVaultKeepersVersion
 
@@ -1782,7 +1782,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegiste
 expectedAppVaultKeepersVersion: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegisteredVaultVersions.ts:9](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegisteredVaultVersions.ts#L9)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegisteredVaultVersions.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegisteredVaultVersions.ts)
 
 ##### expectedUniversalChallengersVersion
 
@@ -1790,7 +1790,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegiste
 expectedUniversalChallengersVersion: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegisteredVaultVersions.ts:10](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegisteredVaultVersions.ts#L10)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegisteredVaultVersions.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegisteredVaultVersions.ts)
 
 ##### expectedVaultCoreVersion
 
@@ -1798,7 +1798,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegiste
 expectedVaultCoreVersion: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegisteredVaultVersions.ts:18](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegisteredVaultVersions.ts#L18)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegisteredVaultVersions.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegisteredVaultVersions.ts)
 
 Vault core (tx-graph) version the BTC artifacts were BUILT with. The
 contract stamps `activeVaultCoreVersion` at registration-tx execution
@@ -1810,7 +1810,7 @@ lock BTC into a graph no resume path can rebuild.
 
 ### WaitForPeginStatusParams
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/waitForPeginStatus.ts:19](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/waitForPeginStatus.ts#L19)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/waitForPeginStatus.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/waitForPeginStatus.ts)
 
 #### Properties
 
@@ -1820,7 +1820,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/waitForPeginS
 statusReader: PeginStatusReader;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/waitForPeginStatus.ts:21](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/waitForPeginStatus.ts#L21)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/waitForPeginStatus.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/waitForPeginStatus.ts)
 
 VP client implementing the status reader interface
 
@@ -1830,7 +1830,7 @@ VP client implementing the status reader interface
 peginTxid: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/waitForPeginStatus.ts:23](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/waitForPeginStatus.ts#L23)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/waitForPeginStatus.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/waitForPeginStatus.ts)
 
 BTC pegin transaction ID (unprefixed hex, 64 chars)
 
@@ -1840,7 +1840,7 @@ BTC pegin transaction ID (unprefixed hex, 64 chars)
 targetStatuses: ReadonlySet<DaemonStatus>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/waitForPeginStatus.ts:25](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/waitForPeginStatus.ts#L25)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/waitForPeginStatus.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/waitForPeginStatus.ts)
 
 Set of acceptable statuses — polling stops when the VP reports one of these
 
@@ -1850,7 +1850,7 @@ Set of acceptable statuses — polling stops when the VP reports one of these
 timeoutMs: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/waitForPeginStatus.ts:27](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/waitForPeginStatus.ts#L27)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/waitForPeginStatus.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/waitForPeginStatus.ts)
 
 Maximum time to wait in milliseconds
 
@@ -1860,7 +1860,7 @@ Maximum time to wait in milliseconds
 optional pollIntervalMs: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/waitForPeginStatus.ts:29](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/waitForPeginStatus.ts#L29)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/waitForPeginStatus.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/waitForPeginStatus.ts)
 
 Polling interval in milliseconds (default: 10s)
 
@@ -1870,7 +1870,7 @@ Polling interval in milliseconds (default: 10s)
 optional signal: AbortSignal;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/waitForPeginStatus.ts:31](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/waitForPeginStatus.ts#L31)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/waitForPeginStatus.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/waitForPeginStatus.ts)
 
 AbortSignal for cancellation
 
@@ -1878,7 +1878,7 @@ AbortSignal for cancellation
 
 ### HintMatch
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/participants/indexerKeyHint.ts:48](../../packages/babylon-ts-sdk/src/tbv/core/services/participants/indexerKeyHint.ts#L48)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/participants/indexerKeyHint.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/participants/indexerKeyHint.ts)
 
 Which of the two legitimate on-chain candidates a role's hint matched.
 
@@ -1893,7 +1893,7 @@ Both false means the hint is not explainable by any state the chain is in.
 registration: boolean;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/participants/indexerKeyHint.ts:49](../../packages/babylon-ts-sdk/src/tbv/core/services/participants/indexerKeyHint.ts#L49)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/participants/indexerKeyHint.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/participants/indexerKeyHint.ts)
 
 ##### operation
 
@@ -1901,13 +1901,13 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/participants/indexerK
 operation: boolean;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/participants/indexerKeyHint.ts:50](../../packages/babylon-ts-sdk/src/tbv/core/services/participants/indexerKeyHint.ts#L50)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/participants/indexerKeyHint.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/participants/indexerKeyHint.ts)
 
 ***
 
 ### AssertVaultProviderHintAcceptedParams
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/participants/indexerKeyHint.ts:105](../../packages/babylon-ts-sdk/src/tbv/core/services/participants/indexerKeyHint.ts#L105)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/participants/indexerKeyHint.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/participants/indexerKeyHint.ts)
 
 #### Properties
 
@@ -1917,7 +1917,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/participants/indexerK
 vaultProviderEthAddress: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/participants/indexerKeyHint.ts:107](../../packages/babylon-ts-sdk/src/tbv/core/services/participants/indexerKeyHint.ts#L107)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/participants/indexerKeyHint.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/participants/indexerKeyHint.ts)
 
 Vault provider's admin address, named in the error.
 
@@ -1927,7 +1927,7 @@ Vault provider's admin address, named in the error.
 optional hintBtcPubkey: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/participants/indexerKeyHint.ts:109](../../packages/babylon-ts-sdk/src/tbv/core/services/participants/indexerKeyHint.ts#L109)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/participants/indexerKeyHint.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/participants/indexerKeyHint.ts)
 
 The untrusted hint. Absent means there is nothing to cross-check.
 
@@ -1937,7 +1937,7 @@ The untrusted hint. Absent means there is nothing to cross-check.
 registrationBtcPubkey: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/participants/indexerKeyHint.ts:111](../../packages/babylon-ts-sdk/src/tbv/core/services/participants/indexerKeyHint.ts#L111)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/participants/indexerKeyHint.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/participants/indexerKeyHint.ts)
 
 The vault provider's registration key, already read from chain.
 
@@ -1947,7 +1947,7 @@ The vault provider's registration key, already read from chain.
 readCurrentOperationBtcPubkey: () => Promise<string>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/participants/indexerKeyHint.ts:119](../../packages/babylon-ts-sdk/src/tbv/core/services/participants/indexerKeyHint.ts#L119)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/participants/indexerKeyHint.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/participants/indexerKeyHint.ts)
 
 Reads the vault provider's *current* operation key.
 
@@ -1965,7 +1965,7 @@ no extra RPC. Callers must not pre-read this.
 optional context: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/participants/indexerKeyHint.ts:125](../../packages/babylon-ts-sdk/src/tbv/core/services/participants/indexerKeyHint.ts#L125)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/participants/indexerKeyHint.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/participants/indexerKeyHint.ts)
 
 Sentence appended to the error naming what was aborted, e.g.
 `"Aborting refund."`. The shared half of the message says which keys
@@ -1975,7 +1975,7 @@ failed to match; this says which operation the user just lost.
 
 ### ResolvedParticipant
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/participants/types.ts:16](../../packages/babylon-ts-sdk/src/tbv/core/services/participants/types.ts#L16)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/participants/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/participants/types.ts)
 
 One operator's resolved identity: who it is, and which key it signs with.
 
@@ -1987,7 +1987,7 @@ One operator's resolved identity: who it is, and which key it signs with.
 adminAddress: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/participants/types.ts:21](../../packages/babylon-ts-sdk/src/tbv/core/services/participants/types.ts#L21)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/participants/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/participants/types.ts)
 
 The operator's admin ETH address — its stable identity and the lookup key
 for its operation-key history. This is the roster entry's `ethAddress`.
@@ -1998,7 +1998,7 @@ for its operation-key history. This is the roster entry's `ethAddress`.
 genesisBtcPubkey: OnChainBtcPubkey;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/participants/types.ts:28](../../packages/babylon-ts-sdk/src/tbv/core/services/participants/types.ts#L28)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/participants/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/participants/types.ts)
 
 The operator's genesis BTC key: its roster entry / registration key.
 x-only, lowercase, no `0x`. Retained because indexer hints are still
@@ -2011,7 +2011,7 @@ expressed in these, and because a keeper's genesis is the fallback the
 operationBtcPubkey: OnChainBtcPubkey;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/participants/types.ts:34](../../packages/babylon-ts-sdk/src/tbv/core/services/participants/types.ts#L34)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/participants/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/participants/types.ts)
 
 The operation key this resolution produced — the key that actually goes
 into the Bitcoin scripts. Equals `genesisBtcPubkey` until the operator
@@ -2023,7 +2023,7 @@ rotates.
 rotated: boolean;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/participants/types.ts:36](../../packages/babylon-ts-sdk/src/tbv/core/services/participants/types.ts#L36)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/participants/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/participants/types.ts)
 
 Whether the operation key differs from the genesis key.
 
@@ -2031,7 +2031,7 @@ Whether the operation key differs from the genesis key.
 
 ### ParticipantKeySet
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/participants/types.ts:53](../../packages/babylon-ts-sdk/src/tbv/core/services/participants/types.ts#L53)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/participants/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/participants/types.ts)
 
 Every participant's resolved operation key for one vault (or one about to be
 created).
@@ -2049,7 +2049,7 @@ to a roster entry is wrong the moment anyone rotates.
 vaultProvider: ResolvedParticipant;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/participants/types.ts:54](../../packages/babylon-ts-sdk/src/tbv/core/services/participants/types.ts#L54)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/participants/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/participants/types.ts)
 
 ##### vaultKeepers
 
@@ -2057,7 +2057,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/participants/types.ts
 vaultKeepers: ResolvedParticipant[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/participants/types.ts:55](../../packages/babylon-ts-sdk/src/tbv/core/services/participants/types.ts#L55)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/participants/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/participants/types.ts)
 
 ##### universalChallengers
 
@@ -2065,7 +2065,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/participants/types.ts
 universalChallengers: ResolvedParticipant[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/participants/types.ts:56](../../packages/babylon-ts-sdk/src/tbv/core/services/participants/types.ts#L56)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/participants/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/participants/types.ts)
 
 ##### vaultKeeperOperationKeysSorted
 
@@ -2073,7 +2073,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/participants/types.ts
 vaultKeeperOperationKeysSorted: string[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/participants/types.ts:58](../../packages/babylon-ts-sdk/src/tbv/core/services/participants/types.ts#L58)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/participants/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/participants/types.ts)
 
 Sorted keeper operation keys — what script construction consumes.
 
@@ -2083,7 +2083,7 @@ Sorted keeper operation keys — what script construction consumes.
 universalChallengerOperationKeysSorted: string[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/participants/types.ts:60](../../packages/babylon-ts-sdk/src/tbv/core/services/participants/types.ts#L60)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/participants/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/participants/types.ts)
 
 Sorted challenger operation keys — what script construction consumes.
 
@@ -2093,7 +2093,7 @@ Sorted challenger operation keys — what script construction consumes.
 resolvedAt: KeyResolutionMode;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/participants/types.ts:62](../../packages/babylon-ts-sdk/src/tbv/core/services/participants/types.ts#L62)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/participants/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/participants/types.ts)
 
 Provenance of this resolution.
 
@@ -2103,7 +2103,7 @@ Provenance of this resolution.
 query: OperationKeyQuery;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/participants/types.ts:71](../../packages/babylon-ts-sdk/src/tbv/core/services/participants/types.ts#L71)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/participants/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/participants/types.ts)
 
 The rosters and addresses this set was resolved against.
 
@@ -2116,7 +2116,7 @@ drift.
 
 ### VaultBatchEntry
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:113](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L113)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts)
 
 One vault's per-HTLC binding in a Pre-PegIn batch. Carries the fields
 needed to reconstruct the WASM `WasmPrePeginTx` template byte-for-byte
@@ -2130,7 +2130,7 @@ against the funded transaction.
 hashlock: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:115](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L115)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts)
 
 SHA-256 hashlock commitment for this vault (bytes32, 0x-prefixed).
 
@@ -2140,7 +2140,7 @@ SHA-256 hashlock commitment for this vault (bytes32, 0x-prefixed).
 amount: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:123](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L123)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts)
 
 Vault deposit (peg-in) amount in satoshis — the on-chain contract's
 `amount` field. This is the peg-in amount WASM expects in `pegInAmounts`,
@@ -2154,7 +2154,7 @@ output, so this value is passed straight through.
 htlcVout: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:125](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L125)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts)
 
 Index of this vault's HTLC output in the funded Pre-PegIn tx.
 
@@ -2162,7 +2162,7 @@ Index of this vault's HTLC output in the funded Pre-PegIn tx.
 
 ### VaultRefundData
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:141](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L141)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts)
 
 Authoritative vault fields needed to build a refund. Versioning fields,
 the hashlock, and htlcVout must come from the on-chain contract (never the
@@ -2184,7 +2184,7 @@ so the WASM template matches the funded tx's shape.
 vaultCoreVersion: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:147](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L147)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts)
 
 Vault core (tx-graph) version stamped on-chain at registration
 (`BTCVaultProtocolInfo.vaultCoreVersion`). The refund template must be
@@ -2196,7 +2196,7 @@ reconstructed under the same graph version the Pre-PegIn was built with.
 hashlock: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:148](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L148)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts)
 
 ##### htlcVout
 
@@ -2204,7 +2204,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadc
 htlcVout: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:149](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L149)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts)
 
 ##### offchainParamsVersion
 
@@ -2212,7 +2212,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadc
 offchainParamsVersion: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:150](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L150)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts)
 
 ##### appVaultKeepersVersion
 
@@ -2220,7 +2220,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadc
 appVaultKeepersVersion: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:151](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L151)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts)
 
 ##### universalChallengersVersion
 
@@ -2228,7 +2228,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadc
 universalChallengersVersion: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:152](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L152)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts)
 
 ##### vaultProvider
 
@@ -2236,7 +2236,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadc
 vaultProvider: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:153](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L153)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts)
 
 ##### applicationEntryPoint
 
@@ -2244,7 +2244,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadc
 applicationEntryPoint: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:154](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L154)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts)
 
 ##### amount
 
@@ -2252,7 +2252,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadc
 amount: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:156](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L156)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts)
 
 Vault deposit (peg-in) amount in satoshis — the on-chain `amount` field.
 
@@ -2262,7 +2262,7 @@ Vault deposit (peg-in) amount in satoshis — the on-chain `amount` field.
 unsignedPrePeginTxHex: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:162](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L162)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts)
 
 Funded, pre-witness Pre-PegIn transaction hex. 0x prefix optional.
 The name mirrors the contract/indexer schema; the bytes are the
@@ -2274,7 +2274,7 @@ funded form (refund construction needs real outpoints).
 depositorBtcPubkey: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:164](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L164)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts)
 
 Depositor's BTC public key (x-only or compressed hex; 0x prefix optional).
 
@@ -2284,7 +2284,7 @@ Depositor's BTC public key (x-only or compressed hex; 0x prefix optional).
 batch: readonly VaultBatchEntry[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:171](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L171)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts)
 
 Full vout-ordered HTLC vector for the funded Pre-PegIn (one entry
 per sibling vault, including the target vault). Must satisfy
@@ -2295,7 +2295,7 @@ per sibling vault, including the target vault). Must satisfy
 
 ### RefundPrePeginContext
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:186](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L186)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts)
 
 Version-resolved protocol context that parameterises the HTLC's taproot
 scripts. The *signer-set* fields (`vaultKeeperPubkeys`,
@@ -2316,7 +2316,7 @@ script derivation).
 vaultProviderPubkey: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:187](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L187)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts)
 
 ##### vaultKeeperPubkeys
 
@@ -2324,7 +2324,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadc
 vaultKeeperPubkeys: readonly string[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:188](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L188)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts)
 
 ##### universalChallengerPubkeys
 
@@ -2332,7 +2332,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadc
 universalChallengerPubkeys: readonly string[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:189](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L189)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts)
 
 ##### timelockRefund
 
@@ -2340,7 +2340,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadc
 timelockRefund: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:190](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L190)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts)
 
 ##### feeRate
 
@@ -2348,7 +2348,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadc
 feeRate: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:191](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L191)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts)
 
 ##### minPeginFeeRate
 
@@ -2356,7 +2356,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadc
 minPeginFeeRate: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:192](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L192)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts)
 
 ##### numLocalChallengers
 
@@ -2364,7 +2364,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadc
 numLocalChallengers: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:193](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L193)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts)
 
 ##### councilQuorum
 
@@ -2372,7 +2372,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadc
 councilQuorum: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:194](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L194)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts)
 
 ##### councilSize
 
@@ -2380,7 +2380,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadc
 councilSize: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:195](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L195)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts)
 
 ##### network
 
@@ -2388,13 +2388,13 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadc
 network: Network;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:196](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L196)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts)
 
 ***
 
 ### BtcBroadcastResult
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:200](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L200)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts)
 
 Minimum shape required from a broadcast result.
 
@@ -2406,13 +2406,13 @@ Minimum shape required from a broadcast result.
 txId: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:201](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L201)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts)
 
 ***
 
 ### RefundInput
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:212](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L212)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts)
 
 #### Type Parameters
 
@@ -2428,7 +2428,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadc
 vaultId: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:215](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L215)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts)
 
 ##### readVault()
 
@@ -2436,7 +2436,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadc
 readVault: () => Promise<VaultRefundData>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:221](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L221)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts)
 
 Fetch authoritative on-chain + indexer vault data. The SDK passes no
 arguments — the caller closes over `vaultId` (or any other context it
@@ -2452,7 +2452,7 @@ needs).
 readPrePeginContext: (vault) => Promise<RefundPrePeginContext>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:226](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L226)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts)
 
 Fetch the version-pinned refund context (sorted pubkeys, timelock, etc.)
 derived from the vault's locked versions.
@@ -2473,7 +2473,7 @@ derived from the vault's locked versions.
 feeRate: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:235](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L235)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts)
 
 Mempool-derived sat/vB fee rate to use for the refund tx (positive
 number). Caller fetches this before invoking — it does not depend on
@@ -2486,7 +2486,7 @@ orchestration honest.
 signPsbt: RefundPsbtSigner;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:237](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L237)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts)
 
 BTC wallet signer; receives a PSBT hex + taproot script-path options.
 
@@ -2496,7 +2496,7 @@ BTC wallet signer; receives a PSBT hex + taproot script-path options.
 broadcastTx: BtcBroadcaster<R>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:239](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L239)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts)
 
 Broadcast callback — returns whatever shape the caller needs.
 
@@ -2506,7 +2506,7 @@ Broadcast callback — returns whatever shape the caller needs.
 optional signal: AbortSignal;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:241](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L241)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts)
 
 Checked at every async boundary.
 
@@ -2518,7 +2518,7 @@ Checked at every async boundary.
 type EthContractWriter<R> = (call) => Promise<R>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVault.ts:79](../../packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVault.ts#L79)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVault.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVault.ts)
 
 Caller-provided contract writer. The generic `R` lets callers return any
 transport-specific result shape (e.g. `{ transactionHash, receipt }`);
@@ -2548,7 +2548,7 @@ the SDK forwards that shape back through `activateVault`.
 type ExpirationReason = "ack_timeout" | "proof_timeout" | "activation_timeout";
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts:36](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts#L36)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts)
 
 Reason why a vault expired
 
@@ -2567,7 +2567,7 @@ type KeyResolutionMode =
 };
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/participants/types.ts:40](../../packages/babylon-ts-sdk/src/tbv/core/services/participants/types.ts#L40)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/participants/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/participants/types.ts)
 
 How a [ParticipantKeySet](#participantkeyset) was resolved. Carried for diagnostics.
 
@@ -2579,7 +2579,7 @@ How a [ParticipantKeySet](#participantkeyset) was resolved. Carried for diagnost
 type BtcBroadcaster<R> = (signedTxHex) => Promise<R>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:204](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L204)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts)
 
 #### Type Parameters
 
@@ -2605,7 +2605,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadc
 type RefundPsbtSigner = (psbtHex, opts) => Promise<string>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:207](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L207)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts)
 
 #### Parameters
 
@@ -2629,7 +2629,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadc
 function activateVault<R>(input): Promise<R>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVault.ts:167](../../packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVault.ts#L167)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVault.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVault.ts)
 
 Reveal the HTLC secret on Ethereum and activate the vault.
 
@@ -2689,7 +2689,7 @@ whatever the injected `writeContract` throws
 function activateVaultAndRedeem<R>(input): Promise<R>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVault.ts:245](../../packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVault.ts#L245)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVault.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/activation/activateVault.ts)
 
 Depositor escape hatch: reveal the HTLC secret and immediately redeem the
 vault for the depositor, without any application activation. The contract
@@ -2747,7 +2747,7 @@ whatever the injected `writeContract` throws
 function getPeginProtocolState(contractStatus, options): PeginProtocolState;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts:132](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts#L132)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts)
 
 Determine the current protocol state and available actions based on contract
 status and vault provider state. Framework-agnostic: returns only
@@ -2785,7 +2785,7 @@ Protocol state with available actions
 function canPerformAction(state, action): boolean;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts:228](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts#L228)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts)
 
 Check if a specific action is available in the current state
 
@@ -2811,7 +2811,7 @@ Check if a specific action is available in the current state
 function isActivationDeadlinePassedOnChain(params): boolean;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts:245](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts#L245)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts)
 
 Whether a vault's on-chain activation window has closed. Mirrors the
 BTCVaultRegistry check that reverts `ActivationDeadlineExpired`:
@@ -2846,7 +2846,7 @@ boundary-equal block is NOT expired. All values are Ethereum block numbers.
 function runDepositorPresignFlow(params): Promise<void>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts:413](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts#L413)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts)
 
 Poll for payout transactions, sign them, sign the depositor graph,
 and submit all signatures to the vault provider.
@@ -2875,7 +2875,7 @@ Error on timeout, abort, signing failure, or RPC error
 function signDepositorGraph(params): Promise<DepositorAsClaimerPresignatures>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts:578](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts#L578)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts)
 
 Sign all depositor graph transactions and assemble into presignatures.
 
@@ -2903,7 +2903,7 @@ Flow:
 function submitWotsPublicKey(params): Promise<void>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/submitWotsPublicKey.ts:52](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/submitWotsPublicKey.ts#L52)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/submitWotsPublicKey.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/submitWotsPublicKey.ts)
 
 Submit WOTS public keys to the vault provider.
 
@@ -2929,7 +2929,7 @@ Error on timeout, abort, or RPC error
 function validateOnChainParticipantKeys(params): Promise<ValidatedOnChainParticipantKeys>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnChainParticipantKeys.ts:76](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnChainParticipantKeys.ts#L76)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnChainParticipantKeys.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnChainParticipantKeys.ts)
 
 #### Parameters
 
@@ -2949,7 +2949,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnCha
 function isDepositAmountValid(params): boolean;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts:102](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts#L102)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts)
 
 Check if deposit amount is within valid range and affordable.
 
@@ -2977,7 +2977,7 @@ function validateDepositAmount(
    maxDeposit?): ValidationResult;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts:129](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts#L129)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts)
 
 Validate deposit amount against minimum and maximum constraints.
 
@@ -3007,7 +3007,7 @@ Validate deposit amount against minimum and maximum constraints.
 function validateRemainingCapacity(params): ValidationResult;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts:161](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts#L161)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts)
 
 Validate that the requested deposit fits within the effective remaining cap.
 
@@ -3029,7 +3029,7 @@ Validate that the requested deposit fits within the effective remaining cap.
 function validateProviderSelection(selectedProviders, availableProviders): ValidationResult;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts:189](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts#L189)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts)
 
 Validate that selected providers exist in the available set.
 
@@ -3060,7 +3060,7 @@ function validateVaultAmounts(
    maxDeposit?): ValidationResult;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts:223](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts#L223)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts)
 
 Validate vault amounts array for multi-vault deposits.
 Checks count, positivity, and per-vault min/max protocol limits.
@@ -3093,7 +3093,7 @@ Max vault count limits are the caller's responsibility.
 function validateVaultProviderPubkey(pubkey): ValidationResult;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts:263](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts#L263)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts)
 
 Validate vault provider BTC public key format.
 
@@ -3115,7 +3115,7 @@ Validate vault provider BTC public key format.
 function validateMultiVaultDepositInputs(params): void;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts:317](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts#L317)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/validation.ts)
 
 Validate protocol-level multi-vault deposit inputs.
 Throws an error if any validation fails.
@@ -3141,7 +3141,7 @@ performed by the caller before invoking this function.
 function isParticipantKeyDriftError(err): err is ParticipantKeyDriftError;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegisteredParticipantKeys.ts:61](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegisteredParticipantKeys.ts#L61)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegisteredParticipantKeys.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegisteredParticipantKeys.ts)
 
 #### Parameters
 
@@ -3161,7 +3161,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegiste
 function verifyRegisteredParticipantKeys(params): Promise<void>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegisteredParticipantKeys.ts:97](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegisteredParticipantKeys.ts#L97)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegisteredParticipantKeys.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegisteredParticipantKeys.ts)
 
 #### Parameters
 
@@ -3181,7 +3181,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegiste
 function isRegisteredVaultVersionMismatchError(err): err is RegisteredVaultVersionMismatchError;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegisteredVaultVersions.ts:32](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegisteredVaultVersions.ts#L32)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegisteredVaultVersions.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegisteredVaultVersions.ts)
 
 #### Parameters
 
@@ -3201,7 +3201,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegiste
 function verifyRegisteredVaultVersions(params): Promise<void>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegisteredVaultVersions.ts:41](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegisteredVaultVersions.ts#L41)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegisteredVaultVersions.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegisteredVaultVersions.ts)
 
 #### Parameters
 
@@ -3221,7 +3221,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegiste
 function waitForPeginStatus(params): Promise<DaemonStatus>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/waitForPeginStatus.ts:42](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/waitForPeginStatus.ts#L42)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/waitForPeginStatus.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/waitForPeginStatus.ts)
 
 Poll `getPeginStatus` until the VP reaches one of the target statuses.
 
@@ -3251,7 +3251,7 @@ Error on timeout, abort, non-transient RPC error, or any terminal status (`Expir
 function computeHashlock(secret): `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/htlc/index.ts:77](../../packages/babylon-ts-sdk/src/tbv/core/services/htlc/index.ts#L77)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/htlc/index.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/htlc/index.ts)
 
 Compute the SHA-256 hashlock from a secret preimage.
 
@@ -3284,7 +3284,7 @@ if secret is not exactly 32 bytes
 function validateSecretAgainstHashlock(secret, hashlock): boolean;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/htlc/index.ts:95](../../packages/babylon-ts-sdk/src/tbv/core/services/htlc/index.ts#L95)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/htlc/index.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/htlc/index.ts)
 
 Validate that a secret's SHA-256 hash matches the expected hashlock.
 
@@ -3323,7 +3323,7 @@ if secret or hashlock is not exactly 32 bytes
 function isHintAccepted(match): boolean;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/participants/indexerKeyHint.ts:60](../../packages/babylon-ts-sdk/src/tbv/core/services/participants/indexerKeyHint.ts#L60)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/participants/indexerKeyHint.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/participants/indexerKeyHint.ts)
 
 The accept-either policy itself.
 
@@ -3352,7 +3352,7 @@ function matchKeyHint(
    operationKey): HintMatch;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/participants/indexerKeyHint.ts:65](../../packages/babylon-ts-sdk/src/tbv/core/services/participants/indexerKeyHint.ts#L65)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/participants/indexerKeyHint.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/participants/indexerKeyHint.ts)
 
 Match a single hinted key against both candidates.
 
@@ -3385,7 +3385,7 @@ function matchKeySetHint(
    operationKeys): HintMatch;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/participants/indexerKeyHint.ts:85](../../packages/babylon-ts-sdk/src/tbv/core/services/participants/indexerKeyHint.ts#L85)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/participants/indexerKeyHint.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/participants/indexerKeyHint.ts)
 
 Match a hinted key *set* against both candidate sets.
 
@@ -3420,7 +3420,7 @@ readonly `string`[]
 function assertVaultProviderHintAccepted(params): Promise<void>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/participants/indexerKeyHint.ts:135](../../packages/babylon-ts-sdk/src/tbv/core/services/participants/indexerKeyHint.ts#L135)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/participants/indexerKeyHint.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/participants/indexerKeyHint.ts)
 
 Assert an indexer-hinted vault provider key is one the chain can explain.
 
@@ -3446,7 +3446,7 @@ way, since resolution is chain-only.
 function resolveCurrentParticipantKeys(params): Promise<ParticipantKeySet>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/participants/resolveParticipantKeys.ts:154](../../packages/babylon-ts-sdk/src/tbv/core/services/participants/resolveParticipantKeys.ts#L154)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/participants/resolveParticipantKeys.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/participants/resolveParticipantKeys.ts)
 
 Resolve every participant's *current* operation key.
 
@@ -3477,7 +3477,7 @@ the extended `getBtcVaultProtocolInfo` ABI.
 function resolveParticipantKeysAtEpochs(params): Promise<ParticipantKeySet>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/participants/resolveParticipantKeys.ts:172](../../packages/babylon-ts-sdk/src/tbv/core/services/participants/resolveParticipantKeys.ts#L172)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/participants/resolveParticipantKeys.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/participants/resolveParticipantKeys.ts)
 
 Resolve every participant's operation key bonded at a vault's frozen epochs.
 
@@ -3514,7 +3514,7 @@ back to.
 function isRecognizedPegoutStatus(status): boolean;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/pegout/state.ts:27](../../packages/babylon-ts-sdk/src/tbv/core/services/pegout/state.ts#L27)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/pegout/state.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/pegout/state.ts)
 
 Whether a claimer status string maps to a known pegout state.
 
@@ -3536,7 +3536,7 @@ Whether a claimer status string maps to a known pegout state.
 function isPegoutTerminalStatus(claimerStatus): boolean;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/pegout/state.ts:38](../../packages/babylon-ts-sdk/src/tbv/core/services/pegout/state.ts#L38)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/pegout/state.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/pegout/state.ts)
 
 Whether a claimer status is a hard-terminal pegout status
 (PayoutBroadcast or PayoutBlocked). Soft-terminal conditions (polling
@@ -3560,7 +3560,7 @@ thresholds) are a consumer-side concern.
 function estimateRefundFeeSats(feeRateSatsVb): bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:80](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L80)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts)
 
 Network fee (sats) the SDK will charge for a refund tx at the given
 sat/vB rate. Mirrors the internal computation in
@@ -3585,7 +3585,7 @@ have to duplicate the constant.
 function buildAndBroadcastRefund<R>(input): Promise<R>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:408](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L408)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts)
 
 Build, sign, and broadcast a refund transaction for an expired vault.
 
@@ -3635,7 +3635,7 @@ anything `readVault`, `readPrePeginContext`,
 
 ### ContractStatus
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts:16](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts#L16)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts)
 
 Vault status — combines on-chain contract status (0-4) with indexer-derived
 statuses (5-7). The contract enum (BTCVaultRegistry.sol BTCVaultStatus) only
@@ -3655,7 +3655,7 @@ IMPORTANT: With the new contract architecture:
 PENDING: 0;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts:18](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts#L18)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts)
 
 Status 0: Request submitted, waiting for ACKs
 
@@ -3665,7 +3665,7 @@ Status 0: Request submitted, waiting for ACKs
 VERIFIED: 1;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts:20](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts#L20)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts)
 
 Status 1: All ACKs collected, ready for secret activation
 
@@ -3675,7 +3675,7 @@ Status 1: All ACKs collected, ready for secret activation
 ACTIVE: 2;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts:22](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts#L22)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts)
 
 Status 2: HTLC secret revealed, vault is active and usable (stays here even when used by apps)
 
@@ -3685,7 +3685,7 @@ Status 2: HTLC secret revealed, vault is active and usable (stays here even when
 REDEEMED: 3;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts:24](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts#L24)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts)
 
 Status 3: Vault has been redeemed, BTC is claimable
 
@@ -3695,7 +3695,7 @@ Status 3: Vault has been redeemed, BTC is claimable
 LIQUIDATED: 4;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts:26](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts#L26)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts)
 
 Status 4 (indexer-only): Vault was liquidated (collateral seized due to unpaid debt)
 
@@ -3705,7 +3705,7 @@ Status 4 (indexer-only): Vault was liquidated (collateral seized due to unpaid d
 INVALID: 5;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts:28](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts#L28)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts)
 
 Status 5 (indexer-only): Vault is invalid — BTC UTXOs were spent in a different transaction
 
@@ -3715,7 +3715,7 @@ Status 5 (indexer-only): Vault is invalid — BTC UTXOs were spent in a differen
 DEPOSITOR_WITHDRAWN: 6;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts:30](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts#L30)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts)
 
 Status 6 (indexer-only): Depositor has withdrawn their BTC (redemption complete)
 
@@ -3725,7 +3725,7 @@ Status 6 (indexer-only): Depositor has withdrawn their BTC (redemption complete)
 EXPIRED: 7;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts:32](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts#L32)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts)
 
 Status 7 (indexer-only): Vault expired due to AckTimeout or ActivationTimeout
 
@@ -3733,7 +3733,7 @@ Status 7 (indexer-only): Vault expired due to AckTimeout or ActivationTimeout
 
 ### PeginAction
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts:48](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts#L48)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts)
 
 Available actions user can take
 
@@ -3745,7 +3745,7 @@ Available actions user can take
 SUBMIT_WOTS_KEY: "SUBMIT_WOTS_KEY";
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts:50](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts#L50)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts)
 
 Submit WOTS key (re-derives via wallet `deriveContextHash`)
 
@@ -3755,7 +3755,7 @@ Submit WOTS key (re-derives via wallet `deriveContextHash`)
 SIGN_PAYOUT_TRANSACTIONS: "SIGN_PAYOUT_TRANSACTIONS";
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts:52](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts#L52)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts)
 
 Sign payout transactions
 
@@ -3765,7 +3765,7 @@ Sign payout transactions
 SIGN_AND_BROADCAST_TO_BITCOIN: "SIGN_AND_BROADCAST_TO_BITCOIN";
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts:54](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts#L54)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts)
 
 Sign and broadcast peg-in transaction to Bitcoin
 
@@ -3775,7 +3775,7 @@ Sign and broadcast peg-in transaction to Bitcoin
 ACTIVATE_VAULT: "ACTIVATE_VAULT";
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts:56](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts#L56)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts)
 
 Reveal HTLC secret on Ethereum to activate vault
 
@@ -3785,7 +3785,7 @@ Reveal HTLC secret on Ethereum to activate vault
 ACTIVATE_AND_REDEEM: "ACTIVATE_AND_REDEEM";
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts:63](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts#L63)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts)
 
 Escape hatch: reveal the HTLC secret and immediately redeem the vault for
 the depositor (`activateVaultWithSecretAndRedeem`), skipping application
@@ -3798,7 +3798,7 @@ vault could not be activated (application paused / activation revert).
 REFUND_HTLC: "REFUND_HTLC";
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts:65](../../packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts#L65)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginState.ts)
 
 Sign and broadcast HTLC refund transaction for an expired vault
 
@@ -3806,7 +3806,7 @@ Sign and broadcast HTLC refund transaction for an expired vault
 
 ### ClaimerPegoutStatusValue
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/pegout/state.ts:13](../../packages/babylon-ts-sdk/src/tbv/core/services/pegout/state.ts#L13)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/pegout/state.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/pegout/state.ts)
 
 Claimer-side pegout statuses reported by the VP.
 
@@ -3818,7 +3818,7 @@ Claimer-side pegout statuses reported by the VP.
 CLAIM_EVENT_RECEIVED: "ClaimEventReceived";
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/pegout/state.ts:14](../../packages/babylon-ts-sdk/src/tbv/core/services/pegout/state.ts#L14)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/pegout/state.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/pegout/state.ts)
 
 ##### CLAIM\_BROADCAST
 
@@ -3826,7 +3826,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/pegout/state.ts:14](.
 CLAIM_BROADCAST: "ClaimBroadcast";
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/pegout/state.ts:15](../../packages/babylon-ts-sdk/src/tbv/core/services/pegout/state.ts#L15)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/pegout/state.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/pegout/state.ts)
 
 ##### ASSERT\_BROADCAST
 
@@ -3834,7 +3834,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/pegout/state.ts:15](.
 ASSERT_BROADCAST: "AssertBroadcast";
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/pegout/state.ts:16](../../packages/babylon-ts-sdk/src/tbv/core/services/pegout/state.ts#L16)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/pegout/state.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/pegout/state.ts)
 
 ##### PAYOUT\_BROADCAST
 
@@ -3842,7 +3842,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/pegout/state.ts:16](.
 PAYOUT_BROADCAST: "PayoutBroadcast";
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/pegout/state.ts:17](../../packages/babylon-ts-sdk/src/tbv/core/services/pegout/state.ts#L17)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/pegout/state.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/pegout/state.ts)
 
 ##### PAYOUT\_BLOCKED
 
@@ -3850,7 +3850,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/pegout/state.ts:17](.
 PAYOUT_BLOCKED: "PayoutBlocked";
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/pegout/state.ts:18](../../packages/babylon-ts-sdk/src/tbv/core/services/pegout/state.ts#L18)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/pegout/state.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/pegout/state.ts)
 
 ## Variables
 
@@ -3860,7 +3860,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/pegout/state.ts:18](.
 const REFUND_VSIZE: 160 = 160;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:47](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L47)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts)
 
 ***
 
@@ -3870,7 +3870,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadc
 const REFUND_MAX_FEE_RATE_SATS_VB: 2000 = 2000;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:63](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L63)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts)
 
 ***
 
@@ -3880,7 +3880,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadc
 const REFUND_MAX_FEE_FRACTION_NUMERATOR: 10n = 10n;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:71](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L71)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts)
 
 ***
 
@@ -3890,4 +3890,4 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadc
 const REFUND_MAX_FEE_FRACTION_DENOMINATOR: 100n = 100n;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts:72](../../packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts#L72)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts)

--- a/packages/babylon-ts-sdk/docs/api/utils.md
+++ b/packages/babylon-ts-sdk/docs/api/utils.md
@@ -8,7 +8,7 @@ Pure helpers for the primitives and services layers. No wallet, no network, no c
 
 ### UtxoNotAvailableError
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/availability.ts:53](../../packages/babylon-ts-sdk/src/tbv/core/utils/utxo/availability.ts#L53)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/availability.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/utxo/availability.ts)
 
 Error thrown when UTXOs are not available.
 
@@ -24,7 +24,7 @@ Error thrown when UTXOs are not available.
 new UtxoNotAvailableError(missingUtxos): UtxoNotAvailableError;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/availability.ts:56](../../packages/babylon-ts-sdk/src/tbv/core/utils/utxo/availability.ts#L56)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/availability.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/utxo/availability.ts)
 
 ###### Parameters
 
@@ -50,13 +50,13 @@ Error.constructor
 readonly missingUtxos: MissingUtxoInfo[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/availability.ts:54](../../packages/babylon-ts-sdk/src/tbv/core/utils/utxo/availability.ts#L54)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/availability.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/utxo/availability.ts)
 
 ## Interfaces
 
 ### CombinedAbortSignal
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/abortSignals.ts:7](../../packages/babylon-ts-sdk/src/tbv/core/utils/abortSignals.ts#L7)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/abortSignals.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/abortSignals.ts)
 
 #### Properties
 
@@ -66,7 +66,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/abortSignals.ts:7](../..
 signal: AbortSignal;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/abortSignals.ts:8](../../packages/babylon-ts-sdk/src/tbv/core/utils/abortSignals.ts#L8)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/abortSignals.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/abortSignals.ts)
 
 ##### cleanup()
 
@@ -74,7 +74,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/abortSignals.ts:8](../..
 cleanup: () => void;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/abortSignals.ts:10](../../packages/babylon-ts-sdk/src/tbv/core/utils/abortSignals.ts#L10)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/abortSignals.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/abortSignals.ts)
 
 Remove listeners from the source signals. Call once the request settles.
 
@@ -86,7 +86,7 @@ Remove listeners from the source signals. Call once the request settles.
 
 ### PsbtInputFields
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/btc/psbtInputFields.ts:16](../../packages/babylon-ts-sdk/src/tbv/core/utils/btc/psbtInputFields.ts#L16)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/btc/psbtInputFields.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/btc/psbtInputFields.ts)
 
 PSBT input fields for supported script types (P2TR, P2WPKH, P2WSH).
 
@@ -98,7 +98,7 @@ PSBT input fields for supported script types (P2TR, P2WPKH, P2WSH).
 optional witnessUtxo: object;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/btc/psbtInputFields.ts:17](../../packages/babylon-ts-sdk/src/tbv/core/utils/btc/psbtInputFields.ts#L17)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/btc/psbtInputFields.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/btc/psbtInputFields.ts)
 
 ###### script
 
@@ -118,7 +118,7 @@ value: number;
 optional witnessScript: Buffer<ArrayBufferLike>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/btc/psbtInputFields.ts:21](../../packages/babylon-ts-sdk/src/tbv/core/utils/btc/psbtInputFields.ts#L21)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/btc/psbtInputFields.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/btc/psbtInputFields.ts)
 
 ##### tapInternalKey?
 
@@ -126,13 +126,13 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/btc/psbtInputFields.ts:2
 optional tapInternalKey: Buffer<ArrayBufferLike>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/btc/psbtInputFields.ts:22](../../packages/babylon-ts-sdk/src/tbv/core/utils/btc/psbtInputFields.ts#L22)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/btc/psbtInputFields.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/btc/psbtInputFields.ts)
 
 ***
 
 ### UtxoForPsbt
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/btc/psbtInputFields.ts:30](../../packages/babylon-ts-sdk/src/tbv/core/utils/btc/psbtInputFields.ts#L30)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/btc/psbtInputFields.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/btc/psbtInputFields.ts)
 
 UTXO information for PSBT construction.
 
@@ -146,7 +146,7 @@ Only supports Taproot (P2TR) and native SegWit (P2WPKH, P2WSH) script types.
 txid: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/btc/psbtInputFields.ts:32](../../packages/babylon-ts-sdk/src/tbv/core/utils/btc/psbtInputFields.ts#L32)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/btc/psbtInputFields.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/btc/psbtInputFields.ts)
 
 Transaction ID of the UTXO
 
@@ -156,7 +156,7 @@ Transaction ID of the UTXO
 vout: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/btc/psbtInputFields.ts:34](../../packages/babylon-ts-sdk/src/tbv/core/utils/btc/psbtInputFields.ts#L34)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/btc/psbtInputFields.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/btc/psbtInputFields.ts)
 
 Output index (vout) of the UTXO
 
@@ -166,7 +166,7 @@ Output index (vout) of the UTXO
 value: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/btc/psbtInputFields.ts:36](../../packages/babylon-ts-sdk/src/tbv/core/utils/btc/psbtInputFields.ts#L36)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/btc/psbtInputFields.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/btc/psbtInputFields.ts)
 
 Value of the UTXO in satoshis
 
@@ -176,7 +176,7 @@ Value of the UTXO in satoshis
 scriptPubKey: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/btc/psbtInputFields.ts:38](../../packages/babylon-ts-sdk/src/tbv/core/utils/btc/psbtInputFields.ts#L38)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/btc/psbtInputFields.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/btc/psbtInputFields.ts)
 
 ScriptPubKey of the UTXO (hex string)
 
@@ -186,7 +186,7 @@ ScriptPubKey of the UTXO (hex string)
 optional witnessScript: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/btc/psbtInputFields.ts:40](../../packages/babylon-ts-sdk/src/tbv/core/utils/btc/psbtInputFields.ts#L40)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/btc/psbtInputFields.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/btc/psbtInputFields.ts)
 
 Witness script (required for P2WSH)
 
@@ -194,7 +194,7 @@ Witness script (required for P2WSH)
 
 ### WaitForTransactionReceiptSmartAwareParams
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/eth/waitForTransactionReceiptSmartAware.ts:40](../../packages/babylon-ts-sdk/src/tbv/core/utils/eth/waitForTransactionReceiptSmartAware.ts#L40)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/eth/waitForTransactionReceiptSmartAware.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/eth/waitForTransactionReceiptSmartAware.ts)
 
 #### Properties
 
@@ -204,7 +204,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/eth/waitForTransactionRe
 publicClient: object;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/eth/waitForTransactionReceiptSmartAware.ts:41](../../packages/babylon-ts-sdk/src/tbv/core/utils/eth/waitForTransactionReceiptSmartAware.ts#L41)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/eth/waitForTransactionReceiptSmartAware.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/eth/waitForTransactionReceiptSmartAware.ts)
 
 ##### walletAddress
 
@@ -212,7 +212,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/eth/waitForTransactionRe
 walletAddress: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/eth/waitForTransactionReceiptSmartAware.ts:42](../../packages/babylon-ts-sdk/src/tbv/core/utils/eth/waitForTransactionReceiptSmartAware.ts#L42)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/eth/waitForTransactionReceiptSmartAware.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/eth/waitForTransactionReceiptSmartAware.ts)
 
 ##### hash
 
@@ -220,7 +220,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/eth/waitForTransactionRe
 hash: `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/eth/waitForTransactionReceiptSmartAware.ts:43](../../packages/babylon-ts-sdk/src/tbv/core/utils/eth/waitForTransactionReceiptSmartAware.ts#L43)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/eth/waitForTransactionReceiptSmartAware.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/eth/waitForTransactionReceiptSmartAware.ts)
 
 ##### confirmations?
 
@@ -228,7 +228,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/eth/waitForTransactionRe
 optional confirmations: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/eth/waitForTransactionReceiptSmartAware.ts:44](../../packages/babylon-ts-sdk/src/tbv/core/utils/eth/waitForTransactionReceiptSmartAware.ts#L44)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/eth/waitForTransactionReceiptSmartAware.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/eth/waitForTransactionReceiptSmartAware.ts)
 
 ##### timeout?
 
@@ -236,7 +236,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/eth/waitForTransactionRe
 optional timeout: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/eth/waitForTransactionReceiptSmartAware.ts:49](../../packages/babylon-ts-sdk/src/tbv/core/utils/eth/waitForTransactionReceiptSmartAware.ts#L49)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/eth/waitForTransactionReceiptSmartAware.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/eth/waitForTransactionReceiptSmartAware.ts)
 
 Forwarded to viem on the EOA (externally owned account) path.
 Ignored on the smart-account path — see safePollTimeoutMs.
@@ -247,7 +247,7 @@ Ignored on the smart-account path — see safePollTimeoutMs.
 optional safePollTimeoutMs: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/eth/waitForTransactionReceiptSmartAware.ts:51](../../packages/babylon-ts-sdk/src/tbv/core/utils/eth/waitForTransactionReceiptSmartAware.ts#L51)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/eth/waitForTransactionReceiptSmartAware.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/eth/waitForTransactionReceiptSmartAware.ts)
 
 Total budget for waiting on Safe quorum + execution. Default 4h.
 
@@ -257,7 +257,7 @@ Total budget for waiting on Safe quorum + execution. Default 4h.
 optional safePollIntervalMs: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/eth/waitForTransactionReceiptSmartAware.ts:53](../../packages/babylon-ts-sdk/src/tbv/core/utils/eth/waitForTransactionReceiptSmartAware.ts#L53)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/eth/waitForTransactionReceiptSmartAware.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/eth/waitForTransactionReceiptSmartAware.ts)
 
 Poll cadence against the Safe Transaction Service. Default 5s.
 
@@ -265,7 +265,7 @@ Poll cadence against the Safe Transaction Service. Default 5s.
 
 ### ComputeBaseFeeParams
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts:23](../../packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts#L23)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts)
 
 #### Properties
 
@@ -275,7 +275,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts:23](
 numInputs: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts:24](../../packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts#L24)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts)
 
 ##### numOutputs
 
@@ -283,7 +283,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts:24](
 numOutputs: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts:31](../../packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts#L31)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts)
 
 Number of outputs in the unfunded transaction (HTLC vault outputs +
 CPFP anchor + optional auth-anchor OP_RETURN). Excludes the change
@@ -296,13 +296,13 @@ separately.
 feeRate: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts:32](../../packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts#L32)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts)
 
 ***
 
 ### ApplyChangeOutputPolicyParams
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts:75](../../packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts#L75)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts)
 
 #### Properties
 
@@ -312,7 +312,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts:75](
 totalInputValue: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts:76](../../packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts#L76)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts)
 
 ##### peginAmount
 
@@ -320,7 +320,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts:76](
 peginAmount: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts:77](../../packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts#L77)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts)
 
 ##### baseFee
 
@@ -328,7 +328,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts:77](
 baseFee: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts:78](../../packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts#L78)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts)
 
 ##### changeOutputFee
 
@@ -336,13 +336,13 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts:78](
 changeOutputFee: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts:79](../../packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts#L79)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts)
 
 ***
 
 ### ChangeOutputPolicyResult
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts:82](../../packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts#L82)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts)
 
 #### Properties
 
@@ -352,7 +352,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts:82](
 fee: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts:84](../../packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts#L84)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts)
 
 Final transaction fee (sats).
 
@@ -362,7 +362,7 @@ Final transaction fee (sats).
 changeAmount: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts:90](../../packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts#L90)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts)
 
 Final change amount (sats). 0n when no change output is emitted.
 When `emitChangeOutput` is false, the would-be change is paid to
@@ -374,7 +374,7 @@ miners as part of `fee` — i.e. it is dust by policy.
 emitChangeOutput: boolean;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts:92](../../packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts#L92)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts)
 
 Whether the funded transaction must include a change output.
 
@@ -382,7 +382,7 @@ Whether the funded transaction must include a change output.
 
 ### ComputeMaxDepositParams
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts:149](../../packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts#L149)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts)
 
 #### Properties
 
@@ -392,7 +392,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts:149]
 numInputs: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts:150](../../packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts#L150)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts)
 
 ##### numOutputs
 
@@ -400,7 +400,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts:150]
 numOutputs: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts:157](../../packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts#L157)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts)
 
 Number of outputs in the unfunded transaction. Use the worst-case
 count for the use case being budgeted (e.g. max-batch with
@@ -413,7 +413,7 @@ and assumes no change output.
 totalBalance: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts:158](../../packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts#L158)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts)
 
 ##### feeRate
 
@@ -421,13 +421,13 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts:158]
 feeRate: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts:159](../../packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts#L159)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts)
 
 ***
 
 ### FundPeginTransactionParams
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/transaction/fundPeginTransaction.ts:23](../../packages/babylon-ts-sdk/src/tbv/core/utils/transaction/fundPeginTransaction.ts#L23)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/transaction/fundPeginTransaction.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/transaction/fundPeginTransaction.ts)
 
 #### Properties
 
@@ -437,7 +437,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/transaction/fundPeginTra
 unfundedTxHex: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/transaction/fundPeginTransaction.ts:25](../../packages/babylon-ts-sdk/src/tbv/core/utils/transaction/fundPeginTransaction.ts#L25)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/transaction/fundPeginTransaction.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/transaction/fundPeginTransaction.ts)
 
 Unfunded transaction hex from SDK (0 inputs, vault + depositor claim outputs)
 
@@ -447,7 +447,7 @@ Unfunded transaction hex from SDK (0 inputs, vault + depositor claim outputs)
 selectedUTXOs: UTXO[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/transaction/fundPeginTransaction.ts:27](../../packages/babylon-ts-sdk/src/tbv/core/utils/transaction/fundPeginTransaction.ts#L27)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/transaction/fundPeginTransaction.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/transaction/fundPeginTransaction.ts)
 
 Selected UTXOs to use as inputs
 
@@ -457,7 +457,7 @@ Selected UTXOs to use as inputs
 changeAddress: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/transaction/fundPeginTransaction.ts:29](../../packages/babylon-ts-sdk/src/tbv/core/utils/transaction/fundPeginTransaction.ts#L29)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/transaction/fundPeginTransaction.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/transaction/fundPeginTransaction.ts)
 
 Change address (from wallet)
 
@@ -467,7 +467,7 @@ Change address (from wallet)
 changeAmount: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/transaction/fundPeginTransaction.ts:31](../../packages/babylon-ts-sdk/src/tbv/core/utils/transaction/fundPeginTransaction.ts#L31)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/transaction/fundPeginTransaction.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/transaction/fundPeginTransaction.ts)
 
 Change amount in satoshis
 
@@ -477,7 +477,7 @@ Change amount in satoshis
 network: Network;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/transaction/fundPeginTransaction.ts:33](../../packages/babylon-ts-sdk/src/tbv/core/utils/transaction/fundPeginTransaction.ts#L33)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/transaction/fundPeginTransaction.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/transaction/fundPeginTransaction.ts)
 
 Bitcoin network
 
@@ -485,7 +485,7 @@ Bitcoin network
 
 ### ParsedOutput
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/transaction/fundPeginTransaction.ts:37](../../packages/babylon-ts-sdk/src/tbv/core/utils/transaction/fundPeginTransaction.ts#L37)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/transaction/fundPeginTransaction.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/transaction/fundPeginTransaction.ts)
 
 A single parsed output from the unfunded WASM transaction
 
@@ -497,7 +497,7 @@ A single parsed output from the unfunded WASM transaction
 value: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/transaction/fundPeginTransaction.ts:38](../../packages/babylon-ts-sdk/src/tbv/core/utils/transaction/fundPeginTransaction.ts#L38)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/transaction/fundPeginTransaction.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/transaction/fundPeginTransaction.ts)
 
 ##### script
 
@@ -505,13 +505,13 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/transaction/fundPeginTra
 script: Buffer;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/transaction/fundPeginTransaction.ts:39](../../packages/babylon-ts-sdk/src/tbv/core/utils/transaction/fundPeginTransaction.ts#L39)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/transaction/fundPeginTransaction.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/transaction/fundPeginTransaction.ts)
 
 ***
 
 ### UtxoRef
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/availability.ts:23](../../packages/babylon-ts-sdk/src/tbv/core/utils/utxo/availability.ts#L23)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/availability.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/utxo/availability.ts)
 
 Reference to a Bitcoin UTXO by its outpoint (txid + vout).
 
@@ -528,7 +528,7 @@ lowercase hex.
 txid: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/availability.ts:24](../../packages/babylon-ts-sdk/src/tbv/core/utils/utxo/availability.ts#L24)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/availability.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/utxo/availability.ts)
 
 ##### vout
 
@@ -536,13 +536,13 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/availability.ts:24]
 vout: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/availability.ts:25](../../packages/babylon-ts-sdk/src/tbv/core/utils/utxo/availability.ts#L25)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/availability.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/utxo/availability.ts)
 
 ***
 
 ### MissingUtxoInfo
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/availability.ts:31](../../packages/babylon-ts-sdk/src/tbv/core/utils/utxo/availability.ts#L31)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/availability.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/utxo/availability.ts)
 
 Information about a missing/spent UTXO.
 
@@ -554,7 +554,7 @@ Information about a missing/spent UTXO.
 txid: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/availability.ts:33](../../packages/babylon-ts-sdk/src/tbv/core/utils/utxo/availability.ts#L33)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/availability.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/utxo/availability.ts)
 
 Transaction ID of the missing UTXO
 
@@ -564,7 +564,7 @@ Transaction ID of the missing UTXO
 vout: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/availability.ts:35](../../packages/babylon-ts-sdk/src/tbv/core/utils/utxo/availability.ts#L35)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/availability.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/utxo/availability.ts)
 
 Output index of the missing UTXO
 
@@ -572,7 +572,7 @@ Output index of the missing UTXO
 
 ### UtxoValidationResult
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/availability.ts:41](../../packages/babylon-ts-sdk/src/tbv/core/utils/utxo/availability.ts#L41)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/availability.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/utxo/availability.ts)
 
 Result of UTXO validation.
 
@@ -584,7 +584,7 @@ Result of UTXO validation.
 allAvailable: boolean;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/availability.ts:43](../../packages/babylon-ts-sdk/src/tbv/core/utils/utxo/availability.ts#L43)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/availability.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/utxo/availability.ts)
 
 Whether all UTXOs are still available
 
@@ -594,7 +594,7 @@ Whether all UTXOs are still available
 missingUtxos: MissingUtxoInfo[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/availability.ts:45](../../packages/babylon-ts-sdk/src/tbv/core/utils/utxo/availability.ts#L45)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/availability.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/utxo/availability.ts)
 
 List of missing UTXOs (if any)
 
@@ -604,7 +604,7 @@ List of missing UTXOs (if any)
 totalInputs: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/availability.ts:47](../../packages/babylon-ts-sdk/src/tbv/core/utils/utxo/availability.ts#L47)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/availability.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/utxo/availability.ts)
 
 Total number of inputs checked
 
@@ -612,7 +612,7 @@ Total number of inputs checked
 
 ### PendingPeginLike
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/reservation.ts:22](../../packages/babylon-ts-sdk/src/tbv/core/utils/utxo/reservation.ts#L22)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/reservation.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/utxo/reservation.ts)
 
 Locally-known pending pegin. `id` is the bytes32 vault id.
 
@@ -624,7 +624,7 @@ Locally-known pending pegin. `id` is the bytes32 vault id.
 optional id: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/reservation.ts:23](../../packages/babylon-ts-sdk/src/tbv/core/utils/utxo/reservation.ts#L23)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/reservation.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/utxo/reservation.ts)
 
 ##### unsignedTxHex?
 
@@ -632,13 +632,13 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/reservation.ts:23](
 optional unsignedTxHex: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/reservation.ts:24](../../packages/babylon-ts-sdk/src/tbv/core/utils/utxo/reservation.ts#L24)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/reservation.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/utxo/reservation.ts)
 
 ***
 
 ### VaultLike
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/reservation.ts:28](../../packages/babylon-ts-sdk/src/tbv/core/utils/utxo/reservation.ts#L28)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/reservation.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/utxo/reservation.ts)
 
 On-chain vault row from the indexer.
 
@@ -650,7 +650,7 @@ On-chain vault row from the indexer.
 optional id: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/reservation.ts:29](../../packages/babylon-ts-sdk/src/tbv/core/utils/utxo/reservation.ts#L29)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/reservation.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/utxo/reservation.ts)
 
 ##### status
 
@@ -658,7 +658,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/reservation.ts:29](
 status: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/reservation.ts:30](../../packages/babylon-ts-sdk/src/tbv/core/utils/utxo/reservation.ts#L30)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/reservation.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/utxo/reservation.ts)
 
 ##### unsignedPrePeginTx
 
@@ -666,13 +666,13 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/reservation.ts:30](
 unsignedPrePeginTx: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/reservation.ts:31](../../packages/babylon-ts-sdk/src/tbv/core/utils/utxo/reservation.ts#L31)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/reservation.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/utxo/reservation.ts)
 
 ***
 
 ### FindOverlappingPendingVaultsParams
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/reservation.ts:34](../../packages/babylon-ts-sdk/src/tbv/core/utils/utxo/reservation.ts#L34)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/reservation.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/utxo/reservation.ts)
 
 #### Properties
 
@@ -682,7 +682,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/reservation.ts:34](
 selectedOutpoints: readonly UtxoRef[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/reservation.ts:35](../../packages/babylon-ts-sdk/src/tbv/core/utils/utxo/reservation.ts#L35)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/reservation.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/utxo/reservation.ts)
 
 ##### vaults?
 
@@ -690,7 +690,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/reservation.ts:35](
 optional vaults: readonly VaultLike[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/reservation.ts:36](../../packages/babylon-ts-sdk/src/tbv/core/utils/utxo/reservation.ts#L36)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/reservation.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/utxo/reservation.ts)
 
 ##### pendingPegins?
 
@@ -698,13 +698,13 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/reservation.ts:36](
 optional pendingPegins: readonly PendingPeginLike[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/reservation.ts:37](../../packages/babylon-ts-sdk/src/tbv/core/utils/utxo/reservation.ts#L37)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/reservation.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/utxo/reservation.ts)
 
 ***
 
 ### UTXO
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/selectUtxos.ts:19](../../packages/babylon-ts-sdk/src/tbv/core/utils/utxo/selectUtxos.ts#L19)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/selectUtxos.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/utxo/selectUtxos.ts)
 
 Unspent Transaction Output (UTXO) for funding peg-in transactions.
 
@@ -716,7 +716,7 @@ Unspent Transaction Output (UTXO) for funding peg-in transactions.
 txid: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/selectUtxos.ts:23](../../packages/babylon-ts-sdk/src/tbv/core/utils/utxo/selectUtxos.ts#L23)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/selectUtxos.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/utxo/selectUtxos.ts)
 
 Transaction ID of the UTXO (64-char hex without 0x prefix).
 
@@ -726,7 +726,7 @@ Transaction ID of the UTXO (64-char hex without 0x prefix).
 vout: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/selectUtxos.ts:28](../../packages/babylon-ts-sdk/src/tbv/core/utils/utxo/selectUtxos.ts#L28)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/selectUtxos.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/utxo/selectUtxos.ts)
 
 Output index within the transaction.
 
@@ -736,7 +736,7 @@ Output index within the transaction.
 value: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/selectUtxos.ts:33](../../packages/babylon-ts-sdk/src/tbv/core/utils/utxo/selectUtxos.ts#L33)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/selectUtxos.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/utxo/selectUtxos.ts)
 
 Value in satoshis.
 
@@ -746,7 +746,7 @@ Value in satoshis.
 scriptPubKey: string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/selectUtxos.ts:38](../../packages/babylon-ts-sdk/src/tbv/core/utils/utxo/selectUtxos.ts#L38)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/selectUtxos.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/utxo/selectUtxos.ts)
 
 Script public key hex.
 
@@ -754,7 +754,7 @@ Script public key hex.
 
 ### UTXOSelectionResult
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/selectUtxos.ts:41](../../packages/babylon-ts-sdk/src/tbv/core/utils/utxo/selectUtxos.ts#L41)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/selectUtxos.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/utxo/selectUtxos.ts)
 
 #### Properties
 
@@ -764,7 +764,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/selectUtxos.ts:41](
 selectedUTXOs: UTXO[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/selectUtxos.ts:42](../../packages/babylon-ts-sdk/src/tbv/core/utils/utxo/selectUtxos.ts#L42)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/selectUtxos.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/utxo/selectUtxos.ts)
 
 ##### totalValue
 
@@ -772,7 +772,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/selectUtxos.ts:42](
 totalValue: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/selectUtxos.ts:43](../../packages/babylon-ts-sdk/src/tbv/core/utils/utxo/selectUtxos.ts#L43)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/selectUtxos.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/utxo/selectUtxos.ts)
 
 ##### fee
 
@@ -780,7 +780,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/selectUtxos.ts:43](
 fee: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/selectUtxos.ts:44](../../packages/babylon-ts-sdk/src/tbv/core/utils/utxo/selectUtxos.ts#L44)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/selectUtxos.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/utxo/selectUtxos.ts)
 
 ##### changeAmount
 
@@ -788,7 +788,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/selectUtxos.ts:44](
 changeAmount: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/selectUtxos.ts:45](../../packages/babylon-ts-sdk/src/tbv/core/utils/utxo/selectUtxos.ts#L45)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/selectUtxos.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/utxo/selectUtxos.ts)
 
 ## Functions
 
@@ -798,7 +798,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/selectUtxos.ts:45](
 function getNetwork(network): Network;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts:330](../../packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts#L330)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts)
 
 Map SDK network type to bitcoinjs-lib Network object.
 
@@ -824,7 +824,7 @@ bitcoinjs-lib Network object
 function combineAbortSignals(signals): CombinedAbortSignal;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/abortSignals.ts:24](../../packages/babylon-ts-sdk/src/tbv/core/utils/abortSignals.ts#L24)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/abortSignals.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/abortSignals.ts)
 
 Compose several AbortSignals into one that aborts when any input aborts,
 propagating the reason of whichever fired first.
@@ -854,7 +854,7 @@ outright on those browsers.
 function getPsbtInputFields(utxo, publicKeyNoCoord?): PsbtInputFields;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/btc/psbtInputFields.ts:53](../../packages/babylon-ts-sdk/src/tbv/core/utils/btc/psbtInputFields.ts#L53)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/btc/psbtInputFields.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/btc/psbtInputFields.ts)
 
 Get PSBT input fields for a given UTXO based on its script type.
 
@@ -892,7 +892,7 @@ Error if required input data is missing or unsupported script type
 function getScriptType(scriptPubKey): BitcoinScriptType;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/btc/scriptType.ts:35](../../packages/babylon-ts-sdk/src/tbv/core/utils/btc/scriptType.ts#L35)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/btc/scriptType.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/btc/scriptType.ts)
 
 Detect the type of a Bitcoin script.
 
@@ -927,7 +927,7 @@ if (scriptType === BitcoinScriptType.P2TR) {
 function waitForTransactionReceiptSmartAware(params): Promise<TransactionReceipt>;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/eth/waitForTransactionReceiptSmartAware.ts:56](../../packages/babylon-ts-sdk/src/tbv/core/utils/eth/waitForTransactionReceiptSmartAware.ts#L56)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/eth/waitForTransactionReceiptSmartAware.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/eth/waitForTransactionReceiptSmartAware.ts)
 
 #### Parameters
 
@@ -947,7 +947,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/eth/waitForTransactionRe
 function rateBasedTxBufferFee(feeRate): number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/fee/constants.ts:37](../../packages/babylon-ts-sdk/src/tbv/core/utils/fee/constants.ts#L37)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/fee/constants.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/fee/constants.ts)
 
 Adds a buffer to the transaction fee calculation if the fee rate is low.
 
@@ -977,7 +977,7 @@ Buffer amount in satoshis to add to the transaction fee
 function peginOutputCount(vaultCount, hasAuthAnchor): number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/fee/constants.ts:77](../../packages/babylon-ts-sdk/src/tbv/core/utils/fee/constants.ts#L77)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/fee/constants.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/fee/constants.ts)
 
 Compute the total number of outputs (before change) in a Pre-PegIn
 transaction.
@@ -1024,7 +1024,7 @@ If `vaultCount` is not a positive integer.
 function computePeginBaseFeeSats(params): bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts:42](../../packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts#L42)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts)
 
 Compute the base fee (sats) for a Pre-PegIn transaction with no change
 output, including the low-fee-rate buffer.
@@ -1050,7 +1050,7 @@ decides whether to add the incremental change-output fee.
 function computeChangeOutputFeeSats(feeRate): bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts:71](../../packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts#L71)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts)
 
 Incremental fee (sats) for adding one P2TR-sized change output at the
 given fee rate. Does NOT include the low-fee-rate buffer — that is part
@@ -1074,7 +1074,7 @@ of the base fee, paid once per transaction.
 function applyChangeOutputPolicy(params): ChangeOutputPolicyResult;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts:115](../../packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts#L115)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts)
 
 Apply the change-output dust policy: emit a change output iff the
 post-change-output-fee residual strictly exceeds DUST_THRESHOLD.
@@ -1115,7 +1115,7 @@ If `totalInputValue < peginAmount + baseFee` (insufficient funds
 function computeMaxDeposit(params): bigint | null;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts:170](../../packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts#L170)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts)
 
 Compute the maximum depositable amount (sats) given a fixed-cost
 sweep: every UTXO is spent, no change output is emitted, fee is the
@@ -1142,7 +1142,7 @@ alone exceeds the balance.
 function createTaprootScriptPathSignOptions(publicKey, inputCount): SignPsbtOptions;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/signing.ts:15](../../packages/babylon-ts-sdk/src/tbv/core/utils/signing.ts#L15)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/signing.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/signing.ts)
 
 Create SignPsbtOptions for Taproot script-path PSBT signing.
 
@@ -1178,7 +1178,7 @@ Number of inputs to sign. Generates entries
 function calculateBtcTxHash(txHex): `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/transaction/btcTxHash.ts:23](../../packages/babylon-ts-sdk/src/tbv/core/utils/transaction/btcTxHash.ts#L23)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/transaction/btcTxHash.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/transaction/btcTxHash.ts)
 
 Calculate Bitcoin transaction hash
 
@@ -1210,7 +1210,7 @@ The transaction hash as Hex (with 0x prefix)
 function parseUnfundedWasmTransaction(unfundedTxHex): ParsedUnfundedTx;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/transaction/fundPeginTransaction.ts:64](../../packages/babylon-ts-sdk/src/tbv/core/utils/transaction/fundPeginTransaction.ts#L64)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/transaction/fundPeginTransaction.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/transaction/fundPeginTransaction.ts)
 
 Parses an unfunded transaction hex from WASM.
 
@@ -1248,7 +1248,7 @@ Error if transaction structure is invalid
 function fundPeginTransaction(params): string;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/transaction/fundPeginTransaction.ts:129](../../packages/babylon-ts-sdk/src/tbv/core/utils/transaction/fundPeginTransaction.ts#L129)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/transaction/fundPeginTransaction.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/transaction/fundPeginTransaction.ts)
 
 Funds an unfunded peg-in transaction by adding inputs and change output.
 
@@ -1278,7 +1278,7 @@ Transaction hex string ready for wallet signing
 function extractInputsFromTransaction(unsignedTxHex): object[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/availability.ts:75](../../packages/babylon-ts-sdk/src/tbv/core/utils/utxo/availability.ts#L75)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/availability.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/utxo/availability.ts)
 
 Extract input references (txid:vout) from an unsigned transaction.
 
@@ -1304,7 +1304,7 @@ Array of input references
 function validateUtxosAvailable(unsignedTxHex, availableUtxos): UtxoValidationResult;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/availability.ts:109](../../packages/babylon-ts-sdk/src/tbv/core/utils/utxo/availability.ts#L109)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/availability.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/utxo/availability.ts)
 
 Validate that all UTXOs in a transaction are still available.
 
@@ -1340,7 +1340,7 @@ Validation result with missing UTXO details
 function assertUtxosAvailable(unsignedTxHex, availableUtxos): void;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/availability.ts:168](../../packages/babylon-ts-sdk/src/tbv/core/utils/utxo/availability.ts#L168)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/availability.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/utxo/availability.ts)
 
 Validate UTXOs and throw if any are not available.
 
@@ -1380,7 +1380,7 @@ Error if validation fails
 function findOverlappingPendingVaults(params): string[];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/reservation.ts:61](../../packages/babylon-ts-sdk/src/tbv/core/utils/utxo/reservation.ts#L61)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/reservation.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/utxo/reservation.ts)
 
 Return the ids of pending vaults whose committed Pre-PegIn inputs
 overlap any of the just-selected outpoints. On-chain `PENDING` vaults
@@ -1408,7 +1408,7 @@ function selectUtxosForPegin(
    numOutputs): UTXOSelectionResult;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/selectUtxos.ts:87](../../packages/babylon-ts-sdk/src/tbv/core/utils/utxo/selectUtxos.ts#L87)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/selectUtxos.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/utxo/selectUtxos.ts)
 
 Selects UTXOs to fund a peg-in transaction with iterative fee calculation.
 
@@ -1466,7 +1466,7 @@ Error if insufficient funds or no valid UTXOs
 function shouldAddChangeOutput(changeAmount): boolean;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/selectUtxos.ts:176](../../packages/babylon-ts-sdk/src/tbv/core/utils/utxo/selectUtxos.ts#L176)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/selectUtxos.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/utxo/selectUtxos.ts)
 
 Checks if change amount is above dust threshold.
 
@@ -1492,7 +1492,7 @@ true if change should be added as output, false if it should go to miners
 function getDustThreshold(): number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/selectUtxos.ts:185](../../packages/babylon-ts-sdk/src/tbv/core/utils/utxo/selectUtxos.ts#L185)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/selectUtxos.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/utxo/selectUtxos.ts)
 
 Gets the dust threshold value.
 
@@ -1506,7 +1506,7 @@ Dust threshold in satoshis
 
 ### BitcoinScriptType
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/btc/scriptType.ts:12](../../packages/babylon-ts-sdk/src/tbv/core/utils/btc/scriptType.ts#L12)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/btc/scriptType.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/btc/scriptType.ts)
 
 Bitcoin script types.
 
@@ -1518,7 +1518,7 @@ Bitcoin script types.
 P2PKH: "P2PKH";
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/btc/scriptType.ts:13](../../packages/babylon-ts-sdk/src/tbv/core/utils/btc/scriptType.ts#L13)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/btc/scriptType.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/btc/scriptType.ts)
 
 ##### P2SH
 
@@ -1526,7 +1526,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/btc/scriptType.ts:13](..
 P2SH: "P2SH";
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/btc/scriptType.ts:14](../../packages/babylon-ts-sdk/src/tbv/core/utils/btc/scriptType.ts#L14)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/btc/scriptType.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/btc/scriptType.ts)
 
 ##### P2WPKH
 
@@ -1534,7 +1534,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/btc/scriptType.ts:14](..
 P2WPKH: "P2WPKH";
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/btc/scriptType.ts:15](../../packages/babylon-ts-sdk/src/tbv/core/utils/btc/scriptType.ts#L15)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/btc/scriptType.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/btc/scriptType.ts)
 
 ##### P2WSH
 
@@ -1542,7 +1542,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/btc/scriptType.ts:15](..
 P2WSH: "P2WSH";
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/btc/scriptType.ts:16](../../packages/babylon-ts-sdk/src/tbv/core/utils/btc/scriptType.ts#L16)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/btc/scriptType.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/btc/scriptType.ts)
 
 ##### P2TR
 
@@ -1550,7 +1550,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/btc/scriptType.ts:16](..
 P2TR: "P2TR";
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/btc/scriptType.ts:17](../../packages/babylon-ts-sdk/src/tbv/core/utils/btc/scriptType.ts#L17)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/btc/scriptType.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/btc/scriptType.ts)
 
 ##### UNKNOWN
 
@@ -1558,7 +1558,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/btc/scriptType.ts:17](..
 UNKNOWN: "UNKNOWN";
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/btc/scriptType.ts:18](../../packages/babylon-ts-sdk/src/tbv/core/utils/btc/scriptType.ts#L18)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/btc/scriptType.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/btc/scriptType.ts)
 
 ## Variables
 
@@ -1568,7 +1568,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/btc/scriptType.ts:18](..
 const P2TR_INPUT_SIZE: 58 = 58;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/fee/constants.ts:7](../../packages/babylon-ts-sdk/src/tbv/core/utils/fee/constants.ts#L7)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/fee/constants.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/fee/constants.ts)
 
 Fee calculation constants for Bitcoin transactions.
 Based on btc-staking-ts values, adapted for vault peg-in transactions.
@@ -1581,7 +1581,7 @@ Based on btc-staking-ts values, adapted for vault peg-in transactions.
 const MAX_NON_LEGACY_OUTPUT_SIZE: 43 = 43;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/fee/constants.ts:10](../../packages/babylon-ts-sdk/src/tbv/core/utils/fee/constants.ts#L10)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/fee/constants.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/fee/constants.ts)
 
 ***
 
@@ -1591,7 +1591,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/fee/constants.ts:10](../
 const TX_BUFFER_SIZE_OVERHEAD: 11 = 11;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/fee/constants.ts:13](../../packages/babylon-ts-sdk/src/tbv/core/utils/fee/constants.ts#L13)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/fee/constants.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/fee/constants.ts)
 
 ***
 
@@ -1601,7 +1601,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/fee/constants.ts:13](../
 const BTC_DUST_SAT: 546 = 546;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/fee/constants.ts:16](../../packages/babylon-ts-sdk/src/tbv/core/utils/fee/constants.ts#L16)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/fee/constants.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/fee/constants.ts)
 
 ***
 
@@ -1611,7 +1611,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/fee/constants.ts:16](../
 const DUST_THRESHOLD: bigint;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/fee/constants.ts:19](../../packages/babylon-ts-sdk/src/tbv/core/utils/fee/constants.ts#L19)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/fee/constants.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/fee/constants.ts)
 
 Pre-computed BigInt dust threshold to avoid repeated conversions in hot paths
 
@@ -1623,7 +1623,7 @@ Pre-computed BigInt dust threshold to avoid repeated conversions in hot paths
 const LOW_RATE_ESTIMATION_ACCURACY_BUFFER: 30 = 30;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/fee/constants.ts:22](../../packages/babylon-ts-sdk/src/tbv/core/utils/fee/constants.ts#L22)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/fee/constants.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/fee/constants.ts)
 
 ***
 
@@ -1633,7 +1633,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/fee/constants.ts:22](../
 const WALLET_RELAY_FEE_RATE_THRESHOLD: 2 = 2;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/fee/constants.ts:25](../../packages/babylon-ts-sdk/src/tbv/core/utils/fee/constants.ts#L25)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/fee/constants.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/fee/constants.ts)
 
 ***
 
@@ -1643,7 +1643,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/fee/constants.ts:25](../
 const PEGIN_FIXED_OUTPUTS: 1 = 1;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/fee/constants.ts:47](../../packages/babylon-ts-sdk/src/tbv/core/utils/fee/constants.ts#L47)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/fee/constants.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/fee/constants.ts)
 
 Number of always-present fixed (non-HTLC) outputs in a Pre-PegIn
 transaction. Currently this is 1 CPFP anchor output.
@@ -1656,7 +1656,7 @@ transaction. Currently this is 1 CPFP anchor output.
 const PEGIN_AUTH_ANCHOR_OUTPUTS: 1 = 1;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/fee/constants.ts:56](../../packages/babylon-ts-sdk/src/tbv/core/utils/fee/constants.ts#L56)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/fee/constants.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/fee/constants.ts)
 
 Size of the auth-anchor `OP_RETURN` output when committed into a
 Pre-PegIn. The output carries `OP_RETURN <PUSH32 hash>` = 34 script
@@ -1672,7 +1672,7 @@ toward the fee-estimation output budget.
 const SPLIT_TX_FEE_SAFETY_MULTIPLIER: 5 = 5;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/fee/constants.ts:99](../../packages/babylon-ts-sdk/src/tbv/core/utils/fee/constants.ts#L99)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/fee/constants.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/fee/constants.ts)
 
 Safety multiplier for split transaction fee validation.
 The signed PSBT's fee rate and absolute fee must not exceed this multiple
@@ -1687,7 +1687,7 @@ catching catastrophic wallet-side overpayment.
 const MAX_REASONABLE_PEGIN_VBYTES: 100000n = 100_000n;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/fee/constants.ts:109](../../packages/babylon-ts-sdk/src/tbv/core/utils/fee/constants.ts#L109)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/fee/constants.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/fee/constants.ts)
 
 Binary-independent cap on the implied per-HTLC reserve
 (`htlcValue - peginAmount - depositorClaimValue`): the exact identity in
@@ -1704,7 +1704,7 @@ at 99 VKs + 99 UCs), so it can never false-positive.
 const HEX_RE: RegExp;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/validation.ts:9](../../packages/babylon-ts-sdk/src/tbv/core/utils/validation.ts#L9)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/validation.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/validation.ts)
 
 Non-empty string of hexadecimal characters (case-insensitive).
 
@@ -1716,7 +1716,7 @@ Non-empty string of hexadecimal characters (case-insensitive).
 const TXID_RE: RegExp;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/validation.ts:12](../../packages/babylon-ts-sdk/src/tbv/core/utils/validation.ts#L12)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/validation.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/validation.ts)
 
 Bitcoin txid: exactly 64 hex characters (32 bytes).
 
@@ -1728,7 +1728,7 @@ Bitcoin txid: exactly 64 hex characters (32 bytes).
 const BITCOIN_ADDRESS_RE: RegExp;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/validation.ts:21](../../packages/babylon-ts-sdk/src/tbv/core/utils/validation.ts#L21)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/validation.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/validation.ts)
 
 Bitcoin address format gate: 25–90 alphanumeric characters.
 Covers legacy (P2PKH/P2SH), bech32 (P2WPKH/P2WSH), bech32m (P2TR),
@@ -1744,7 +1744,7 @@ This is a format gate to prevent path-traversal — not full address validation.
 const KNOWN_SCRIPT_PREFIXES: readonly ["76a914", "a914", "0014", "0020", "5120"];
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/validation.ts:31](../../packages/babylon-ts-sdk/src/tbv/core/utils/validation.ts#L31)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/validation.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/validation.ts)
 
 Known Bitcoin scriptPubKey prefixes:
 - P2PKH:  76a914...88ac (25 bytes)
@@ -1761,7 +1761,7 @@ Known Bitcoin scriptPubKey prefixes:
 const MAX_REASONABLE_FEE_SATS: 1000000n = 1_000_000n;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/validation.ts:45](../../packages/babylon-ts-sdk/src/tbv/core/utils/validation.ts#L45)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/validation.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/validation.ts)
 
 Upper bound on the implied miner fee (0.01 BTC = 1,000,000 sats).
 Catches inflated input values from a compromised mempool API — if inputs are

--- a/packages/babylon-ts-sdk/docs/api/wallets.md
+++ b/packages/babylon-ts-sdk/docs/api/wallets.md
@@ -16,7 +16,7 @@ for adapter patterns and the canonical `deriveContextHash` flow
 type Hash = `0x${string}`;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/shared/wallets/interfaces/EthereumWallet.ts:5](../../packages/babylon-ts-sdk/src/shared/wallets/interfaces/EthereumWallet.ts#L5)
+Defined in: [packages/babylon-ts-sdk/src/shared/wallets/interfaces/EthereumWallet.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/shared/wallets/interfaces/EthereumWallet.ts)
 
 Ethereum transaction hash type (hex string with 0x prefix).
 Alias for viem's Hex type, provided for convenience.
@@ -53,7 +53,7 @@ Re-exports [SignPsbtOptions](managers.md#signpsbtoptions)
 const BitcoinNetworks: object;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts:10](../../packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts#L10)
+Defined in: [packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/shared/wallets/interfaces/BitcoinWallet.ts)
 
 Bitcoin network constants
 

--- a/packages/babylon-ts-sdk/typedoc-plugin.mjs
+++ b/packages/babylon-ts-sdk/typedoc-plugin.mjs
@@ -2,8 +2,20 @@
  * TypeDoc plugin for customizing the generated API documentation
  *
  * This plugin adds helpful navigation and context to the auto-generated
- * API documentation, making it easier for developers to find what they need.
+ * API documentation, making it easier for developers to find what they need,
+ * and strips line numbers from source references.
  */
+import { MarkdownPageEvent } from "typedoc-plugin-markdown";
+
+/** `Defined in: [path/foo.ts:53](url/foo.ts#L53)` — line number in both halves. */
+const LINKED_SOURCE_REF =
+  /^(Defined in: \[[^\]]+?):\d+(\]\([^)]+?)#L\d+(\))$/gm;
+
+/** `Defined in: .../dist/index.d.ts:100` — unlinked, since `dist/` is gitignored. */
+const UNLINKED_SOURCE_REF = /^(Defined in: (?!\[)\S+?):\d+$/gm;
+
+const SOURCE_REF_WITH_LINE = /^Defined in:.*?:\d+.*$/gm;
+
 export function load(app) {
   // Add description and quick links at the beginning of the index page
   app.renderer.markdownHooks.on("index.page.begin", () => {
@@ -35,5 +47,30 @@ export function load(app) {
 ---
 
 `;
+  });
+
+  /**
+   * Drop line numbers from source references, keeping the file link.
+   *
+   * `docs/api/` is committed, so line numbers made any code movement restale
+   * 1,401 lines of it (#2196). The throw below is because these patterns depend
+   * on typedoc-plugin-markdown's output format: if that changes, fail loudly
+   * rather than silently letting the churn back in.
+   */
+  app.renderer.on(MarkdownPageEvent.END, (page) => {
+    if (typeof page.contents !== "string") return;
+
+    page.contents = page.contents
+      .replace(LINKED_SOURCE_REF, "$1$2$3")
+      .replace(UNLINKED_SOURCE_REF, "$1");
+
+    const stale = page.contents.match(SOURCE_REF_WITH_LINE);
+    if (stale) {
+      throw new Error(
+        `typedoc-plugin.mjs: ${stale.length} source reference(s) in ${page.url} ` +
+          `still carry a line number (e.g. ${stale[0]}) — the patterns above no ` +
+          `longer match what typedoc-plugin-markdown emits.`,
+      );
+    }
   });
 }

--- a/packages/babylon-ts-sdk/typedoc.json
+++ b/packages/babylon-ts-sdk/typedoc.json
@@ -34,7 +34,5 @@
   "navigationLinks": {
     "Quickstart": "../quickstart/",
     "GitHub": "https://github.com/babylonlabs-io/babylon-toolkit"
-  },
-  "includeVersion": true,
-  "sourceLinkTemplate": "../../{path}#L{line}"
+  }
 }


### PR DESCRIPTION
Closes https://github.com/babylonlabs-io/babylon-toolkit/issues/2196

`docs/api/` is committed but nothing regenerates it, so it refreshes only when some unrelated PR happens to touch it — and in between it documents symbols that no longer exist. This removes the reason regeneration was expensive, fixes source links that never worked, and adds the CI check that stops the drift coming back.

**The diff is ~2,900 lines and almost all of it is regenerated output.** 103 lines across 3 files are hand-written. The cheap review: check out the branch, run `pnpm --filter @babylonlabs-io/ts-sdk run docs:clean`, confirm `git status` is clean — which is now literally what CI does.

## With / without

| | Without this change | With this change |
|---|---|---|
| A source edit that only moves code | Restales up to 1,401 `Defined in:` lines | No docs change at all |
| A WASM rebuild (`VAULT_WASM_COMMIT` bump) | Restales 32 lines in `primitives.md` | No docs change |
| A **public API change with no regeneration** | Merges silently; docs rot until someone notices months later | **CI fails the PR**, with the diff and the one-command fix in the job summary |
| A version bump | Would restale `README.md` and fail the new gate on every release | No docs change |
| Jump-to-source links | **Dead** — resolved nowhere | Working GitHub links |
| If the plugin's output format changes | Churn silently returns | Docs build fails, naming the page and the offending line |

## Will this gate fail *my* PR?

Mostly no. `✓` = verified by probe on this branch, not reasoned.

| Your PR | Gate |
|---|---|
| Doesn't touch `ts-sdk` at all (vault, core-ui, wallet-connector, CI…) | ✓ **passes** — costs ~2.5s in a job that already builds everything |
| Refactors `ts-sdk`, moves code, shifts every line number | ✓ **passes** — this is the whole point of the PR |
| Changes non-exported / internal `ts-sdk` code | ✓ **passes** |
| Adds, removes or changes a **public export** | ✓ **fails** — regenerate |
| Edits **JSDoc prose** on an exported symbol | ✓ **fails** — regenerate |
| **Reorders** members of an exported class/interface (identical API) | ✓ **fails** — regenerate |
| Bumps the package version / release PR | ✓ **passes** (why `includeVersion` had to go) |
| Rebuilds WASM / bumps `VAULT_WASM_COMMIT` | passes, unless the WASM package's *exported types* changed |
| Adds or removes an exported module (new/orphaned doc file) | fails — the gate uses `git status --porcelain`, so untracked and deleted files count |
| Hand-edits a file under `docs/api/` | fails — regeneration overwrites it. Hand edits can no longer be merged |
| Upgrades `typedoc` / `typedoc-plugin-markdown` | likely fails; regenerate. If the upgrade breaks the strip, the plugin guard fails loudly rather than silently resuming churn |
| Two SDK-API PRs in flight at once | the second fails once the first merges (`pull_request` builds the merge ref). Rebase and regenerate — same friction as a lockfile conflict |

**The fix is always the same one command**, with the diff and this line printed into the failed job's summary:

```bash
pnpm --filter @babylonlabs-io/ts-sdk run docs:clean
```

Two rows are worth internalising, because "I didn't change the API" won't always mean the gate stays quiet: **JSDoc is the docs**, so comment-only edits count (#2225 was comment-only and would have tripped this); and `typedoc.json` sets `sort: ["source-order", …]`, so **declaration order is part of the output**. Both are genuinely different docs — just not what "API change" usually brings to mind.

No per-commit noise: source links use the literal `blob/main` rather than a commit SHA, and the output contains no timestamps.

## Why the docs churned

`typedoc.json` set no `disableSources`, so every symbol emitted a source reference carrying a line number **twice** — visible text and href:

```
Defined in: [.../availability.ts:53](../../.../availability.ts#L53)
```

1,401 such lines across 9 files. Any edit that merely moved code changed them, so the committed docs went stale on almost every SDK PR regardless of whether the public API moved. Rare regeneration is why the docs ended up describing deleted symbols.

This is also why a staleness gate was not viable before: it would have fired on nearly every PR for reasons nobody could act on. Removing the churn is what makes the gate meaningful — a failure now means the public API really changed.

## What changed

**`typedoc-plugin.mjs`** — a `MarkdownPageEvent.END` handler stripping the line number from both forms of source reference, keeping the file link:

1. **Linked** (1,369 refs) — `:NNN` from the text, `#LNNN` from the href.
2. **Unlinked** (32 refs, all `primitives.md`) — symbols re-exported from the WASM package resolve to `packages/babylon-tbv-rust-wasm/dist/index.d.ts:100` as *plain text with no link*, because `dist/` is gitignored so TypeDoc has nothing to link to. These need their own pattern, and they are the worse churn source: `dist/` is generated, so a WASM rebuild alone moves them.

Plus an assertion: after substituting, throw if any `Defined in:` line still carries a line number. The honest weakness of this approach is that it couples to typedoc-plugin-markdown's output format, and a format change would silently stop matching. Now it fails the build. Scoped to `^Defined in:` lines rather than any `file.ts:NNN`, so a doc comment mentioning `payout.ts:677` in prose can't false-positive it.

**`typedoc.json`** — two removals:

- **`sourceLinkTemplate: "../../{path}#L{line}"`** was broken, and had been for a long time. `{path}` is repo-root-relative but the docs live 4 levels deep, so every source link resolved nowhere; a single relative template also cannot be correct for both `docs/api/*.md` and the deeper `docs/api/integrations/aave.md`. Removing it lets TypeDoc build absolute GitHub URLs from the `gitRevision: "main"` already configured, which work at both depths. Folded in here because it costs **zero** extra diff lines — every `Defined in:` line is being rewritten anyway — whereas a follow-up would rewrite all 1,401 a second time.
- **`includeVersion: true`** put `# @babylonlabs-io/ts-sdk v0.1.2` in `docs/api/README.md`. That is the one line that changes on a **version bump rather than an API change**, so it would have failed the new gate on every release PR for something the author didn't cause. Left in, it is the most likely reason the gate gets disabled six months from now.

**`.github/workflows/verify.yml`** — the staleness gate, replacing the former *"Validate TypeDoc"* step.

Replacing rather than adding, because it strictly supersedes it: `docs:clean` runs the same TypeDoc validation as `--emit none` **and** renders pages. That matters more than it sounds — `typedoc --emit none` never renders, so the old step could not see the plugin guard at all. Without this change the guard would have been decorative, only protecting whoever regenerated by hand.

Two implementation details:

- Uses `git status --porcelain`, not `git diff`. `docs:clean` does `rm -rf docs/api` and regenerates, so a file for a newly added module would be untracked and invisible to a diff.
- Writes the offending diff into `$GITHUB_STEP_SUMMARY`, matching the existing *"Append test summary"* step. The fix is deterministic, so the author should not have to reproduce anything locally to see what is stale.
- Carries a comment pinning it **after "Build all"**: those 32 WASM references resolve through the gitignored `dist/`, so regenerating before the build silently produces different output. Reordering the job would break the check quietly.

## The drift this was filed for got fixed by accident — again

When this branch was opened, the committed docs carried **7 references to `getVaultProviderBtcPubKey`** (a public `VaultRegistryReader` method renamed by #2206, so following one gave a compile error) and were **missing `activateVaultAndRedeem()` / `ActivateVaultAndRedeemInput`** entirely, a real exported function from #2159.

Both are already gone from `main`. Not because anyone fixed them — because #2214, a wallet-connector PR, happened to regenerate the docs on its way past.

That is the third recorded instance of the same thing: the issue notes #2201 sweeping up `AUTH_EXPIRED_DATA_KIND` the same way, and #2169 before that. It is the clearest possible argument for the gate in this PR. The docs are not maintained; they are occasionally, accidentally, correct.

It also means this PR's remaining value is structural rather than corrective — which is the right place for it to be.

## Verification

Measured against `origin/main` at `33f2fee9a` (this branch is rebased onto it):

| check | `origin/main` | this branch |
|---|---|---|
| `Defined in:` lines | 1401 | **1401** — none lost |
| …carrying a line number | 1401 | **0** |
| `#L` references anywhere | 502+ | **0** |
| relative (dead) source hrefs in `clients.md` | 502 | **0** |
| distinct link targets that resolve | 0 | **85 / 85** |
| `README.md` version suffix | `v0.1.2` | none — decoupled from version bumps |
| TypeDoc output | 0 errors, 536 warnings | **unchanged** |
| regeneration is a fixed point | — | yes, second `docs:clean` is a no-op |
| `pnpm run lint` | — | 0 errors |
| SDK test suite | — | 1502 passing |
| `verify.yml` | — | parses; 12 steps; gate last, after `Build all` |

The 536 warnings are the pre-existing unresolved-`{@link}` ones, out of scope here, and must stay at that count — a change there means something else moved.

### Every guard was proven to fire

A guard nobody has seen fail isn't a guard, so each was broken deliberately and reverted:

| probe | result |
|---|---|
| add a public export without regenerating | gate detects it — `utils.md` gains 12 lines including `GATE_PROBE_SENTINEL` |
| bump the package version | docs unchanged → gate stays green on release PRs (this is the `includeVersion` regression, confirmed fixed) |
| break the linked strip pattern | `docs:clean` exits 5: *"2 source reference(s) in wallets.md still carry a line number"* |
| break the unlinked (WASM) pattern | `docs:clean` exits 5: *"32 source reference(s) in primitives.md…"* |

The third and fourth also confirm the plugin guard is now reachable from CI, since the gate's own command is what triggers it.

## Note on scope

This is deliberately not a purely mechanical PR. The plan recorded on the issue was to ship the churn fix alone and judge the gate later, after the fix had proven itself. That changed on discovering the old CI step could not see the plugin guard: shipping without the gate would have added **no automated enforcement at all**, and left the docs free to drift again from the day this merged. Given the issue exists precisely because "we'll automate it later" lasted months, the gate belongs here.

It is also what makes `Closes #2196` accurate. The issue is titled *"drift because nothing regenerates them"* — without the gate, nothing does.

## Follow-up, deliberately not here

**Whether these docs should be tracked at all.** If nothing consumes `docs/api/`, the honest move is untracking it and generating on demand rather than building enforcement around files that exist to rot. The source links being broken for a long time without anyone noticing is real evidence for that. A gate is right if the docs are a product and ceremony if they are a byproduct — worth one deliberate decision, but not one to make inside this PR.
