### PR TITLE
feat(ts-sdk): thread the intent ceremony through the Pre-PegIn broadcast

### DIFF
--- a/packages/babylon-ts-sdk/docs/api/deposit-terms.md
+++ b/packages/babylon-ts-sdk/docs/api/deposit-terms.md
@@ -286,6 +286,9 @@ provider). Provider obligations:
 
 Seam invariant: any derive invalidates a prior approval, so the SDK
 re-approves after every derive and before the next terms-bound signature.
+The re-approval sites are `PeginManager.preparePegin`,
+`runDepositorPresignFlow`, and `signAndBroadcast` (the Pre-PegIn broadcast,
+which derives immediately before approving — see `ensurePrePeginTermsApproval`).
 
 #### Methods
 
@@ -433,6 +436,105 @@ peginMaxFee: bigint;
 
 Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts)
 
+***
+
+### PrePeginApprovalWallet
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/prePeginApproval.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/prePeginApproval.ts)
+
+Minimal structural wallet for the Pre-PegIn ceremony. Mirrors
+`DeriveContextHashCapableWallet` so an app-side wrapper object qualifies
+without implementing all of `BitcoinWallet`. Both methods are optional so
+the capability probe below can run on any wallet.
+
+#### Methods
+
+##### deriveContextHash()?
+
+```ts
+optional deriveContextHash(appName, context): Promise<string>;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/prePeginApproval.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/prePeginApproval.ts)
+
+###### Parameters
+
+###### appName
+
+`string`
+
+###### context
+
+`string`
+
+###### Returns
+
+`Promise`\<`string`\>
+
+##### approveDepositTerms()?
+
+```ts
+optional approveDepositTerms(terms): Promise<void>;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/prePeginApproval.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/prePeginApproval.ts)
+
+###### Parameters
+
+###### terms
+
+[`DepositTerms`](#depositterms)
+
+###### Returns
+
+`Promise`\<`void`\>
+
+***
+
+### EnsurePrePeginTermsApprovalParams
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/prePeginApproval.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/prePeginApproval.ts)
+
+#### Properties
+
+##### wallet
+
+```ts
+wallet: PrePeginApprovalWallet;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/prePeginApproval.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/prePeginApproval.ts)
+
+##### depositTerms
+
+```ts
+depositTerms: DepositTerms | undefined;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/prePeginApproval.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/prePeginApproval.ts)
+
+The approved terms — required for approval-capable wallets, ignored (but still txid-checked) otherwise.
+
+##### fundedPrePeginTxHex
+
+```ts
+fundedPrePeginTxHex: string;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/prePeginApproval.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/prePeginApproval.ts)
+
+Funded Pre-PegIn tx hex (0x optional): the funding outpoints AND the txid the terms must match.
+
+##### depositorBtcPubkey
+
+```ts
+depositorBtcPubkey: string;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/prePeginApproval.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/prePeginApproval.ts)
+
+x-only depositor pubkey (64 hex, 0x optional) — the identity the PSBT is signed with.
+
 ## Type Aliases
 
 ### DepositTermsRejectionReason
@@ -538,6 +640,42 @@ errors that `instanceof` cannot see.
 #### Returns
 
 `err is DepositTermsRejectedError`
+
+***
+
+### ensurePrePeginTermsApproval()
+
+```ts
+function ensurePrePeginTermsApproval(params): Promise<void>;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/prePeginApproval.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/prePeginApproval.ts)
+
+Run the derive → approve ceremony (or a no-op) before a Pre-PegIn signature.
+
+- Non-approval wallets: no-op, after asserting the terms (if any) match the tx.
+- Approval-capable wallets: require terms, assert they match this tx's txid,
+  derive the vault root over the tx's funding outpoints, then approve.
+
+Always derives first: the host cannot read device state, a one-shot cap means
+every retry needs the full ceremony, and whether interleaved signing
+nullifies a loaded intent is unresolved — so the broadcast path never
+approves-only.
+
+#### Parameters
+
+##### params
+
+[`EnsurePrePeginTermsApprovalParams`](#ensureprepegintermsapprovalparams)
+
+#### Returns
+
+`Promise`\<`void`\>
+
+#### Throws
+
+If approval-capable but no terms are provided, or the provided terms
+  are for a different transaction.
 
 ## Variables
 

--- a/packages/babylon-ts-sdk/docs/api/managers.md
+++ b/packages/babylon-ts-sdk/docs/api/managers.md
@@ -1694,6 +1694,20 @@ Key format: "txid:vout" (e.g. "abc123...def:0").
 When provided, matching inputs skip the mempool API fetch.
 Useful for split transactions where outputs are unconfirmed.
 
+##### depositTerms?
+
+```ts
+optional depositTerms: DepositTerms;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
+
+Approved deposit terms. REQUIRED when `config.btcWallet` supports deposit
+approval (`supportsDepositApproval`) — the device signs the Pre-PegIn only
+from an approved intent matching this tx. Pass `PreparePeginResult.
+depositTerms` for fresh flows, or a resume rebuild. For non-approval
+wallets it is ignored, but still validated against the tx's txid if given.
+
 ***
 
 ### PopSignature

