### PR TITLE
chore(ledger-vault-signer): address #2238 review

### DIFF
--- a/packages/babylon-ledger-vault-signer/THIRD-PARTY-NOTICES.md
+++ b/packages/babylon-ledger-vault-signer/THIRD-PARTY-NOTICES.md
@@ -1,8 +1,8 @@
 # Third-party notices
 
-This file covers third-party source vendored into this repository's package tree
-and bundled into published artifacts. It is not an exhaustive inventory of every
-bundled npm dependency — those retain their own license files. Vendored source:
+This file covers third-party source vendored into this repository's package tree.
+It is not an exhaustive inventory of every bundled npm dependency — those retain
+their own license files. Vendored source:
 
 ---
 
@@ -11,11 +11,11 @@ bundled npm dependency — those retain their own license files. Vendored source
 - Project: LedgerHQ/app-bitcoin (formerly app-bitcoin-new)
 - Source: https://github.com/LedgerHQ/app-bitcoin
 - Version: ledger-bitcoin@0.3.0 (commit 0a9e9e141f3340d29e7c6181177d4e5e9483a9f7)
-- Files: bundled from packages/babylon-ledger-vault-signer/src/vendor/ledger-bitcoin/
+- Files: vendored under packages/babylon-ledger-vault-signer/src/vendor/ledger-bitcoin/
+  (source-in-tree; not yet reachable from the published bundle)
 - License: Apache License 2.0
 - Modifications: see the per-file provenance headers in the vendored source
-  (explicit Buffer import, defensive strict-null guards, formatting; the
-  object-level PSBT conversion was removed).
+  (explicit Buffer import, defensive strict-null guards, formatting).
 
 ### Apache License 2.0
 

--- a/packages/babylon-ledger-vault-signer/src/vendor/ledger-bitcoin/README.md
+++ b/packages/babylon-ledger-vault-signer/src/vendor/ledger-bitcoin/README.md
@@ -17,6 +17,11 @@ v6-compatible source and gate it with golden vectors.
   reproduced; attribution is by project name and URL (Apache-2.0 §4(a)/(c)).
 - Each file's header records its upstream path, version, upstream sha256, and the
   exact modifications made (§4(b)).
+- **Known upstream behaviour (kept):** `parseVarint` accepts non-canonical
+  (overlong) encodings — e.g. `fd0100` decodes to `1` — with no minimality check,
+  matching upstream and the Python oracle. Harmless while we only emit varints via
+  `createVarint`, but a hazard once PSBT bytes are parsed and reserialized;
+  revisit when `psbtv2` lands.
 
 ## Modifications (applied to every file)
 
@@ -25,24 +30,35 @@ v6-compatible source and gate it with golden vectors.
   bare `Buffer` from the standalone dist.
 - Strict-null / strict-index fixes for this repo's strict `tsconfig`.
 - Prettier/quote formatting to the package style.
-- `psbtv2.ts` (lands in a later increment): the object-level `fromBitcoinJS` is
-  dropped (it throws on taproot inputs — exactly our case; the map-level
-  `normalizeToV2` is the path we use).
 
 Everything else — protocol logic, byte layout, function surface — is verbatim.
 
 Vendored so far: `varint.ts`, `merkle.ts`, `merkleMap.ts`. The PSBT layer
 (`buffertools.ts`, `psbtv2.ts`, `merkelizedPsbt.ts`) and the client-command
-interpreter (`clientCommands.ts`, `policy.ts`) follow in later increments.
+interpreter (`clientCommands.ts`, `policy.ts`) follow in later increments. Until
+then these three modules are referenced only by their golden-vector tests, not by
+any production entrypoint (nothing reachable from `src/index.ts` imports them), so
+the bundler tree-shakes them out of the JS bundle and the vendor dir is excluded
+from declaration emission (see `vite.config.ts`) — the published `dist/` ships none
+of the vendored code (no JS, no `.d.ts`), and the `bitcoinjs-lib` / `buffer` deps
+they pull in stay out of the bundle, until the PSBT layer lands.
+
+### Planned (not yet vendored)
+
+- `psbtv2.ts`: the object-level `fromBitcoinJS` will be dropped (it throws on
+  taproot inputs — exactly our case; the map-level `normalizeToV2` is the path we
+  use).
 
 ## Golden-vector gate
 
 `__tests__/*.golden.test.ts` check the vendored modules against vectors generated
 by **Ledger's own Python client** (`ledger-bitcoin==0.4.0`, the version the vault
 firmware's device tests drive SIGN_PSBT through). `varint` and `merkle` have
