### PR TITLE
test(core-ui): repaint and reshape buttons to demo the visual regression check

### DIFF
--- a/packages/babylon-core-ui/src/components/Button/Button.css
+++ b/packages/babylon-core-ui/src/components/Button/Button.css
@@ -1,5 +1,5 @@
 .bbn-btn {
-  @apply rounded-md tracking-0.4 transition-all duration-200;
+  @apply rounded-full tracking-0.4 transition-all duration-200;
 
   &-fluid {
     @apply w-full;
@@ -7,11 +7,11 @@
 
   &-contained {
     &.bbn-btn-primary {
-      @apply text-accent-contrast bg-primary-light hover:brightness-110 disabled:bg-primary-light/30;
+      @apply text-accent-contrast bg-error-main hover:brightness-110 disabled:bg-error-main/30;
     }
 
     &.bbn-btn-secondary {
-      @apply text-accent-contrast bg-secondary-main hover:brightness-110 disabled:opacity-30;
+      @apply text-accent-contrast bg-success-main hover:brightness-110 disabled:opacity-30;
     }
   }
 


### PR DESCRIPTION
> **Do not merge.** This exists only to exercise the visual regression check on a real pull request. Close it once the comment has been reviewed.

## What

Restyles the shared button in core-ui so the change is impossible to miss. Three declarations in `Button.css`:

| | before | after |
|---|---|---|
| radius | `rounded-md` | `rounded-full` |
| contained primary | teal `#387085` | red `#D32F2F` |
| contained secondary | orange `#CE6533` | green `#2E7D32` |

## Why

The visual regression workflow landed on `main` in #2218, but nothing has yet shown it working end to end on a live pull request. This gives it something unmistakable to catch, so the before/after comment can be reviewed for whether it is actually useful to a reviewer.

The button was chosen because it is the one component that moves both captured surfaces at once. `scripts/visual-embed.mjs` reserves two of its five embedded groups per surface, so a change that only touched Storybook would leave half the comment empty.

## How

Verified locally before opening, using the same harness CI runs:

- **Vault: 12 of 12 screens changed.** Every route renders a `Connect` button (contained secondary) in the header and a `Retry` button (contained primary) on the error card, at both the desktop and mobile viewports.
- **Storybook: 329 stories captured**, with every button story rendering as a red or green pill.

Both captures were diffed with `scripts/visual-diff.mjs`, which reported all 12 vault screens changed, ranging from 0.7% to 4.3% of pixels.

## What to look at

The workflow's comment on this PR - whether the screens it picked are the ones a reviewer would want to see, and whether the before/after images are legible enough to judge without downloading the artifact.
