### PR TITLE
fix(ci): make the visual check photograph the vault app, not its error modal

### DIFF
--- a/packages/babylon-core-ui/src/components/Dialog/Dialog.tsx
+++ b/packages/babylon-core-ui/src/components/Dialog/Dialog.tsx
@@ -29,7 +29,11 @@ export const Dialog = ({
 
   return (
     <Portal mounted={mounted}>
-      <div {...restProps} className={twJoin("bbn-dialog-wrapper", className)} data-testid="dialog-wrapper">
+      {/* The testid is a default, so it must precede the spread: after it, a
+          caller passing its own `data-testid` is silently overridden here and
+          cannot address its dialog at all. MobileDialog already spreads last,
+          so the two rendered the same dialog under different testids. */}
+      <div data-testid="dialog-wrapper" {...restProps} className={twJoin("bbn-dialog-wrapper", className)}>
         <div
           className={twJoin("bbn-dialog", open ? "animate-modal-in" : "animate-modal-out", dialogClassName)}
           onAnimationEnd={unmount}

--- a/services/vault/e2e/visual/routes.visual.spec.ts
+++ b/services/vault/e2e/visual/routes.visual.spec.ts
@@ -81,6 +81,21 @@ for (const target of VISUAL_TARGETS) {
       await page.goto(target.path, { waitUntil: "domcontentloaded" });
       await waitForVisualStability(page);
 
+      // The app raises a blocking error dialog when it cannot boot - most
+      // often a required env var missing from `MOCK_ENV_VARS`, which a
+      // developer machine hides because vite reads the `.env` files a clean
+      // runner does not have. Photographing that is worse than failing: the
+      // modal covers every screen, both sides of the diff agree on it, and
+      // the check reports "no visual changes" for a PR whose UI it never
+      // rendered - which is what it did until this gate landed.
+      await expect(
+        page.getByTestId("error-dialog"),
+        `${target.name} captured the app's blocking error dialog instead of ` +
+          `the page. The app did not boot - fix the capture environment ` +
+          `(services/vault/playwright.config.ts) rather than accepting this ` +
+          `as a baseline.`,
+      ).toHaveCount(0);
+
       const fileName = screenshotFileName(target, viewport);
       const buffer = await page.screenshot({ fullPage: true });
       await fs.writeFile(path.join(OUTPUT_DIR, fileName), buffer);

--- a/services/vault/playwright.config.ts
+++ b/services/vault/playwright.config.ts
@@ -22,6 +22,16 @@ export const MOCK_ENV_VARS = {
   NEXT_PUBLIC_TBV_GRAPHQL_ENDPOINT: "http://localhost:9999/graphql",
   NEXT_PUBLIC_TBV_VP_PROXY_URL: "http://localhost:9998",
   NEXT_PUBLIC_ETH_RPC_URL: "http://localhost:9997/rpc",
+  // Both are required by `validateEnvVars` (src/config/env.ts), and their
+  // absence here was invisible on a developer machine: vite-plugin-environment
+  // reads `.env` files as well as the process env, and `services/vault/.env`
+  // supplies them. A clean runner has no `.env`, so validation failed,
+  // `envInitError` was set, and the app rendered the blocking "Configuration
+  // Error" modal on every screen instead of itself. Anything spawned from this
+  // object must therefore stand on its own, without a `.env` behind it.
+  // Sepolia + signet is the pairing `configureBabylonConfig` accepts.
+  NEXT_PUBLIC_ETH_CHAINID: "11155111",
+  NEXT_PUBLIC_BTC_NETWORK: "signet",
   // Pinned mempool base so route handlers in
   // `services/vault/e2e/fixtures/networkRoutes.ts` can match
   // deterministic paths. Without this the dApp falls through to a


### PR DESCRIPTION
## What
The visual-regression check was not looking at the vault app. All 12 of its
vault screens were photographs of a "Configuration Error" pop-up sitting over
an empty page, so it reported "no visual changes" no matter what changed in
the app.

This makes the app start properly during the check, and makes the check fail
loudly if that ever stops being true.

## Why
The app needs a couple of settings to start. They were missing from the test
setup, but a developer's own machine quietly supplies them from a local file
that CI does not have - so it worked for everyone locally and had never worked
in CI. Both the before and after pictures showed the same error pop-up, they
matched perfectly, and the check happily said nothing had changed.

## How
Adds the two missing settings, and adds a check that fails the run if the app
shows its start-up error pop-up instead of the page. A capture is now either a
real screenshot of the app or a red build - never a silent pass.

Also makes a pop-up keep the name the app gives it. The shared component was
overwriting it, which is why the new check could only see the error pop-up on
phone-sized screens.

Verified by running the capture locally with the local settings file hidden,
which is what CI sees: 12 screens fail without the fix, 12 pass with it.

This makes the vault screens real; it does not make them deep. Pages that need
wallet or contract data still photograph an empty state, and the deposit form
is a pop-up that no route can reach, so component-level changes there remain
uncovered. That needs its own surface and is not in this PR.