-direct golden vectors (`varint.json`, `merkle_mth.json`); `merkleMap`'s
-commitment is exercised through the PSBT map vectors once `psbtv2` lands. Any
-behavioural drift from upstream fails these. The Python client is the primary
+direct golden vectors (`varint.json`, `merkle_mth.json`); `merkleMap`'s commitment
+(keys root, values root, the `varint(n) ‖ keysRoot ‖ valuesRoot` layout, and the
+outer Merkle-of-maps roots) is checked today against per-map commitment vectors the
+Python client emits over the firmware's PSBT fixtures (`__tests__/vectors/signpsbt/*.json`).
+Any behavioural drift from upstream fails these. The Python client is the primary
 oracle; the deprecated npm package is a secondary check.
 
 ## Re-diff procedure (on an upstream update)

--- a/packages/babylon-ledger-vault-signer/src/vendor/ledger-bitcoin/__tests__/merkleMap.golden.test.ts
+++ b/packages/babylon-ledger-vault-signer/src/vendor/ledger-bitcoin/__tests__/merkleMap.golden.test.ts
@@ -11,7 +11,9 @@
 import { Buffer } from "buffer";
 import { describe, expect, it } from "vitest";
 
+import { Merkle, hashLeaf } from "../merkle";
 import { MerkleMap } from "../merkleMap";
+import { createVarint } from "../varint";
 import payoutVector from "./vectors/signpsbt/deposit-flow__claimer_payout__2.json";
 import graphVector from "./vectors/signpsbt/deposit-flow__depositor_graph__0.json";
 import peginVector from "./vectors/signpsbt/deposit-flow__pegin__0.json";
@@ -20,12 +22,17 @@ type MapEntry = [string, string];
 type Commitment = { commitment_hex: string; keys_root: string; values_root: string; sorted_key_order: string[] };
 type SignPsbtVector = {
   fixture: string;
+  n_inputs: number;
+  n_outputs: number;
   global_map: MapEntry[];
   input_maps: MapEntry[][];
   output_maps: MapEntry[][];
   global_commitment: Commitment;
   input_commitments: Commitment[];
   output_commitments: Commitment[];
+  inputs_maps_root: string;
+  outputs_maps_root: string;
+  sign_psbt_cdata_hex: string;
 };
 
 /** Every merkelized map in a fixture, labelled, in the order the header commits them. */
@@ -58,6 +65,36 @@ describe("MerkleMap commitment golden vectors", () => {
     expect(map.keysTree.getRoot().toString("hex")).toBe(commitment.keys_root);
     expect(map.valuesTree.getRoot().toString("hex")).toBe(commitment.values_root);
     expect(map.commitment().toString("hex")).toBe(commitment.commitment_hex);
+  });
+});
+
+const fixtures = [peginVector, payoutVector, graphVector] as unknown as SignPsbtVector[];
+
+describe("SIGN_PSBT header: outer maps-roots + client-data golden vectors", () => {
+  // The outer tree hashes each per-map COMMITMENT as a leaf — a distinct byte
+  // treatment from the inner keys/values trees. A wrong outer-leaf hash or a
+  // wrong map order passes every per-map assertion above but fails here.
+  const outerRoot = (cs: Commitment[]): string =>
+    new Merkle(cs.map((c) => hashLeaf(Buffer.from(c.commitment_hex, "hex")))).getRoot().toString("hex");
+
+  it.each(fixtures)("commits $fixture inputs/outputs maps-roots", (v) => {
+    expect(outerRoot(v.input_commitments)).toBe(v.inputs_maps_root);
+    expect(outerRoot(v.output_commitments)).toBe(v.outputs_maps_root);
+  });
+
+  it.each(fixtures)("reconstructs the $fixture SIGN_PSBT client data", (v) => {
+    // globalCommitment ‖ varint(nIn) ‖ inputsMapsRoot ‖ varint(nOut) ‖
+    // outputsMapsRoot ‖ 64-byte tail (wallet-policy id + hmac, zero in these
+    // no-registration fixtures). Exercises createVarint in its real context.
+    const cdata = Buffer.concat([
+      Buffer.from(v.global_commitment.commitment_hex, "hex"),
+      createVarint(v.n_inputs),
+      Buffer.from(v.inputs_maps_root, "hex"),
+      createVarint(v.n_outputs),
+      Buffer.from(v.outputs_maps_root, "hex"),
+      Buffer.alloc(64, 0),
+    ]);
+    expect(cdata.toString("hex")).toBe(v.sign_psbt_cdata_hex);
   });
 });
 

