### PR TITLE
test(vault): e2e v3 ui

### DIFF
--- a/services/vault/e2e/README.md
+++ b/services/vault/e2e/README.md
@@ -80,11 +80,10 @@ import {
   mockVpProxy,
 } from "./fixtures";
 
-test("dashboard reflects seeded BTC balance", async ({
+test("vaults page reflects seeded BTC balance", async ({
   page,
   seededBtcWallet,
   installWalletSentinel,
-  appShell,
   dashboard,
 }) => {
   const wallet = seededBtcWallet({ amount: 250_000n });
@@ -92,8 +91,8 @@ test("dashboard reflects seeded BTC balance", async ({
   await mockVpProxy(page);
   await installWalletSentinel({ btc: wallet });
 
-  await appShell.goto();
-  await expect(dashboard.vaultCard(/BTC/i)).toBeVisible();
+  await dashboard.goto();
+  await expect(dashboard.vaultRow(/BTC/i)).toBeVisible();
 });
 ```
 

--- a/services/vault/e2e/pages/AppShell.ts
+++ b/services/vault/e2e/pages/AppShell.ts
@@ -10,14 +10,7 @@
 
 import type { Locator, Page } from "@playwright/test";
 
-/** Sidebar section ids, mirroring `src/config/v3Navigation.ts`. */
-export type NavSection =
-  | "overview"
-  | "vaults"
-  | "loans"
-  | "activity"
-  | "liquidations"
-  | "explore";
+import type { V3NavItemId } from "@/config/v3Navigation";
 
 export class AppShell {
   constructor(public readonly page: Page) {}
@@ -36,12 +29,17 @@ export class AppShell {
    * A sidebar nav link, by section id (`AppSidebar`'s `nav-<id>` testid).
    * The sidebar is hidden on the disconnected entry layout, so this only
    * resolves once the app is connected or on a non-root route.
+   *
+   * The id type comes from the production nav config rather than a copy here,
+   * so adding a section can't leave this file silently stale — a new id is
+   * accepted automatically, and a renamed one fails to compile. Type-only, so
+   * nothing from `src` is pulled in at runtime.
    */
-  navLink(section: NavSection): Locator {
+  navLink(section: V3NavItemId): Locator {
     return this.page.getByTestId(`nav-${section}`);
   }
 
-  async openSection(section: NavSection): Promise<void> {
+  async openSection(section: V3NavItemId): Promise<void> {
     await this.navLink(section).click();
   }
 }

--- a/services/vault/e2e/pages/AppShell.ts
+++ b/services/vault/e2e/pages/AppShell.ts
@@ -1,7 +1,6 @@
 /**
- * Page object for the vault dApp's persistent shell: top nav, connect
- * button, theme toggle, and the route-level entry points (Applications
- * tab, Activity tab).
+ * Page object for the vault dApp's persistent shell: sidebar nav, connect
+ * button, and the route-level entry points.
  *
  * Selectors prefer role+name with COPY constants so that copy edits
  * keep tests passing. Where a stable data-testid exists in source, it
@@ -10,6 +9,15 @@
  */
 
 import type { Locator, Page } from "@playwright/test";
+
+/** Sidebar section ids, mirroring `src/config/v3Navigation.ts`. */
+export type NavSection =
+  | "overview"
+  | "vaults"
+  | "loans"
+  | "activity"
+  | "liquidations"
+  | "explore";
 
 export class AppShell {
   constructor(public readonly page: Page) {}
@@ -24,19 +32,16 @@ export class AppShell {
     return this.page.getByRole("button", { name: /^Connect/i });
   }
 
-  get applicationsTab(): Locator {
-    return this.page.getByRole("link", { name: /Applications/i });
+  /**
+   * A sidebar nav link, by section id (`AppSidebar`'s `nav-<id>` testid).
+   * The sidebar is hidden on the disconnected entry layout, so this only
+   * resolves once the app is connected or on a non-root route.
+   */
+  navLink(section: NavSection): Locator {
+    return this.page.getByTestId(`nav-${section}`);
   }
 
-  get activityTab(): Locator {
-    return this.page.getByRole("link", { name: /Activity/i });
-  }
-
-  async openActivity(): Promise<void> {
-    await this.activityTab.click();
-  }
-
-  async openApplications(): Promise<void> {
-    await this.applicationsTab.click();
+  async openSection(section: NavSection): Promise<void> {
+    await this.navLink(section).click();
   }
 }

--- a/services/vault/e2e/pages/Dashboard.ts
+++ b/services/vault/e2e/pages/Dashboard.ts
@@ -1,7 +1,7 @@
 /**
- * Page object for the post-connect dashboard at `/`. Exposes the
- * vault-card locator (testid-scoped to `CollateralVaultItem`) used by
- * per-flow tests; the deposit / withdraw entry points land alongside
+ * Page object for the vaults list at `/vaults`. Exposes the vault-row
+ * locator (testid-scoped to `VaultsActiveSection`'s `ActiveVaultRow`) used
+ * by per-flow tests; the deposit / withdraw entry points land alongside
  * their respective flow tickets so we don't ship selectors without a
  * caller.
  */
@@ -12,19 +12,19 @@ export class Dashboard {
   constructor(public readonly page: Page) {}
 
   async goto(): Promise<void> {
-    await this.page.goto("/");
+    await this.page.goto("/vaults");
   }
 
   /**
-   * Locator for a vault card matched by visible text (truncated pegin
-   * tx hash, provider name, BTC amount, etc.). Scoped to the
-   * `data-testid="vault-card"` div emitted by `CollateralVaultItem`,
-   * so the matcher only narrows among real cards instead of running
+   * Locator for an active-vault row matched by visible text (truncated
+   * pegin tx hash, provider name, BTC amount, etc.). Scoped to the
+   * `data-testid="vault-row-<vaultId>"` div emitted by `ActiveVaultRow`,
+   * so the matcher only narrows among real rows instead of running
    * against every ancestor `<div>`.
    */
-  vaultCard(matcher: string | RegExp): Locator {
+  vaultRow(matcher: string | RegExp): Locator {
     return this.page
-      .getByTestId("vault-card")
+      .locator('[data-testid^="vault-row-"]')
       .filter({ hasText: matcher })
       .first();
   }

--- a/services/vault/e2e/real/actions/borrow.ts
+++ b/services/vault/e2e/real/actions/borrow.ts
@@ -2,15 +2,16 @@
  * The "borrow" action: draw a borrowable token (Aave-style) against an activated BTC-Vault position,
  * end-to-end on real Sepolia. Two shapes, selected by the CLI:
  *   - REUSE (default): borrow against the depositor's existing collateral. run.ts already refused the
- *     run before the browser if there's no active collateral (fetchBorrowContext), so we land on the
- *     dashboard with the Borrow button enabled.
+ *     run before the browser if there's no active collateral (fetchBorrowContext), so the /loans
+ *     Borrow button is enabled as soon as we navigate there.
  *   - PEGIN-FIRST (`--pegin-first`): peg in fresh collateral first (the shared `runPeginFlow`, which
- *     ends on the dashboard with an active vault), then borrow — all in one browser session.
+ *     ends with an active vault), then borrow — all in one browser session.
  *
- * The borrow flow itself is short and has NO multi-minute on-chain gates (unlike pegin): open Loans →
- * Borrow, pick the token in the "Select asset" modal, enter the amount (a conservative fraction of the
- * real-data max, or the form's Max), submit, and approve the single MetaMask transaction. Then the
- * "Borrow successful" screen confirms it.
+ * The borrow flow itself is short and has NO multi-minute on-chain gates (unlike pegin): navigate to
+ * /loans (v3 moved the loan CTAs off the dashboard — see markdown/e2e-v3/03-borrow.md) → Borrow, pick
+ * the token in the "Select asset" picker, enter the amount (a conservative fraction of the real-data
+ * max, or the form's Max), submit, and approve the single MetaMask transaction. Then the "Borrow
+ * successful" screen confirms it.
  *
  * Selectors are testid-first (added to the src borrow controls, mirroring `activate-vault-button`) with
  * tolerant text/role/class fallbacks so a deployed build that predates the testids still works. No SDK
@@ -42,6 +43,7 @@ import {
 import { formatTokenAmount } from "../tokenAmount";
 
 import { installPopupApprover, sweepApprovals } from "./approver";
+import { goToSection } from "./navigation";
 import { runPeginFlow } from "./pegin";
 import { startRecording } from "./recording";
 import {
@@ -59,8 +61,8 @@ import {
 import { type Action, type ActionContext } from "./types";
 import { connectWallets } from "./walletConnect";
 
-// Dashboard "Loans" section → Borrow (testid-first; the fallback matches the button only while it reads
-// exactly "Borrow", which is fine on the dashboard where the CTA isn't relabeled). The shared loan-form
+// The /loans summary → Borrow (testid-first; the anchored fallback matches that CTA only while it reads
+// exactly "Borrow", so the page's per-loan "Borrow more" row buttons can't win it). The shared loan-form
 // selectors (amount input, Max button, "Select asset" title, success-modal Done, tx-failed) live in
 // selectors.ts — borrow-specific ones stay here.
 const LOANS_BORROW_TESTID = '[data-testid="loans-borrow-button"]';
@@ -145,8 +147,9 @@ async function resolveBorrowAmount(ctx: ActionContext): Promise<BorrowAmount> {
   return { mode: "amount", value };
 }
 
-/** Open the borrow flow from the dashboard: click Loans → Borrow, wait for the "Select asset" modal. */
+/** Open the borrow flow: navigate to /loans, click Borrow, wait for the "Select asset" picker. */
 async function openBorrow(page: Page, log: (m: string) => void): Promise<void> {
+  await goToSection(page, "loans", log);
   const borrow = firstByTestid(
     page,
     LOANS_BORROW_TESTID,
@@ -155,8 +158,8 @@ async function openBorrow(page: Page, log: (m: string) => void): Promise<void> {
   await borrow.waitFor({ state: "visible", timeout: STEP_TIMEOUT_MS });
   // The button is gated on `hasCollateral` (collateral > 0). A JUST-activated vault (pegin-first) takes
   // a moment to propagate into the app's position read, so the button can be briefly disabled right
-  // after "Go to Dashboard". Poll for it to enable rather than failing on the first check; only treat a
-  // persistently-disabled button as "no collateral". (A reuse run already passed run.ts's collateral
+  // after the peg-in finishes. Poll for it to enable rather than failing on the first check; only treat
+  // a persistently-disabled button as "no collateral". (A reuse run already passed run.ts's collateral
   // gate, so its button is enabled almost immediately.)
   const deadline = Date.now() + BORROW_BUTTON_ENABLE_TIMEOUT_MS;
   let enabled = await borrow.isEnabled().catch(() => false);
@@ -166,9 +169,9 @@ async function openBorrow(page: Page, log: (m: string) => void): Promise<void> {
   }
   if (!enabled)
     throw new Error(
-      `The dashboard Borrow button stayed disabled for ${Math.round(BORROW_BUTTON_ENABLE_TIMEOUT_MS / MS_PER_SECOND)}s — this position has no active BTC Vault collateral to borrow against. Peg in first (or re-run with --pegin-first).`,
+      `The /loans Borrow button stayed disabled for ${Math.round(BORROW_BUTTON_ENABLE_TIMEOUT_MS / MS_PER_SECOND)}s — this position has no active BTC Vault collateral to borrow against. Peg in first (or re-run with --pegin-first).`,
     );
-  log("Opening the borrow flow (Loans → Borrow)");
+  log("Opening the borrow flow (/loans → Borrow)");
   await borrow.click();
   await page
     .getByText(ASSET_SELECT_TITLE, { exact: true })

--- a/services/vault/e2e/real/actions/navigation.ts
+++ b/services/vault/e2e/real/actions/navigation.ts
@@ -1,0 +1,83 @@
+/**
+ * Section navigation for the v3 UI.
+ *
+ * The v2 dashboard put deposit, collateral, pending deposits and the loan CTAs on ONE page, so the
+ * actions never navigated. v3 splits them across routes (see markdown/e2e-v3/00-overview.md):
+ *   /        overview — connect entry only
+ *   /vaults  deposit CTA, pending-deposit rows + resume CTA, active vault rows, per-row Withdraw
+ *   /loans   Borrow + Repay CTAs
+ * so every action now opens its flow from a specific section.
+ *
+ * We CLICK the sidebar nav link rather than `page.goto`: a goto is a full reload, which re-hydrates
+ * wagmi/AppKit and drops in-memory deposit state. Chained runs (`withdraw --borrow-first --pegin-first`)
+ * navigate mid-lifecycle, so a reload there would be a real hazard; the nav link is a client-side route
+ * change. The `a[href]` fallback keeps a run working against a deployed build that predates the testids.
+ */
+import type { Page } from "@playwright/test";
+
+import { FORM_SETTLE_MS, MS_PER_SECOND, STEP_TIMEOUT_MS } from "../timing";
+
+import { firstByTestid } from "./selectors";
+
+/** The sections the actions navigate to (ids + paths mirror src/config/v3Navigation.ts). */
+export const SECTION_PATHS = {
+  overview: "/",
+  vaults: "/vaults",
+  loans: "/loans",
+} as const;
+
+export type SectionId = keyof typeof SECTION_PATHS;
+
+/** Whether the browser is already showing `path` (pathname only — the loan overlays add ?search). */
+function isOnSection(page: Page, path: string): boolean {
+  try {
+    return new URL(page.url()).pathname === path;
+  } catch {
+    return false; // about:blank / a non-URL page — treat as "not there yet"
+  }
+}
+
+/**
+ * Navigate to a v3 section by clicking its sidebar link, and wait for the route to settle. Idempotent:
+ * a no-op when the page is already on that section, so every action can navigate unconditionally
+ * (including the chained legs, which start from wherever the previous leg finished).
+ *
+ * THROWS when the link never appears. RootLayout renders the sidebar only when
+ * `!isMobileView && !isEntryLayout`, so an absent link almost always means the app is not connected
+ * yet (the entry layout hides it) — a clearer failure than the flow's own "control not found" a step
+ * later. The runs are maximized, so the mobile branch (nav behind a drawer) doesn't apply.
+ */
+export async function goToSection(
+  page: Page,
+  section: SectionId,
+  log: (m: string) => void,
+): Promise<void> {
+  const path = SECTION_PATHS[section];
+  if (isOnSection(page, path)) return;
+
+  const link = firstByTestid(
+    page,
+    `[data-testid="nav-${section}"]`,
+    page.locator(`a[href="${path}"]`),
+  );
+  const appeared = await link
+    .waitFor({ state: "visible", timeout: STEP_TIMEOUT_MS })
+    .then(() => true)
+    .catch(() => false);
+  if (!appeared)
+    throw new Error(
+      `Could not navigate to ${path}: its sidebar link never appeared within ${Math.round(STEP_TIMEOUT_MS / MS_PER_SECOND)}s. The sidebar is hidden on the disconnected entry screen, so this usually means the app is not in the connected state.`,
+    );
+
+  log(`Navigating to ${path}`);
+  await link.click({ timeout: STEP_TIMEOUT_MS });
+
+  const deadline = Date.now() + STEP_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    if (isOnSection(page, path)) return;
+    await page.waitForTimeout(FORM_SETTLE_MS);
+  }
+  throw new Error(
+    `Clicked the ${path} nav link but the route stayed on ${page.url()} after ${Math.round(STEP_TIMEOUT_MS / MS_PER_SECOND)}s.`,
+  );
+}

--- a/services/vault/e2e/real/actions/pegin.ts
+++ b/services/vault/e2e/real/actions/pegin.ts
@@ -35,6 +35,7 @@
  */
 import type { Locator, Page } from "@playwright/test";
 
+import { fetchActiveVaultCount } from "../borrowParams";
 import {
   DEPOSIT_CTA_ENABLE_TIMEOUT_MS,
   FORM_SETTLE_MS,
@@ -49,7 +50,7 @@ import { startRecording } from "./recording";
 import { FLUID_CTA_SELECTOR } from "./selectors";
 import {
   assertActivatedAndOnDashboard,
-  countActiveVaultRows,
+  assertVaultCountRose,
   walkStepMachine,
 } from "./stepMachine";
 import { type Action, type ActionContext } from "./types";
@@ -79,10 +80,8 @@ const TWO_VAULT_SPLIT_RX = /Two-vault split/; // COPY.deposit.form.splitOptionLa
 
 /**
  * Fill the deposit form (navigate to /vaults → amount → provider → submit). The form has NO testids,
- * so selectors are copy/role-driven and were verified against the real DOM. Returns the active-vault
- * row count seen on /vaults BEFORE the deposit — the finish line's split cross-check asserts the count
- * rose by the number of vaults this run creates — once the deposit progress view has opened (the fluid
- * CTA click transitions to it).
+ * so selectors are copy/role-driven and were verified against the real DOM. Returns once the deposit
+ * progress view has opened (the fluid CTA click transitions to it).
  */
 export async function fillDepositForm(
   page: Page,
@@ -90,20 +89,15 @@ export async function fillDepositForm(
   amountBtc: string,
   provider: string | undefined,
   split: boolean,
-): Promise<number> {
+): Promise<void> {
   await goToSection(page, "vaults", log);
   log(
     `Opening deposit form (${split ? "two-vault split, " : ""}amount ${amountBtc} sBTC, provider ${provider ?? "first available"})`,
   );
-  const depositButton = page.locator(DEPOSIT_BUTTON_TESTID).first();
-  await depositButton.waitFor({ state: "visible", timeout: STEP_TIMEOUT_MS });
-  // Count only AFTER the CTA renders. `goToSection` returns the moment the URL settles, but the vault
-  // list is data-driven — counting there reads 0 rows every time and silently zeroes the baseline the
-  // split cross-check subtracts against. VaultsPage renders this CTA only once its queries resolve
-  // (loading shows a Loader instead), in both the populated and empty layouts, so its presence means
-  // the row list is settled — including the legitimately-empty first-deposit case.
-  const baselineRowCount = await countActiveVaultRows(page);
-  await depositButton.click({ timeout: STEP_TIMEOUT_MS });
+  await page
+    .locator(DEPOSIT_BUTTON_TESTID)
+    .first()
+    .click({ timeout: STEP_TIMEOUT_MS });
 
   const amount = page.getByPlaceholder(AMOUNT_PLACEHOLDER).first();
   await amount.waitFor({ state: "visible", timeout: STEP_TIMEOUT_MS });
@@ -117,7 +111,6 @@ export async function fillDepositForm(
   const cta = await waitForDepositCta(page, log);
   log("Deposit CTA enabled — submitting the form");
   await cta.click();
-  return baselineRowCount;
 }
 
 /**
@@ -308,14 +301,17 @@ export async function runPeginFlow(
   const provider = ctx.config.peginProvider?.trim() || undefined;
   const split = ctx.config.split ?? false;
 
-  onStep("deposit-form");
-  const baselineRowCount = await fillDepositForm(
-    page,
-    log,
-    amountBtc,
-    provider,
-    split,
+  const expectedVaults = split ? 2 : 1;
+  // The on-chain vault count BEFORE this run — the baseline the post-condition asserts against. Read
+  // from `getPosition`, not the UI: /vaults renders optimistic rows for vaults this run activates, so
+  // a row count could never tell us whether the deposit actually landed.
+  const vaultsBefore = await fetchActiveVaultCount(
+    ctx.config.network,
+    ctx.eth.address,
   );
+
+  onStep("deposit-form");
+  await fillDepositForm(page, log, amountBtc, provider, split);
 
   onStep("sign-transaction");
   await startSigning(page, log);
@@ -325,19 +321,15 @@ export async function runPeginFlow(
     page,
     context,
     log,
-    split ? 2 : 1,
+    expectedVaults,
     onStep,
   );
 
   onStep("finish");
-  await assertActivatedAndOnDashboard(
-    page,
-    log,
-    amountBtc,
-    prePeginTxid,
-    split ? 2 : 1,
-    baselineRowCount,
-  );
+  await assertActivatedAndOnDashboard(page, log, amountBtc, prePeginTxid);
+
+  onStep("verify");
+  await assertVaultCountRose(ctx, vaultsBefore, expectedVaults);
   log(
     `✅ Pegin complete: ${split ? "two BTC Vaults" : "BTC Vault"} activated and shown on the dashboard.`,
   );

--- a/services/vault/e2e/real/actions/pegin.ts
+++ b/services/vault/e2e/real/actions/pegin.ts
@@ -23,9 +23,12 @@
  * offline instead of re-run blind.
  *
  * Selectors + copy strings below were verified against a real observe recording AND the React
- * components (DepositForm, VaultProviderSelector, DepositProgressView, ActivateConfirmationModal,
- * InStepArtifactCallout, VaultActivatedView, CollateralSection/CollateralVaultItem). No product/SDK
- * code is reimplemented — this only drives the UI; the frozen critical paths stay owned by the app.
+ * components (DepositForm, VaultProviderSelectorV3, DepositProgressView, ActivateConfirmationModal,
+ * InStepArtifactCallout, VaultActivatedView, VaultsActiveSection). No product/SDK code is
+ * reimplemented — this only drives the UI; the frozen critical paths stay owned by the app.
+ *
+ * The deposit modal is a RootLayout overlay opened from the /vaults deposit CTA (v3 moved it off the
+ * dashboard — see markdown/e2e-v3/02-pegin.md), so the form phase navigates there first.
  *
  * NEVER run without an explicit go-ahead: it spends real signet BTC + Sepolia ETH and is not
  * idempotent (a crash after the Pre-PegIn broadcast leaves an on-chain in-flight deposit).
@@ -41,9 +44,14 @@ import {
 } from "../timing";
 
 import { installPopupApprover } from "./approver";
+import { goToSection } from "./navigation";
 import { startRecording } from "./recording";
 import { FLUID_CTA_SELECTOR } from "./selectors";
-import { assertActivatedAndOnDashboard, walkStepMachine } from "./stepMachine";
+import {
+  assertActivatedAndOnDashboard,
+  countActiveVaultRows,
+  walkStepMachine,
+} from "./stepMachine";
 import { type Action, type ActionContext } from "./types";
 import { connectWallets } from "./walletConnect";
 
@@ -51,7 +59,9 @@ import { connectWallets } from "./walletConnect";
 // a comment pointing at their `services/vault/src/copy.ts` source. Finish-line matchers below are
 // tolerant regexes instead — the activated-view copy has been observed to drift between source and the
 // deployed build, so those key on stable/actionable elements rather than exact wording.
-const DEPOSIT_BUTTON_TESTID = '[data-testid="deposit-button"]'; // dashboard Collateral-section "Deposit"
+// The /vaults deposit CTA — rendered by both the summary card (VaultsSummaryCard) and the empty state
+// (VaultsEmptyState), so `.first()` picks whichever the page is showing.
+const DEPOSIT_BUTTON_TESTID = '[data-testid="deposit-button"]';
 const AMOUNT_PLACEHOLDER = "0"; // DepositForm amount input
 const SELECT_VP_LABEL = "Select vault provider"; // COPY.deposit.form.selectVaultProvider
 const DEPOSIT_CTA_LABEL = "Deposit"; // enabled DepositForm CTA (fluid button)
@@ -68,9 +78,11 @@ const DO_NOT_SPLIT_TEXT = "Do not split"; // COPY.deposit.form.doNotSplit
 const TWO_VAULT_SPLIT_RX = /Two-vault split/; // COPY.deposit.form.splitOptionLabel / TWO_VAULT_SPLIT_NAME
 
 /**
- * Fill the deposit form (amount → provider → submit). The form has almost no testids, so selectors
- * are copy/role-driven and were verified against the real DOM. Returns once the deposit progress view
- * has opened (the fluid CTA click transitions to it).
+ * Fill the deposit form (navigate to /vaults → amount → provider → submit). The form has NO testids,
+ * so selectors are copy/role-driven and were verified against the real DOM. Returns the active-vault
+ * row count seen on /vaults BEFORE the deposit — the finish line's split cross-check asserts the count
+ * rose by the number of vaults this run creates — once the deposit progress view has opened (the fluid
+ * CTA click transitions to it).
  */
 export async function fillDepositForm(
   page: Page,
@@ -78,14 +90,20 @@ export async function fillDepositForm(
   amountBtc: string,
   provider: string | undefined,
   split: boolean,
-): Promise<void> {
+): Promise<number> {
+  await goToSection(page, "vaults", log);
   log(
     `Opening deposit form (${split ? "two-vault split, " : ""}amount ${amountBtc} sBTC, provider ${provider ?? "first available"})`,
   );
-  await page
-    .locator(DEPOSIT_BUTTON_TESTID)
-    .first()
-    .click({ timeout: STEP_TIMEOUT_MS });
+  const depositButton = page.locator(DEPOSIT_BUTTON_TESTID).first();
+  await depositButton.waitFor({ state: "visible", timeout: STEP_TIMEOUT_MS });
+  // Count only AFTER the CTA renders. `goToSection` returns the moment the URL settles, but the vault
+  // list is data-driven — counting there reads 0 rows every time and silently zeroes the baseline the
+  // split cross-check subtracts against. VaultsPage renders this CTA only once its queries resolve
+  // (loading shows a Loader instead), in both the populated and empty layouts, so its presence means
+  // the row list is settled — including the legitimately-empty first-deposit case.
+  const baselineRowCount = await countActiveVaultRows(page);
+  await depositButton.click({ timeout: STEP_TIMEOUT_MS });
 
   const amount = page.getByPlaceholder(AMOUNT_PLACEHOLDER).first();
   await amount.waitFor({ state: "visible", timeout: STEP_TIMEOUT_MS });
@@ -99,6 +117,7 @@ export async function fillDepositForm(
   const cta = await waitForDepositCta(page, log);
   log("Deposit CTA enabled — submitting the form");
   await cta.click();
+  return baselineRowCount;
 }
 
 /**
@@ -290,7 +309,13 @@ export async function runPeginFlow(
   const split = ctx.config.split ?? false;
 
   onStep("deposit-form");
-  await fillDepositForm(page, log, amountBtc, provider, split);
+  const baselineRowCount = await fillDepositForm(
+    page,
+    log,
+    amountBtc,
+    provider,
+    split,
+  );
 
   onStep("sign-transaction");
   await startSigning(page, log);
@@ -311,6 +336,7 @@ export async function runPeginFlow(
     amountBtc,
     prePeginTxid,
     split ? 2 : 1,
+    baselineRowCount,
   );
   log(
     `✅ Pegin complete: ${split ? "two BTC Vaults" : "BTC Vault"} activated and shown on the dashboard.`,

--- a/services/vault/e2e/real/actions/repay.ts
+++ b/services/vault/e2e/real/actions/repay.ts
@@ -2,7 +2,8 @@
  * The "repay" action: pay down (or clear) a loan drawn against a BTC-Vault position, end-to-end on real
  * Sepolia. Two shapes, selected by the CLI:
  *   - REUSE (default): repay a loan the depositor already holds. run.ts refuses the run before the
- *     browser if there's no debt, so we land on the dashboard with the Repay button ready.
+ *     browser if there's no debt, so the /loans Repay button is ready as soon as we navigate there
+ *     (v3 moved the loan CTAs off the dashboard — see markdown/e2e-v3/04-repay.md).
  *   - BORROW-FIRST (`--borrow-first`): borrow first (the shared `runBorrowWithOptionalPegin`), then
  *     repay that loan — all in one browser session. Adding `--pegin-first` pegs in fresh collateral
  *     ahead of the borrow, giving the full pegin → borrow → repay lifecycle in one run.
@@ -45,6 +46,7 @@ import { formatTokenAmount } from "../tokenAmount";
 
 import { installPopupApprover, sweepApprovals } from "./approver";
 import { runBorrowWithOptionalPegin } from "./borrow";
+import { goToSection } from "./navigation";
 import { startRecording } from "./recording";
 import {
   AMOUNT_INPUT,
@@ -61,8 +63,8 @@ import {
 import { type Action, type ActionContext } from "./types";
 import { connectWallets } from "./walletConnect";
 
-// Dashboard "Loans" section → Repay (testid-first; the fallback matches the button only while it reads
-// exactly "Repay", which is fine on the dashboard where the CTA isn't relabeled). The shared loan-form
+// The /loans summary → Repay (testid-first; the page ALSO renders a per-loan "Repay" row button, so the
+// anchored-text fallback is genuinely ambiguous here — the testid is what disambiguates). The shared loan-form
 // selectors (amount input — also used to detect a single-loan repay skipping the picker — Max button,
 // "Select asset" title, success-modal Done, tx-failed) live in selectors.ts; repay-specific ones here.
 const LOANS_REPAY_TESTID = '[data-testid="loans-repay-button"]';
@@ -154,9 +156,9 @@ async function resolveRepayAmount(
 }
 
 /**
- * Open the repay flow from the dashboard: click Loans → Repay, then wait for EITHER the "Select asset"
- * picker (multiple loans) OR the repay form itself (a single loan skips the picker — see the app's
- * DashboardPage.handleRepay). Returns whether the picker appeared, so the caller knows to select an
+ * Open the repay flow: navigate to /loans, click Repay, then wait for EITHER the "Select asset" picker
+ * (multiple loans) OR the repay form itself (a single loan skips the picker — see the app's
+ * useLoanActions.openRepay). Returns whether the picker appeared, so the caller knows to select an
  * asset. The Repay button is only RENDERED when the position has a loan (`{hasLoans && …}`) and is
  * enabled once connected — so after a borrow-first the button's VISIBILITY, not just its enabled state,
  * lags while the new loan propagates. We therefore poll for it to appear AND enable within a single
@@ -167,6 +169,7 @@ async function openRepay(
   page: Page,
   log: (m: string) => void,
 ): Promise<{ pickerOpened: boolean }> {
+  await goToSection(page, "loans", log);
   const repay = firstByTestid(
     page,
     LOANS_REPAY_TESTID,
@@ -181,14 +184,14 @@ async function openRepay(
   }
   if (!enabled)
     throw new Error(
-      `The dashboard Repay button stayed disabled/absent for ${Math.round(REPAY_BUTTON_ENABLE_TIMEOUT_MS / MS_PER_SECOND)}s — this position has no loan to repay.`,
+      `The /loans Repay button stayed disabled/absent for ${Math.round(REPAY_BUTTON_ENABLE_TIMEOUT_MS / MS_PER_SECOND)}s — this position has no loan to repay.`,
     );
-  log("Opening the repay flow (Loans → Repay)");
+  log("Opening the repay flow (/loans → Repay)");
   await repay.click();
 
   // Race the two possible landings. The picker is identified by its "Select asset" title; the repay form
-  // by its numeric amount input (present on the form, absent on the dashboard) — a more specific signal
-  // than the generic fluid CTA, so a stray dashboard fluid button can't be mistaken for the form.
+  // by its numeric amount input (present on the form, absent on /loans) — a more specific signal than
+  // the generic fluid CTA, so a stray page-level fluid button can't be mistaken for the form.
   const pickerTitle = page
     .getByText(ASSET_SELECT_TITLE, { exact: true })
     .first();

--- a/services/vault/e2e/real/actions/resume.ts
+++ b/services/vault/e2e/real/actions/resume.ts
@@ -1,25 +1,28 @@
 /**
- * The "resume" action: recover an interrupted peg-in from the dashboard's Pending Deposits UI and drive
+ * The "resume" action: recover an interrupted peg-in from the /vaults pending-deposits list and drive
  * it through to an activated vault.
  *
  * A real peg-in spans 30 min–2 hr and the app is built to survive interruption: once the Pre-PegIn is
- * broadcast the deposit is on-chain, and the dashboard resurfaces it under "Pending Deposits" with a
- * resume action (Submit WOTS Key → Sign Payouts → Activate) driven from live vault-provider state. This
- * action opens that pending card and hands off to the SAME `walkStepMachine` the `pegin` action uses —
- * the resume flow renders the IDENTICAL `DepositProgressView` stepper — so the walk, the Activate-Vault
- * gate, and the activated-view finish line are shared, not reimplemented.
+ * broadcast the deposit is on-chain, and /vaults resurfaces it as a pending row with a resume action
+ * (Submit WOTS Key → Sign Payouts → Activate) driven from live vault-provider state. This action opens
+ * that pending row and hands off to the SAME `walkStepMachine` the `pegin` action uses — the resume
+ * flow renders the IDENTICAL `DepositProgressView` stepper — so the walk, the Activate-Vault gate, and
+ * the activated-view finish line are shared, not reimplemented.
  *
  * Two shapes:
- *   - default: resume an ALREADY-pending deposit (by `--txid`, else the first actionable card).
+ *   - default: resume an ALREADY-pending deposit (by `--txid`, else the first actionable row).
  *   - `--interrupt-fresh`: peg in a fresh deposit, interrupt it right after Pre-PegIn broadcast (reload
- *     the page to a cold state), then resume it from the dashboard — a fully self-contained run.
+ *     the page to a cold state), then resume it from /vaults — a fully self-contained run.
  *
- * Cold-resume specifics: unlike the happy path (which holds the vault root in memory), the dashboard
- * resume RE-DERIVES the vault root from the BTC wallet — a `deriveContextHash` approval dialog — to
- * recompute the WOTS keys and verify them against the on-chain hash. That dialog is the same one normal
- * peg-in step 1 (DERIVE_VAULT_SECRET) fires, so the shared pop-up approver already handles it; the
- * resume steps otherwise auto-fire on mount, so the only dapp-page interactions are the pending-card
- * click, the Activate gate, and "Go to Dashboard" — all owned by `walkStepMachine`.
+ * Cold-resume specifics: unlike the happy path (which holds the vault root in memory), the resume
+ * RE-DERIVES the vault root from the BTC wallet — a `deriveContextHash` approval dialog — to recompute
+ * the WOTS keys and verify them against the on-chain hash. That dialog is the same one normal peg-in
+ * step 1 (DERIVE_VAULT_SECRET) fires, so the shared pop-up approver already handles it; the resume steps
+ * otherwise auto-fire on mount, so the only dapp-page interactions are the pending-row CTA click, the
+ * Activate gate, and "Go to Dashboard" — all owned by `walkStepMachine`.
+ *
+ * v3 note (markdown/e2e-v3/06-resume.md): pending deposits are flat, always-visible rows — the v2
+ * expander they used to hide behind is gone, so there is nothing to expand.
  *
  * NEVER run `--interrupt-fresh` without an explicit go-ahead: it spends real signet BTC + Sepolia ETH.
  */
@@ -29,57 +32,55 @@ import {
   CONNECT_STATE_POLL_MS,
   CONNECT_STATE_TIMEOUT_MS,
   RESUME_ACTIONABLE_TIMEOUT_MS,
-  RESUME_CARD_APPEAR_TIMEOUT_MS,
   RESUME_POLL_INTERVAL_MS,
+  RESUME_ROW_APPEAR_TIMEOUT_MS,
   STEP_TIMEOUT_MS,
 } from "../timing";
 
 import { installPopupApprover, sweepApprovals } from "./approver";
+import { goToSection } from "./navigation";
 import { fillDepositForm, startSigning } from "./pegin";
 import { startRecording } from "./recording";
 import {
   assertActivatedAndOnDashboard,
+  countActiveVaultRows,
   walkStepMachine,
   walkUntilPrePeginBroadcast,
 } from "./stepMachine";
 import { type Action, type ActionContext } from "./types";
-import { connectWallets } from "./walletConnect";
+import { connectWallets, WALLET_MENU_TRIGGER_TESTID } from "./walletConnect";
 
-const DEPOSIT_BUTTON_TESTID = '[data-testid="deposit-button"]'; // connected-state signal (dashboard)
 const CONNECT_BUTTON_TESTID = '[data-testid="connect-wallet-button"]'; // shown when disconnected
-// PendingDepositSection's ExpandMenuButton — the pending list (and each card's resume CTA) lives behind
-// it (aria-label="Pending deposit details"). The button is only rendered when a pending deposit exists,
-// so its presence doubles as "there is something to resume".
-const PENDING_EXPAND_RX = /pending deposit details/i;
-// Added to services/vault/src for this action (see PendingDepositCard.tsx): the card root carries the
-// deposit's Pre-PegIn txid (its tx-hash row links it), and the resume CTA renders ONLY once the deposit
-// is actionable — so waiting for the CTA is waiting for vault-provider readiness.
-const PENDING_CARD_TESTID = '[data-testid="pending-deposit-card"]';
+// VaultsLifecycleSections' PendingRow: the row carries the deposit's Pre-PegIn txid (its hash cell
+// links it), and it is rendered only while a deposit is pending — so its presence doubles as "there is
+// something to resume". The resume CTA inside renders ONLY once the deposit is actionable, so waiting
+// for the CTA is waiting for vault-provider readiness.
+const PENDING_ROW_TESTID = '[data-testid="pending-deposit-row"]';
 const PENDING_RESUME_CTA_TESTID = '[data-testid="pending-deposit-resume-cta"]';
 
-/** Normalize a Pre-PegIn txid flag to the bare lowercase hex the card's explorer href contains. */
+/** Normalize a Pre-PegIn txid flag to the bare lowercase hex the row's explorer href contains. */
 function normalizeTxid(txid: string | undefined): string | undefined {
   const hex = txid?.trim().replace(/^0x/i, "").toLowerCase();
   return hex && /^[0-9a-f]{64}$/.test(hex) ? hex : undefined;
 }
 
 /**
- * After the interrupt reload, make sure the app is connected before we look for the pending card (the
+ * After the interrupt reload, make sure the app is connected before we look for the pending row (the
  * pending list reads the connected ETH address). wagmi/AppKit usually auto-reconnects on reload (the
- * deposit button reappears with no pop-up); if instead the Connect button is shown, re-run the connect
- * flow. Neither appearing is left to the pending-card wait to surface a clearer error.
+ * header wallet menu reappears with no pop-up); if instead the Connect button is shown, re-run the
+ * connect flow. Neither appearing is left to the pending-row wait to surface a clearer error.
  */
 async function ensureConnected(ctx: ActionContext): Promise<void> {
   const { page, context, log } = ctx;
-  const deposit = page.locator(DEPOSIT_BUTTON_TESTID).first();
+  const walletMenu = page.locator(WALLET_MENU_TRIGGER_TESTID).first();
   const connect = page.locator(CONNECT_BUTTON_TESTID).first();
   const deadline = Date.now() + CONNECT_STATE_TIMEOUT_MS;
   while (Date.now() < deadline) {
-    if (await deposit.isVisible().catch(() => false)) return; // auto-reconnected
+    if (await walletMenu.isVisible().catch(() => false)) return; // auto-reconnected
     // Only click Connect once it's actually ENABLED. Right after the reload the app re-hydrates and the
     // Connect button renders visible-but-DISABLED for a beat while wagmi/AppKit auto-reconnects; clicking
     // that transient disabled button just times out (it detaches the instant the connected state swaps
-    // in). Waiting instead lets the auto-reconnect win and the deposit button appear above.
+    // in). Waiting instead lets the auto-reconnect win and the wallet menu appear above.
     if (
       (await connect.isVisible().catch(() => false)) &&
       (await connect.isEnabled().catch(() => false))
@@ -96,94 +97,76 @@ async function ensureConnected(ctx: ActionContext): Promise<void> {
   );
 }
 
-/**
- * Expand the Pending Deposits section if it's collapsed (the deposit cards + their CTAs live behind it).
- * Idempotent: the ExpandMenuButton reflects state via `aria-expanded`, so we match it ONLY while
- * collapsed (`expanded: false`) and click once. Clicking unconditionally on every poll would toggle the
- * section open→closed and race the CTA click against a collapsing panel (landing on the wrong deposit).
- */
-async function ensurePendingExpanded(
-  page: Page,
-  log: (m: string) => void,
-): Promise<void> {
-  const collapsedToggle = page
-    .getByRole("button", { name: PENDING_EXPAND_RX, expanded: false })
-    .first();
-  if (await collapsedToggle.isVisible().catch(() => false)) {
-    log("Expanding the Pending Deposits section");
-    await collapsedToggle.click().catch(() => {});
-  }
-}
-
-/** A concise snapshot of the target pending card's state, for a heads-up log while waiting. */
-async function readPendingCardState(
+/** A concise snapshot of the target pending row's state, for a heads-up log while waiting. */
+async function readPendingRowState(
   page: Page,
   txid: string | undefined,
 ): Promise<string> {
-  const card = txid
+  const row = txid
     ? page
-        .locator(PENDING_CARD_TESTID)
+        .locator(PENDING_ROW_TESTID)
         .filter({ has: page.locator(`a[href*="${txid}"]`) })
         .first()
-    : page.locator(PENDING_CARD_TESTID).first();
-  return (await card.innerText().catch(() => ""))
+    : page.locator(PENDING_ROW_TESTID).first();
+  return (await row.innerText().catch(() => ""))
     .replace(/\s+/g, " ")
     .trim()
     .slice(0, 80);
 }
 
 /**
- * Open the target pending deposit's resume flow: wait for the pending section, expand it, wait for the
- * deposit to become actionable (its resume CTA renders only then — gated on the VP reaching the next
+ * Open the target pending deposit's resume flow: navigate to /vaults, wait for a pending row, wait for
+ * the deposit to become actionable (its resume CTA renders only then — gated on the VP reaching the next
  * step, which for a just-confirmed Pre-PegIn waits on signet block time), then click the CTA to open the
- * continuation view. Targets the `--txid` card when given (its tx-hash row links the Pre-PegIn), else the
- * first actionable card.
+ * continuation view. Targets the `--txid` row when given (its hash cell links the Pre-PegIn), else the
+ * first actionable row.
+ *
+ * Returns the active-vault row count seen before resuming, which the finish line's split cross-check
+ * asserts against (see assertActivatedAndOnDashboard).
  */
 async function openPendingDeposit(
   ctx: ActionContext,
   txid: string | undefined,
-): Promise<void> {
+): Promise<number> {
   const { page, context, log } = ctx;
 
-  // 1. Wait for the pending section (the expander is only rendered when a deposit is pending).
-  const expander = page
-    .getByRole("button", { name: PENDING_EXPAND_RX })
-    .first();
-  const appearDeadline = Date.now() + RESUME_CARD_APPEAR_TIMEOUT_MS;
+  await goToSection(page, "vaults", log);
+
+  // 1. Wait for a pending row (rendered only while a deposit is in flight).
+  const pendingRow = page.locator(PENDING_ROW_TESTID).first();
+  const appearDeadline = Date.now() + RESUME_ROW_APPEAR_TIMEOUT_MS;
   while (Date.now() < appearDeadline) {
-    if (await expander.isVisible().catch(() => false)) break;
+    if (await pendingRow.isVisible().catch(() => false)) break;
     await sweepApprovals(context, page, log);
     await page.waitForTimeout(RESUME_POLL_INTERVAL_MS);
   }
-  if (!(await expander.isVisible().catch(() => false)))
+  if (!(await pendingRow.isVisible().catch(() => false)))
     throw new Error(
-      "resume: no pending deposit found on the dashboard to resume. Peg in and interrupt one first (or re-run with --interrupt-fresh), or resume with an ETH account that has an in-flight deposit.",
+      "resume: no pending deposit found on /vaults to resume. Peg in and interrupt one first (or re-run with --interrupt-fresh), or resume with an ETH account that has an in-flight deposit.",
     );
 
-  await ensurePendingExpanded(page, log);
+  // Count only now: `goToSection` returns the moment the URL settles, but the lists are data-driven, so
+  // counting there reads 0 rows every time and silently zeroes the baseline the split cross-check
+  // subtracts against. A rendered pending row means the deposits query resolved, so the sibling
+  // active-vault list is settled too.
+  const baselineRowCount = await countActiveVaultRows(page);
 
-  // 2. The resume CTA. A single deposit exposes the CTA inside its own pending-deposit-card; a
-  //    batched/split deposit renders ONE group-level CTA (Broadcast / Continue / Activate) as a sibling
-  //    of its cards, inside the group's role=button wrapper. Both carry the same resume-cta testid, so we
-  //    scope one locator to the card and one to the wrapper (each filtered to the --txid deposit, else the
-  //    first actionable), and click whichever is present.
+  // 2. The resume CTA. v3 gives EVERY pending deposit its own row and its own CTA — including each half
+  //    of a split, which is why a two-vault batch shows two rows sharing one Pre-PegIn hash. Clicking
+  //    either one resumes the WHOLE batch: the row's action routes to `onOpenDetails`, which expands the
+  //    deposit through `getBatchSiblings` (every activity sharing that Pre-PegIn) and opens the
+  //    multistepper over all of them. So one row-scoped locator covers both shapes — there is no
+  //    group-level CTA in v3 (the v2 `role="button"` batch wrapper is gone).
   const txidHref = txid ? `a[href*="${txid}"]` : undefined;
-  const singleCta = txidHref
+  const cta = txidHref
     ? page
-        .locator(PENDING_CARD_TESTID)
-        .filter({ has: page.locator(txidHref) })
-        .locator(PENDING_RESUME_CTA_TESTID)
-        .first()
-    : page.locator(PENDING_RESUME_CTA_TESTID).first();
-  const batchedCta = txidHref
-    ? page
-        .locator('[role="button"]')
+        .locator(PENDING_ROW_TESTID)
         .filter({ has: page.locator(txidHref) })
         .locator(PENDING_RESUME_CTA_TESTID)
         .first()
     : page.locator(PENDING_RESUME_CTA_TESTID).first();
 
-  // 3. Wait for either to become actionable — can be long (VP must ingest the confirmed Pre-PegIn).
+  // 3. Wait for it to become actionable — can be long (VP must ingest the confirmed Pre-PegIn).
   log(
     txid
       ? `Waiting for pending deposit ${txid.slice(0, 8)}… to become resumable (vault-provider readiness)…`
@@ -192,10 +175,8 @@ async function openPendingDeposit(
   const actionableDeadline = Date.now() + RESUME_ACTIONABLE_TIMEOUT_MS;
   let lastState = "";
   while (Date.now() < actionableDeadline) {
-    await ensurePendingExpanded(page, log);
-    if (await singleCta.isVisible().catch(() => false)) break;
-    if (await batchedCta.isVisible().catch(() => false)) break;
-    const state = await readPendingCardState(page, txid);
+    if (await cta.isVisible().catch(() => false)) break;
+    const state = await readPendingRowState(page, txid);
     if (state && state !== lastState) {
       lastState = state;
       log(`Pending deposit → ${state}`);
@@ -203,12 +184,9 @@ async function openPendingDeposit(
     await sweepApprovals(context, page, log);
     await page.waitForTimeout(RESUME_POLL_INTERVAL_MS);
   }
-  const cta = (await singleCta.isVisible().catch(() => false))
-    ? singleCta
-    : batchedCta;
   if (!(await cta.isVisible().catch(() => false)))
     throw new Error(
-      "resume: the pending deposit never became resumable within the budget — the vault provider may not have ingested the confirmed Pre-PegIn (signet confirmation delay / VP availability), or the deposit hit a terminal state. Retry once the card shows a resume action.",
+      "resume: the pending deposit never became resumable within the budget — the vault provider may not have ingested the confirmed Pre-PegIn (signet confirmation delay / VP availability), or the deposit hit a terminal state. Retry once the row shows a resume action.",
     );
 
   const label = (await cta.innerText().catch(() => ""))
@@ -216,20 +194,21 @@ async function openPendingDeposit(
     .trim()
     .slice(0, 40);
   log(`Resuming pending deposit — clicking "${label || "resume"}"`);
-  // `force`: a batched deposit's group is a role=button wrapper whose card children overlap the CTA's
-  // click point (the app's known "card-as-button" nesting), so the strict pointer-intercept check fails
-  // even though the CTA is the right, visible element; clicking it still fires the same group action.
-  await cta.click({ timeout: STEP_TIMEOUT_MS, force: true });
+  // A plain <button> in the row's action slot, rendered only while the deposit is actionable — so the
+  // standard actionability checks apply and are worth keeping (v2 needed `force` to punch through the
+  // batch group's role=button wrapper, which v3 no longer has).
+  await cta.click({ timeout: STEP_TIMEOUT_MS });
+  return baselineRowCount;
 }
 
 /**
  * `--interrupt-fresh`: peg in a fresh deposit only as far as the Pre-PegIn broadcast, then reload the
- * page to a cold state so the deposit must be resumed from the dashboard (the realistic "closed the tab,
+ * page to a cold state so the deposit must be resumed from /vaults (the realistic "closed the tab,
  * came back later" scenario). Reuses the pegin form + signing helpers and the shared broadcast walk.
  *
  * Returns the fresh Pre-PegIn txid so the caller can target exactly THIS deposit when resuming — without
- * it the resume would fall back to the first actionable pending card and could pick up an unrelated
- * deposit (the dashboard commonly lists several in flight).
+ * it the resume would fall back to the first actionable pending row and could pick up an unrelated
+ * deposit (/vaults commonly lists several in flight).
  */
 async function peginUntilInterrupt(
   ctx: ActionContext,
@@ -267,10 +246,10 @@ async function peginUntilInterrupt(
 
 /**
  * Resume the pending deposit through to activation: open its resume flow, then hand off to the shared
- * step machine (WOTS → Sign → Activate → Go to Dashboard) and the dashboard collateral cross-check.
+ * step machine (WOTS → Sign → Activate → Go to Dashboard) and the /vaults collateral cross-check.
  *
  * `targetTxid` (the just-created deposit's Pre-PegIn txid under `--interrupt-fresh`) takes precedence
- * over `--txid`; when neither is set, `openPendingDeposit` falls back to the first actionable card.
+ * over `--txid`; when neither is set, `openPendingDeposit` falls back to the first actionable row.
  */
 async function runResumeFlow(
   ctx: ActionContext,
@@ -279,14 +258,14 @@ async function runResumeFlow(
 ): Promise<void> {
   const { page, context, log } = ctx;
 
-  // The deposit we're resuming (a fresh interrupt txid wins over --txid). Used BOTH to target the card
-  // AND as the ground-truth Pre-PegIn for the dashboard cross-check: walkStepMachine re-reads the first
-  // on-page /tx link, which in a resume is the dashboard *behind* the continuation view — a DIFFERENT
+  // The deposit we're resuming (a fresh interrupt txid wins over --txid). Used BOTH to target the row
+  // AND as the ground-truth Pre-PegIn for the /vaults cross-check: walkStepMachine re-reads the first
+  // on-page /tx link, which in a resume is the page *behind* the continuation view — a DIFFERENT
   // deposit — so we prefer this known txid and only fall back to the read one (first-actionable resume).
   const knownTxid = normalizeTxid(targetTxid ?? ctx.config.resumeTxid);
 
   onStep("open-pending-deposit");
-  await openPendingDeposit(ctx, knownTxid);
+  const baselineRowCount = await openPendingDeposit(ctx, knownTxid);
 
   onStep("resume-step-machine");
   const expectedVaults = ctx.config.split ? 2 : 1;
@@ -300,16 +279,18 @@ async function runResumeFlow(
 
   onStep("finish");
   // The resume flow doesn't always know the original deposit amount (a plain resume of a pre-existing
-  // deposit), so the dashboard cross-check runs by Pre-PegIn txid; --interrupt-fresh does pass the amount.
+  // deposit), so the single-vault cross-check falls back to the Pre-PegIn txid; --interrupt-fresh does
+  // pass the amount. A split resume uses the row-count delta instead — see the split branch.
   await assertActivatedAndOnDashboard(
     page,
     log,
     ctx.config.peginAmountBtc,
     knownTxid ?? prePeginTxid,
     expectedVaults,
+    baselineRowCount,
   );
   log(
-    "✅ Resume complete: the interrupted deposit reached an activated vault on the dashboard.",
+    "✅ Resume complete: the interrupted deposit reached an activated vault on /vaults.",
   );
 }
 
@@ -332,7 +313,7 @@ export const resumeAction: Action = {
     try {
       await connectWallets(ctx);
       // --interrupt-fresh / --interrupt-only peg in a new deposit and return its Pre-PegIn txid; fresh
-      // then resumes it (targeting exactly that card, not the first actionable one), while only stops
+      // then resumes it (targeting exactly that row, not the first actionable one), while only stops
       // here so the deposit can be resumed later in stages (manual on-chain checkpoints between).
       const freshTxid =
         ctx.config.interruptFresh || ctx.config.interruptOnly

--- a/services/vault/e2e/real/actions/resume.ts
+++ b/services/vault/e2e/real/actions/resume.ts
@@ -28,6 +28,7 @@
  */
 import type { Page } from "@playwright/test";
 
+import { fetchActiveVaultCount } from "../borrowParams";
 import {
   CONNECT_STATE_POLL_MS,
   CONNECT_STATE_TIMEOUT_MS,
@@ -43,7 +44,7 @@ import { fillDepositForm, startSigning } from "./pegin";
 import { startRecording } from "./recording";
 import {
   assertActivatedAndOnDashboard,
-  countActiveVaultRows,
+  assertVaultCountRose,
   walkStepMachine,
   walkUntilPrePeginBroadcast,
 } from "./stepMachine";
@@ -120,14 +121,11 @@ async function readPendingRowState(
  * step, which for a just-confirmed Pre-PegIn waits on signet block time), then click the CTA to open the
  * continuation view. Targets the `--txid` row when given (its hash cell links the Pre-PegIn), else the
  * first actionable row.
- *
- * Returns the active-vault row count seen before resuming, which the finish line's split cross-check
- * asserts against (see assertActivatedAndOnDashboard).
  */
 async function openPendingDeposit(
   ctx: ActionContext,
   txid: string | undefined,
-): Promise<number> {
+): Promise<void> {
   const { page, context, log } = ctx;
 
   await goToSection(page, "vaults", log);
@@ -144,12 +142,6 @@ async function openPendingDeposit(
     throw new Error(
       "resume: no pending deposit found on /vaults to resume. Peg in and interrupt one first (or re-run with --interrupt-fresh), or resume with an ETH account that has an in-flight deposit.",
     );
-
-  // Count only now: `goToSection` returns the moment the URL settles, but the lists are data-driven, so
-  // counting there reads 0 rows every time and silently zeroes the baseline the split cross-check
-  // subtracts against. A rendered pending row means the deposits query resolved, so the sibling
-  // active-vault list is settled too.
-  const baselineRowCount = await countActiveVaultRows(page);
 
   // 2. The resume CTA. v3 gives EVERY pending deposit its own row and its own CTA — including each half
   //    of a split, which is why a two-vault batch shows two rows sharing one Pre-PegIn hash. Clicking
@@ -198,7 +190,6 @@ async function openPendingDeposit(
   // standard actionability checks apply and are worth keeping (v2 needed `force` to punch through the
   // batch group's role=button wrapper, which v3 no longer has).
   await cta.click({ timeout: STEP_TIMEOUT_MS });
-  return baselineRowCount;
 }
 
 /**
@@ -264,8 +255,15 @@ async function runResumeFlow(
   // deposit — so we prefer this known txid and only fall back to the read one (first-actionable resume).
   const knownTxid = normalizeTxid(targetTxid ?? ctx.config.resumeTxid);
 
+  // Snapshot the on-chain vault count BEFORE resuming — the post-condition's baseline. Read from
+  // `getPosition`, never the UI: /vaults renders optimistic rows for the vaults this resume activates.
+  const vaultsBefore = await fetchActiveVaultCount(
+    ctx.config.network,
+    ctx.eth.address,
+  );
+
   onStep("open-pending-deposit");
-  const baselineRowCount = await openPendingDeposit(ctx, knownTxid);
+  await openPendingDeposit(ctx, knownTxid);
 
   onStep("resume-step-machine");
   const expectedVaults = ctx.config.split ? 2 : 1;
@@ -279,16 +277,16 @@ async function runResumeFlow(
 
   onStep("finish");
   // The resume flow doesn't always know the original deposit amount (a plain resume of a pre-existing
-  // deposit), so the single-vault cross-check falls back to the Pre-PegIn txid; --interrupt-fresh does
-  // pass the amount. A split resume uses the row-count delta instead — see the split branch.
+  // deposit), so this display check falls back to the Pre-PegIn txid; --interrupt-fresh does pass the
+  // amount. Either way it only confirms the row rendered — the on-chain assert below is the real one.
   await assertActivatedAndOnDashboard(
     page,
     log,
     ctx.config.peginAmountBtc,
     knownTxid ?? prePeginTxid,
-    expectedVaults,
-    baselineRowCount,
   );
+
+  await assertVaultCountRose(ctx, vaultsBefore, expectedVaults);
   log(
     "✅ Resume complete: the interrupted deposit reached an activated vault on /vaults.",
   );

--- a/services/vault/e2e/real/actions/stepMachine.ts
+++ b/services/vault/e2e/real/actions/stepMachine.ts
@@ -2,9 +2,9 @@
  * The shared peg-in signing step-machine + activated-view finish line, driven purely by AWAITING UI
  * transitions (the `role="progressbar"` and each active step's `aria-label="Step N active"`), never
  * fixed sleeps. Extracted from the `pegin` action so both `pegin` (form → sign → walk) and `resume`
- * (dashboard pending card → walk) share ONE implementation of the 15-step `DepositProgressView` walk,
+ * (/vaults pending row → walk) share ONE implementation of the 15-step `DepositProgressView` walk,
  * the Activate-Vault / artifact-Skip dapp gates, the transient-tx Retry gate, the WOTS-skip fast-fail,
- * and the dashboard collateral cross-check.
+ * and the /vaults collateral cross-check.
  *
  * The resume flow renders the IDENTICAL `DepositProgressView` stepper as the initial deposit, so the
  * walk works unchanged for both. The artifact-Skip gate is re-armed per appearance and simply never
@@ -25,6 +25,7 @@ import {
 } from "../timing";
 
 import { sweepApprovals } from "./approver";
+import { goToSection } from "./navigation";
 import { firstByTestid } from "./selectors";
 
 // The activation modal's confirm button. Selected testid-first (stable + text-independent) with a
@@ -58,8 +59,24 @@ function retryButton(page: Page): Locator {
 // copy.ts), and we key on the stable actionable control (the "Go to Dashboard" button) rather than the
 // heading text so a wording tweak can't strand the run at the activated screen.
 const GO_TO_DASHBOARD_RX = /go to dashboard/i; // COPY.deposit.vaultActivatedSuccess.goToDashboard
-const VAULT_OPTIONS_RX = /vault options/i; // CollateralSection ExpandMenuButton aria-label ("[BTC ]Vault options")
-const VAULT_CARD_TESTID = '[data-testid="vault-card"]'; // CollateralVaultItem VaultCardShell (stable testid)
+// One active-vault row on /vaults, keyed by on-chain vaultId (VaultsActiveSection ActiveVaultRow).
+// v3 renders these inline — the v2 collateral expander they used to hide behind is gone.
+const VAULT_ROW_SELECTOR = '[data-testid^="vault-row-"]';
+// The deposit/resume overlay's root (V3ModalShell → core-ui FullScreenDialog). The page behind it stays
+// mounted, so anything read "from the progress view" must be scoped to this — see readPrePeginTxid.
+const DEPOSIT_DIALOG_SELECTOR = ".bbn-dialog-fullscreen";
+
+/**
+ * How many active-vault rows /vaults is currently showing. Callers snapshot this BEFORE starting a
+ * deposit so the finish line can assert the count rose by the number of vaults the run creates — see
+ * assertActivatedAndOnDashboard's split branch. Assumes the page is already on /vaults.
+ */
+export function countActiveVaultRows(page: Page): Promise<number> {
+  return page
+    .locator(VAULT_ROW_SELECTOR)
+    .count()
+    .catch(() => 0);
+}
 
 /** True once the terminal activated view is showing — detected by its "Go to Dashboard" button. */
 function activatedViewReached(page: Page): Promise<boolean> {
@@ -120,13 +137,20 @@ async function handleArtifactSkip(
 /**
  * Capture this deposit's Pre-PegIn txid from the progress view. Explorer links render as
  * `<host>/tx/<txid>` anchors (CopyableHash); the depositor broadcasts + links the Pre-PegIn early in
- * the flow (well before the VP broadcasts the peg-in), so the first BTC txid to appear is this run's
- * Pre-PegIn. Used to pin the dashboard cross-check to THIS run's vault — a returning depositor's
- * dashboard lists several. Scans hrefs Node-side (no page-context function) and skips ETH links: an
- * ETH `/tx/0x…` hash never matches the 64-hex-no-0x BTC pattern.
+ * the flow (well before the VP broadcasts the peg-in), so the first BTC txid to appear inside the
+ * deposit dialog is this run's Pre-PegIn. Used to pin the /vaults cross-check to THIS run's vault — a
+ * returning depositor's list holds several. Scans hrefs Node-side (no page-context function) and skips
+ * ETH links: an ETH `/tx/0x…` hash never matches the 64-hex-no-0x BTC pattern.
+ *
+ * SCOPED TO THE DIALOG, deliberately. The deposit flow is a full-screen overlay (V3ModalShell →
+ * core-ui FullScreenDialog) and /vaults stays mounted behind it, so a page-wide scan reads the FIRST
+ * active-vault row's hash cell — an unrelated, already-activated deposit — the instant the depositor
+ * holds any vault. That mis-capture is silent: the single-vault finish line just falls back to its
+ * amount match, and the split branch (txid-only) reports "0/N matched" and blames indexer lag. Same
+ * hazard resume.ts documents when it prefers a known txid over the read one.
  */
 async function readPrePeginTxid(page: Page): Promise<string | undefined> {
-  const links = page.locator('a[href*="/tx/"]');
+  const links = page.locator(`${DEPOSIT_DIALOG_SELECTOR} a[href*="/tx/"]`);
   const count = await links.count().catch(() => 0);
   for (let i = 0; i < count; i++) {
     const href = await links
@@ -387,13 +411,19 @@ export async function walkUntilPrePeginBroadcast(
 }
 
 /**
- * Finish line: click "Go to Dashboard", then best-effort confirm the vault landed as collateral. The
- * activated view is the definitive success signal (we're only here because its "Go to Dashboard"
- * button appeared); the dashboard card is a secondary check, so a copy/layout drift on the dashboard
- * is logged as a warning rather than hanging or failing an otherwise-successful peg-in.
+ * Finish line: click "Go to Dashboard", navigate to /vaults, then best-effort confirm the vault landed
+ * as collateral. The activated view is the definitive success signal (we're only here because its "Go
+ * to Dashboard" button appeared); the vault row is a secondary check, so a copy/layout drift on
+ * /vaults is logged as a warning rather than hanging or failing an otherwise-successful peg-in.
+ *
+ * "Go to Dashboard" lands on the overview (`/`), which in v3 shows position totals but no per-vault
+ * rows — the rows live on /vaults, hence the explicit navigation.
  *
  * `amountBtc` may be undefined (the resume flow doesn't know the original deposit amount) — the
- * amount cross-check is then skipped and the txid / first-card path is used instead.
+ * amount cross-check is then skipped and the txid / first-row path is used instead.
+ *
+ * `baselineRowCount` is the active-row count from BEFORE this run's deposit (countActiveVaultRows on
+ * /vaults). The split branch needs it; see there for why a txid match cannot work.
  */
 export async function assertActivatedAndOnDashboard(
   page: Page,
@@ -401,6 +431,7 @@ export async function assertActivatedAndOnDashboard(
   amountBtc: string | undefined,
   prePeginTxid: string | undefined,
   expectedVaults: number,
+  baselineRowCount: number | undefined,
 ): Promise<void> {
   log("✅ Activated view reached — clicking Go to Dashboard");
   await page
@@ -408,85 +439,84 @@ export async function assertActivatedAndOnDashboard(
     .first()
     .click({ timeout: STEP_TIMEOUT_MS });
 
-  // The freshly activated vault surfaces as collateral behind the per-vault options expander (its
-  // label may render "BTC Vault options" or "Vault options" depending on the build). Bounded waits so
-  // a dashboard drift can never hang the run.
-  const options = page.getByRole("button", { name: VAULT_OPTIONS_RX }).first();
-  const optionsShown = await options
-    .waitFor({ state: "visible", timeout: DASHBOARD_VAULT_TIMEOUT_MS })
+  // The cross-check is secondary — a navigation hiccup must not fail an otherwise-successful peg-in.
+  const navigated = await goToSection(page, "vaults", log)
     .then(() => true)
     .catch(() => false);
-  if (!optionsShown) {
+  if (!navigated) {
     log(
-      "⚠️ Dashboard collateral controls not found within the wait — activation succeeded; skipping the card cross-check.",
+      "⚠️ Could not navigate to /vaults after activation — activation succeeded; skipping the vault-row cross-check.",
     );
     return;
   }
 
-  // Expand the collateral panel so the vault cards render.
-  const cards = page.locator(VAULT_CARD_TESTID);
-  if (
-    !(await cards
-      .first()
-      .isVisible()
-      .catch(() => false))
-  ) {
-    await options.click().catch(() => {});
-    await cards
-      .first()
-      .waitFor({ state: "visible", timeout: STEP_TIMEOUT_MS })
-      .catch(() => {});
+  // v3 renders active vaults as always-visible rows (no expander to open). Bounded wait so a slow
+  // indexer can never hang the run.
+  const rows = page.locator(VAULT_ROW_SELECTOR);
+  const rowsShown = await rows
+    .first()
+    .waitFor({ state: "visible", timeout: DASHBOARD_VAULT_TIMEOUT_MS })
+    .then(() => true)
+    .catch(() => false);
+  if (!rowsShown) {
+    log(
+      "⚠️ No active-vault row rendered on /vaults within the wait — activation succeeded; skipping the row cross-check.",
+    );
+    return;
   }
 
-  // Two-vault split: both fresh cards share THIS run's single (batched) Pre-PegIn txid, and each shows
-  // its own split sub-amount (not the full requested amount), so the single-vault amount cross-check
-  // below doesn't apply. "Both vaults activated" is already guaranteed upstream — walkStepMachine only
-  // finishes once it has driven both activations — so this dashboard count is a SOFT secondary
-  // confirmation: the indexer commonly lags a just-activated vault's tx-hash row, so a miss is logged
-  // (not failed) rather than turning indexer lag into a false failure on a real-funds run.
+  // Two-vault split: identify this run's vaults by the ROW COUNT RISING, not by txid.
+  //
+  // A txid match cannot work here. An active row renders `peginTxHash ?? prePeginTxHash`
+  // (VaultsActiveSection) — i.e. the PEG-IN transaction, which is a different tx from the Pre-PegIn we
+  // capture mid-flow. The two only coincide in the narrow window before the indexer populates
+  // `peginTxHash`, so the match is guaranteed to fail once indexing lands. Nor can the single-vault
+  // amount match substitute: each split row shows its own allocated sub-amount (e.g. 26/74 of the
+  // deposit), which the harness never computes — the app does.
+  //
+  // The count delta is indexer-independent and checks the thing the split actually claims: N more
+  // vaults exist than before. Still SOFT — "both vaults activated" is already guaranteed upstream
+  // (walkStepMachine only finishes once it has driven every activation), so this is a secondary
+  // confirmation and a miss must not fail an otherwise-successful real-funds run.
   if (expectedVaults > 1) {
-    // Both fresh split cards share this run's Pre-PegIn txid, but the indexer commonly lags a
-    // just-activated vault's tx-hash row — so poll (bounded) for both cards to link the txid rather
-    // than snapshotting once and warning on a transient 1/2.
-    const matchingCards = () =>
-      prePeginTxid
-        ? cards
-            .filter({ has: page.locator(`a[href*="${prePeginTxid}"]`) })
-            .count()
-            .catch(() => 0)
-        : Promise.resolve(0);
-    let matched = await matchingCards();
-    const deadline = Date.now() + DASHBOARD_VAULT_TIMEOUT_MS;
-    while (matched < expectedVaults && Date.now() < deadline) {
-      await page.waitForTimeout(PEGIN_POLL_INTERVAL_MS);
-      matched = await matchingCards();
-    }
-    const total = await cards.count().catch(() => 0);
-    if (matched >= expectedVaults)
+    if (baselineRowCount === undefined) {
       log(
-        `Dashboard shows ${matched} split vaults for this run (matched by Pre-PegIn txid ${prePeginTxid?.slice(0, 8)}…).`,
+        `⚠️ No pre-deposit row count was captured, so the ${expectedVaults}-vault split cross-check was skipped — activation still succeeded.`,
+      );
+      return;
+    }
+    const target = baselineRowCount + expectedVaults;
+    let total = await rows.count().catch(() => 0);
+    const deadline = Date.now() + DASHBOARD_VAULT_TIMEOUT_MS;
+    while (total < target && Date.now() < deadline) {
+      await page.waitForTimeout(PEGIN_POLL_INTERVAL_MS);
+      total = await rows.count().catch(() => 0);
+    }
+    if (total >= target)
+      log(
+        `/vaults shows ${total} active vaults, up ${total - baselineRowCount} from ${baselineRowCount} before this run — the ${expectedVaults}-vault split landed.`,
       );
     else
       log(
-        `⚠️ Dashboard matched ${matched}/${expectedVaults} split vaults by Pre-PegIn txid within the wait (${total} cards total) — activation succeeded; the indexer may still be catching up to the fresh vaults' tx-hash rows.`,
+        `⚠️ /vaults shows ${total} active vaults, up ${total - baselineRowCount} from ${baselineRowCount} — expected ${expectedVaults} more within the wait. Activation succeeded; the indexer may still be catching up.`,
       );
     return;
   }
 
-  // A returning depositor's dashboard lists several vault cards, so `.first()` is not necessarily the
-  // one this run created — matching the first card against the requested amount produced a false
-  // mismatch warning against an older vault. Prefer THIS run's Pre-PegIn txid captured mid-flow: the
-  // card links it in its "TX Hash" row (PeginTxHashRow, linkPrePegin default) as `<a href=".../tx/…">`.
-  // But that row is indexer-sourced, and for a JUST-activated vault the indexer commonly lags the click
-  // to the dashboard — the fresh card shows its amount (from activation state) before its tx-hash row
-  // populates. So the amount match is the expected, immediately-authoritative identifier for a fresh
-  // vault; the txid match engages once the indexer has caught up (e.g. an already-indexed vault). First
-  // card is the last resort when neither is captured.
+  // A returning depositor's /vaults lists several vault rows, so `.first()` is not necessarily the one
+  // this run created — matching the first row against the requested amount produced a false mismatch
+  // warning against an older vault. Prefer THIS run's Pre-PegIn txid captured mid-flow: the row links
+  // it in its transaction-hash cell (CopyableHash) as `<a href=".../tx/…">`. But that cell is
+  // indexer-sourced, and for a JUST-activated vault the indexer commonly lags the click to the
+  // dashboard — the fresh row shows its amount (from activation state) before its hash cell populates.
+  // So the amount match is the expected, immediately-authoritative identifier for a fresh vault; the
+  // txid match engages once the indexer has caught up (e.g. an already-indexed vault). First row is the
+  // last resort when neither is captured.
   const byTxid = prePeginTxid
-    ? cards.filter({ has: page.locator(`a[href*="${prePeginTxid}"]`) }).first()
+    ? rows.filter({ has: page.locator(`a[href*="${prePeginTxid}"]`) }).first()
     : null;
   const byAmount = amountBtc
-    ? cards
+    ? rows
         .filter({
           hasText: new RegExp(
             `${amountBtc.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\s*sBTC`,
@@ -495,31 +525,31 @@ export async function assertActivatedAndOnDashboard(
         .first()
     : null;
 
-  let card = cards.first();
-  let matchedBy = "first card (fallback)";
+  let row = rows.first();
+  let matchedBy = "first row (fallback)";
   if (byTxid && (await byTxid.isVisible().catch(() => false))) {
-    card = byTxid;
+    row = byTxid;
     matchedBy = `Pre-PegIn txid ${prePeginTxid?.slice(0, 8)}…`;
   } else if (byAmount && (await byAmount.isVisible().catch(() => false))) {
-    card = byAmount;
+    row = byAmount;
     matchedBy = `amount ${amountBtc}`;
   }
 
-  const cardText = (await card.innerText().catch(() => ""))
+  const rowText = (await row.innerText().catch(() => ""))
     .replace(/\s+/g, " ")
     .trim();
-  // With no known amount (resume), reaching the activated view + a rendered collateral card is the
-  // success signal; the amount-substring assertion only applies when the caller passed an amount.
+  // With no known amount (resume), reaching the activated view + a rendered vault row is the success
+  // signal; the amount-substring assertion only applies when the caller passed an amount.
   if (!amountBtc)
     log(
-      `Dashboard shows the resumed vault as collateral (matched by ${matchedBy}).`,
+      `/vaults shows the resumed vault as collateral (matched by ${matchedBy}).`,
     );
-  else if (cardText.includes(amountBtc))
+  else if (rowText.includes(amountBtc))
     log(
-      `Dashboard shows this run's vault as collateral (${amountBtc} sBTC, matched by ${matchedBy}).`,
+      `/vaults shows this run's vault as collateral (${amountBtc} sBTC, matched by ${matchedBy}).`,
     );
   else
     log(
-      `⚠️ Dashboard vault card did not clearly show "${amountBtc}" (matched by ${matchedBy}; card: "${cardText.slice(0, 120)}") — activation still succeeded.`,
+      `⚠️ The /vaults row did not clearly show "${amountBtc}" (matched by ${matchedBy}; row: "${rowText.slice(0, 120)}") — activation still succeeded.`,
     );
 }

--- a/services/vault/e2e/real/actions/stepMachine.ts
+++ b/services/vault/e2e/real/actions/stepMachine.ts
@@ -16,8 +16,12 @@
  */
 import type { BrowserContext, Locator, Page } from "@playwright/test";
 
+import { fetchActiveVaultCount } from "../borrowParams";
 import {
   DASHBOARD_VAULT_TIMEOUT_MS,
+  FRESH_COLLATERAL_POLL_MS,
+  FRESH_COLLATERAL_TIMEOUT_MS,
+  MS_PER_SECOND,
   PEGIN_POLL_INTERVAL_MS,
   PEGIN_STEP_MACHINE_BUDGET_MS,
   PEGIN_TX_FAILURE_RETRY_LIMIT,
@@ -27,6 +31,7 @@ import {
 import { sweepApprovals } from "./approver";
 import { goToSection } from "./navigation";
 import { firstByTestid } from "./selectors";
+import { type ActionContext } from "./types";
 
 // The activation modal's confirm button. Selected testid-first (stable + text-independent) with a
 // tolerant-text fallback: the button copy drifts (COPY.deposit.activateConfirmation.activateButton
@@ -65,18 +70,6 @@ const VAULT_ROW_SELECTOR = '[data-testid^="vault-row-"]';
 // The deposit/resume overlay's root (V3ModalShell → core-ui FullScreenDialog). The page behind it stays
 // mounted, so anything read "from the progress view" must be scoped to this — see readPrePeginTxid.
 const DEPOSIT_DIALOG_SELECTOR = ".bbn-dialog-fullscreen";
-
-/**
- * How many active-vault rows /vaults is currently showing. Callers snapshot this BEFORE starting a
- * deposit so the finish line can assert the count rose by the number of vaults the run creates — see
- * assertActivatedAndOnDashboard's split branch. Assumes the page is already on /vaults.
- */
-export function countActiveVaultRows(page: Page): Promise<number> {
-  return page
-    .locator(VAULT_ROW_SELECTOR)
-    .count()
-    .catch(() => 0);
-}
 
 /** True once the terminal activated view is showing — detected by its "Go to Dashboard" button. */
 function activatedViewReached(page: Page): Promise<boolean> {
@@ -422,16 +415,17 @@ export async function walkUntilPrePeginBroadcast(
  * `amountBtc` may be undefined (the resume flow doesn't know the original deposit amount) — the
  * amount cross-check is then skipped and the txid / first-row path is used instead.
  *
- * `baselineRowCount` is the active-row count from BEFORE this run's deposit (countActiveVaultRows on
- * /vaults). The split branch needs it; see there for why a txid match cannot work.
+ * DISPLAY ONLY — this cannot tell you the peg-in landed, and must never be treated as if it could.
+ * The app renders an optimistic row per just-activated vault from in-memory state
+ * (ActivatingVaultsContext, 90s TTL, no indexer), carrying the same `vault-row-<vaultId>` testid and
+ * the same amount as a real row. So every identifier available here is satisfied by a row THIS RUN's
+ * own activations created, ingested or not. `assertVaultCountRose` is the authoritative check.
  */
 export async function assertActivatedAndOnDashboard(
   page: Page,
   log: (m: string) => void,
   amountBtc: string | undefined,
   prePeginTxid: string | undefined,
-  expectedVaults: number,
-  baselineRowCount: number | undefined,
 ): Promise<void> {
   log("✅ Activated view reached — clicking Go to Dashboard");
   await page
@@ -462,44 +456,6 @@ export async function assertActivatedAndOnDashboard(
     log(
       "⚠️ No active-vault row rendered on /vaults within the wait — activation succeeded; skipping the row cross-check.",
     );
-    return;
-  }
-
-  // Two-vault split: identify this run's vaults by the ROW COUNT RISING, not by txid.
-  //
-  // A txid match cannot work here. An active row renders `peginTxHash ?? prePeginTxHash`
-  // (VaultsActiveSection) — i.e. the PEG-IN transaction, which is a different tx from the Pre-PegIn we
-  // capture mid-flow. The two only coincide in the narrow window before the indexer populates
-  // `peginTxHash`, so the match is guaranteed to fail once indexing lands. Nor can the single-vault
-  // amount match substitute: each split row shows its own allocated sub-amount (e.g. 26/74 of the
-  // deposit), which the harness never computes — the app does.
-  //
-  // The count delta is indexer-independent and checks the thing the split actually claims: N more
-  // vaults exist than before. Still SOFT — "both vaults activated" is already guaranteed upstream
-  // (walkStepMachine only finishes once it has driven every activation), so this is a secondary
-  // confirmation and a miss must not fail an otherwise-successful real-funds run.
-  if (expectedVaults > 1) {
-    if (baselineRowCount === undefined) {
-      log(
-        `⚠️ No pre-deposit row count was captured, so the ${expectedVaults}-vault split cross-check was skipped — activation still succeeded.`,
-      );
-      return;
-    }
-    const target = baselineRowCount + expectedVaults;
-    let total = await rows.count().catch(() => 0);
-    const deadline = Date.now() + DASHBOARD_VAULT_TIMEOUT_MS;
-    while (total < target && Date.now() < deadline) {
-      await page.waitForTimeout(PEGIN_POLL_INTERVAL_MS);
-      total = await rows.count().catch(() => 0);
-    }
-    if (total >= target)
-      log(
-        `/vaults shows ${total} active vaults, up ${total - baselineRowCount} from ${baselineRowCount} before this run — the ${expectedVaults}-vault split landed.`,
-      );
-    else
-      log(
-        `⚠️ /vaults shows ${total} active vaults, up ${total - baselineRowCount} from ${baselineRowCount} — expected ${expectedVaults} more within the wait. Activation succeeded; the indexer may still be catching up.`,
-      );
     return;
   }
 
@@ -552,4 +508,52 @@ export async function assertActivatedAndOnDashboard(
     log(
       `⚠️ The /vaults row did not clearly show "${amountBtc}" (matched by ${matchedBy}; row: "${rowText.slice(0, 120)}") — activation still succeeded.`,
     );
+}
+
+/**
+ * THE peg-in post-condition: assert the depositor's on-chain position gained exactly the vaults this
+ * run created. Polls `fetchActiveVaultCount` (a `getPosition` read) until it reaches
+ * `beforeCount + expectedVaults`, then THROWS — mirroring the on-chain post-conditions borrow, repay
+ * and withdraw already carry (debt rose / debt fell / collateral fell). Peg-in previously had none,
+ * which is how a UI check that could not fail came to stand in for verification.
+ *
+ * Deliberately NOT a UI read. /vaults renders an optimistic row per just-activated vault from
+ * in-memory state, so any row-based count after driving N activations is satisfied by the harness's
+ * own side effects — see `fetchActiveVaultCount` and `assertActivatedAndOnDashboard`.
+ *
+ * Budget is borrow's post-activation settle window: activation confirms on Sepolia in seconds and
+ * `getPosition` reads that state directly, so this is normally immediate; the allowance absorbs a slow
+ * read rather than a slow indexer (there is no indexer in this path).
+ */
+export async function assertVaultCountRose(
+  ctx: ActionContext,
+  beforeCount: number,
+  expectedVaults: number,
+): Promise<void> {
+  const target = beforeCount + expectedVaults;
+  const deadline = Date.now() + FRESH_COLLATERAL_TIMEOUT_MS;
+  let lastCount = beforeCount;
+  let read = false;
+  while (Date.now() < deadline) {
+    const count = await fetchActiveVaultCount(
+      ctx.config.network,
+      ctx.eth.address,
+    ).catch(() => null);
+    if (count != null) {
+      read = true;
+      lastCount = count;
+      if (count >= target) {
+        ctx.log(
+          `✅ On-chain vaults rose: ${beforeCount} → ${count} (+${count - beforeCount}, expected +${expectedVaults}).`,
+        );
+        return;
+      }
+    }
+    await ctx.page.waitForTimeout(FRESH_COLLATERAL_POLL_MS);
+  }
+  throw new Error(
+    read
+      ? `Peg-in reached the activated view but the on-chain position holds ${lastCount} vault(s), not the expected ${target} (${beforeCount} before this run + ${expectedVaults}) within ${Math.round(FRESH_COLLATERAL_TIMEOUT_MS / MS_PER_SECOND)}s — the activation(s) did not register as collateral.`
+      : `Peg-in reached the activated view but the on-chain vault count could not be read within ${Math.round(FRESH_COLLATERAL_TIMEOUT_MS / MS_PER_SECOND)}s, so the deposit is unverified. Check the Sepolia RPC and re-check the position manually.`,
+  );
 }

--- a/services/vault/e2e/real/actions/walletConnect.ts
+++ b/services/vault/e2e/real/actions/walletConnect.ts
@@ -5,7 +5,12 @@
  *   Connect (connect-wallet-button) → Select Bitcoin Wallet (select-bitcoin-wallet-button) →
  *   wallet-option-<id> → approve in the BTC extension popup → Select Ethereum Wallet
  *   (select-ethereum-wallet-button) → MetaMask (Reown AppKit) → approve MetaMask popup →
- *   Connect (chains-connect-button) → the dashboard deposit CTA (data-testid="deposit-button") appears.
+ *   Connect (chains-connect-button) → the header wallet menu (data-testid="wallet-menu-trigger")
+ *   appears.
+ *
+ * The connected-state signal is the header's wallet-menu trigger, NOT a page CTA: v3 splits the old
+ * dashboard across routes, so the deposit CTA now lives on /vaults only (markdown/e2e-v3/01-connect.md).
+ * The menu trigger renders on every route the moment both wallets are connected.
  *
  * It assumes a pop-up approver is ALREADY installed on the context (see `approver.ts`) — the approval
  * pop-ups fire asynchronously during these clicks. Callers own the approver lifecycle so they can keep
@@ -30,8 +35,15 @@ import type { ActionContext } from "./types";
 const ETH_APPKIT_NAME: Record<EthWalletId, RegExp> = { metamask: /metamask/i };
 
 /**
- * Drive the connect flow to the connected state (the dashboard deposit button visible). Requires an
- * active pop-up approver on `ctx.context`.
+ * The header's connected wallet menu (the avatar-group trigger, src/components/Wallet/Connect.tsx). It
+ * renders ONLY once both wallets are connected and on EVERY route, which makes it both the connected-
+ * state signal and the menu trigger.
+ */
+export const WALLET_MENU_TRIGGER_TESTID = '[data-testid="wallet-menu-trigger"]';
+
+/**
+ * Drive the connect flow to the connected state (the header wallet menu visible). Requires an active
+ * pop-up approver on `ctx.context`.
  */
 export async function connectWallets(ctx: ActionContext): Promise<void> {
   const { page, context, log } = ctx;
@@ -68,29 +80,30 @@ export async function connectWallets(ctx: ActionContext): Promise<void> {
     .click({ timeout: STEP_TIMEOUT_MS })
     .catch(() => {});
 
-  log("Waiting for connected state (deposit button)");
+  log("Waiting for connected state (header wallet menu)");
   // Poll for the connected state while actively sweeping approval popups. MetaMask can insert an EXTRA
   // approval AFTER the initial connect — a "Review permissions / Use your enabled networks" prompt whose
   // Confirm (page-container-footer-next) must be clicked before the app flips to connected. That prompt
   // can land after the popup approver's per-window rounds have ended (or in a reused window that fires no
   // 'page' event), so a one-shot waitFor would just time out with it hanging. Sweeping each tick clicks
   // it (clickApprove already matches that Confirm), the same way the borrow/repay confirm loops do.
-  const deposit = page.locator('[data-testid="deposit-button"]').first();
+  const walletMenu = page.locator(WALLET_MENU_TRIGGER_TESTID).first();
   const deadline = Date.now() + CONNECT_STATE_TIMEOUT_MS;
   while (Date.now() < deadline) {
-    if (await deposit.isVisible().catch(() => false)) return;
+    if (await walletMenu.isVisible().catch(() => false)) return;
     await sweepApprovals(context, page, log);
     await page.waitForTimeout(CONNECT_STATE_POLL_MS);
   }
   throw new Error(
-    `connect: the connected state (deposit button) did not appear within ${Math.round(CONNECT_STATE_TIMEOUT_MS / MS_PER_SECOND)}s — a wallet approval popup (e.g. MetaMask "Review permissions") may be unconfirmed.`,
+    `connect: the connected state (header wallet menu) did not appear within ${Math.round(CONNECT_STATE_TIMEOUT_MS / MS_PER_SECOND)}s — a wallet approval popup (e.g. MetaMask "Review permissions") may be unconfirmed.`,
   );
 }
 
 /**
  * Open the connected wallet menu. core-ui's `Menu` clones the trigger (the avatar group) and adds
  * `aria-haspopup="true"` + toggles `aria-expanded`, rendering the address cards in a Popover when open.
- * Click the haspopup trigger and confirm the menu opened (retry with the avatar image as a fallback).
+ * Click the trigger and confirm the menu opened (one retry, since the header can swallow the first
+ * click while it settles).
  */
 export async function openWalletMenu(
   page: Page,
@@ -106,12 +119,9 @@ export async function openWalletMenu(
       .then(() => true)
       .catch(() => false);
 
-  // The header has TWO aria-haspopup triggers: the wallet avatar group and the settings gear. Target
-  // the avatar group specifically (it contains the wallet avatar images), not the gear.
-  const trigger = page
-    .locator('[aria-haspopup="true"]')
-    .filter({ has: page.locator("img.bbn-avatar-img") })
-    .first();
+  // The header has TWO aria-haspopup triggers: the wallet avatar group and the settings gear — hence
+  // the testid on the avatar group rather than a structural match on either.
+  const trigger = page.locator(WALLET_MENU_TRIGGER_TESTID).first();
   await trigger
     .waitFor({ state: "visible", timeout: STEP_TIMEOUT_MS })
     .catch(() => {});

--- a/services/vault/e2e/real/actions/withdraw.ts
+++ b/services/vault/e2e/real/actions/withdraw.ts
@@ -314,6 +314,25 @@ export async function runWithdrawFlow(
     );
     if (!all) break;
 
+    // The success screen MUST be gone before the next pass looks at the rows. The withdraw flow is an
+    // overlay and never changes the URL, so `goToSection` below is a no-op here and synchronises
+    // nothing; /vaults stays mounted underneath it. Scanning too early reads those covered rows — and a
+    // covered button still reports `isEnabled()`, so the scan would hand back a vaultId whose click then
+    // hangs to timeout on a pointer intercept, far from the real cause. `confirmWithdrawSuccess`
+    // deliberately tolerates a failed Done click (success is already proven by the initiated screen, so
+    // a missed click must not fail an otherwise-good withdrawal), which is exactly how the overlay can
+    // still be up at this point — so wait it out here and fail with the real reason if it never closes.
+    const overlayClosed = await page
+      .locator(WITHDRAW_DONE_TESTID)
+      .first()
+      .waitFor({ state: "hidden", timeout: STEP_TIMEOUT_MS })
+      .then(() => true)
+      .catch(() => false);
+    if (!overlayClosed)
+      throw new Error(
+        `The withdraw success screen stayed open for ${Math.round(STEP_TIMEOUT_MS / MS_PER_SECOND)}s after releasing vault ${shortenVaultId(vaultId)} — its Done button did not dismiss it, so the remaining vaults can't be reached. ${released.size} vault(s) were released; re-run to continue.`,
+      );
+
     // Another pass only if a withdrawable row remains. The just-released vault leaves the active list,
     // so this settles at "nothing left to release" rather than needing a count decided up front.
     await goToSection(page, "vaults", log);

--- a/services/vault/e2e/real/actions/withdraw.ts
+++ b/services/vault/e2e/real/actions/withdraw.ts
@@ -39,7 +39,6 @@
  */
 import type { BrowserContext, Page } from "@playwright/test";
 
-import { fetchCollateralSats } from "../borrowParams";
 import { formatBtc } from "../preflight";
 import {
   FORM_SETTLE_MS,
@@ -50,6 +49,7 @@ import {
   WITHDRAW_TX_TIMEOUT_MS,
   WITHDRAW_VERIFY_POLL_MS,
 } from "../timing";
+import { fetchWithdrawContext } from "../withdrawParams";
 
 import { installPopupApprover, sweepApprovals } from "./approver";
 import { runBorrowWithOptionalPegin } from "./borrow";
@@ -124,7 +124,25 @@ async function findWithdrawableVaultId(
  * disabled — waiting that out is not the same as "nothing withdrawable". `released` holds the vaults
  * this run has already put through the flow, so a `--withdraw-all` pass can't re-enter one whose row
  * hasn't left the list yet.
+ *
+ * The poll lives in `waitForWithdrawableVaultId` so the `--withdraw-all` loop decides "is there another
+ * one?" on exactly the same terms. A single unpolled scan there would end the batch early on any
+ * transient — `findWithdrawableVaultId` reports every locator failure as "nothing withdrawable", and
+ * /vaults re-renders right after each withdrawal settles — releasing a subset while still exiting green.
  */
+async function waitForWithdrawableVaultId(
+  page: Page,
+  released: ReadonlySet<string>,
+): Promise<{ vaultId: string; rowCount: number } | { rowCount: number }> {
+  const deadline = Date.now() + WITHDRAW_CTA_ENABLE_TIMEOUT_MS;
+  let found = await findWithdrawableVaultId(page, released);
+  while (!("vaultId" in found) && Date.now() < deadline) {
+    await page.waitForTimeout(FORM_SETTLE_MS);
+    found = await findWithdrawableVaultId(page, released);
+  }
+  return found;
+}
+
 async function openWithdrawForRow(
   page: Page,
   log: (m: string) => void,
@@ -132,12 +150,7 @@ async function openWithdrawForRow(
 ): Promise<string> {
   await goToSection(page, "vaults", log);
 
-  const deadline = Date.now() + WITHDRAW_CTA_ENABLE_TIMEOUT_MS;
-  let found = await findWithdrawableVaultId(page, released);
-  while (!("vaultId" in found) && Date.now() < deadline) {
-    await page.waitForTimeout(FORM_SETTLE_MS);
-    found = await findWithdrawableVaultId(page, released);
-  }
+  const found = await waitForWithdrawableVaultId(page, released);
   if (!("vaultId" in found)) {
     if (found.rowCount === 0)
       throw new Error(
@@ -243,35 +256,45 @@ async function confirmWithdrawSuccess(
 }
 
 /**
- * After the success screen, verify on-chain that the position's collateral actually fell — the UI
- * "Withdrawal initiated" alone doesn't prove the vault left the position. Polls `fetchCollateralSats`
- * (on-chain `getPosition.totalCollateralBTC`) until it drops below the pre-withdraw baseline (inverse of
- * borrow's collateral-rose wait). Never silently passes; throws if collateral doesn't move.
+ * After the success screen(s), verify on-chain that EXACTLY the vaults this run released actually left
+ * the position: poll `getPosition` until `vaultCount === beforeCount - released`, then throw.
+ *
+ * The count, not the collateral total, is the post-condition. `collateral fell at all` cannot tell 1
+ * released from 10 — the snapshot is taken once before the first pass and asserted once after the last,
+ * so the very first release satisfies it permanently and a `--withdraw-all` run that quietly released a
+ * subset still reports success. The count is exact, so a missing release fails.
+ *
+ * A read failure is retried inside the budget and then FAILS rather than being skipped: the whole point
+ * is the post-condition, so silently dropping it would leave the run verified by UI markers alone.
  */
-async function assertCollateralDecreased(
+async function assertVaultsReleased(
   ctx: ActionContext,
-  beforeSats: bigint,
-): Promise<void> {
+  beforeCount: number,
+  releasedCount: number,
+): Promise<number> {
+  const target = beforeCount - releasedCount;
   const deadline = Date.now() + WITHDRAW_TX_TIMEOUT_MS;
-  let lastSats = beforeSats;
+  let lastCount: number | null = null;
   while (Date.now() < deadline) {
-    const sats = await fetchCollateralSats(
+    const context = await fetchWithdrawContext(
       ctx.config.network,
       ctx.eth.address,
     ).catch(() => null);
-    if (sats != null) {
-      lastSats = sats;
-      if (sats < beforeSats) {
+    if (context) {
+      lastCount = context.vaultCount;
+      if (context.vaultCount === target) {
         ctx.log(
-          `✅ On-chain collateral fell: ${formatBtc(beforeSats)} → ${formatBtc(sats)}.`,
+          `✅ On-chain vaults fell: ${beforeCount} → ${context.vaultCount} (released ${releasedCount}); collateral now ${formatBtc(context.collateralSats)}.`,
         );
-        return;
+        return context.vaultCount;
       }
     }
     await ctx.page.waitForTimeout(WITHDRAW_VERIFY_POLL_MS);
   }
   throw new Error(
-    `Withdraw reached the success screen but on-chain collateral did not fall within ${Math.round(WITHDRAW_TX_TIMEOUT_MS / MS_PER_SECOND)}s (before ${formatBtc(beforeSats)}, last ${formatBtc(lastSats)}) — the position doesn't reflect the withdrawal.`,
+    lastCount == null
+      ? `Withdraw reached the success screen but the on-chain position could not be read within ${Math.round(WITHDRAW_TX_TIMEOUT_MS / MS_PER_SECOND)}s, so the ${releasedCount} release(s) are unverified. Check the Sepolia RPC and the position manually.`
+      : `Withdraw released ${releasedCount} vault(s) in the UI but the on-chain position holds ${lastCount}, not the expected ${target} (${beforeCount} before this run − ${releasedCount}) within ${Math.round(WITHDRAW_TX_TIMEOUT_MS / MS_PER_SECOND)}s — at least one withdrawal did not take effect.`,
   );
 }
 
@@ -281,7 +304,7 @@ async function assertCollateralDecreased(
  * `--withdraw-all` repeats row → Review → Done — one on-chain transaction each — until no withdrawable
  * row is left. The default releases exactly one, keeping the position alive for reuse.
  *
- * The on-chain collateral snapshot is taken before the FIRST pass and asserted after the LAST, so the
+ * The on-chain vault count is snapshotted before the FIRST pass and asserted after the LAST, so the
  * post-condition covers the whole batch rather than re-reading between transactions.
  */
 export async function runWithdrawFlow(
@@ -291,12 +314,18 @@ export async function runWithdrawFlow(
   const { page, context, log } = ctx;
   const all = ctx.config.withdrawAll === true;
 
-  // Snapshot on-chain collateral BEFORE submitting so we can assert it fell afterwards (a real-data
-  // post-condition on top of the UI success screen).
-  const collateralBeforeSats = await fetchCollateralSats(
+  // Snapshot the on-chain position BEFORE submitting: `vaultCount` is the baseline the post-condition
+  // asserts against, and `hasDebt` decides whether leftover vaults are legitimate (health-factor gating)
+  // or a silent under-release. Fail now rather than discover at verification time that there is no
+  // baseline to compare against — that is how the check used to skip itself.
+  const before = await fetchWithdrawContext(
     ctx.config.network,
     ctx.eth.address,
-  ).catch(() => null);
+  ).catch((error: unknown) => {
+    throw new Error(
+      `withdraw: could not read the on-chain position before withdrawing (${error instanceof Error ? error.message : error}), so the run would be unverifiable. Re-run against a reachable Sepolia RPC.`,
+    );
+  });
 
   const released = new Set<string>();
   for (;;) {
@@ -333,19 +362,37 @@ export async function runWithdrawFlow(
         `The withdraw success screen stayed open for ${Math.round(STEP_TIMEOUT_MS / MS_PER_SECOND)}s after releasing vault ${shortenVaultId(vaultId)} — its Done button did not dismiss it, so the remaining vaults can't be reached. ${released.size} vault(s) were released; re-run to continue.`,
       );
 
-    // Another pass only if a withdrawable row remains. The just-released vault leaves the active list,
-    // so this settles at "nothing left to release" rather than needing a count decided up front.
+    // Everything the position held is now released — stop without paying the poll below for a row that
+    // cannot exist.
+    if (released.size >= before.vaultCount) break;
+
+    // Another pass only if a withdrawable row remains — POLLED, on the same terms as the entry path.
+    // A single scan here would end the batch on any transient (a re-render mid-refetch, a sibling still
+    // `isActivating`), silently releasing a subset while still exiting green.
     await goToSection(page, "vaults", log);
-    const next = await findWithdrawableVaultId(page, released);
+    const next = await waitForWithdrawableVaultId(page, released);
     if (!("vaultId" in next)) break;
   }
 
   onStep("withdraw-verify");
-  if (collateralBeforeSats == null)
+  const remaining = await assertVaultsReleased(
+    ctx,
+    before.vaultCount,
+    released.size,
+  );
+
+  // `--withdraw-all` promises to drain the position. Leftovers are only legitimate when debt is still
+  // health-factor-gating them; with no debt every vault was releasable, so anything left means the loop
+  // stopped early and the run must not report success.
+  if (all && remaining > 0) {
+    if (!before.hasDebt)
+      throw new Error(
+        `--withdraw-all released ${released.size} of ${before.vaultCount} vault(s) but ${remaining} remain, and the position carries no debt to health-factor-gate them — the loop stopped before draining the position.`,
+      );
     log(
-      "⚠️ Skipping the on-chain collateral check — couldn't read the pre-withdraw collateral to compare against.",
+      `⚠️ --withdraw-all released ${released.size} of ${before.vaultCount} vault(s); ${remaining} remain, held back by the $${before.currentDebtUsd.toFixed(2)} debt's health-factor gate. Repay first (--repay-first) to release them.`,
     );
-  else await assertCollateralDecreased(ctx, collateralBeforeSats);
+  }
 
   log(`Withdraw released ${released.size} vault(s).`);
 }

--- a/services/vault/e2e/real/actions/withdraw.ts
+++ b/services/vault/e2e/real/actions/withdraw.ts
@@ -327,6 +327,15 @@ export async function runWithdrawFlow(
     );
   });
 
+  // A zero baseline is not a withdrawable position, and `fetchWithdrawContext` also reports 0 when the
+  // position exists but holds no collateral. Reject it here so the run names that cause, rather than
+  // releasing whatever the UI still offers and then failing `assertVaultsReleased` against a NEGATIVE
+  // target — an impossible expectation that would read as a broken assertion, not a bad starting state.
+  if (before.vaultCount === 0)
+    throw new Error(
+      "withdraw: the on-chain position reports 0 vaults before withdrawing — there is nothing to release, and no baseline to verify a release against.",
+    );
+
   const released = new Set<string>();
   for (;;) {
     const pass = released.size + 1;

--- a/services/vault/e2e/real/actions/withdraw.ts
+++ b/services/vault/e2e/real/actions/withdraw.ts
@@ -9,8 +9,8 @@
  *   - AS-IS (default): withdraw against the current position. A vault is withdrawable while the projected
  *     health factor after removing it stays ≥ 1.0 — so with NO debt every active vault is freely
  *     withdrawable (mirrors src/applications/aave/utils/withdrawEligibility.ts). When the position still
- *     carries debt, some/all vaults may be HF-gated; the modal's per-vault checkbox + the Review screen's
- *     HF gate enforce that, and we surface it rather than guessing.
+ *     carries debt, some/all vaults may be HF-gated; the Review screen's HF gate enforces that, and we
+ *     surface it rather than guessing.
  *   - REPAY-FIRST (`--repay-first`): repay the outstanding debt in full (the shared `runRepayFlow` with
  *     the amount forced to Max), then withdraw — clearing the HF gate so collateral releases cleanly.
  *   - BORROW-FIRST (`--borrow-first`): borrow (the shared `runBorrowWithOptionalPegin`), then repay that
@@ -20,14 +20,20 @@
  *     (`--pegin-first ⟹ --borrow-first ⟹ --repay-first`) sets these, so this action just runs whichever
  *     legs are enabled in order.
  *
- * Click path (all modal-driven — unlike repay there is no route change):
- *   Collateral "⋯" menu → "Withdraw" → selection modal (checkbox list of vaults) → "Withdraw {amount}"
- *   → Review ("Confirm") → one MetaMask tx → "Withdrawal initiated" → "Done".
+ * Click path (v3 — the "⋯" menu and the vault-selection modal are gone; see
+ * markdown/e2e-v3/05-withdraw.md):
+ *   /vaults → a row's "Withdraw" → Review ("Confirm") → one MetaMask tx → "Withdrawal initiated" →
+ *   "Done".
  *
- * Default selection is ONE vault (the first withdrawable), keeping the position alive for reuse;
- * `--withdraw-all` ticks every selectable vault. Selectors are testid-first (added to the src withdraw
- * controls, mirroring borrow/repay) with tolerant role/text fallbacks. No SDK / product logic is
- * reimplemented — the live modal + Review HF gate are authoritative.
+ * The row's Withdraw button IS the eligibility gate: the app disables it for a paused protocol, a vault
+ * that is not in use, a demo (`displayOnly`) row and an optimistic (`isActivating`) one — see
+ * VaultsActiveSection. Health-factor gating surfaces one step later, on the Review screen.
+ *
+ * Default withdraws ONE vault (the first withdrawable), keeping the position alive for reuse.
+ * `--withdraw-all` repeats the whole row → Review → Done cycle per withdrawable vault: v3 opens the
+ * flow with exactly one preselected vault, so releasing several means several transactions, not one
+ * multi-select. No SDK / product logic is reimplemented — the row's disabled state + the Review HF gate
+ * are authoritative.
  *
  * NEVER run without an explicit go-ahead: it moves real value (releases BTC collateral + real withdraw gas).
  */
@@ -40,7 +46,6 @@ import {
   MS_PER_SECOND,
   STEP_TIMEOUT_MS,
   WITHDRAW_CTA_ENABLE_TIMEOUT_MS,
-  WITHDRAW_MENU_TIMEOUT_MS,
   WITHDRAW_MODAL_TIMEOUT_MS,
   WITHDRAW_TX_TIMEOUT_MS,
   WITHDRAW_VERIFY_POLL_MS,
@@ -48,32 +53,23 @@ import {
 
 import { installPopupApprover, sweepApprovals } from "./approver";
 import { runBorrowWithOptionalPegin } from "./borrow";
+import { goToSection } from "./navigation";
 import { startRecording } from "./recording";
 import { runRepayFlow } from "./repay";
 import { DONE_BUTTON_RX, firstByTestid, TX_FAILED_RX } from "./selectors";
 import { type Action, type ActionContext } from "./types";
 import { connectWallets } from "./walletConnect";
 
-// ── Withdraw selectors (testid-first; tolerant role/text fallbacks) ──────────────
-// Collateral summary card → "⋯" overflow menu (aria-label COPY.collateral.menu.triggerLabel).
-const COLLATERAL_ACTIONS_TESTID = '[data-testid="collateral-actions-button"]';
-const COLLATERAL_ACTIONS_RX = /collateral options/i;
-// The "Withdraw" item inside the "⋯" menu (COPY.collateral.menu.withdraw). Disabled only when the
-// protocol has paused withdrawals.
-const WITHDRAW_MENU_TESTID = '[data-testid="collateral-withdraw-button"]';
-const WITHDRAW_MENU_RX = /^withdraw$/i;
-// Per-vault selection row in the modal: `withdraw-vault-row-<vaultId>`, each with a trailing checkbox.
-const VAULT_ROW_TESTID_PREFIX = "withdraw-vault-row-";
+// ── Withdraw selectors ────────────────────────────────────────────────────────
+// One active-vault row on /vaults, keyed by on-chain vaultId (VaultsActiveSection ActiveVaultRow), and
+// the per-row "Withdraw" button inside it. The button's `disabled` state is the app's own eligibility
+// gate, which is exactly how we tell a withdrawable vault apart.
+const VAULT_ROW_TESTID_PREFIX = "vault-row-";
 const VAULT_ROW_SELECTOR = `[data-testid^="${VAULT_ROW_TESTID_PREFIX}"]`;
-// The core-ui Checkbox renders a real <input type="checkbox">; it's `disabled` when the vault is not
-// selectable (not in use, or HF-gated), which is exactly how we tell a withdrawable vault apart.
-const VAULT_CHECKBOX_SELECTOR = 'input[type="checkbox"]';
-// The selection modal's "Withdraw {amount}" confirm (COPY.withdraw.modal.confirmButton*).
-const MODAL_CONFIRM_TESTID = '[data-testid="withdraw-modal-confirm-button"]';
-// The Review screen's "Confirm" submit + its blocking HF warning + the reason shown when confirm is off.
+const ROW_WITHDRAW_TESTID = '[data-testid="vault-withdraw-button"]';
+// The Review screen's "Confirm" submit + its blocking HF warning.
 const REVIEW_CONFIRM_TESTID = '[data-testid="withdraw-confirm-button"]';
 const HF_BLOCK_TESTID = '[data-testid="withdraw-hf-block-warning"]';
-const DISABLED_REASON_TESTID = '[data-testid="withdraw-disabled-reason"]';
 // Success screen: "Withdrawal initiated" (COPY.withdraw.initiated.title) + its Done button. Both are
 // unique to the withdraw progress view (not the shared LoanSuccessModal), so either safely marks success.
 const WITHDRAW_DONE_TESTID = '[data-testid="withdraw-done-button"]';
@@ -92,163 +88,84 @@ function shortenVaultId(id: string): string {
 }
 
 /**
- * Open the withdraw flow from the dashboard: click the Collateral "⋯" menu, then its "Withdraw" item,
- * and wait for the selection modal. The "⋯" trigger is only rendered when the position holds collateral,
- * so we poll for it to appear AND enable within one window (not a short visibility wait before a long
- * enable wait, which would abort early on a slow-to-render menu).
+ * The `vaultId` of the first row whose Withdraw button is enabled and whose vault hasn't been released
+ * yet in this run, or `undefined` when there is none. Reads the id off the row's testid so the caller
+ * can log and de-duplicate by vault rather than by list position (rows shift as vaults leave the list).
  */
-async function openWithdraw(
+async function findWithdrawableVaultId(
+  page: Page,
+  released: ReadonlySet<string>,
+): Promise<{ vaultId: string; rowCount: number } | { rowCount: number }> {
+  const rows = page.locator(VAULT_ROW_SELECTOR);
+  const rowCount = await rows.count().catch(() => 0);
+  for (let i = 0; i < rowCount; i++) {
+    const row = rows.nth(i);
+    const testid = await row.getAttribute("data-testid").catch(() => null);
+    if (!testid?.startsWith(VAULT_ROW_TESTID_PREFIX)) continue;
+    const vaultId = testid.slice(VAULT_ROW_TESTID_PREFIX.length);
+    if (released.has(vaultId)) continue;
+    const enabled = await row
+      .locator(ROW_WITHDRAW_TESTID)
+      .first()
+      .isEnabled()
+      .catch(() => false);
+    if (enabled) return { vaultId, rowCount };
+  }
+  return { rowCount };
+}
+
+/**
+ * Open the withdraw flow for one vault: on /vaults, click the first withdrawable row's "Withdraw", which
+ * opens the flow with THAT vault preselected, and wait for the Review screen. Returns the released
+ * `vaultId`.
+ *
+ * Polls for a withdrawable row rather than checking once: after a chained `--repay-first` the app's
+ * position/HF read can lag the on-chain debt clear by a poll cycle, briefly leaving every row's button
+ * disabled — waiting that out is not the same as "nothing withdrawable". `released` holds the vaults
+ * this run has already put through the flow, so a `--withdraw-all` pass can't re-enter one whose row
+ * hasn't left the list yet.
+ */
+async function openWithdrawForRow(
   page: Page,
   log: (m: string) => void,
-): Promise<void> {
-  const trigger = firstByTestid(
-    page,
-    COLLATERAL_ACTIONS_TESTID,
-    page.getByRole("button", { name: COLLATERAL_ACTIONS_RX }),
-  );
-  const deadline = Date.now() + WITHDRAW_MENU_TIMEOUT_MS;
-  let ready = false;
-  while (!ready && Date.now() < deadline) {
-    if (await trigger.isVisible().catch(() => false))
-      ready = await trigger.isEnabled().catch(() => false);
-    if (!ready) await page.waitForTimeout(FORM_SETTLE_MS);
+  released: ReadonlySet<string>,
+): Promise<string> {
+  await goToSection(page, "vaults", log);
+
+  const deadline = Date.now() + WITHDRAW_CTA_ENABLE_TIMEOUT_MS;
+  let found = await findWithdrawableVaultId(page, released);
+  while (!("vaultId" in found) && Date.now() < deadline) {
+    await page.waitForTimeout(FORM_SETTLE_MS);
+    found = await findWithdrawableVaultId(page, released);
   }
-  if (!ready)
+  if (!("vaultId" in found)) {
+    if (found.rowCount === 0)
+      throw new Error(
+        "No active vault rows on /vaults — this position has nothing to withdraw.",
+      );
     throw new Error(
-      `The Collateral "⋯" actions menu stayed absent/disabled for ${Math.round(WITHDRAW_MENU_TIMEOUT_MS / MS_PER_SECOND)}s — this position has no active collateral to withdraw.`,
+      `No withdrawable vault on /vaults after ${Math.round(WITHDRAW_CTA_ENABLE_TIMEOUT_MS / MS_PER_SECOND)}s (${found.rowCount} row(s) shown — every Withdraw button is disabled: the vault is not in use, still activating, or withdrawals are paused by the protocol). Repay outstanding debt first so collateral can be released.`,
     );
-  log('Opening the withdraw flow (Collateral → "⋯" → Withdraw)');
-  await trigger.click();
+  }
 
-  const menuItem = firstByTestid(
-    page,
-    WITHDRAW_MENU_TESTID,
-    page.getByRole("menuitem", { name: WITHDRAW_MENU_RX }),
-  );
-  await menuItem.waitFor({ state: "visible", timeout: STEP_TIMEOUT_MS });
-  if (!(await menuItem.isEnabled().catch(() => false)))
-    throw new Error(
-      "The Withdraw menu item is disabled — withdrawals are paused by the protocol right now.",
-    );
-  await menuItem.click();
+  const { vaultId } = found;
+  log(`Opening the withdraw flow for vault ${shortenVaultId(vaultId)}`);
+  await page
+    .locator(`[data-testid="${VAULT_ROW_TESTID_PREFIX}${vaultId}"]`)
+    .locator(ROW_WITHDRAW_TESTID)
+    .first()
+    .click({ timeout: STEP_TIMEOUT_MS });
 
-  const confirm = page.locator(MODAL_CONFIRM_TESTID).first();
+  const confirm = page.locator(REVIEW_CONFIRM_TESTID).first();
   const appeared = await confirm
     .waitFor({ state: "visible", timeout: WITHDRAW_MODAL_TIMEOUT_MS })
     .then(() => true)
     .catch(() => false);
   if (!appeared)
     throw new Error(
-      `The withdraw selection modal did not open within ${Math.round(WITHDRAW_MODAL_TIMEOUT_MS / MS_PER_SECOND)}s after clicking Withdraw.`,
+      `The withdraw review screen did not open within ${Math.round(WITHDRAW_MODAL_TIMEOUT_MS / MS_PER_SECOND)}s after clicking the row's Withdraw.`,
     );
-  log("Withdraw selection modal opened");
-}
-
-/** Index of the first row with an enabled (selectable) checkbox, or -1 if none. */
-async function findSelectableRow(
-  rows: ReturnType<Page["locator"]>,
-  count: number,
-): Promise<number> {
-  for (let i = 0; i < count; i++) {
-    if (
-      await rows
-        .nth(i)
-        .locator(VAULT_CHECKBOX_SELECTOR)
-        .isEnabled()
-        .catch(() => false)
-    )
-      return i;
-  }
-  return -1;
-}
-
-/**
- * Tick the vault checkbox(es) in the selection modal. A row's checkbox is `disabled` unless the vault is
- * selectable (in use AND withdrawable without breaching HF) — the same eligibility the modal enforces —
- * so we skip disabled rows. Default selects the FIRST selectable vault (keeps the position alive);
- * `all` ticks every selectable one. Returns the selected `vaultId`s (read from the row testids). THROWS
- * when nothing is selectable (all HF-gated or none in use).
- *
- * Polls for a selectable row first: after a chained `--repay-first` the app's position/HF read can lag
- * the on-chain debt clear by a poll cycle, briefly leaving every vault HF-gated — so we wait for one to
- * become selectable rather than mistaking that transient for "nothing withdrawable".
- */
-async function selectVaults(
-  page: Page,
-  log: (m: string) => void,
-  all: boolean,
-): Promise<string[]> {
-  const rows = page.locator(VAULT_ROW_SELECTOR);
-  const deadline = Date.now() + WITHDRAW_CTA_ENABLE_TIMEOUT_MS;
-  let count = 0;
-  let firstSelectable = -1;
-  while (Date.now() < deadline) {
-    count = await rows.count();
-    if (count > 0) {
-      firstSelectable = await findSelectableRow(rows, count);
-      if (firstSelectable >= 0) break;
-    }
-    await page.waitForTimeout(FORM_SETTLE_MS);
-  }
-  if (count === 0)
-    throw new Error(
-      "The withdraw modal showed no vault rows — this position has nothing to withdraw.",
-    );
-  if (firstSelectable < 0)
-    throw new Error(
-      `No withdrawable vault in the modal after ${Math.round(WITHDRAW_CTA_ENABLE_TIMEOUT_MS / MS_PER_SECOND)}s (${count} shown — all are health-factor-gated or not in use). Repay outstanding debt first so collateral can be released.`,
-    );
-
-  const selectedIds: string[] = [];
-  for (let i = firstSelectable; i < count; i++) {
-    const row = rows.nth(i);
-    const checkbox = row.locator(VAULT_CHECKBOX_SELECTOR);
-    if (!(await checkbox.isEnabled().catch(() => false))) continue; // not selectable
-    // The input is visually replaced by an SVG (zero-size), so bypass actionability with force; check()
-    // is idempotent (ensures the box ends up ticked).
-    await checkbox.check({ force: true });
-    const testid = await row.getAttribute("data-testid").catch(() => null);
-    if (testid?.startsWith(VAULT_ROW_TESTID_PREFIX))
-      selectedIds.push(testid.slice(VAULT_ROW_TESTID_PREFIX.length));
-    if (!all) break;
-  }
-
-  log(
-    `Selected ${selectedIds.length} vault(s) to withdraw: ${selectedIds.map(shortenVaultId).join(", ")}`,
-  );
-  return selectedIds;
-}
-
-/**
- * Click the selection modal's "Withdraw {amount}" confirm once it enables (a selection is made and the
- * projected HF holds). On timeout, surface the modal's own disabled reason so a blocked run explains why.
- */
-async function confirmSelection(
-  page: Page,
-  log: (m: string) => void,
-): Promise<void> {
-  const confirm = page.locator(MODAL_CONFIRM_TESTID).first();
-  const deadline = Date.now() + WITHDRAW_CTA_ENABLE_TIMEOUT_MS;
-  while (Date.now() < deadline) {
-    if (await confirm.isEnabled().catch(() => false)) {
-      log("Confirming the vault selection");
-      await confirm.click();
-      return;
-    }
-    await page.waitForTimeout(FORM_SETTLE_MS);
-  }
-  const reason = (
-    await page
-      .locator(DISABLED_REASON_TESTID)
-      .first()
-      .innerText()
-      .catch(() => "")
-  )
-    .replace(/\s+/g, " ")
-    .trim();
-  throw new Error(
-    `The withdraw modal's confirm button stayed disabled for ${Math.round(WITHDRAW_CTA_ENABLE_TIMEOUT_MS / MS_PER_SECOND)}s${reason ? ` — ${reason}` : ""}.`,
-  );
+  return vaultId;
 }
 
 /**
@@ -262,15 +179,6 @@ async function submitReview(
 ): Promise<void> {
   const confirm = page.locator(REVIEW_CONFIRM_TESTID).first();
   const hfBlock = page.locator(HF_BLOCK_TESTID).first();
-  const appeared = await confirm
-    .waitFor({ state: "visible", timeout: STEP_TIMEOUT_MS })
-    .then(() => true)
-    .catch(() => false);
-  if (!appeared)
-    throw new Error(
-      `The withdraw review screen did not appear within ${Math.round(STEP_TIMEOUT_MS / MS_PER_SECOND)}s after confirming the selection.`,
-    );
-
   const deadline = Date.now() + WITHDRAW_CTA_ENABLE_TIMEOUT_MS;
   while (Date.now() < deadline) {
     if (await hfBlock.isVisible().catch(() => false))
@@ -367,22 +275,21 @@ async function assertCollateralDecreased(
   );
 }
 
-/** Drive the withdraw flow proper (assumes wallets connected + approver/recorder installed by the caller). */
+/**
+ * Drive the withdraw flow proper (assumes wallets connected + approver/recorder installed by the
+ * caller). One pass per released vault: v3's flow opens with a single preselected vault, so
+ * `--withdraw-all` repeats row → Review → Done — one on-chain transaction each — until no withdrawable
+ * row is left. The default releases exactly one, keeping the position alive for reuse.
+ *
+ * The on-chain collateral snapshot is taken before the FIRST pass and asserted after the LAST, so the
+ * post-condition covers the whole batch rather than re-reading between transactions.
+ */
 export async function runWithdrawFlow(
   ctx: ActionContext,
   onStep: (step: string) => void,
 ): Promise<void> {
   const { page, context, log } = ctx;
-
-  onStep("withdraw-open");
-  await openWithdraw(page, log);
-
-  onStep("withdraw-select");
-  const selectedIds = await selectVaults(
-    page,
-    log,
-    ctx.config.withdrawAll === true,
-  );
+  const all = ctx.config.withdrawAll === true;
 
   // Snapshot on-chain collateral BEFORE submitting so we can assert it fell afterwards (a real-data
   // post-condition on top of the UI success screen).
@@ -391,13 +298,28 @@ export async function runWithdrawFlow(
     ctx.eth.address,
   ).catch(() => null);
 
-  onStep("withdraw-modal-confirm");
-  await confirmSelection(page, log);
+  const released = new Set<string>();
+  for (;;) {
+    const pass = released.size + 1;
+    onStep(`withdraw-open${all ? `:${pass}` : ""}`);
+    const vaultId = await openWithdrawForRow(page, log, released);
 
-  onStep("withdraw-review");
-  await submitReview(page, log);
+    onStep(`withdraw-review${all ? `:${pass}` : ""}`);
+    await submitReview(page, log);
 
-  await confirmWithdrawSuccess(page, context, log);
+    await confirmWithdrawSuccess(page, context, log);
+    released.add(vaultId);
+    log(
+      `Released vault ${shortenVaultId(vaultId)} (${released.size} this run).`,
+    );
+    if (!all) break;
+
+    // Another pass only if a withdrawable row remains. The just-released vault leaves the active list,
+    // so this settles at "nothing left to release" rather than needing a count decided up front.
+    await goToSection(page, "vaults", log);
+    const next = await findWithdrawableVaultId(page, released);
+    if (!("vaultId" in next)) break;
+  }
 
   onStep("withdraw-verify");
   if (collateralBeforeSats == null)
@@ -406,7 +328,7 @@ export async function runWithdrawFlow(
     );
   else await assertCollateralDecreased(ctx, collateralBeforeSats);
 
-  log(`Withdraw released ${selectedIds.length} vault(s).`);
+  log(`Withdraw released ${released.size} vault(s).`);
 }
 
 export const withdrawAction: Action = {

--- a/services/vault/e2e/real/borrowParams.ts
+++ b/services/vault/e2e/real/borrowParams.ts
@@ -270,6 +270,26 @@ export async function fetchCollateralSats(
 }
 
 /**
+ * Read how many BTC Vaults the depositor's on-chain position currently holds (`position.vaultIds`, the
+ * same quantity `fetchWithdrawContext` reports as `vaultCount`). Same single `getPosition` read as
+ * `fetchCollateralSats`, so it's cheap to poll.
+ *
+ * This is the ONLY trustworthy answer to "did the peg-in land?". The /vaults row count cannot answer
+ * it: the app renders an optimistic row per just-activated vault straight from in-memory activation
+ * state (ActivatingVaultsContext, 90s TTL, no indexer involved) under the same `vault-row-<vaultId>`
+ * testid as a real one — so counting rows after driving N activations just measures the N rows those
+ * activations created. Returns 0 when no position exists yet (a first-ever vault, before activation
+ * creates one).
+ */
+export async function fetchActiveVaultCount(
+  network: NetworkName,
+  ethAddress: string,
+): Promise<number> {
+  const { position } = await openPosition(network, ethAddress);
+  return position?.vaultIds.length ?? 0;
+}
+
+/**
  * Max tokens borrowable while keeping health factor ≥ MIN_HEALTH_FACTOR_FOR_BORROW — the exact formula
  * of the app's `calculateMaxBorrowTokens` (the helper itself is app-side, but `BPS_SCALE` +
  * `MIN_HEALTH_FACTOR_FOR_BORROW` are SDK-exported). Not floored to token precision here — the caller

--- a/services/vault/e2e/real/run.ts
+++ b/services/vault/e2e/real/run.ts
@@ -189,7 +189,7 @@ export async function runE2E(config: RunConfig): Promise<void> {
     // Withdraw pre-flight (withdraw run, EXCEPT --pegin-first — which pegs in the collateral DURING the
     // run, so there's nothing to read yet; the max-vault cap gate above covers that pegin). Read the
     // position from real data and refuse a doomed run BEFORE the browser if there's no active collateral
-    // to release. A fetch failure is non-fatal: the absent "⋯" menu + the modal's per-vault eligibility
+    // to release. A fetch failure is non-fatal: the absent vault rows + each row's disabled Withdraw
     // backstop it, so we warn. The debt handling depends on the chain: --borrow-first creates the debt
     // during the run (nothing to require here); --repay-first needs an EXISTING debt to clear; a plain
     // withdraw with lingering debt is only HF-gated (a heads-up, not a hard block). Which vault(s) to
@@ -227,7 +227,7 @@ export async function runE2E(config: RunConfig): Promise<void> {
           );
         } else if (withdrawContext.hasDebt) {
           artifacts.log(
-            `⚠️ Position carries $${withdrawContext.currentDebtUsd.toFixed(2)} debt — withdraw is health-factor-gated, so some/all vaults may not be selectable. Re-run with --repay-first for a clean release.`,
+            `⚠️ Position carries $${withdrawContext.currentDebtUsd.toFixed(2)} debt — withdraw is health-factor-gated, so the Review screen may block some/all vaults. Re-run with --repay-first for a clean release.`,
           );
         }
         artifacts.log(

--- a/services/vault/e2e/real/timing.ts
+++ b/services/vault/e2e/real/timing.ts
@@ -18,7 +18,7 @@ export const HEADER_SETTLE_MS = 1_500;
 export const APPROVAL_WAIT_MS = 6_000;
 
 /**
- * The connected state (the header "deposit" CTA) to appear after finalizing the connect. Generous
+ * The connected state (the header wallet menu) to appear after finalizing the connect. Generous
  * because MetaMask can insert an EXTRA approval after the initial connect — a "Review permissions / Use
  * your enabled networks" prompt — which must be confirmed before the app flips to connected. We poll +
  * sweep approvals across this window so that late/reused-window prompt is clicked (a single one-shot
@@ -75,17 +75,17 @@ export const PEGIN_POLL_INTERVAL_MS = 3_000;
  */
 export const PEGIN_TX_FAILURE_RETRY_LIMIT = 3;
 /**
- * The activated vault to surface as collateral on the dashboard after "Go to Dashboard" — it appears
- * optimistically ("Activating collateral…") but can lag the indexer catching up.
+ * The activated vault to surface as an active-vault row on /vaults after "Go to Dashboard" — it
+ * appears optimistically ("Activating collateral…") but can lag the indexer catching up.
  */
 export const DASHBOARD_VAULT_TIMEOUT_MS = 60_000;
 
 // ── borrow ────────────────────────────────────────────────────────────────────
 /**
- * The dashboard "Borrow" button to become enabled after landing on the dashboard. It's gated on
+ * The /loans "Borrow" button to become enabled after landing on that page. It's gated on
  * `hasCollateral` (the position's on-chain collateral > 0); a JUST-activated vault (pegin-first) takes
- * a little time to propagate into that read, so the button can be briefly disabled right after
- * "Go to Dashboard". Generous so a fresh activation isn't mistaken for "no collateral" (a hard fail);
+ * a little time to propagate into that read, so the button can be briefly disabled right after the
+ * peg-in finishes. Generous so a fresh activation isn't mistaken for "no collateral" (a hard fail);
  * a reuse run already had its collateral gated by run.ts, so the button is enabled well within this.
  */
 export const BORROW_BUTTON_ENABLE_TIMEOUT_MS = 180_000;
@@ -116,7 +116,7 @@ export const BORROW_TX_TIMEOUT_MS = 90_000;
 
 // ── repay ─────────────────────────────────────────────────────────────────────
 /**
- * The dashboard "Repay" button to become visible + enabled. It only renders when `hasLoans` and is
+ * The /loans "Repay" button to become visible + enabled. It only renders when `hasLoans` and is
  * enabled once connected; a loan created earlier in the SAME session (borrow-first) takes a moment to
  * propagate into that read, so we poll rather than fail on the first check. A reuse run's loan is
  * already on-chain, so the button is ready almost immediately.
@@ -140,19 +140,13 @@ export const REPAY_TX_TIMEOUT_MS = 120_000;
 export const REPAY_VERIFY_POLL_MS = 3_000;
 
 // ── withdraw ───────────────────────────────────────────────────────────────────
-/**
- * The Collateral "⋯" actions menu to appear + enable on the dashboard. It's only RENDERED when the
- * position holds collateral, so after a chained repay/borrow it can lag while the position settles;
- * generous so a slow-to-render menu isn't mistaken for "no collateral" (a hard fail).
- */
-export const WITHDRAW_MENU_TIMEOUT_MS = 30_000;
-/** The withdraw selection modal to render after clicking the "Withdraw" menu item. */
+/** The withdraw Review screen to render after clicking a vault row's "Withdraw". */
 export const WITHDRAW_MODAL_TIMEOUT_MS = 15_000;
 /**
- * A withdraw CTA (the modal's "Withdraw {amount}" confirm, then the Review "Confirm") to enable after a
- * selection is made — the Review screen recomputes the projected health factor + fees first. Generous so
- * a slow risk-param read isn't mistaken for a blocked withdrawal; a genuine HF breach fails fast via the
- * block warning.
+ * Two waits share this budget: a vault row's "Withdraw" button becoming enabled on /vaults, and then the
+ * Review screen's "Confirm" — which waits on the projected health factor + fees being recomputed.
+ * Generous so a slow risk-param read (or a position still settling after a chained repay) isn't mistaken
+ * for a blocked withdrawal; a genuine HF breach fails fast via the block warning.
  */
 export const WITHDRAW_CTA_ENABLE_TIMEOUT_MS = 90_000;
 /**
@@ -166,11 +160,11 @@ export const WITHDRAW_VERIFY_POLL_MS = 3_000;
 
 // ── resume (recover an interrupted peg-in from the dashboard) ────────────────────
 /**
- * After landing on the dashboard, how long to wait for a resumable pending-deposit card to appear. A
- * same-tab storage event + the indexer poll surface it quickly, so this is short — its absence means
- * there is nothing to resume (a clear fail), not a slow read.
+ * After landing on /vaults, how long to wait for a resumable pending-deposit row to appear. A same-tab
+ * storage event + the indexer poll surface it quickly, so this is short — its absence means there is
+ * nothing to resume (a clear fail), not a slow read.
  */
-export const RESUME_CARD_APPEAR_TIMEOUT_MS = 60_000;
+export const RESUME_ROW_APPEAR_TIMEOUT_MS = 60_000;
 /**
  * How long to wait for a pending deposit to become ACTIONABLE (its resume CTA rendered). This can be
  * LONG: the vault provider must ingest the confirmed Pre-PegIn before "Submit WOTS Key" appears, and the
@@ -178,7 +172,7 @@ export const RESUME_CARD_APPEAR_TIMEOUT_MS = 60_000;
  * the step machine so a slow-but-healthy signet confirmation isn't mistaken for a dead deposit.
  */
 export const RESUME_ACTIONABLE_TIMEOUT_MS = PEGIN_STEP_MACHINE_BUDGET_MS;
-/** Poll cadence while waiting for the pending card to appear / become actionable (sweeps pop-ups too). */
+/** Poll cadence while waiting for the pending row to appear / become actionable (sweeps pop-ups too). */
 export const RESUME_POLL_INTERVAL_MS = 5_000;
 
 // ── sign-conformance (per-wallet signing replay) ─────────────────────────────

--- a/services/vault/playwright.visual.config.ts
+++ b/services/vault/playwright.visual.config.ts
@@ -55,9 +55,9 @@ export const VISUAL_OUTPUT_DIR =
  * copy would drift silently, and the capture would still pass — against a
  * different app than the e2e suite tests.
  *
- * Feature flags are forced ON because the v3 shell and its sections are the
- * surface worth protecting, and a flag that flipped between the two sides
- * would read as a visual regression.
+ * Feature flags are forced ON because the flag-gated sections are the surface
+ * worth protecting, and a flag that flipped between the two sides would read as
+ * a visual regression.
  */
 const VISUAL_ENV_VARS = {
   ...MOCK_ENV_VARS,
@@ -65,7 +65,6 @@ const VISUAL_ENV_VARS = {
   // needs the opposite (it asserts on tunnelled events).
   NEXT_PUBLIC_SENTRY_DSN: "",
   NEXT_PUBLIC_SENTRY_TUNNEL_URL: "",
-  NEXT_PUBLIC_FF_ENABLE_V3_UI: "true",
   NEXT_PUBLIC_FF_ENABLE_EXPLORE: "true",
   NEXT_PUBLIC_FF_LIQUIDATION_ANALYSIS_CHART: "true",
   // Dev-only panel; would overlay every screen it mounts on.

--- a/services/vault/src/components/Wallet/Connect.tsx
+++ b/services/vault/src/components/Wallet/Connect.tsx
@@ -111,7 +111,12 @@ export const Connect: React.FC<ConnectProps> = ({ loading = false, text }) => {
       <div className="flex flex-row items-center gap-4">
         <BtcEthWalletMenu
           trigger={
-            <div className="cursor-pointer">
+            // This control's data-testid is a real-wallet E2E hook
+            // (e2e/real/actions/walletConnect.ts, e2e/real/actions/resume.ts) —
+            // carry it over if you move or rename the element. It renders only
+            // once both wallets are connected, on every route, so the harness
+            // uses it as its route-independent "connected" signal.
+            <div className="cursor-pointer" data-testid="wallet-menu-trigger">
               <AvatarGroup max={3} className="!-space-x-2">
                 {displayWallets["BTC"] && (
                   <WalletIcon

--- a/services/vault/src/components/shared/AppSidebar.tsx
+++ b/services/vault/src/components/shared/AppSidebar.tsx
@@ -45,7 +45,15 @@ function V3NavLinks() {
           {group.map(({ id, path, label }) => {
             const Icon = V3_NAV_ICONS[id];
             return (
-              <NavLink key={path} to={path} end={path === "/"}>
+              // These links' data-testids are real-wallet E2E hooks
+              // (e2e/real/actions/navigation.ts) — the harness changes section
+              // through them, so carry them over if you move or rename the nav.
+              <NavLink
+                key={path}
+                to={path}
+                end={path === "/"}
+                data-testid={`nav-${id}`}
+              >
                 {({ isActive }) => (
                   <SidebarItem
                     icon={<Icon size={24} />}

--- a/services/vault/src/components/shared/__tests__/AppSidebar.test.tsx
+++ b/services/vault/src/components/shared/__tests__/AppSidebar.test.tsx
@@ -110,6 +110,27 @@ describe("AppSidebar", () => {
     );
   });
 
+  it("gives each nav link a nav-<id> testid pointing at its route", () => {
+    render(
+      <MemoryRouter initialEntries={["/"]}>
+        <AppSidebar />
+      </MemoryRouter>,
+    );
+
+    // The real-wallet E2E CLI changes section through these testids
+    // (e2e/real/actions/navigation.ts), so they are load-bearing.
+    for (const [id, path] of [
+      ["overview", "/"],
+      ["vaults", "/vaults"],
+      ["loans", "/loans"],
+      ["activity", "/activity"],
+      ["liquidations", "/liquidations"],
+      ["explore", "/explore"],
+    ]) {
+      expect(screen.getByTestId(`nav-${id}`)).toHaveAttribute("href", path);
+    }
+  });
+
   it("marks Overview active at the exact root path", () => {
     render(
       <MemoryRouter initialEntries={["/"]}>

--- a/services/vault/src/components/vaults/VaultsActiveSection.tsx
+++ b/services/vault/src/components/vaults/VaultsActiveSection.tsx
@@ -50,7 +50,14 @@ function ActiveVaultRow({
   const hash = vault.peginTxHash ?? vault.prePeginTxHash;
 
   return (
-    <ListRowCard className={LIST_ROW_MIN_HEIGHT_CLASS}>
+    // This row's data-testid is a real-wallet E2E hook
+    // (e2e/real/actions/withdraw.ts, e2e/real/actions/stepMachine.ts) — carry it
+    // over if you move or rename the element. It keys on the on-chain vaultId,
+    // which is what the withdraw flow selects on.
+    <ListRowCard
+      testId={`vault-row-${vault.vaultId}`}
+      className={LIST_ROW_MIN_HEIGHT_CLASS}
+    >
       {/* Amount + liquidation ordinal */}
       <div
         className={`flex items-center gap-2 ${LIST_ROW_LEADING_COLUMN_CLASS}`}
@@ -123,8 +130,12 @@ function ActiveVaultRow({
       </div>
 
       <div className={LIST_ROW_ACTION_SLOT_CLASS}>
+        {/* This control's data-testid is a real-wallet E2E hook
+            (e2e/real/actions/withdraw.ts) — carry it over if you move or rename
+            the element. Its disabled state is the harness's eligibility gate. */}
         <button
           type="button"
+          data-testid="vault-withdraw-button"
           onClick={() => onWithdraw(vault.vaultId)}
           disabled={
             isWithdrawDisabled ||

--- a/services/vault/src/components/vaults/VaultsLifecycleSections.tsx
+++ b/services/vault/src/components/vaults/VaultsLifecycleSections.tsx
@@ -156,7 +156,11 @@ function PendingRow({
   const hash = activity.prePeginTxHash ?? activity.peginTxHash;
 
   return (
+    // This row's data-testid is a real-wallet E2E hook
+    // (e2e/real/actions/resume.ts) — carry it over if you move or rename the
+    // element. The harness scopes a --txid resume to one row through it.
     <div
+      data-testid="pending-deposit-row"
       className={`${LIST_ROW_MIN_HEIGHT_CLASS} flex w-full flex-wrap items-center gap-x-4 gap-y-3 rounded-lg border border-secondary-strokeLight p-4`}
     >
       {/* Amount + step position */}

--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -974,11 +974,6 @@ export const COPY = {
       body: (symbol: string) =>
         `Add ${symbol} as collateral so you can begin borrowing assets.`,
     },
-    // The "⋯" actions menu on the Collateral summary card.
-    menu: {
-      withdraw: "Withdraw",
-      reorder: "Reorder",
-    },
   },
   // Links to the Babylon BTC Vault explorer (Xangle). Only rendered when
   // NEXT_PUBLIC_TBV_VP_EXPLORER_URL is set; icon links use these as the
@@ -990,14 +985,6 @@ export const COPY = {
       "Explore BTC Vault activity, liquidity metrics, and protocol statistics in the",
   },
   withdraw: {
-    // Collateral-selection modal opened from the Collateral "⋯" menu. Picks
-    // which vaults to withdraw before handing off to the withdrawal flow.
-    modal: {
-      title: "Withdraw",
-      subtitle:
-        "Choose the collateral you want to withdraw. Remaining BTC Vaults will move up in priority order.",
-      confirmButton: "Withdraw",
-    },
     // Shared labels (review + initiated screens).
     estimatedTimeLabel: "Estimated time until payout",
     nominatedAddressLabel: "Nominated address",


### PR DESCRIPTION
# Restore the real-wallet E2E CLI against the v3 UI

## What was broken

The real-wallet E2E CLI (`services/vault/e2e/real/`) drives the whole depositor lifecycle — connect, peg-in, borrow, repay, withdraw, resume — against real signet BTC and Sepolia ETH. It stopped working and nobody noticed, because it is run by hand rather than in CI.

The cause was [#2184](https://github.com/babylonlabs-io/babylon-toolkit/pull/2184), which retired the `ENABLE_V3_UI` flag and deleted the v2 shell. Two things broke:

1. **One page became six routes.** The v2 dashboard had deposit, collateral, pending deposits and the loan buttons all on `/`. In v3 they live on `/vaults` and `/loans`. The harness still opened `/` and looked for everything there.
2. **Nine selectors were deleted along with the v2 components.** Five of them were the entire first half of the withdraw flow.

The worst part: **connect itself failed**. It waited for the deposit button as its "we're connected now" signal, and that button only exists on `/vaults` in v3. So the wallets connected fine and then the run sat for 60 seconds and died.

Last green run was 22 July; last harness change 24 July. The v3 rewrite landed after both.

## What this PR does

Two sides, both small, because **the flows themselves did not change — only where they live and what identifies them**.

### App side: five test hooks added back

Each one carries the pointer comment that the "E2E TEST HOOKS" rule in `CLAUDE.md` requires. That comment is exactly what was missing before: five withdraw hooks had no comment, so [#2184](https://github.com/babylonlabs-io/babylon-toolkit/pull/2184) deleted them and nothing flagged it.

| testid | file | used by |
|---|---|---|
| `nav-<id>` | `AppSidebar.tsx` | changing section |
| `wallet-menu-trigger` | `Wallet/Connect.tsx` | "connected" signal |
| `vault-row-<vaultId>` | `VaultsActiveSection.tsx` | finding a vault |
| `vault-withdraw-button` | `VaultsActiveSection.tsx` | withdraw entry |
| `pending-deposit-row` | `VaultsLifecycleSections.tsx` | resume entry |

`vault-row` uses `ListRowCard`'s existing `testId` prop, which was already there but no caller passed.

No behaviour changes, no copy changes, no critical-path files touched.

### Test side

- **New `goToSection()` helper.** Every action now navigates to its page first.
- **Connect** keys on the wallet menu instead of a page button, so it no longer depends on which route we're on.
- **Peg-in, borrow, repay** each needed one navigation call and nothing else.
- **Withdraw** was rewritten. v3 deleted the "⋯" menu, the vault-selection modal and its confirm step — you now click Withdraw on a vault row and go straight to Review. Four functions and five dead selectors removed.
- **Resume** now waits for a pending row instead of the deleted expander.

## Approaches considered

### How to navigate between pages

| option | why not / why yes |
|---|---|
| `page.goto('/vaults')` | Simple, but it is a full page reload. That re-initialises the wallet connection and throws away in-memory deposit state. Chained runs (`withdraw --borrow-first --pegin-first`) change page mid-lifecycle, so this could break a run halfway through a real deposit. |
| **Click the sidebar link** ✅ | Normal client-side navigation, nothing is lost, and it tests the real routing the way a user would. |

### How to find things on the page

| option | why not / why yes |
|---|---|
| Text and structure only (no app changes) | Zero diff in `src`, but it means matching on button labels and DOM shape. That breaks again the next time someone edits copy or moves a `div`. It is also how we got here. |
| **Add test IDs back to the app** ✅ | Five one-line additions, each with a comment saying which test file depends on it. Stable, and it makes the dependency visible to the next person who refactors the component. |

### `--withdraw-all` with no multi-select

v3 opens the withdraw flow with exactly one vault preselected, so the old "tick several checkboxes" approach cannot be reproduced. We could have faked it, but the honest equivalent is to repeat the whole row → Review → Done cycle once per vault. That is one on-chain transaction per vault, which is what actually happens.

## Bugs found while verifying

Three real bugs surfaced during the test runs. Two were pre-existing; the third was introduced and fixed within this PR.

**1. The Pre-PegIn transaction ID was read from the wrong place.** The helper scanned the whole page for the first transaction link. The deposit dialog is a full-screen overlay with `/vaults` still mounted underneath, so as soon as the depositor had any vault, it picked up an unrelated vault's hash. A split run made this obvious: the final check "matched" a vault from a previous run and then blamed indexer lag. Now scoped to the dialog. Pre-existing — `resume.ts` already documented the same trap and worked around it.

**2. The split check compared two different transactions.** For a two-vault split it matched rows by Pre-PegIn transaction ID, but an active row shows the **peg-in** transaction (`peginTxHash ?? prePeginTxHash`), which is a different transaction. It could only ever match in the brief window before the indexer fills that field in — so it was guaranteed to fail later. Replaced with a simpler check: count the vault rows before and after, and assert the count went up by the expected number.

**3. That new check was wrong on the first attempt.** It counted rows immediately after navigating, before the list had loaded, so the "before" number was always 0 — which made the check pass no matter what. A real run caught it (`up 8 from 0` where 6 was correct). Fixed by counting only once the page has visibly loaded. This one was ours, found and fixed inside this PR.

**4. Repeated withdrawals could start before the previous success screen closed.** Flagged in review. The withdraw flow is an overlay that never changes the URL, so the `goToSection` call between passes synchronised nothing, and the next pass could scan rows still covered by the overlay — where a covered button still reports as enabled, so the run would fail later with a confusing timeout. The next pass now waits for the overlay to close first. The Done click stays tolerant of failure on purpose: success is already proven by the initiated screen, so a missed click must not fail a real withdrawal.

Also removed: the dead `NEXT_PUBLIC_FF_ENABLE_V3_UI` env var in the visual config, and the orphaned `COPY.withdraw.modal` / `COPY.collateral.menu` blocks — all left behind by [#2184](https://github.com/babylonlabs-io/babylon-toolkit/pull/2184).

## Testing

Every leg was run for real on signet + Sepolia. Each one checks on-chain state, not just that a screen appeared.

| leg | proof |
|---|---|
| connect | both wallet addresses matched |
| peg-in | vault activated and shown on `/vaults` |
| borrow | debt $0.00 → $113.22 |
| repay | debt $113.22 → $84.92 |
| withdraw | collateral 1,000,000 → 0 sats |
| resume | interrupted deposit → activated vault |
| split peg-in | 8 → 10 vaults (`up 2 from 8`) |
| split resume | one row's button drove both vaults |
| withdraw all | 10 vaults released in one run, 17,353,536 → 0 sats |

Also: `tsc` clean, lint clean (0 errors), **3207 unit tests pass**, and every test ID the harness uses was confirmed to exist in the app.

## Reviewer notes

- The `src` diff is five one-line test IDs plus their comments, one deleted env var and two deleted copy blocks. Everything else is test code.
- If you move or rename any element carrying one of those test IDs, carry the ID over — there is no compile error if you drop one, the E2E run just fails later.