--- a/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/__tests__/prePeginApproval.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/__tests__/prePeginApproval.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Tests for the Pre-PegIn approval ceremony helper. The device layer is
+ * abstracted behind the structural PrePeginApprovalWallet, so these pin the
+ * orchestration: the capability gate, the txid match, and the strict
+ * derive-then-approve order for approval wallets.
+ */
+
+import { Transaction } from "bitcoinjs-lib";
+import { Buffer } from "buffer";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  hexToUint8Array,
+  uint8ArrayToHex,
+} from "../../primitives/utils/bitcoin";
+import { buildVaultContext, VAULT_APP_NAME } from "../../vault-secrets";
+import type { DepositTerms } from "../depositTerms";
+import {
+  ensurePrePeginTermsApproval,
+  type PrePeginApprovalWallet,
+} from "../prePeginApproval";
+
+/** A funded Pre-PegIn tx with two inputs, so the funding-outpoint derivation is exercised. */
+function makeFundedTx(): { hex: string; txid: string; inputTxids: string[] } {
+  const tx = new Transaction();
+  tx.version = 2;
+  // Non-palindromic on purpose: reverse(txid) !== txid, so a dropped .reverse()
+  // anywhere on the derive path changes the funding outpoints — and the context
+  // assertion below would then fail instead of passing on a byte-order bug.
+  const inputTxids = ["0011".repeat(16), "2233".repeat(16)];
+  for (const txid of inputTxids) {
+    // input.hash is internal byte order — the reverse of the display txid.
+    tx.addInput(Buffer.from(txid, "hex").reverse(), 0);
+  }
+  tx.addOutput(
+    Buffer.from(
+      "512000000000000000000000000000000000000000000000000000000000000000",
+      "hex",
+    ),
+    1000,
+  );
+  return { hex: tx.toHex(), txid: tx.getId(), inputTxids };
+}
+
+const DEPOSITOR_PUBKEY = "ab".repeat(32);
+
+function makeTerms(txid: string): DepositTerms {
+  return {
+    vaultCoreVersion: 2,
+    protocolFeeRate: 2n,
+    timelockPegin: 684,
+    timelockAssert: 684,
+    timelockRefund: 2016,
+    prepeginTxid: txid,
+    prepeginMaxFee: 1500n,
+    vaultKeeperBtcPubkeys: ["cc".repeat(32)],
+    universalChallengerBtcPubkeys: ["dd".repeat(32)],
+    vaults: [
+      {
+        htlcVout: 0,
+        vaultProviderBtcPubkey: "ff".repeat(32),
+        peginAmount: 1_000_000n,
+        commissionFee: 10_000n,
+        depositorClaimValue: 20_000n,
+        peginMaxFee: 800n,
+      },
+    ],
+  };
+}
+
+describe("ensurePrePeginTermsApproval", () => {
+  it("is a no-op for a wallet without approveDepositTerms", async () => {
+    const { hex } = makeFundedTx();
+    const wallet: PrePeginApprovalWallet = { deriveContextHash: vi.fn() };
+
+    await expect(
+      ensurePrePeginTermsApproval({
+        wallet,
+        depositTerms: undefined,
+        fundedPrePeginTxHex: hex,
+        depositorBtcPubkey: DEPOSITOR_PUBKEY,
+      }),
+    ).resolves.toBeUndefined();
+    expect(wallet.deriveContextHash).not.toHaveBeenCalled();
+  });
+
+  it("validates supplied terms against the txid even for a non-approval wallet", async () => {
+    const { hex } = makeFundedTx();
+    const wallet: PrePeginApprovalWallet = {};
+
+    await expect(
+      ensurePrePeginTermsApproval({
+        wallet,
+        depositTerms: makeTerms("00".repeat(32)),
+        fundedPrePeginTxHex: hex,
+        depositorBtcPubkey: DEPOSITOR_PUBKEY,
+      }),
+    ).rejects.toThrow(/do not match the transaction/);
+  });
+
+  it("throws when an approval wallet is given no terms", async () => {
+    const { hex } = makeFundedTx();
+    const wallet: PrePeginApprovalWallet = {
+      deriveContextHash: vi.fn(async () => "ab".repeat(32)),
+      approveDepositTerms: vi.fn(),
+    };
+
+    await expect(
+      ensurePrePeginTermsApproval({
+        wallet,
+        depositTerms: undefined,
+        fundedPrePeginTxHex: hex,
+        depositorBtcPubkey: DEPOSITOR_PUBKEY,
+      }),
+    ).rejects.toThrow(/requires approved deposit terms/);
+    expect(wallet.approveDepositTerms).not.toHaveBeenCalled();
+  });
+
+  it("throws for an approval wallet that cannot derive", async () => {
+    const { hex, txid } = makeFundedTx();
+    const wallet: PrePeginApprovalWallet = { approveDepositTerms: vi.fn() };
+
+    await expect(
+      ensurePrePeginTermsApproval({
+        wallet,
+        depositTerms: makeTerms(txid),
+        fundedPrePeginTxHex: hex,
+        depositorBtcPubkey: DEPOSITOR_PUBKEY,
+      }),
+    ).rejects.toThrow(/must also implement deriveContextHash/);
+  });
+
+  it("rejects terms for a different transaction before any device call", async () => {
+    const { hex } = makeFundedTx();
+    const wallet: PrePeginApprovalWallet = {
+      deriveContextHash: vi.fn(async () => "ab".repeat(32)),
+      approveDepositTerms: vi.fn(),
+    };
+
+    await expect(
+      ensurePrePeginTermsApproval({
+        wallet,
+        depositTerms: makeTerms("99".repeat(32)),
+        fundedPrePeginTxHex: hex,
+        depositorBtcPubkey: DEPOSITOR_PUBKEY,
+      }),
+    ).rejects.toThrow(/do not match the transaction/);
+    expect(wallet.deriveContextHash).not.toHaveBeenCalled();
+    expect(wallet.approveDepositTerms).not.toHaveBeenCalled();
+  });
+
+  it("derives then approves, in that order, for a matching approval wallet", async () => {
+    const { hex, txid, inputTxids } = makeFundedTx();
+    const order: string[] = [];
+    const wallet: PrePeginApprovalWallet = {
+      deriveContextHash: vi.fn(async () => {
+        order.push("derive");
+        return "ab".repeat(32);
+      }),
+      approveDepositTerms: vi.fn(async () => {
+        order.push("approve");
+      }),
+    };
+    const terms = makeTerms(txid);
+
+    await ensurePrePeginTermsApproval({
+      wallet,
+      depositTerms: terms,
+      fundedPrePeginTxHex: hex,
+      depositorBtcPubkey: DEPOSITOR_PUBKEY,
+    });
+
+    expect(order).toEqual(["derive", "approve"]);
+    expect(wallet.approveDepositTerms).toHaveBeenCalledWith(terms);
+
+    // Pin the exact derive input: the funding outpoints must be display-order
+    // txids (proving the input.hash reversal), keyed to the depositor pubkey.
+    // A dropped reversal or wrong pubkey would change this context hex.
+    const expectedContext = uint8ArrayToHex(
+      buildVaultContext({
+        depositorBtcPubkey: hexToUint8Array(DEPOSITOR_PUBKEY),
+        fundingOutpoints: inputTxids.map((t) => ({
+          txid: hexToUint8Array(t),
+          vout: 0,
+        })),
+      }),
+    );
+    expect(wallet.deriveContextHash).toHaveBeenCalledWith(
+      VAULT_APP_NAME,
+      expectedContext,
+    );
+  });
+
+  it("accepts a 0x-prefixed prepeginTxid in the terms", async () => {
+    const { hex, txid } = makeFundedTx();
+    const wallet: PrePeginApprovalWallet = {
+      deriveContextHash: vi.fn(async () => "ab".repeat(32)),
+      approveDepositTerms: vi.fn(),
+    };
+
+    await expect(
+      ensurePrePeginTermsApproval({
+        wallet,
+        depositTerms: makeTerms(`0x${txid}`),
+        fundedPrePeginTxHex: hex,
+        depositorBtcPubkey: DEPOSITOR_PUBKEY,
+      }),
+    ).resolves.toBeUndefined();
+    expect(wallet.approveDepositTerms).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts
@@ -103,6 +103,9 @@ export interface DepositTerms {
  *
  * Seam invariant: any derive invalidates a prior approval, so the SDK
  * re-approves after every derive and before the next terms-bound signature.
+ * The re-approval sites are `PeginManager.preparePegin`,
+ * `runDepositorPresignFlow`, and `signAndBroadcast` (the Pre-PegIn broadcast,
+ * which derives immediately before approving — see `ensurePrePeginTermsApproval`).
  */
 export interface DepositTermsApprover {
   approveDepositTerms(terms: DepositTerms): Promise<void>;

--- a/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/index.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/index.ts
@@ -10,3 +10,4 @@
 export * from "./buildDepositTerms";
 export * from "./depositTerms";
 export * from "./depositTermsErrors";
+export * from "./prePeginApproval";

--- a/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/prePeginApproval.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/prePeginApproval.ts
@@ -1,0 +1,134 @@
+/**
+ * The Pre-PegIn approval ceremony for intent-based signing wallets.
+ *
+ * A shared helper because there are two Pre-PegIn broadcast paths — the SDK's
+ * {@link PeginManager.signAndBroadcast} and the vault app's own
+ * `broadcastPrePeginTransaction` (a near-duplicate). Both must run the exact
+ * same derive → approve sequence immediately before `signPsbt`, or the two
+ * copies drift on a signing-critical path.
+ *
+ * The device signs a Pre-PegIn only from `INTENT_LOADED`, and only if the
+ * approved intent's `prepegin_txid` matches this tx and its fee is within the
+ * approved `prepegin_max_fee`. So an approval-capable wallet must be shown the
+ * terms (and derive the context root that gates the intent) before it signs.
+ *
+ * @module deposit-terms/prePeginApproval
+ */
+
+import { Transaction } from "bitcoinjs-lib";
+
+import { normalizeXOnlyPubkey } from "../managers/pegin/normalizeWalletInputs";
+import { hexToUint8Array } from "../primitives/utils/bitcoin";
+import { deriveVaultRoot, parseFundingOutpointsFromTx } from "../vault-secrets";
+import type { DepositTerms } from "./depositTerms";
+
+/**
+ * Minimal structural wallet for the Pre-PegIn ceremony. Mirrors
+ * `DeriveContextHashCapableWallet` so an app-side wrapper object qualifies
+ * without implementing all of `BitcoinWallet`. Both methods are optional so
+ * the capability probe below can run on any wallet.
+ */
+export interface PrePeginApprovalWallet {
+  deriveContextHash?(appName: string, context: string): Promise<string>;
+  approveDepositTerms?(terms: DepositTerms): Promise<void>;
+}
+
+export interface EnsurePrePeginTermsApprovalParams {
+  wallet: PrePeginApprovalWallet;
+  /** The approved terms — required for approval-capable wallets, ignored (but still txid-checked) otherwise. */
+  depositTerms: DepositTerms | undefined;
+  /** Funded Pre-PegIn tx hex (0x optional): the funding outpoints AND the txid the terms must match. */
+  fundedPrePeginTxHex: string;
+  /** x-only depositor pubkey (64 hex, 0x optional) — the identity the PSBT is signed with. */
+  depositorBtcPubkey: string;
+}
+
+/**
+ * Run the derive → approve ceremony (or a no-op) before a Pre-PegIn signature.
+ *
+ * - Non-approval wallets: no-op, after asserting the terms (if any) match the tx.
+ * - Approval-capable wallets: require terms, assert they match this tx's txid,
+ *   derive the vault root over the tx's funding outpoints, then approve.
+ *
+ * Always derives first: the host cannot read device state, a one-shot cap means
+ * every retry needs the full ceremony, and whether interleaved signing
+ * nullifies a loaded intent is unresolved — so the broadcast path never
+ * approves-only.
+ *
+ * @throws If approval-capable but no terms are provided, or the provided terms
+ *   are for a different transaction.
+ */
+export async function ensurePrePeginTermsApproval(
+  params: EnsurePrePeginTermsApprovalParams,
+): Promise<void> {
+  const { wallet, depositTerms, fundedPrePeginTxHex, depositorBtcPubkey } =
+    params;
+  // Gate on typeof (the seam's supportsDepositApproval convention) so a spread
+  // non-function value is treated as absent rather than reaching the approve
+  // call and throwing a raw TypeError. Also narrows it to a function below.
+  const approveDepositTerms =
+    typeof wallet.approveDepositTerms === "function"
+      ? wallet.approveDepositTerms
+      : undefined;
+
+  // Nothing to do — not an approval wallet and no terms to validate — so skip
+  // parsing the tx entirely.
+  if (!approveDepositTerms && !depositTerms) {
+    return;
+  }
+
+  const cleanHex = fundedPrePeginTxHex.startsWith("0x")
+    ? fundedPrePeginTxHex.slice(2)
+    : fundedPrePeginTxHex;
+  const tx = Transaction.fromHex(cleanHex);
+  const txid = tx.getId();
+
+  // Whatever the wallet, if terms were supplied they must be for THIS tx.
+  // Complements runDepositorPresignFlow's assertDepositTermsMatchSigningContext,
+  // which checks the graph scalars and rosters but never the txid.
+  if (
+    depositTerms &&
+    depositTerms.prepeginTxid.replace(/^0x/, "").toLowerCase() !== txid
+  ) {
+    throw new Error(
+      `Deposit terms do not match the transaction being broadcast: terms are for ` +
+        `prepeginTxid ${depositTerms.prepeginTxid}, but this transaction is ${txid}.`,
+    );
+  }
+
+  if (!approveDepositTerms) {
+    return;
+  }
+
+  if (!depositTerms) {
+    throw new Error(
+      "This wallet requires approved deposit terms before signing the Pre-PegIn transaction, " +
+        "but none were provided. Pass PreparePeginResult.depositTerms (fresh flows) or a resume rebuild.",
+    );
+  }
+
+  if (typeof wallet.deriveContextHash !== "function") {
+    throw new Error(
+      "A deposit-approval wallet must also implement deriveContextHash, but this one does not.",
+    );
+  }
+
+  // Same funding outpoints preparePegin derived over, via the shared
+  // golden-tested parser (display order; also rejects an input-less tx).
+  const fundingOutpoints = parseFundingOutpointsFromTx(fundedPrePeginTxHex);
+
+  const root = await deriveVaultRoot(
+    { deriveContextHash: wallet.deriveContextHash.bind(wallet) },
+    {
+      depositorBtcPubkey: hexToUint8Array(
+        normalizeXOnlyPubkey(depositorBtcPubkey),
+      ),
+      fundingOutpoints,
+    },
+  );
+  // The derive gates the intent on-device; the broadcast path needs no
+  // secrets, so wipe the returned root immediately.
+  root.fill(0);
+
+  await approveDepositTerms(depositTerms);
+}

--- a/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts
@@ -52,6 +52,7 @@ import type { WotsBlockPublicKey } from "../clients/vault-provider/types";
 import { BTCVaultRegistryABI, handleContractError } from "../contracts";
 import {
   buildDepositTerms,
+  ensurePrePeginTermsApproval,
   supportsDepositApproval,
   type DepositTerms,
 } from "../deposit-terms";
@@ -426,6 +427,15 @@ export interface SignAndBroadcastParams {
    * Useful for split transactions where outputs are unconfirmed.
    */
   localPrevouts?: Record<string, { scriptPubKey: string; value: number }>;
+
+  /**
+   * Approved deposit terms. REQUIRED when `config.btcWallet` supports deposit
+   * approval (`supportsDepositApproval`) — the device signs the Pre-PegIn only
+   * from an approved intent matching this tx. Pass `PreparePeginResult.
+   * depositTerms` for fresh flows, or a resume rebuild. For non-approval
+   * wallets it is ignored, but still validated against the tx's txid if given.
+   */
+  depositTerms?: DepositTerms;
 }
 
 /**
@@ -1194,6 +1204,18 @@ export class PeginManager {
         value: output.value,
       });
     }
+
+    // Step 3.5: intent-wallet ceremony (derive → approve) immediately before
+    // signing. Placed after prevout resolution — a network failure there must
+    // not burn a two-screen device ceremony — and adjacent to signPsbt to keep
+    // the approve→sign gap minimal (the seam invariant). No-op for wallets that
+    // do not support deposit approval.
+    await ensurePrePeginTermsApproval({
+      wallet: this.config.btcWallet,
+      depositTerms: params.depositTerms,
+      fundedPrePeginTxHex,
+      depositorBtcPubkey,
+    });
 
     // Step 4: Sign PSBT via wallet
     const requestedPsbtHex = psbt.toHex();

--- a/packages/babylon-ts-sdk/src/tbv/core/managers/__tests__/PeginManager.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/__tests__/PeginManager.test.ts
@@ -24,7 +24,10 @@ import type { SignPsbtOptions } from "../../../../shared/wallets";
 import { MockBitcoinWallet, MockEthereumWallet } from "../../../../testing";
 import { MEMPOOL_API_URLS } from "../../clients/mempool";
 import { BTCVaultRegistryABI } from "../../contracts";
-import type { DepositTerms } from "../../deposit-terms";
+import {
+  DepositTermsRejectedError,
+  type DepositTerms,
+} from "../../deposit-terms";
 import {
   deriveNativeSegwitAddress,
   deriveTaprootAddress,
@@ -1702,6 +1705,194 @@ describe("PeginManager", () => {
       ).rejects.toThrow(/scriptPubKey differs/);
 
       expect(rebind).toHaveBeenCalledTimes(1);
+    });
+
+    it("runs the intent ceremony (derive then approve) before signing for an approval wallet", async () => {
+      const { assertPsbtUnsignedTxMatches } = await import(
+        "../../primitives/psbt/assertPsbtUnsignedTxMatches"
+      );
+      const rebind = vi.mocked(assertPsbtUnsignedTxMatches);
+
+      // An approval-capable wallet: MockBitcoinWallet already derives; add
+      // approveDepositTerms and record call order relative to signPsbt.
+      const order: string[] = [];
+      const btcWallet = new MockBitcoinWallet({
+        publicKeyHex: TEST_KEYS.DEPOSITOR,
+      });
+      const deriveSpy = vi
+        .spyOn(btcWallet, "deriveContextHash")
+        .mockImplementation(async () => {
+          order.push("derive");
+          return "ab".repeat(32);
+        });
+      vi.spyOn(btcWallet, "signPsbt").mockImplementation(
+        async (psbtHex: string) => {
+          order.push("sign");
+          return psbtHex;
+        },
+      );
+      const approveSpy = vi.fn(async () => {
+        order.push("approve");
+      });
+      (
+        btcWallet as unknown as { approveDepositTerms: typeof approveSpy }
+      ).approveDepositTerms = approveSpy;
+
+      const ethWallet = new MockEthereumWallet();
+      const manager = new PeginManager({
+        btcNetwork: "signet",
+        btcWallet,
+        ethWallet: ethWallet as any,
+        ethChain: TEST_CHAIN,
+        publicClient: TEST_PUBLIC_CLIENT,
+        vaultContracts: { btcVaultRegistry: TEST_CONTRACT_ADDRESS },
+        mempoolApiUrl: MEMPOOL_API_URLS.signet,
+      });
+
+      const prepared = await manager.preparePegin({
+        amounts: [TEST_AMOUNTS.PEGIN],
+        ...BASE_PREPARE_PEGIN_PARAMS,
+      });
+      const localPrevouts = TEST_UTXOS.reduce<
+        Record<string, { scriptPubKey: string; value: number }>
+      >((acc, u) => {
+        acc[`${u.txid}:${u.vout}`] = {
+          scriptPubKey: u.scriptPubKey,
+          value: u.value,
+        };
+        return acc;
+      }, {});
+
+      // Terms must match this tx's txid or the ceremony rejects first.
+      const fundedTxid = bitcoin.Transaction.fromHex(
+        prepared.transaction.fundedPrePeginTxHex,
+      ).getId();
+      const depositTerms: DepositTerms = {
+        vaultCoreVersion: 2,
+        protocolFeeRate: 2n,
+        timelockPegin: 684,
+        timelockAssert: 684,
+        timelockRefund: 2016,
+        prepeginTxid: fundedTxid,
+        prepeginMaxFee: 1500n,
+        vaultKeeperBtcPubkeys: ["cc".repeat(32)],
+        universalChallengerBtcPubkeys: ["dd".repeat(32)],
+        vaults: [
+          {
+            htlcVout: 0,
+            vaultProviderBtcPubkey: "ff".repeat(32),
+            peginAmount: 1_000_000n,
+            commissionFee: 10_000n,
+            depositorClaimValue: 20_000n,
+            peginMaxFee: 800n,
+          },
+        ],
+      };
+
+      // Abort at rebind (after signing) so we never hit the network — the
+      // ceremony has already run by then, which is what we assert.
+      deriveSpy.mockClear();
+      order.length = 0;
+      rebind.mockClear();
+      rebind.mockImplementationOnce(() => {
+        throw new Error("stop before broadcast");
+      });
+
+      await expect(
+        manager.signAndBroadcast({
+          fundedPrePeginTxHex: prepared.transaction.fundedPrePeginTxHex,
+          depositorBtcPubkey: TEST_KEYS.DEPOSITOR,
+          localPrevouts,
+          depositTerms,
+        }),
+      ).rejects.toThrow(/stop before broadcast/);
+
+      expect(approveSpy).toHaveBeenCalledWith(depositTerms);
+      // derive → approve → sign, exactly.
+      expect(order).toEqual(["derive", "approve", "sign"]);
+    });
+
+    it("propagates an approval rejection unwrapped, without signing", async () => {
+      const btcWallet = new MockBitcoinWallet({
+        publicKeyHex: TEST_KEYS.DEPOSITOR,
+      });
+      vi.spyOn(btcWallet, "deriveContextHash").mockResolvedValue(
+        "ab".repeat(32),
+      );
+      const signSpy = vi.spyOn(btcWallet, "signPsbt");
+      // preparePegin is itself a re-approval site, so approval must succeed
+      // there; the rejection is injected only for the broadcast ceremony below.
+      const approveSpy = vi.fn(async () => {});
+      (
+        btcWallet as unknown as { approveDepositTerms: typeof approveSpy }
+      ).approveDepositTerms = approveSpy;
+
+      const ethWallet = new MockEthereumWallet();
+      const manager = new PeginManager({
+        btcNetwork: "signet",
+        btcWallet,
+        ethWallet: ethWallet as any,
+        ethChain: TEST_CHAIN,
+        publicClient: TEST_PUBLIC_CLIENT,
+        vaultContracts: { btcVaultRegistry: TEST_CONTRACT_ADDRESS },
+        mempoolApiUrl: MEMPOOL_API_URLS.signet,
+      });
+
+      const prepared = await manager.preparePegin({
+        amounts: [TEST_AMOUNTS.PEGIN],
+        ...BASE_PREPARE_PEGIN_PARAMS,
+      });
+      const localPrevouts = TEST_UTXOS.reduce<
+        Record<string, { scriptPubKey: string; value: number }>
+      >((acc, u) => {
+        acc[`${u.txid}:${u.vout}`] = {
+          scriptPubKey: u.scriptPubKey,
+          value: u.value,
+        };
+        return acc;
+      }, {});
+      const fundedTxid = bitcoin.Transaction.fromHex(
+        prepared.transaction.fundedPrePeginTxHex,
+      ).getId();
+      const depositTerms: DepositTerms = {
+        vaultCoreVersion: 2,
+        protocolFeeRate: 2n,
+        timelockPegin: 684,
+        timelockAssert: 684,
+        timelockRefund: 2016,
+        prepeginTxid: fundedTxid,
+        prepeginMaxFee: 1500n,
+        vaultKeeperBtcPubkeys: ["cc".repeat(32)],
+        universalChallengerBtcPubkeys: ["dd".repeat(32)],
+        vaults: [
+          {
+            htlcVout: 0,
+            vaultProviderBtcPubkey: "ff".repeat(32),
+            peginAmount: 1_000_000n,
+            commissionFee: 10_000n,
+            depositorClaimValue: 20_000n,
+            peginMaxFee: 800n,
+          },
+        ],
+      };
+
+      // The manager must not swallow or re-wrap the typed rejection, and must
+      // never reach signing once approval fails.
+      const rejection = new DepositTermsRejectedError("declined on device");
+      approveSpy.mockClear();
+      approveSpy.mockRejectedValueOnce(rejection);
+      signSpy.mockClear();
+
+      await expect(
+        manager.signAndBroadcast({
+          fundedPrePeginTxHex: prepared.transaction.fundedPrePeginTxHex,
+          depositorBtcPubkey: TEST_KEYS.DEPOSITOR,
+          localPrevouts,
+          depositTerms,
+        }),
+      ).rejects.toBe(rejection);
+
+      expect(signSpy).not.toHaveBeenCalled();
     });
   });
 

--- a/services/vault/src/hooks/deposit/useDepositFlow.ts
+++ b/services/vault/src/hooks/deposit/useDepositFlow.ts
@@ -16,6 +16,7 @@ import type { BitcoinWallet } from "@babylonlabs-io/ts-sdk/shared";
 import {
   ensureHexPrefix,
   forwardDepositApproval,
+  isDepositTermsRejectedError,
   isRegisteredVaultVersionMismatchError,
   stripHexPrefix,
   validateOnChainParticipantKeys,
@@ -815,11 +816,22 @@ export function useDepositFlow(
             btcWalletProvider: {
               signPsbt: (psbtHex: string) =>
                 confirmedBtcWallet.signPsbt(psbtHex),
+              deriveContextHash: (appName: string, context: string) =>
+                confirmedBtcWallet.deriveContextHash(appName, context),
+              // Object spread drops prototype methods — see forwardDepositApproval.
+              ...forwardDepositApproval(confirmedBtcWallet),
             },
             depositorBtcPubkey: batchResult.depositorBtcPubkey,
             expectedUtxos: utxosToExpectedRecord(batchResult.selectedUTXOs),
+            depositTerms: batchResult.depositTerms,
           });
         } catch (error) {
+          // Preserve a typed intent rejection so the error mapper can show the
+          // intent-rejection copy instead of a generic broadcast failure — the
+          // broadcast service already keeps it typed at its boundary.
+          if (isDepositTermsRejectedError(error)) {
+            throw error;
+          }
           const errorMsg =
             error instanceof Error ? error.message : String(error);
           throw new Error(

--- a/services/vault/src/services/vault/__tests__/vaultPeginBroadcastService.test.ts
+++ b/services/vault/src/services/vault/__tests__/vaultPeginBroadcastService.test.ts
@@ -1,4 +1,8 @@
 import { pushTx } from "@babylonlabs-io/ts-sdk";
+import {
+  DepositTermsRejectedError,
+  type DepositTerms,
+} from "@babylonlabs-io/ts-sdk/tbv/core";
 import { assertPsbtUnsignedTxMatches } from "@babylonlabs-io/ts-sdk/tbv/core/primitives";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -40,6 +44,9 @@ const { mockFetchUTXO, mockPsbt, mockSignedPsbt, mockTx, mockInput } =
         outs: [{ script: Buffer.from("0014deadbeef", "hex"), value: 90000 }],
         version: 2,
         locktime: 0,
+        // Only the approval-ceremony path reads this; non-approval tests
+        // short-circuit before it.
+        getId: () => "cc".repeat(32),
       },
       mockInput: input,
     };
@@ -361,5 +368,84 @@ describe("broadcastPrePeginTransaction — resolveInputUtxo behavior", () => {
     );
 
     expect(mockSignedPsbt.extractTransaction).not.toHaveBeenCalled();
+  });
+});
+
+describe("broadcastPrePeginTransaction — intent-approval ceremony", () => {
+  // Matches mockTx.getId() so the terms bind to the tx being broadcast.
+  const CEREMONY_TXID = "cc".repeat(32);
+  const pubkey = "ab".repeat(32);
+
+  const makeTerms = (): DepositTerms => ({
+    vaultCoreVersion: 2,
+    protocolFeeRate: 2n,
+    timelockPegin: 684,
+    timelockAssert: 684,
+    timelockRefund: 2016,
+    prepeginTxid: CEREMONY_TXID,
+    prepeginMaxFee: 1500n,
+    vaultKeeperBtcPubkeys: ["cc".repeat(32)],
+    universalChallengerBtcPubkeys: ["dd".repeat(32)],
+    vaults: [
+      {
+        htlcVout: 0,
+        vaultProviderBtcPubkey: "ff".repeat(32),
+        peginAmount: 1_000_000n,
+        commissionFee: 10_000n,
+        depositorClaimValue: 20_000n,
+        peginMaxFee: 800n,
+      },
+    ],
+  });
+
+  it("runs the derive→approve ceremony before signing for an approval wallet", async () => {
+    const order: string[] = [];
+    const wallet = {
+      signPsbt: vi.fn(async (psbtHex: string) => {
+        order.push("sign");
+        return psbtHex;
+      }),
+      deriveContextHash: vi.fn(async () => {
+        order.push("derive");
+        return "ab".repeat(32);
+      }),
+      approveDepositTerms: vi.fn(async () => {
+        order.push("approve");
+      }),
+    };
+
+    const txid = await broadcastPrePeginTransaction({
+      unsignedTxHex: "deadbeef",
+      btcWalletProvider: wallet,
+      depositorBtcPubkey: pubkey,
+      depositTerms: makeTerms(),
+    });
+
+    expect(order).toEqual(["derive", "approve", "sign"]);
+    expect(wallet.approveDepositTerms).toHaveBeenCalledTimes(1);
+    expect(txid).toBe("mock-txid");
+  });
+
+  it("rethrows a device-envelope rejection unwrapped, without signing", async () => {
+    const signPsbt = vi.fn();
+    const rejection = new DepositTermsRejectedError("user declined on device");
+    const wallet = {
+      signPsbt,
+      deriveContextHash: vi.fn(async () => "ab".repeat(32)),
+      approveDepositTerms: vi.fn(async () => {
+        throw rejection;
+      }),
+    };
+
+    await expect(
+      broadcastPrePeginTransaction({
+        unsignedTxHex: "deadbeef",
+        btcWalletProvider: wallet,
+        depositorBtcPubkey: pubkey,
+        depositTerms: makeTerms(),
+      }),
+    ).rejects.toBe(rejection);
+
+    expect(signPsbt).not.toHaveBeenCalled();
   });
 });

--- a/services/vault/src/services/vault/vaultPeginBroadcastService.ts
+++ b/services/vault/src/services/vault/vaultPeginBroadcastService.ts
@@ -11,6 +11,12 @@ import {
   TXID_RE,
   pushTx,
 } from "@babylonlabs-io/ts-sdk";
+import {
+  ensurePrePeginTermsApproval,
+  isDepositTermsRejectedError,
+  type DepositTerms,
+  type PrePeginApprovalWallet,
+} from "@babylonlabs-io/ts-sdk/tbv/core";
 import { assertPsbtUnsignedTxMatches } from "@babylonlabs-io/ts-sdk/tbv/core/primitives";
 import { getPsbtInputFields } from "@babylonlabs-io/ts-sdk/tbv/core/utils";
 import { Psbt, Transaction } from "bitcoinjs-lib";
@@ -62,11 +68,22 @@ export interface BroadcastPrePeginParams {
   unsignedTxHex: string;
 
   /**
-   * BTC wallet provider with signing capability
+   * BTC wallet provider with signing capability. May also implement the
+   * intent-approval methods (`deriveContextHash`/`approveDepositTerms`); when it
+   * does, `depositTerms` is required and the approval ceremony runs before
+   * signing.
    */
   btcWalletProvider: {
     signPsbt: (psbtHex: string) => Promise<string>;
-  };
+  } & PrePeginApprovalWallet;
+
+  /**
+   * Approved deposit terms — required when `btcWalletProvider` supports deposit
+   * approval. Fresh flows pass `PreparePeginResult.depositTerms`; the resume
+   * path will rebuild them from chain state (Part 2). Ignored (but still
+   * txid-validated) for non-approval wallets.
+   */
+  depositTerms?: DepositTerms;
 
   /**
    * Depositor's BTC public key (x-only format, 32 bytes hex)
@@ -282,6 +299,7 @@ export async function broadcastPrePeginTransaction(
     btcWalletProvider,
     depositorBtcPubkey,
     expectedUtxos,
+    depositTerms,
   } = params;
 
   try {
@@ -305,6 +323,15 @@ export async function broadcastPrePeginTransaction(
       expectedUtxos,
     );
 
+    // Intent-wallet ceremony (derive → approve) immediately before signing.
+    // No-op for wallets that do not support deposit approval.
+    await ensurePrePeginTermsApproval({
+      wallet: btcWalletProvider,
+      depositTerms,
+      fundedPrePeginTxHex: unsignedTxHex,
+      depositorBtcPubkey,
+    });
+
     // Sign and finalize
     const signedTxHex = await signAndFinalizePsbt(
       psbt.toHex(),
@@ -314,6 +341,12 @@ export async function broadcastPrePeginTransaction(
     // Broadcast to network
     return await pushTx(signedTxHex, getMempoolApiUrl());
   } catch (error) {
+    // A device-envelope rejection is a distinct, user-actionable outcome — let
+    // it through unwrapped so the UI can show the intent-rejection copy instead
+    // of a generic broadcast failure.
+    if (isDepositTermsRejectedError(error)) {
+      throw error;
+    }
     const message = error == null ? "Unknown error" : formatError(error);
     throw new Error(`Failed to broadcast Pre-PegIn transaction: ${message}`);
   }


### PR DESCRIPTION
Part 1 of #2220: give the Pre-PegIn broadcast an intent-approval seam so Ledger (intent) wallets can sign it.

- **New `ensurePrePeginTermsApproval` helper** (ts-sdk) — the shared derive→approve ceremony both broadcast paths run immediately before signing. No-op for software wallets; for intent wallets it verifies the terms match the tx, derives the vault root over the funding outpoints, then approves.
- **`PeginManager.signAndBroadcast`** — new optional `depositTerms`; ceremony runs before `signPsbt`.
- **Vault app** — `broadcastPrePeginTransaction` gains the same ceremony (device-rejection errors pass through unwrapped so the UI shows intent-rejection copy); the fresh-deposit call site forwards the wallet's approval capability + terms.
- Exported `capMaxAcceptableCommissionBps` (needed by the resume rebuild).

**Follow-up (Part 2, tracked in #2220):** the *resume* path — reconstruct terms from chain/indexer (`rebuildBroadcastDepositTerms`, with byte-verified sibling completeness) and rewire `useVaultActions` handleBroadcast.