--- a/packages/babylon-ledger-vault-signer/src/vendor/ledger-bitcoin/merkle.ts
+++ b/packages/babylon-ledger-vault-signer/src/vendor/ledger-bitcoin/merkle.ts
@@ -7,10 +7,13 @@
  * Upstream sha256: 733ecf485c0b98ad3732234945506bb6dda0d9814e27f8802f1def78cdad52d0
  * Vendored:        2026-08-13
  * License:         Apache-2.0 — see ./LICENSE (verbatim upstream copy)
- * Modifications:   explicit `import { Buffer } from "buffer"`; defensive
- *                  strict-null guards on getLeafHash/getProof and a
- *                  `leaves[0] as Buffer` narrowing at the n===1 branch
- *                  (behaviour-preserving; valid indices unchanged); formatting.
+ * Modifications:   explicit `import { Buffer } from "buffer"`; strict-null
+ *                  guards on getLeafHash/getProof — invalid indices now throw a
+ *                  typed Error("Index out of bounds") instead of upstream's raw
+ *                  TypeError (getLeafHash was unguarded; getProof guarded only
+ *                  index >= length, not negatives), valid indices unchanged —
+ *                  and a `leaves[0] as Buffer` narrowing at the n===1 branch;
+ *                  formatting.
  *
  * Ledger's Merkle tree, documented at
  * https://github.com/LedgerHQ/app-bitcoin-new/blob/master/doc/merkle.md

--- a/packages/babylon-ledger-vault-signer/vite.config.ts
+++ b/packages/babylon-ledger-vault-signer/vite.config.ts
@@ -8,7 +8,10 @@ export default defineConfig({
       tsconfigPath: "./tsconfig.lib.json",
       insertTypesEntry: true,
       include: ["src"],
-      exclude: ["src/**/__tests__/**"],
+      // Vendored SIGN_PSBT primitives are unreferenced by index.ts (test-only
+      // until #2219) — keep their declarations out of the published dist too,
+      // so nothing vendored ships until the code is actually wired in.
+      exclude: ["src/**/__tests__/**", "src/vendor/**"],
     }),
   ],
   build: {
@@ -34,5 +37,9 @@ export default defineConfig({
       },
     },
   },
+  // Strips comments from dist/, including the vendored files' Apache-2.0 §4(b)
+  // provenance headers. That attribution deliberately lives in
+  // THIRD-PARTY-NOTICES.md (shipped via `files`), which is the redistribution
+  // record — revisit if the vendored source ever needs its headers in-bundle.
   esbuild: { legalComments: "none" },
 });


### PR DESCRIPTION
Follow-up to #2238 — the vendored `ledger-bitcoin` §4(b) record ran ahead of the
code, and the reviewer's top ask (outer maps-roots coverage) was derivable today.

- **§4(b) accuracy** (NOTICES / README / `merkle.ts` header): dropped the
not-yet-vendored `psbtv2` modification + "bundled" claim, fixed the
invalid-index note (raw `TypeError` → typed `Error`), recorded non-canonical
`parseVarint`, moved `psbtv2` to a Planned subsection.
- **`dist/` now ships no vendored code** — excluded the vendor dir from `dts`
emission (was shipping `dist/vendor/**/*.d.ts`).
- **+6 golden assertions** — outer maps-roots + `sign_psbt_cdata_hex`, all 3
fixtures.