### PR TITLE
Feat/vault resume terms rebuild

### DIFF
--- a/packages/babylon-ts-sdk/docs/api/deposit-terms.md
+++ b/packages/babylon-ts-sdk/docs/api/deposit-terms.md
@@ -601,7 +601,7 @@ fundedPrePeginTxHex: string;
 
 Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/rebuildDepositTermsCore.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/rebuildDepositTermsCore.ts)
 
-Funded Pre-PegIn tx hex — already hash-verified vs on-chain prePeginTxHash by the app (Gate 0).
+Funded Pre-PegIn tx hex. Gate 0 (hash vs prepeginTxid) is SELF-verified below — callers need not pre-verify.
 
 ##### depositorBtcPubkey
 

--- a/packages/babylon-ts-sdk/docs/api/deposit-terms.md
+++ b/packages/babylon-ts-sdk/docs/api/deposit-terms.md
@@ -535,6 +535,198 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/prePeginApproval
 
 x-only depositor pubkey (64 hex, 0x optional) — the identity the PSBT is signed with.
 
+***
+
+### RebuildSibling
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/rebuildDepositTermsCore.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/rebuildDepositTermsCore.ts)
+
+One HTLC in the shared Pre-PegIn tx, ordered by (and contiguous in) htlcVout.
+
+#### Properties
+
+##### hashlock
+
+```ts
+hashlock: string;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/rebuildDepositTermsCore.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/rebuildDepositTermsCore.ts)
+
+x-only or 0x-prefixed hex hashlock, per-vault (feeds the HTLC scriptPubKey).
+
+##### amount
+
+```ts
+amount: bigint;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/rebuildDepositTermsCore.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/rebuildDepositTermsCore.ts)
+
+btc-vault `pegin_amount` for this sibling (satoshis).
+
+***
+
+### RebuildDepositTermsCoreInput
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/rebuildDepositTermsCore.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/rebuildDepositTermsCore.ts)
+
+#### Properties
+
+##### vaultCoreVersion
+
+```ts
+vaultCoreVersion: number;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/rebuildDepositTermsCore.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/rebuildDepositTermsCore.ts)
+
+Stamped tx-graph version (NOT chain-active).
+
+##### siblings
+
+```ts
+siblings: readonly RebuildSibling[];
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/rebuildDepositTermsCore.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/rebuildDepositTermsCore.ts)
+
+Sibling HTLCs ordered by htlcVout; index === htlcVout (asserted by the app).
+
+##### fundedPrePeginTxHex
+
+```ts
+fundedPrePeginTxHex: string;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/rebuildDepositTermsCore.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/rebuildDepositTermsCore.ts)
+
+Funded Pre-PegIn tx hex — already hash-verified vs on-chain prePeginTxHash by the app (Gate 0).
+
+##### depositorBtcPubkey
+
+```ts
+depositorBtcPubkey: string;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/rebuildDepositTermsCore.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/rebuildDepositTermsCore.ts)
+
+##### vaultProviderBtcPubkey
+
+```ts
+vaultProviderBtcPubkey: string;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/rebuildDepositTermsCore.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/rebuildDepositTermsCore.ts)
+
+##### vaultKeeperBtcPubkeys
+
+```ts
+vaultKeeperBtcPubkeys: readonly string[];
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/rebuildDepositTermsCore.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/rebuildDepositTermsCore.ts)
+
+##### universalChallengerBtcPubkeys
+
+```ts
+universalChallengerBtcPubkeys: readonly string[];
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/rebuildDepositTermsCore.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/rebuildDepositTermsCore.ts)
+
+##### protocolFeeRate
+
+```ts
+protocolFeeRate: bigint;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/rebuildDepositTermsCore.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/rebuildDepositTermsCore.ts)
+
+##### minPeginFeeRate
+
+```ts
+minPeginFeeRate: bigint;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/rebuildDepositTermsCore.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/rebuildDepositTermsCore.ts)
+
+##### councilQuorum
+
+```ts
+councilQuorum: number;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/rebuildDepositTermsCore.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/rebuildDepositTermsCore.ts)
+
+##### councilSize
+
+```ts
+councilSize: number;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/rebuildDepositTermsCore.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/rebuildDepositTermsCore.ts)
+
+##### timelockPegin
+
+```ts
+timelockPegin: number;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/rebuildDepositTermsCore.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/rebuildDepositTermsCore.ts)
+
+##### timelockAssert
+
+```ts
+timelockAssert: number;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/rebuildDepositTermsCore.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/rebuildDepositTermsCore.ts)
+
+##### timelockRefund
+
+```ts
+timelockRefund: number;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/rebuildDepositTermsCore.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/rebuildDepositTermsCore.ts)
+
+##### prepeginTxid
+
+```ts
+prepeginTxid: string;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/rebuildDepositTermsCore.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/rebuildDepositTermsCore.ts)
+
+##### prepeginMaxFee
+
+```ts
+prepeginMaxFee: bigint;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/rebuildDepositTermsCore.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/rebuildDepositTermsCore.ts)
+
+Funded-tx fee (Σin − Σout), computed by the app; the device's `prepegin_max_fee` bound.
+
+##### maxAcceptableCommissionBps
+
+```ts
+maxAcceptableCommissionBps: number;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/rebuildDepositTermsCore.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/rebuildDepositTermsCore.ts)
+
+##### network
+
+```ts
+network: Network;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/rebuildDepositTermsCore.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/rebuildDepositTermsCore.ts)
+
+WASM network descriptor for scriptPubKey derivation.
+
 ## Type Aliases
 
 ### DepositTermsRejectionReason
@@ -676,6 +868,26 @@ approves-only.
 
 If approval-capable but no terms are provided, or the provided terms
   are for a different transaction.
+
+***
+
+### rebuildDepositTermsCore()
+
+```ts
+function rebuildDepositTermsCore(input): Promise<DepositTerms>;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/rebuildDepositTermsCore.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/rebuildDepositTermsCore.ts)
+
+#### Parameters
+
+##### input
+
+[`RebuildDepositTermsCoreInput`](#rebuilddeposittermscoreinput)
+
+#### Returns
+
+`Promise`\<[`DepositTerms`](#depositterms)\>
 
 ## Variables
 

--- a/packages/babylon-ts-sdk/docs/api/deposit-terms.md
+++ b/packages/babylon-ts-sdk/docs/api/deposit-terms.md
@@ -553,7 +553,7 @@ hashlock: string;
 
 Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/rebuildDepositTermsCore.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/rebuildDepositTermsCore.ts)
 
-x-only or 0x-prefixed hex hashlock, per-vault (feeds the HTLC scriptPubKey).
+32-byte hex hashlock (0x prefix optional), per-vault (feeds the HTLC scriptPubKey).
 
 ##### amount
 
@@ -765,6 +765,31 @@ validation, and non-negative sizing is already asserted by WASM output checks.
 
 ***
 
+### capMaxAcceptableCommissionBps()
+
+```ts
+function capMaxAcceptableCommissionBps(bps): number;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/commissionCeiling.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/commissionCeiling.ts)
+
+The commission ceiling submitted as registration calldata and mirrored
+into `DepositTerms.commissionFee`: quoted + drift headroom, capped.
+Single source for both consumers — feed it the SAME quoted bps at prepare
+and register time so device-accept stays coextensive with contract-accept.
+
+#### Parameters
+
+##### bps
+
+`number`
+
+#### Returns
+
+`number`
+
+***
+
 ### supportsDepositApproval()
 
 ```ts
@@ -890,6 +915,39 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/rebuildDepositTe
 `Promise`\<[`DepositTerms`](#depositterms)\>
 
 ## Variables
+
+### COMMISSION\_BPS\_HEADROOM
+
+```ts
+const COMMISSION_BPS_HEADROOM: 25 = 25;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/commissionCeiling.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/commissionCeiling.ts)
+
+Headroom (in basis points) added to the current VP commission to compute
+`maxAcceptableCommissionBps` at submit time. Lets the VP raise its
+commission by up to this amount between read and submit without forcing
+a re-quote. Capped by [MAX\_ACCEPTABLE\_COMMISSION\_BPS\_CAP](#max_acceptable_commission_bps_cap).
+
+Contract check is strict `>` (PeginLogic.sol `VaultProviderCommissionExceeded`
+revert), so +25 allows up
+to +25 bps of drift.
+
+***
+
+### MAX\_ACCEPTABLE\_COMMISSION\_BPS\_CAP
+
+```ts
+const MAX_ACCEPTABLE_COMMISSION_BPS_CAP: 9999 = 9999;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/commissionCeiling.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/commissionCeiling.ts)
+
+Hard ceiling for `maxAcceptableCommissionBps`. The contract enforces
+`commissionBps < 10000`, so any value at/above that is unreachable;
+`9999` is the maximum useful cap.
+
+***
 
 ### DEPOSIT\_TERMS\_REJECTED\_ERROR\_NAME
 

--- a/packages/babylon-ts-sdk/docs/api/managers.md
+++ b/packages/babylon-ts-sdk/docs/api/managers.md
@@ -2165,7 +2165,7 @@ WOTS hash, payout script). The estimate is approximate — calldata-byte
 gas is correct, contract-side branches that depend on the real values may
 diverge — but it lands within the usual gas-estimate margin.
 
-Passes MAX\_ACCEPTABLE\_COMMISSION\_BPS\_CAP for the
+Passes [MAX\_ACCEPTABLE\_COMMISSION\_BPS\_CAP](deposit-terms.md#max_acceptable_commission_bps_cap) for the
 `maxAcceptableCommissionBps` argument so the simulation does not revert on
 the contract's commission-drift check regardless of the VP's current
 commission. The real submit path resolves an accurate, drift-checked value

--- a/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/__tests__/rebuildDepositTermsCore.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/__tests__/rebuildDepositTermsCore.test.ts
@@ -135,6 +135,26 @@ describe("rebuildDepositTermsCore guards", () => {
       rebuildDepositTermsCore(makeInput({ fundedPrePeginTxHex, siblings: [] })),
     ).rejects.toThrow(/at least one sibling/);
   });
+
+  it("throws when a second auth-anchor-shaped OP_RETURN makes the anchor ambiguous", async () => {
+    // Two OP_RETURN‖PUSH32‖value-0 outputs → findAuthAnchorOpReturn returns
+    // undefined (single-hit rule) → the core must refuse, not pick one.
+    const tx = new Transaction();
+    tx.version = 2;
+    tx.addInput(Buffer.alloc(32, 0x11), 0);
+    tx.addOutput(Buffer.from(`5120${"00".repeat(32)}`, "hex"), 1000);
+    tx.addOutput(
+      Buffer.concat([Buffer.from([0x6a, 0x20]), Buffer.alloc(32, 0xab)]),
+      0,
+    );
+    tx.addOutput(
+      Buffer.concat([Buffer.from([0x6a, 0x20]), Buffer.alloc(32, 0xcd)]),
+      0,
+    );
+    await expect(
+      rebuildDepositTermsCore(makeInput({ fundedPrePeginTxHex: tx.toHex() })),
+    ).rejects.toThrow(/absent or ambiguous/);
+  });
 });
 
 describe("rebuildDepositTermsCore golden (WASM-backed happy path)", () => {
@@ -143,13 +163,16 @@ describe("rebuildDepositTermsCore golden (WASM-backed happy path)", () => {
   });
 
   const NETWORK = "signet" as Network;
+  // All four scalars deliberately DISTINCT: identical rates (or timelocks)
+  // would blind these tests to a swapped-argument bug in the core's WASM
+  // calls or a transposed field in the projection.
   const TIMELOCK_REFUND = 2016;
   const TIMELOCK_PEGIN = 684;
-  const TIMELOCK_ASSERT = 684;
+  const TIMELOCK_ASSERT = 700;
   const COUNCIL_QUORUM = 2;
   const COUNCIL_SIZE = 3;
-  const PROTOCOL_FEE_RATE = 2n;
-  const MIN_PEGIN_FEE_RATE = 2n;
+  const PROTOCOL_FEE_RATE = 3n;
+  const MIN_PEGIN_FEE_RATE = 7n;
   const PREPEGIN_MAX_FEE = 1500n;
   const COMMISSION_BPS = 250;
   const BPS_DENOMINATOR = 10_000n;
@@ -278,7 +301,9 @@ describe("rebuildDepositTermsCore golden (WASM-backed happy path)", () => {
   });
 
   it("rebuilds single-vault v1 terms (zero-anchor branch)", async () => {
-    const siblings: Sibling[] = [{ hashlock: "ef".repeat(32), amount: 750_000n }];
+    const siblings: Sibling[] = [
+      { hashlock: "ef".repeat(32), amount: 750_000n },
+    ];
     const { txHex, dcv, fee, anchor } = await buildRealFundedTx(1, siblings);
     const input = baseInput(1, siblings, txHex);
 
@@ -290,5 +315,40 @@ describe("rebuildDepositTermsCore golden (WASM-backed happy path)", () => {
     expect(terms.vaults[0].peginAmount).toBe(750_000n);
     expect(terms.vaults[0].depositorClaimValue).toBe(dcv);
     expect(terms.vaults[0].peginMaxFee).toBe(fee);
+  });
+
+  // Gate 1 negatives THROUGH the core (not just the helper's own unit tests):
+  // prove the core feeds the funded tx's actual outputs to the byte-match.
+  // The txid is recomputed from the tampered hex so Gate 0 passes and the
+  // failure is attributable to Gate 1 alone.
+
+  it("rejects a funded tx whose HTLC value was tampered (Gate 1 via the core)", async () => {
+    const siblings: Sibling[] = [
+      { hashlock: "ab".repeat(32), amount: 400_000n },
+    ];
+    const { txHex } = await buildRealFundedTx(2, siblings);
+    const tampered = Transaction.fromHex(txHex);
+    tampered.outs[0].value += 1;
+    const tamperedHex = tampered.toHex();
+
+    await expect(
+      rebuildDepositTermsCore(baseInput(2, siblings, tamperedHex)),
+    ).rejects.toThrow(/value .* does not|does not match the cross-checked/);
+  });
+
+  it("rejects a funded tx whose HTLC scriptPubKey was tampered (Gate 1 via the core)", async () => {
+    const siblings: Sibling[] = [
+      { hashlock: "ab".repeat(32), amount: 400_000n },
+    ];
+    const { txHex } = await buildRealFundedTx(2, siblings);
+    const tampered = Transaction.fromHex(txHex);
+    const script = Buffer.from(tampered.outs[0].script);
+    script[script.length - 1] ^= 0x01;
+    tampered.outs[0].script = script;
+    const tamperedHex = tampered.toHex();
+
+    await expect(
+      rebuildDepositTermsCore(baseInput(2, siblings, tamperedHex)),
+    ).rejects.toThrow(/scriptPubKey .* does not match/);
   });
 });

--- a/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/__tests__/rebuildDepositTermsCore.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/__tests__/rebuildDepositTermsCore.test.ts
@@ -1,0 +1,294 @@
+/**
+ * Tests for the resume-rebuild core (#2220 Part 2).
+ *
+ * Two layers:
+ *  - Guards: the fail-closed checks that run BEFORE the WASM recompute (Gate 0
+ *    tx-hash binding, prepeginMaxFee positivity, auth-anchor OP_RETURN
+ *    completeness). No WASM fixture needed.
+ *  - Golden (WASM-backed): a real WASM-shaped funded tx — valid keys, real HTLC
+ *    connector scriptPubKeys, real sizing (DCV + minPeginFee + anchor) — fed
+ *    through the whole pipeline (Gate 0 → OP_RETURN anchor → Gate 1 byte-match →
+ *    projection). Proves the happy path executes end-to-end and projects the
+ *    correct DepositTerms, complementing the guards. Two-vault (mandatory for
+ *    chain logic) + both anchor branches (v1 = 0, v2 = P2A anchor).
+ */
+
+import {
+  computeMinClaimValue,
+  computeMinPeginFee,
+  getPrePeginHtlcConnectorInfo,
+  peginP2aAnchorOutput,
+  type Network,
+} from "@babylonlabs-io/babylon-tbv-rust-wasm";
+import { Transaction } from "bitcoinjs-lib";
+import { Buffer } from "buffer";
+import { beforeAll, describe, expect, it } from "vitest";
+
+import {
+  TEST_KEYS,
+  initializeWasmForTests,
+} from "../../primitives/psbt/__tests__/helpers";
+import { stripHexPrefix } from "../../primitives/utils/bitcoin";
+import { calculateBtcTxHash } from "../../utils/transaction/btcTxHash";
+import {
+  rebuildDepositTermsCore,
+  type RebuildDepositTermsCoreInput,
+} from "../rebuildDepositTermsCore";
+
+/** A funded Pre-PegIn tx: `htlcCount` P2TR-ish HTLC outputs, then (optionally) the
+ * auth-anchor OP_RETURN `6a20<32 bytes>` value 0 at vout `opReturnVout`. */
+function makeFundedTx(opts: {
+  htlcCount: number;
+  opReturnVout?: number;
+}): string {
+  const tx = new Transaction();
+  tx.version = 2;
+  tx.addInput(Buffer.alloc(32, 0x11), 0);
+  for (let i = 0; i < opts.htlcCount; i++) {
+    tx.addOutput(Buffer.from(`5120${"00".repeat(32)}`, "hex"), 1000);
+  }
+  if (opts.opReturnVout !== undefined) {
+    while (tx.outs.length < opts.opReturnVout) {
+      tx.addOutput(Buffer.from(`0014${"00".repeat(20)}`, "hex"), 500);
+    }
+    tx.addOutput(
+      Buffer.concat([Buffer.from([0x6a, 0x20]), Buffer.alloc(32, 0xab)]),
+      0,
+    );
+  }
+  return tx.toHex();
+}
+
+/** A structurally complete input; the fields after the guards are unused because
+ * every test throws before the WASM recompute. */
+function makeInput(
+  over: Partial<RebuildDepositTermsCoreInput> & {
+    fundedPrePeginTxHex: string;
+  },
+): RebuildDepositTermsCoreInput {
+  return {
+    vaultCoreVersion: 2,
+    siblings: [{ hashlock: "ab".repeat(32), amount: 1_000_000n }],
+    depositorBtcPubkey: "ab".repeat(32),
+    vaultProviderBtcPubkey: "cc".repeat(32),
+    vaultKeeperBtcPubkeys: ["dd".repeat(32)],
+    universalChallengerBtcPubkeys: ["ee".repeat(32)],
+    protocolFeeRate: 2n,
+    minPeginFeeRate: 2n,
+    councilQuorum: 1,
+    councilSize: 1,
+    timelockPegin: 684,
+    timelockAssert: 684,
+    timelockRefund: 2016,
+    prepeginTxid: stripHexPrefix(
+      calculateBtcTxHash(over.fundedPrePeginTxHex),
+    ).toLowerCase(),
+    prepeginMaxFee: 500n,
+    maxAcceptableCommissionBps: 100,
+    network: "signet" as never,
+    ...over,
+  };
+}
+
+describe("rebuildDepositTermsCore guards", () => {
+  it("throws when prepeginMaxFee is not positive", async () => {
+    const fundedPrePeginTxHex = makeFundedTx({ htlcCount: 1, opReturnVout: 1 });
+    await expect(
+      rebuildDepositTermsCore(
+        makeInput({ fundedPrePeginTxHex, prepeginMaxFee: 0n }),
+      ),
+    ).rejects.toThrow(/prepeginMaxFee must be > 0/);
+  });
+
+  it("throws when the funded tx does not hash to prepeginTxid (Gate 0)", async () => {
+    const fundedPrePeginTxHex = makeFundedTx({ htlcCount: 1, opReturnVout: 1 });
+    await expect(
+      rebuildDepositTermsCore(
+        makeInput({ fundedPrePeginTxHex, prepeginTxid: "00".repeat(32) }),
+      ),
+    ).rejects.toThrow(/does not hash|hashes to/);
+  });
+
+  it("throws when the auth-anchor OP_RETURN is absent (fail-closed, not skipped)", async () => {
+    const fundedPrePeginTxHex = makeFundedTx({ htlcCount: 1 }); // no OP_RETURN
+    await expect(
+      rebuildDepositTermsCore(makeInput({ fundedPrePeginTxHex })),
+    ).rejects.toThrow(/absent or ambiguous|sibling set is incomplete/);
+  });
+
+  it("throws when the OP_RETURN vout disagrees with the sibling count", async () => {
+    // OP_RETURN at vout 2 but only 1 sibling supplied → incomplete set.
+    const fundedPrePeginTxHex = makeFundedTx({ htlcCount: 2, opReturnVout: 2 });
+    await expect(
+      rebuildDepositTermsCore(
+        makeInput({
+          fundedPrePeginTxHex,
+          siblings: [{ hashlock: "ab".repeat(32), amount: 1_000_000n }],
+        }),
+      ),
+    ).rejects.toThrow(/does not match sibling count/);
+  });
+
+  it("throws on an empty sibling set", async () => {
+    const fundedPrePeginTxHex = makeFundedTx({ htlcCount: 1, opReturnVout: 1 });
+    await expect(
+      rebuildDepositTermsCore(makeInput({ fundedPrePeginTxHex, siblings: [] })),
+    ).rejects.toThrow(/at least one sibling/);
+  });
+});
+
+describe("rebuildDepositTermsCore golden (WASM-backed happy path)", () => {
+  beforeAll(async () => {
+    await initializeWasmForTests();
+  });
+
+  const NETWORK = "signet" as Network;
+  const TIMELOCK_REFUND = 2016;
+  const TIMELOCK_PEGIN = 684;
+  const TIMELOCK_ASSERT = 684;
+  const COUNCIL_QUORUM = 2;
+  const COUNCIL_SIZE = 3;
+  const PROTOCOL_FEE_RATE = 2n;
+  const MIN_PEGIN_FEE_RATE = 2n;
+  const PREPEGIN_MAX_FEE = 1500n;
+  const COMMISSION_BPS = 250;
+  const BPS_DENOMINATOR = 10_000n;
+
+  const DEPOSITOR = TEST_KEYS.DEPOSITOR;
+  const VP = TEST_KEYS.VAULT_PROVIDER;
+  const VKS = [TEST_KEYS.VAULT_KEEPER_1, TEST_KEYS.VAULT_KEEPER_2];
+  const UCS = [TEST_KEYS.UNIVERSAL_CHALLENGER_1];
+
+  interface Sibling {
+    hashlock: string;
+    amount: bigint;
+  }
+
+  /** Amount-independent sizing, recomputed exactly as the core does. */
+  async function sizing(version: number) {
+    const dcv = await computeMinClaimValue(
+      version,
+      VKS.length,
+      UCS.length,
+      COUNCIL_QUORUM,
+      COUNCIL_SIZE,
+      PROTOCOL_FEE_RATE,
+    );
+    const fee = await computeMinPeginFee(
+      version,
+      VKS.length,
+      UCS.length,
+      MIN_PEGIN_FEE_RATE,
+    );
+    const anchor = (await peginP2aAnchorOutput(version))?.value ?? 0n;
+    return { dcv, fee, anchor };
+  }
+
+  /**
+   * Build a funded tx whose HTLC outputs carry the REAL connector scriptPubKey +
+   * `amount + DCV + peginMaxFee + anchor` value, followed by the auth-anchor
+   * OP_RETURN at vout === sibling count — i.e. a tx the core's Gate 1 accepts.
+   */
+  async function buildRealFundedTx(version: number, siblings: Sibling[]) {
+    const { dcv, fee, anchor } = await sizing(version);
+    const tx = new Transaction();
+    tx.version = 2;
+    tx.addInput(Buffer.alloc(32, 0x11), 0);
+    for (const s of siblings) {
+      const info = await getPrePeginHtlcConnectorInfo({
+        txGraphVersion: version,
+        depositorPubkey: DEPOSITOR,
+        vaultProviderPubkey: VP,
+        vaultKeeperPubkeys: VKS,
+        universalChallengerPubkeys: UCS,
+        hashlock: s.hashlock,
+        timelockRefund: TIMELOCK_REFUND,
+        network: NETWORK,
+      });
+      tx.addOutput(
+        Buffer.from(info.scriptPubKey, "hex"),
+        Number(s.amount + dcv + fee + anchor),
+      );
+    }
+    tx.addOutput(
+      Buffer.concat([Buffer.from([0x6a, 0x20]), Buffer.alloc(32, 0xcd)]),
+      0,
+    );
+    return { txHex: tx.toHex(), dcv, fee, anchor };
+  }
+
+  function baseInput(
+    version: number,
+    siblings: Sibling[],
+    txHex: string,
+  ): RebuildDepositTermsCoreInput {
+    return {
+      vaultCoreVersion: version,
+      siblings,
+      fundedPrePeginTxHex: txHex,
+      depositorBtcPubkey: DEPOSITOR,
+      vaultProviderBtcPubkey: VP,
+      vaultKeeperBtcPubkeys: VKS,
+      universalChallengerBtcPubkeys: UCS,
+      protocolFeeRate: PROTOCOL_FEE_RATE,
+      minPeginFeeRate: MIN_PEGIN_FEE_RATE,
+      councilQuorum: COUNCIL_QUORUM,
+      councilSize: COUNCIL_SIZE,
+      timelockPegin: TIMELOCK_PEGIN,
+      timelockAssert: TIMELOCK_ASSERT,
+      timelockRefund: TIMELOCK_REFUND,
+      prepeginTxid: stripHexPrefix(calculateBtcTxHash(txHex)).toLowerCase(),
+      prepeginMaxFee: PREPEGIN_MAX_FEE,
+      maxAcceptableCommissionBps: COMMISSION_BPS,
+      network: NETWORK,
+    };
+  }
+
+  it("rebuilds two-vault v2 terms with per-vault sizing, ordering, and commission ceiling", async () => {
+    const siblings: Sibling[] = [
+      { hashlock: "ab".repeat(32), amount: 1_000_000n },
+      { hashlock: "cd".repeat(32), amount: 2_500_000n },
+    ];
+    const { txHex, dcv, fee, anchor } = await buildRealFundedTx(2, siblings);
+    const input = baseInput(2, siblings, txHex);
+
+    const terms = await rebuildDepositTermsCore(input);
+
+    expect(terms.vaultCoreVersion).toBe(2);
+    expect(terms.prepeginTxid).toBe(input.prepeginTxid);
+    expect(terms.prepeginMaxFee).toBe(PREPEGIN_MAX_FEE);
+    expect(terms.timelockPegin).toBe(TIMELOCK_PEGIN);
+    expect(terms.timelockAssert).toBe(TIMELOCK_ASSERT);
+    expect(terms.timelockRefund).toBe(TIMELOCK_REFUND);
+    expect(terms.vaultKeeperBtcPubkeys).toEqual(VKS);
+    expect(terms.universalChallengerBtcPubkeys).toEqual(UCS);
+    expect(anchor).toBeGreaterThan(0n); // v2 carries the P2A anchor
+    expect(terms.vaults).toHaveLength(2);
+
+    terms.vaults.forEach((v, i) => {
+      expect(v.htlcVout).toBe(i);
+      expect(v.peginAmount).toBe(siblings[i].amount);
+      expect(v.vaultProviderBtcPubkey).toBe(VP);
+      expect(v.depositorClaimValue).toBe(dcv);
+      expect(v.peginMaxFee).toBe(fee);
+      expect(v.commissionFee).toBe(
+        (siblings[i].amount * BigInt(COMMISSION_BPS)) / BPS_DENOMINATOR,
+      );
+    });
+  });
+
+  it("rebuilds single-vault v1 terms (zero-anchor branch)", async () => {
+    const siblings: Sibling[] = [{ hashlock: "ef".repeat(32), amount: 750_000n }];
+    const { txHex, dcv, fee, anchor } = await buildRealFundedTx(1, siblings);
+    const input = baseInput(1, siblings, txHex);
+
+    const terms = await rebuildDepositTermsCore(input);
+
+    expect(anchor).toBe(0n); // v1 has no P2A anchor
+    expect(terms.vaultCoreVersion).toBe(1);
+    expect(terms.vaults).toHaveLength(1);
+    expect(terms.vaults[0].peginAmount).toBe(750_000n);
+    expect(terms.vaults[0].depositorClaimValue).toBe(dcv);
+    expect(terms.vaults[0].peginMaxFee).toBe(fee);
+  });
+});

--- a/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/__tests__/rebuildDepositTermsCore.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/__tests__/rebuildDepositTermsCore.test.ts
@@ -100,6 +100,18 @@ describe("rebuildDepositTermsCore guards", () => {
     ).rejects.toThrow(/prepeginMaxFee must be > 0/);
   });
 
+  it("throws when a sibling carries a non-positive on-chain pegin amount", async () => {
+    const fundedPrePeginTxHex = makeFundedTx({ htlcCount: 1, opReturnVout: 1 });
+    await expect(
+      rebuildDepositTermsCore(
+        makeInput({
+          fundedPrePeginTxHex,
+          siblings: [{ hashlock: "ab".repeat(32), amount: 0n }],
+        }),
+      ),
+    ).rejects.toThrow(/non-positive on-chain pegin amount/);
+  });
+
   it("throws when the funded tx does not hash to prepeginTxid (Gate 0)", async () => {
     const fundedPrePeginTxHex = makeFundedTx({ htlcCount: 1, opReturnVout: 1 });
     await expect(
@@ -113,7 +125,7 @@ describe("rebuildDepositTermsCore guards", () => {
     const fundedPrePeginTxHex = makeFundedTx({ htlcCount: 1 }); // no OP_RETURN
     await expect(
       rebuildDepositTermsCore(makeInput({ fundedPrePeginTxHex })),
-    ).rejects.toThrow(/absent or ambiguous|sibling set is incomplete/);
+    ).rejects.toThrow(/no single, unambiguous auth-anchor/);
   });
 
   it("throws when the OP_RETURN vout disagrees with the sibling count", async () => {
@@ -126,7 +138,7 @@ describe("rebuildDepositTermsCore guards", () => {
           siblings: [{ hashlock: "ab".repeat(32), amount: 1_000_000n }],
         }),
       ),
-    ).rejects.toThrow(/does not match sibling count/);
+    ).rejects.toThrow(/does not match the discovered sibling count/);
   });
 
   it("throws on an empty sibling set", async () => {
@@ -153,7 +165,7 @@ describe("rebuildDepositTermsCore guards", () => {
     );
     await expect(
       rebuildDepositTermsCore(makeInput({ fundedPrePeginTxHex: tx.toHex() })),
-    ).rejects.toThrow(/absent or ambiguous/);
+    ).rejects.toThrow(/no single, unambiguous auth-anchor/);
   });
 });
 

--- a/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/commissionCeiling.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/commissionCeiling.ts
@@ -1,0 +1,56 @@
+/**
+ * The depositor's commission ceiling (`maxAcceptableCommissionBps`) policy:
+ * quoted VP commission + drift headroom, capped below the contract's
+ * exclusive bound. Shared by the fresh path (`PeginManager`) and the
+ * resume-rebuild path so both compute the same ceiling.
+ *
+ * @module deposit-terms/commissionCeiling
+ */
+
+import { MAX_VP_COMMISSION_BPS_EXCLUSIVE } from "../primitives/psbt/constants";
+
+/**
+ * Headroom (in basis points) added to the current VP commission to compute
+ * `maxAcceptableCommissionBps` at submit time. Lets the VP raise its
+ * commission by up to this amount between read and submit without forcing
+ * a re-quote. Capped by {@link MAX_ACCEPTABLE_COMMISSION_BPS_CAP}.
+ *
+ * Contract check is strict `>` (PeginLogic.sol `VaultProviderCommissionExceeded`
+ * revert), so +25 allows up
+ * to +25 bps of drift.
+ */
+export const COMMISSION_BPS_HEADROOM = 25;
+
+/**
+ * Hard ceiling for `maxAcceptableCommissionBps`. The contract enforces
+ * `commissionBps < 10000`, so any value at/above that is unreachable;
+ * `9999` is the maximum useful cap.
+ */
+export const MAX_ACCEPTABLE_COMMISSION_BPS_CAP = 9999;
+
+/**
+ * The commission ceiling submitted as registration calldata and mirrored
+ * into `DepositTerms.commissionFee`: quoted + drift headroom, capped.
+ * Single source for both consumers — feed it the SAME quoted bps at prepare
+ * and register time so device-accept stays coextensive with contract-accept.
+ */
+export function capMaxAcceptableCommissionBps(bps: number): number {
+  // Validate the raw quote before headroom shifts its domain — a negative
+  // quote must throw here, not become a small "legal" ceiling.
+  // Reject an out-of-range quote outright — clamping it to 9999 would turn a
+  // bad read into a 99.99% ceiling, the exact failure the cap exists to stop.
+  if (
+    !Number.isInteger(bps) ||
+    bps < 0 ||
+    bps >= MAX_VP_COMMISSION_BPS_EXCLUSIVE
+  ) {
+    throw new Error(
+      `Quoted commissionBps must be an integer in ` +
+        `[0, ${MAX_VP_COMMISSION_BPS_EXCLUSIVE}), got ${bps}`,
+    );
+  }
+  return Math.min(
+    bps + COMMISSION_BPS_HEADROOM,
+    MAX_ACCEPTABLE_COMMISSION_BPS_CAP,
+  );
+}

--- a/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/commissionCeiling.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/commissionCeiling.ts
@@ -7,6 +7,20 @@
  * @module deposit-terms/commissionCeiling
  */
 
+/*
+ * Commission-check map (each guards a DIFFERENT boundary — do not consolidate):
+ *  1. assertVpCommissionInProtocolRange (vault app, vaultPayoutSignatureService)
+ *     — chain-read trust boundary; mirrors VPKeyRegistryLogic.sol bounds.
+ *  2. capMaxAcceptableCommissionBps (here) — depositor quote → ceiling policy;
+ *     mirrors PeginLogic.sol's strict > check via the +25bps headroom.
+ *  3. buildDepositTerms range check — public-API precondition on the projection
+ *     that mints the device-enforced commissionFee.
+ *  4. payout.ts commission cap — the VP-built tx's output value vs bps at the
+ *     signing site (CLAUDE.md Critical Path #3).
+ *  5. envelope.ts dust/cross-field gates (ledger-vault-signer) — firmware-only
+ *     constants, pre-device-I/O (Critical Path #7).
+ */
+
 import { MAX_VP_COMMISSION_BPS_EXCLUSIVE } from "../primitives/psbt/constants";
 
 /**

--- a/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/index.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/index.ts
@@ -11,3 +11,4 @@ export * from "./buildDepositTerms";
 export * from "./depositTerms";
 export * from "./depositTermsErrors";
 export * from "./prePeginApproval";
+export * from "./rebuildDepositTermsCore";

--- a/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/index.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/index.ts
@@ -8,6 +8,7 @@
  * @module deposit-terms
  */
 export * from "./buildDepositTerms";
+export * from "./commissionCeiling";
 export * from "./depositTerms";
 export * from "./depositTermsErrors";
 export * from "./prePeginApproval";

--- a/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/rebuildDepositTermsCore.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/rebuildDepositTermsCore.ts
@@ -42,7 +42,7 @@ export interface RebuildDepositTermsCoreInput {
   vaultCoreVersion: number;
   /** Sibling HTLCs ordered by htlcVout; index === htlcVout (asserted by the app). */
   siblings: readonly RebuildSibling[];
-  /** Funded Pre-PegIn tx hex — already hash-verified vs on-chain prePeginTxHash by the app (Gate 0). */
+  /** Funded Pre-PegIn tx hex. Gate 0 (hash vs prepeginTxid) is SELF-verified below — callers need not pre-verify. */
   fundedPrePeginTxHex: string;
 
   // Stamped-version participant data (already resolved + sorted by the app).

--- a/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/rebuildDepositTermsCore.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/rebuildDepositTermsCore.ts
@@ -1,0 +1,188 @@
+/**
+ * Pure core of the resume-broadcast DepositTerms rebuild (#2220 Part 2).
+ *
+ * Takes plain chain-derived data (the app orchestrator does the chain reads +
+ * sibling discovery) and: (1) asserts sibling completeness against the funded
+ * tx's auth-anchor OP_RETURN, (2) recomputes the amount-independent sizing
+ * (depositorClaimValue, peginMaxFee, anchor) via WASM, (3) byte-matches each
+ * HTLC output's value + scriptPubKey against the funded tx (Gate 1), then (4)
+ * projects into DepositTerms. No chain access, no browser state — unit-testable.
+ *
+ * btc-vault is the protocol source of truth (`compute_min_htlc_value`,
+ * `derive_challengers_for`). Design: `todo/ledger/2220-part2-resume-rebuild-design.md`.
+ */
+
+import {
+  computeMinClaimValue,
+  computeMinPeginFee,
+  getPrePeginHtlcConnectorInfo,
+  peginP2aAnchorOutput,
+} from "@babylonlabs-io/babylon-tbv-rust-wasm";
+import { Transaction } from "bitcoinjs-lib";
+
+import { findAuthAnchorOpReturn } from "../managers/pegin/assertAuthAnchorOpReturn";
+import { assertEncodedHtlcOutputsMatch } from "../primitives/psbt/assertWasmPeginSizing";
+import { stripHexPrefix } from "../primitives/utils/bitcoin";
+import { calculateBtcTxHash } from "../utils/transaction/btcTxHash";
+
+import { buildDepositTerms } from "./buildDepositTerms";
+import type { DepositTerms } from "./depositTerms";
+
+/** One HTLC in the shared Pre-PegIn tx, ordered by (and contiguous in) htlcVout. */
+export interface RebuildSibling {
+  /** x-only or 0x-prefixed hex hashlock, per-vault (feeds the HTLC scriptPubKey). */
+  hashlock: string;
+  /** btc-vault `pegin_amount` for this sibling (satoshis). */
+  amount: bigint;
+}
+
+export interface RebuildDepositTermsCoreInput {
+  /** Stamped tx-graph version (NOT chain-active). */
+  vaultCoreVersion: number;
+  /** Sibling HTLCs ordered by htlcVout; index === htlcVout (asserted by the app). */
+  siblings: readonly RebuildSibling[];
+  /** Funded Pre-PegIn tx hex — already hash-verified vs on-chain prePeginTxHash by the app (Gate 0). */
+  fundedPrePeginTxHex: string;
+
+  // Stamped-version participant data (already resolved + sorted by the app).
+  depositorBtcPubkey: string;
+  vaultProviderBtcPubkey: string;
+  vaultKeeperBtcPubkeys: readonly string[];
+  universalChallengerBtcPubkeys: readonly string[];
+
+  // Version-locked scalars.
+  protocolFeeRate: bigint;
+  minPeginFeeRate: bigint;
+  councilQuorum: number;
+  councilSize: number;
+  timelockPegin: number;
+  timelockAssert: number;
+  timelockRefund: number;
+
+  // Pass-through into DepositTerms.
+  prepeginTxid: string;
+  /** Funded-tx fee (Σin − Σout), computed by the app; the device's `prepegin_max_fee` bound. */
+  prepeginMaxFee: bigint;
+  maxAcceptableCommissionBps: number;
+
+  /** WASM network descriptor for scriptPubKey derivation. */
+  network: Parameters<typeof getPrePeginHtlcConnectorInfo>[0]["network"];
+}
+
+export async function rebuildDepositTermsCore(
+  input: RebuildDepositTermsCoreInput,
+): Promise<DepositTerms> {
+  const siblingCount = input.siblings.length;
+  if (siblingCount === 0) {
+    throw new Error(
+      "rebuildDepositTermsCore: at least one sibling is required",
+    );
+  }
+  if (input.prepeginMaxFee <= 0n) {
+    throw new Error(
+      `rebuildDepositTermsCore: prepeginMaxFee must be > 0, got ${input.prepeginMaxFee}`,
+    );
+  }
+
+  // Gate 0 (self-verified, not merely trusted from the caller): the funded tx
+  // bytes must hash to the on-chain-pinned prepeginTxid. Everything below trusts
+  // these bytes — without this a substituted tx that replicates the first N HTLC
+  // outputs passes Gate 1 while carrying a different fee/txid the device would
+  // then be asked to approve. Mirrors the refund flow's Gate 0.
+  const expectedTxid = stripHexPrefix(input.prepeginTxid).toLowerCase();
+  const actualTxid = stripHexPrefix(
+    calculateBtcTxHash(input.fundedPrePeginTxHex),
+  ).toLowerCase();
+  if (actualTxid !== expectedTxid) {
+    throw new Error(
+      `Funded Pre-PegIn tx hashes to ${actualTxid}, expected ${expectedTxid} ` +
+        `(on-chain prepeginTxid). Resume refused.`,
+    );
+  }
+
+  // Completeness anchor: the funded tx's auth-anchor OP_RETURN sits at
+  // vout === HTLC count. Production pegins always commit exactly one anchor, so
+  // its absence (or an ambiguous set) MUST reject — this is the only guard
+  // against an indexer-lagged partial sibling set (Gate 1 only inspects 0..N-1).
+  const found = findAuthAnchorOpReturn(
+    stripHexPrefix(input.fundedPrePeginTxHex),
+  );
+  if (found === undefined || found.vout !== siblingCount) {
+    throw new Error(
+      `Auth-anchor OP_RETURN ${
+        found === undefined ? "absent or ambiguous" : `at vout ${found.vout}`
+      } does not match sibling count ${siblingCount}; sibling set is incomplete. ` +
+        `Resume refused.`,
+    );
+  }
+
+  // Amount-independent sizing (btc-vault: DCV + minPeginFee depend on the signer
+  // set + rates, not the pegin amount). Depositor-as-claimer:
+  // numLocalChallengers === numVks (VP excluded) — graph.rs derive_challengers_for.
+  const numVks = input.vaultKeeperBtcPubkeys.length;
+  const numUcs = input.universalChallengerBtcPubkeys.length;
+  const depositorClaimValue = await computeMinClaimValue(
+    input.vaultCoreVersion,
+    numVks,
+    numUcs,
+    input.councilQuorum,
+    input.councilSize,
+    input.protocolFeeRate,
+  );
+  const peginMaxFee = await computeMinPeginFee(
+    input.vaultCoreVersion,
+    numVks,
+    numUcs,
+    input.minPeginFeeRate,
+  );
+  const anchor = await peginP2aAnchorOutput(input.vaultCoreVersion);
+  const anchorValue = anchor?.value ?? 0n;
+
+  // Gate 1: per sibling, expected HTLC value = amount + DCV + peginMaxFee + anchor
+  // (btc-vault compute_min_htlc_value), and expected scriptPubKey from the
+  // sibling's on-chain hashlock. assertEncodedHtlcOutputsMatch byte-matches both
+  // against the funded tx's outputs 0..N-1.
+  const expectedHtlcValues = input.siblings.map(
+    (s) => s.amount + depositorClaimValue + peginMaxFee + anchorValue,
+  );
+  const expectedHtlcScriptPubKeys = await Promise.all(
+    input.siblings.map(async (s) => {
+      const connector = await getPrePeginHtlcConnectorInfo({
+        txGraphVersion: input.vaultCoreVersion,
+        depositorPubkey: input.depositorBtcPubkey,
+        vaultProviderPubkey: input.vaultProviderBtcPubkey,
+        vaultKeeperPubkeys: [...input.vaultKeeperBtcPubkeys],
+        universalChallengerPubkeys: [...input.universalChallengerBtcPubkeys],
+        hashlock: stripHexPrefix(s.hashlock),
+        timelockRefund: input.timelockRefund,
+        network: input.network,
+      });
+      return connector.scriptPubKey;
+    }),
+  );
+  const fundedOutputs = Transaction.fromHex(
+    stripHexPrefix(input.fundedPrePeginTxHex),
+  ).outs.map((o) => ({ value: o.value, script: o.script }));
+  assertEncodedHtlcOutputsMatch(
+    fundedOutputs,
+    expectedHtlcValues,
+    expectedHtlcScriptPubKeys,
+  );
+
+  return buildDepositTerms({
+    vaultCoreVersion: input.vaultCoreVersion,
+    protocolFeeRate: input.protocolFeeRate,
+    timelockPegin: input.timelockPegin,
+    timelockAssert: input.timelockAssert,
+    timelockRefund: input.timelockRefund,
+    prepeginTxid: input.prepeginTxid,
+    prepeginMaxFee: input.prepeginMaxFee,
+    vaultProviderBtcPubkey: input.vaultProviderBtcPubkey,
+    vaultKeeperBtcPubkeys: input.vaultKeeperBtcPubkeys,
+    universalChallengerBtcPubkeys: input.universalChallengerBtcPubkeys,
+    maxAcceptableCommissionBps: input.maxAcceptableCommissionBps,
+    peginAmounts: input.siblings.map((s) => s.amount),
+    depositorClaimValue,
+    peginMaxFee,
+  });
+}

--- a/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/rebuildDepositTermsCore.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/rebuildDepositTermsCore.ts
@@ -9,7 +9,7 @@
  * projects into DepositTerms. No chain access, no browser state — unit-testable.
  *
  * btc-vault is the protocol source of truth (`compute_min_htlc_value`,
- * `derive_challengers_for`). Design: `todo/ledger/2220-part2-resume-rebuild-design.md`.
+ * `derive_challengers_for`).
  */
 
 import {
@@ -31,7 +31,7 @@ import type { DepositTerms } from "./depositTerms";
 
 /** One HTLC in the shared Pre-PegIn tx, ordered by (and contiguous in) htlcVout. */
 export interface RebuildSibling {
-  /** x-only or 0x-prefixed hex hashlock, per-vault (feeds the HTLC scriptPubKey). */
+  /** 32-byte hex hashlock (0x prefix optional), per-vault (feeds the HTLC scriptPubKey). */
   hashlock: string;
   /** btc-vault `pegin_amount` for this sibling (satoshis). */
   amount: bigint;
@@ -79,6 +79,14 @@ export async function rebuildDepositTermsCore(
       "rebuildDepositTermsCore: at least one sibling is required",
     );
   }
+  for (const [i, sibling] of input.siblings.entries()) {
+    if (sibling.amount <= 0n) {
+      throw new Error(
+        `rebuildDepositTermsCore: sibling[${i}] has non-positive on-chain pegin ` +
+          `amount ${sibling.amount}; the chain-read vault record is invalid. Resume refused.`,
+      );
+    }
+  }
   if (input.prepeginMaxFee <= 0n) {
     throw new Error(
       `rebuildDepositTermsCore: prepeginMaxFee must be > 0, got ${input.prepeginMaxFee}`,
@@ -104,12 +112,20 @@ export async function rebuildDepositTermsCore(
   const found = findAuthAnchorOpReturn(
     stripHexPrefix(input.fundedPrePeginTxHex),
   );
-  if (found === undefined || found.vout !== siblingCount) {
+  if (found === undefined) {
     throw new Error(
-      `Auth-anchor OP_RETURN ${
-        found === undefined ? "absent or ambiguous" : `at vout ${found.vout}`
-      } does not match sibling count ${siblingCount}; sibling set is incomplete. ` +
+      `Funded Pre-PegIn carries no single, unambiguous auth-anchor OP_RETURN ` +
+        `commitment — it either predates auth anchoring or is malformed. The ` +
+        `intent resume path requires the anchor to prove sibling completeness. ` +
         `Resume refused.`,
+    );
+  }
+  if (found.vout !== siblingCount) {
+    throw new Error(
+      `Auth-anchor OP_RETURN at vout ${found.vout} does not match the ` +
+        `discovered sibling count ${siblingCount}; the discovered sibling set ` +
+        `does not cover this transaction's HTLC outputs (a lagging index can ` +
+        `cause this — retry later). Resume refused.`,
     );
   }
 

--- a/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/rebuildDepositTermsCore.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/rebuildDepositTermsCore.ts
@@ -23,6 +23,7 @@ import { Transaction } from "bitcoinjs-lib";
 import { findAuthAnchorOpReturn } from "../managers/pegin/assertAuthAnchorOpReturn";
 import { assertEncodedHtlcOutputsMatch } from "../primitives/psbt/assertWasmPeginSizing";
 import { stripHexPrefix } from "../primitives/utils/bitcoin";
+import { MAX_REASONABLE_PEGIN_VBYTES } from "../utils/fee/constants";
 import { calculateBtcTxHash } from "../utils/transaction/btcTxHash";
 
 import { buildDepositTerms } from "./buildDepositTerms";
@@ -84,11 +85,9 @@ export async function rebuildDepositTermsCore(
     );
   }
 
-  // Gate 0 (self-verified, not merely trusted from the caller): the funded tx
-  // bytes must hash to the on-chain-pinned prepeginTxid. Everything below trusts
-  // these bytes — without this a substituted tx that replicates the first N HTLC
-  // outputs passes Gate 1 while carrying a different fee/txid the device would
-  // then be asked to approve. Mirrors the refund flow's Gate 0.
+  // Gate 0, self-verified: everything below trusts these bytes, and a
+  // substituted tx replicating the HTLC outputs would pass Gate 1 with a
+  // different fee/txid.
   const expectedTxid = stripHexPrefix(input.prepeginTxid).toLowerCase();
   const actualTxid = stripHexPrefix(
     calculateBtcTxHash(input.fundedPrePeginTxHex),
@@ -100,10 +99,8 @@ export async function rebuildDepositTermsCore(
     );
   }
 
-  // Completeness anchor: the funded tx's auth-anchor OP_RETURN sits at
-  // vout === HTLC count. Production pegins always commit exactly one anchor, so
-  // its absence (or an ambiguous set) MUST reject — this is the only guard
-  // against an indexer-lagged partial sibling set (Gate 1 only inspects 0..N-1).
+  // Completeness anchor: the single auth-anchor OP_RETURN sits at vout === HTLC
+  // count — the only guard against an indexer-lagged partial sibling set.
   const found = findAuthAnchorOpReturn(
     stripHexPrefix(input.fundedPrePeginTxHex),
   );
@@ -116,9 +113,8 @@ export async function rebuildDepositTermsCore(
     );
   }
 
-  // Amount-independent sizing (btc-vault: DCV + minPeginFee depend on the signer
-  // set + rates, not the pegin amount). Depositor-as-claimer:
-  // numLocalChallengers === numVks (VP excluded) — graph.rs derive_challengers_for.
+  // Amount-independent sizing. Depositor-as-claimer: numLocalChallengers ===
+  // numVks (VP excluded) — btc-vault graph.rs derive_challengers_for.
   const numVks = input.vaultKeeperBtcPubkeys.length;
   const numUcs = input.universalChallengerBtcPubkeys.length;
   const depositorClaimValue = await computeMinClaimValue(
@@ -138,10 +134,41 @@ export async function rebuildDepositTermsCore(
   const anchor = await peginP2aAnchorOutput(input.vaultCoreVersion);
   const anchorValue = anchor?.value ?? 0n;
 
-  // Gate 1: per sibling, expected HTLC value = amount + DCV + peginMaxFee + anchor
-  // (btc-vault compute_min_htlc_value), and expected scriptPubKey from the
-  // sibling's on-chain hashlock. assertEncodedHtlcOutputsMatch byte-matches both
-  // against the funded tx's outputs 0..N-1.
+  // Independent bounds on the WASM outputs (mirrors assertWasmPeginSizing):
+  // Gate 1 only proves the DCV+fee+anchor SUM — these constrain the
+  // decomposition the device is shown.
+  if (depositorClaimValue <= 0n) {
+    throw new Error(
+      `WASM returned non-positive depositorClaimValue ${depositorClaimValue}; ` +
+        `expected > 0. Resume refused.`,
+    );
+  }
+  if (peginMaxFee <= 0n) {
+    throw new Error(
+      `WASM returned non-positive peginMaxFee ${peginMaxFee}; expected > 0. ` +
+        `Resume refused.`,
+    );
+  }
+  // Explicit anchor check: the sum bound alone would let a negative anchor
+  // offset an inflated peginMaxFee (kept local, not inherited from the facade).
+  if (anchorValue < 0n) {
+    throw new Error(
+      `WASM returned negative P2A anchor value ${anchorValue}. Resume refused.`,
+    );
+  }
+  const impliedReserve = peginMaxFee + anchorValue;
+  const maxImpliedReserve = input.minPeginFeeRate * MAX_REASONABLE_PEGIN_VBYTES;
+  if (impliedReserve <= 0n || impliedReserve > maxImpliedReserve) {
+    throw new Error(
+      `WASM implied PegIn reserve ${impliedReserve} sat is outside ` +
+        `(0, ${maxImpliedReserve}] (minPeginFeeRate=${input.minPeginFeeRate} × ` +
+        `${MAX_REASONABLE_PEGIN_VBYTES} vbytes). Resume refused.`,
+    );
+  }
+
+  // Gate 1: per sibling, value = amount + DCV + peginMaxFee + anchor (btc-vault
+  // compute_min_htlc_value) + scriptPubKey from the on-chain hashlock,
+  // byte-matched against outputs 0..N-1.
   const expectedHtlcValues = input.siblings.map(
     (s) => s.amount + depositorClaimValue + peginMaxFee + anchorValue,
   );

--- a/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts
@@ -52,7 +52,10 @@ import type { WotsBlockPublicKey } from "../clients/vault-provider/types";
 import { BTCVaultRegistryABI, handleContractError } from "../contracts";
 import {
   buildDepositTerms,
+  capMaxAcceptableCommissionBps,
+  COMMISSION_BPS_HEADROOM,
   ensurePrePeginTermsApproval,
+  MAX_ACCEPTABLE_COMMISSION_BPS_CAP,
   supportsDepositApproval,
   type DepositTerms,
 } from "../deposit-terms";
@@ -68,7 +71,6 @@ import {
   type Network,
   type PrePeginParams,
 } from "../primitives";
-import { MAX_VP_COMMISSION_BPS_EXCLUSIVE } from "../primitives/psbt/constants";
 import {
   ensureHexPrefix,
   hexToUint8Array,
@@ -97,52 +99,6 @@ import {
 
 /** Referral code sent with pegin registration — 0 means no referral. */
 const NO_REFERRAL_CODE = 0;
-
-/**
- * Headroom (in basis points) added to the current VP commission to compute
- * `maxAcceptableCommissionBps` at submit time. Lets the VP raise its
- * commission by up to this amount between read and submit without forcing
- * a re-quote. Capped by {@link MAX_ACCEPTABLE_COMMISSION_BPS_CAP}.
- *
- * Contract check is strict `>` (PeginLogic.sol `VaultProviderCommissionExceeded`
- * revert), so +25 allows up
- * to +25 bps of drift.
- */
-const COMMISSION_BPS_HEADROOM = 25;
-
-/**
- * Hard ceiling for `maxAcceptableCommissionBps`. The contract enforces
- * `commissionBps < 10000`, so any value at/above that is unreachable;
- * `9999` is the maximum useful cap.
- */
-const MAX_ACCEPTABLE_COMMISSION_BPS_CAP = 9999;
-
-/**
- * The commission ceiling submitted as registration calldata and mirrored
- * into `DepositTerms.commissionFee`: quoted + drift headroom, capped.
- * Single source for both consumers — feed it the SAME quoted bps at prepare
- * and register time so device-accept stays coextensive with contract-accept.
- */
-function capMaxAcceptableCommissionBps(bps: number): number {
-  // Validate the raw quote before headroom shifts its domain — a negative
-  // quote must throw here, not become a small "legal" ceiling.
-  // Reject an out-of-range quote outright — clamping it to 9999 would turn a
-  // bad read into a 99.99% ceiling, the exact failure the cap exists to stop.
-  if (
-    !Number.isInteger(bps) ||
-    bps < 0 ||
-    bps >= MAX_VP_COMMISSION_BPS_EXCLUSIVE
-  ) {
-    throw new Error(
-      `Quoted commissionBps must be an integer in ` +
-        `[0, ${MAX_VP_COMMISSION_BPS_EXCLUSIVE}), got ${bps}`,
-    );
-  }
-  return Math.min(
-    bps + COMMISSION_BPS_HEADROOM,
-    MAX_ACCEPTABLE_COMMISSION_BPS_CAP,
-  );
-}
 
 /**
  * 32-byte zero hex used as a placeholder during the sizing pass for any

--- a/packages/babylon-ts-sdk/src/tbv/core/managers/__tests__/PeginManager.rebuildDepositTerms.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/__tests__/PeginManager.rebuildDepositTerms.test.ts
@@ -16,7 +16,10 @@ import { beforeAll, describe, expect, it, vi } from "vitest";
 
 import { MockBitcoinWallet, MockEthereumWallet } from "../../../../testing";
 import { MEMPOOL_API_URLS } from "../../clients/mempool";
-import { rebuildDepositTermsCore } from "../../deposit-terms";
+import {
+  capMaxAcceptableCommissionBps,
+  rebuildDepositTermsCore,
+} from "../../deposit-terms";
 import { deriveTaprootAddress } from "../../primitives";
 import { initializeWasmForTests } from "../../primitives/psbt/__tests__/helpers";
 import {
@@ -138,7 +141,9 @@ const PARAMS = {
 } as const;
 
 // Fresh path applies `capMaxAcceptableCommissionBps`: quote + 25 bps headroom.
-const EXPECTED_MAX_ACCEPTABLE_BPS = PARAMS.commissionBps + 25;
+const EXPECTED_MAX_ACCEPTABLE_BPS = capMaxAcceptableCommissionBps(
+  PARAMS.commissionBps,
+);
 
 const PREVOUT_VALUES = new Map(
   TEST_UTXOS.map((u) => [`${u.txid}:${u.vout}`, BigInt(u.value)]),

--- a/packages/babylon-ts-sdk/src/tbv/core/managers/__tests__/PeginManager.rebuildDepositTerms.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/__tests__/PeginManager.rebuildDepositTerms.test.ts
@@ -1,0 +1,234 @@
+/**
+ * Cross-path golden for the resume rebuild (#2220 Part 2): the funded tx and
+ * DepositTerms are produced by the PRODUCTION build path
+ * (`PeginManager.preparePegin` → `createPrePeginTransaction` WASM entry point),
+ * then fed through `rebuildDepositTermsCore` (which recomputes sizing and
+ * scripts via the STANDALONE WASM entry points). The deep-equality assertion is
+ * the only JS-side proof that the two WASM paths agree byte-for-byte — the
+ * in-file golden in `rebuildDepositTermsCore.test.ts` builds its fixture from
+ * the same calls the core makes, so it cannot see cross-entry-point drift.
+ */
+
+import * as bitcoin from "bitcoinjs-lib";
+import { Buffer } from "buffer";
+import { zeroAddress, type Address, type Chain, type PublicClient } from "viem";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+import { MockBitcoinWallet, MockEthereumWallet } from "../../../../testing";
+import { MEMPOOL_API_URLS } from "../../clients/mempool";
+import { rebuildDepositTermsCore } from "../../deposit-terms";
+import { deriveTaprootAddress } from "../../primitives";
+import { initializeWasmForTests } from "../../primitives/psbt/__tests__/helpers";
+import {
+  ensureHexPrefix,
+  stripHexPrefix,
+} from "../../primitives/utils/bitcoin";
+import { computeHashlock } from "../../services/htlc";
+import type { UTXO } from "../../utils";
+import { PeginManager } from "../PeginManager";
+
+// Same mock set as PeginManager.test.ts (the mock wallet cannot produce real
+// PSBT signatures) — EXCEPT `btcTxHash`, which stays real: Gate 0 must hash
+// the genuine funded tx or the cross-path comparison proves nothing.
+vi.mock("../../primitives/psbt/peginInput", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../../primitives/psbt/peginInput")>();
+  return {
+    ...actual,
+    buildPeginInputPsbt: vi.fn().mockResolvedValue({ psbtHex: "deadbeef" }),
+    extractPeginInputSignature: vi.fn().mockReturnValue("a".repeat(128)),
+    finalizePeginInputPsbt: vi
+      .fn()
+      .mockReturnValue("mock-depositor-signed-pegin-tx"),
+  };
+});
+vi.mock(
+  "../../primitives/psbt/assertPsbtUnsignedTxMatches",
+  async (importOriginal) => {
+    const actual =
+      await importOriginal<
+        typeof import("../../primitives/psbt/assertPsbtUnsignedTxMatches")
+      >();
+    return { ...actual, assertPsbtUnsignedTxMatches: vi.fn() };
+  },
+);
+vi.mock("../../primitives/psbt/verifyScriptPathSchnorrSignature", () => ({
+  assertScriptPathSchnorrSignature: vi.fn(),
+}));
+
+const TEST_CHAIN: Chain = {
+  id: 11155111,
+  name: "Sepolia",
+  nativeCurrency: { name: "Sepolia ETH", symbol: "ETH", decimals: 18 },
+  rpcUrls: { default: { http: ["https://rpc.sepolia.org"] } },
+};
+
+const TEST_PUBLIC_CLIENT = {
+  estimateGas: vi.fn().mockResolvedValue(100000n),
+  getCode: vi.fn().mockResolvedValue("0x"),
+  waitForTransactionReceipt: vi.fn().mockResolvedValue({
+    status: "success",
+    transactionHash: "0x" + "ab".repeat(32),
+  }),
+  readContract: vi
+    .fn()
+    .mockImplementation(({ functionName }: { functionName: string }) => {
+      if (functionName === "getPegInFee") return Promise.resolve(0n);
+      if (functionName === "getVaultProviderCommission")
+        return Promise.resolve(0);
+      return Promise.resolve({ depositor: zeroAddress });
+    }),
+} as unknown as PublicClient;
+
+const TEST_KEYS = {
+  DEPOSITOR: "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+  VAULT_PROVIDER:
+    "c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5",
+  VAULT_KEEPER_1:
+    "f9308a019258c31049344f85f89d5229b531c845836f99b08601f113bce036f9",
+  VAULT_KEEPER_2:
+    "e493dbf1c10d80f3581e4904930b1404cc6c13900ee0758474fa94abe8c4cd13",
+  UNIVERSAL_CHALLENGER_1:
+    "2f8bde4d1a07209355b4a7250a5c5128e88b84bddc619ab7cba8d569b240efe4",
+} as const;
+
+const TEST_UTXOS: UTXO[] = [
+  {
+    txid: "0000000000000000000000000000000000000000000000000000000000000001",
+    vout: 0,
+    value: 800_000,
+    scriptPubKey: `5120${TEST_KEYS.DEPOSITOR}`,
+  },
+  {
+    txid: "0000000000000000000000000000000000000000000000000000000000000002",
+    vout: 0,
+    value: 800_000,
+    scriptPubKey: `5120${TEST_KEYS.VAULT_PROVIDER}`,
+  },
+  {
+    txid: "0000000000000000000000000000000000000000000000000000000000000003",
+    vout: 1,
+    value: 800_000,
+    scriptPubKey: `5120${TEST_KEYS.VAULT_KEEPER_1}`,
+  },
+];
+
+const TEST_CONTRACT_ADDRESS =
+  "0x742d35cc6634c0532925a3b844bc9e7595f0beb0" as Address;
+
+const AMOUNTS = [90_000n, 120_000n];
+
+// Asymmetric counts + fully distinct scalars: identical values would blind the
+// deep-compare to swapped arguments or transposed fields on either path.
+const PARAMS = {
+  vaultProviderBtcPubkey: TEST_KEYS.VAULT_PROVIDER,
+  vaultKeeperBtcPubkeys: [TEST_KEYS.VAULT_KEEPER_1, TEST_KEYS.VAULT_KEEPER_2],
+  universalChallengerBtcPubkeys: [TEST_KEYS.UNIVERSAL_CHALLENGER_1],
+  timelockPegin: 100,
+  timelockAssert: 150,
+  timelockRefund: 144,
+  protocolFeeRate: 3n,
+  minPeginFeeRate: 7n,
+  mempoolFeeRate: 10,
+  councilQuorum: 2,
+  councilSize: 3,
+  availableUTXOs: TEST_UTXOS,
+  changeAddress: deriveTaprootAddress(TEST_KEYS.DEPOSITOR, "signet"),
+  commissionBps: 250,
+} as const;
+
+// Fresh path applies `capMaxAcceptableCommissionBps`: quote + 25 bps headroom.
+const EXPECTED_MAX_ACCEPTABLE_BPS = PARAMS.commissionBps + 25;
+
+const PREVOUT_VALUES = new Map(
+  TEST_UTXOS.map((u) => [`${u.txid}:${u.vout}`, BigInt(u.value)]),
+);
+
+function sumPrevouts(ins: bitcoin.Transaction["ins"]): bigint {
+  let sum = 0n;
+  for (const input of ins) {
+    const txid = Buffer.from(input.hash).reverse().toString("hex");
+    const value = PREVOUT_VALUES.get(`${txid}:${input.index}`);
+    if (value === undefined) {
+      throw new Error(`Unexpected prevout ${txid}:${input.index}`);
+    }
+    sum += value;
+  }
+  return sum;
+}
+
+describe("rebuildDepositTermsCore reproduces the production build's DepositTerms", () => {
+  beforeAll(async () => {
+    await initializeWasmForTests();
+  });
+
+  it.each([1, 2])(
+    "rebuilds terms deep-equal to preparePegin's for vaultCoreVersion %d",
+    async (vaultCoreVersion) => {
+      const btcWallet = new MockBitcoinWallet({
+        publicKeyHex: TEST_KEYS.DEPOSITOR,
+      });
+      const ethWallet = new MockEthereumWallet();
+      const manager = new PeginManager({
+        btcNetwork: "signet",
+        btcWallet,
+        ethWallet: ethWallet as never,
+        ethChain: TEST_CHAIN,
+        publicClient: TEST_PUBLIC_CLIENT,
+        vaultContracts: { btcVaultRegistry: TEST_CONTRACT_ADDRESS },
+        mempoolApiUrl: MEMPOOL_API_URLS.signet,
+      });
+
+      const prepared = await manager.preparePegin({
+        amounts: AMOUNTS,
+        vaultCoreVersion,
+        ...PARAMS,
+      });
+
+      // Resume-side sibling data: hashlock = SHA-256(secret), the exact
+      // mapping expandPerVaultSecrets committed into the HTLC scripts.
+      const siblings = prepared.derivedSecrets.htlcSecretHexes.map(
+        (secretHex, i) => ({
+          hashlock: stripHexPrefix(computeHashlock(ensureHexPrefix(secretHex))),
+          amount: AMOUNTS[i],
+        }),
+      );
+
+      // Resume-side fee: Σ prevouts − Σ outputs of the funded tx — must equal
+      // the fresh path's published sizing fee (PeginManager asserts this
+      // invariant internally before returning).
+      const tx = bitcoin.Transaction.fromHex(
+        stripHexPrefix(prepared.transaction.fundedPrePeginTxHex),
+      );
+      const fundedTxFee =
+        sumPrevouts(tx.ins) -
+        tx.outs.reduce((sum, o) => sum + BigInt(o.value), 0n);
+      expect(fundedTxFee).toBe(prepared.transaction.fee);
+
+      const rebuilt = await rebuildDepositTermsCore({
+        vaultCoreVersion,
+        siblings,
+        fundedPrePeginTxHex: prepared.transaction.fundedPrePeginTxHex,
+        depositorBtcPubkey: prepared.depositorBtcPubkey,
+        vaultProviderBtcPubkey: PARAMS.vaultProviderBtcPubkey,
+        vaultKeeperBtcPubkeys: PARAMS.vaultKeeperBtcPubkeys,
+        universalChallengerBtcPubkeys: PARAMS.universalChallengerBtcPubkeys,
+        protocolFeeRate: PARAMS.protocolFeeRate,
+        minPeginFeeRate: PARAMS.minPeginFeeRate,
+        councilQuorum: PARAMS.councilQuorum,
+        councilSize: PARAMS.councilSize,
+        timelockPegin: PARAMS.timelockPegin,
+        timelockAssert: PARAMS.timelockAssert,
+        timelockRefund: PARAMS.timelockRefund,
+        prepeginTxid: prepared.transaction.prePeginTxid,
+        prepeginMaxFee: fundedTxFee,
+        maxAcceptableCommissionBps: EXPECTED_MAX_ACCEPTABLE_BPS,
+        network: "signet",
+      });
+
+      // Full deep-compare, zero exclusions: any drift between the standalone
+      // WASM recompute and the production builder shows up here.
+      expect(rebuilt).toEqual(prepared.depositTerms);
+    },
+  );
+});

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/assertWasmPeginSizing.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/assertWasmPeginSizing.ts
@@ -42,6 +42,9 @@ import type { PrePeginParams } from "./pegin";
  * exact, but both sides come from the same binary, which is why the
  * independent bounds above are kept alongside it.
  *
+ * The resume rebuild (`deposit-terms/rebuildDepositTermsCore.ts`) mirrors these
+ * bounds (positivity + reserve band) — keep the two in sync when editing.
+ *
  * @param result - The result returned by `createPrePeginTransaction`.
  * @param params - The parameters that were passed to build it.
  * @returns The independently computed `minPeginFee` this function already

--- a/packages/babylon-ts-sdk/src/tbv/core/vault-secrets/deriveVaultRoot.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/vault-secrets/deriveVaultRoot.ts
@@ -48,6 +48,20 @@ export interface DeriveContextHashCapableWallet {
   deriveContextHash(appName: string, context: string): Promise<string>;
 }
 
+/** Forward the deriveContextHash capability only when the wallet actually has it,
+ * so seam guards (ensurePrePeginTermsApproval) can fire their typed error instead
+ * of a mid-ceremony TypeError. */
+export function forwardDeriveContextHash(
+  wallet: Partial<DeriveContextHashCapableWallet>,
+): Partial<DeriveContextHashCapableWallet> {
+  return typeof wallet.deriveContextHash === "function"
+    ? {
+        deriveContextHash: (appName, context) =>
+          wallet.deriveContextHash!(appName, context),
+      }
+    : {};
+}
+
 /**
  * Derive the 32-byte vault root from a wallet by encoding the
  * canonical {@link VaultContextInput} and forwarding to

--- a/packages/babylon-ts-sdk/src/tbv/core/vault-secrets/index.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/vault-secrets/index.ts
@@ -23,7 +23,11 @@ export { buildFundingOutpointsCommitment, buildVaultContext } from "./context";
 
 export type { FundingOutpoint, VaultContextInput } from "./context";
 
-export { deriveVaultRoot, VAULT_APP_NAME } from "./deriveVaultRoot";
+export {
+  VAULT_APP_NAME,
+  deriveVaultRoot,
+  forwardDeriveContextHash,
+} from "./deriveVaultRoot";
 
 export type { DeriveContextHashCapableWallet } from "./deriveVaultRoot";
 

--- a/services/vault/src/hooks/deposit/__tests__/useVaultActions.test.ts
+++ b/services/vault/src/hooks/deposit/__tests__/useVaultActions.test.ts
@@ -5,6 +5,7 @@
  */
 
 import { OnChainBtcVaultStatus } from "@babylonlabs-io/ts-sdk/tbv/core/clients";
+import { useChainConnector } from "@babylonlabs-io/wallet-connector";
 import { act, renderHook } from "@testing-library/react";
 import type { Hex } from "viem";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -13,6 +14,8 @@ import { getVaultFromChain } from "@/clients/eth-contract/btc-vault-registry/que
 import { getVaultRegistryReader } from "@/clients/eth-contract/sdk-readers";
 import { ContractStatus } from "@/models/peginStateMachine";
 import { broadcastPrePeginTransaction, fetchVaultById } from "@/services/vault";
+import { rebuildDepositTerms } from "@/services/vault/rebuildDepositTerms";
+import { resolveFundedTxFeeAndUtxos } from "@/services/vault/resolveFundedTxFee";
 import { activateVaultWithSecret } from "@/services/vault/vaultActivationService";
 
 import { useVaultActions } from "../useVaultActions";
@@ -141,6 +144,14 @@ vi.mock("@/services/vault/vaultActivationService", () => ({
   activateVaultWithSecret: vi.fn(),
 }));
 
+vi.mock("@/services/vault/rebuildDepositTerms", () => ({
+  rebuildDepositTerms: vi.fn(),
+}));
+
+vi.mock("@/services/vault/resolveFundedTxFee", () => ({
+  resolveFundedTxFeeAndUtxos: vi.fn(),
+}));
+
 vi.mock("@/services/vault/vaultPeginBroadcastService", () => ({
   utxosToExpectedRecord: vi.fn(() => ({})),
 }));
@@ -234,6 +245,7 @@ function makeMatchingProtocolInfoBatch() {
 
 const baseBroadcastParams = {
   vaultId: "0xvaultId" as Hex,
+  depositorEthAddress: "0xconnected_depositor",
   onRefetchActivities: vi.fn(),
   onShowSuccessModal: vi.fn(),
 };
@@ -1203,5 +1215,130 @@ describe("useVaultActions — handleActivation hashlock source", () => {
 
     expect(mockActivateVaultWithSecret).toHaveBeenCalledTimes(1);
     expect(mockLoggerError).not.toHaveBeenCalled();
+  });
+});
+
+// Placed last: these tests override the useChainConnector mock's return value,
+// which persists for the rest of the file.
+describe("useVaultActions — handleBroadcast intent (Ledger) resume branch", () => {
+  const RESOLVED = {
+    expectedUtxos: {
+      ["ab".repeat(32) + ":0"]: { scriptPubKey: "5120aa", value: 500_000 },
+    },
+    fundedTxFee: 1234n,
+  };
+  const REBUILT_TERMS = { prepeginTxid: "ff".repeat(32) };
+
+  function connectIntentWallet() {
+    vi.mocked(useChainConnector).mockReturnValue({
+      connectedWallet: {
+        account: { address: "bc1qdepositor" },
+        provider: {
+          connectWallet: vi.fn().mockResolvedValue(undefined),
+          getAddress: vi.fn().mockResolvedValue("bc1qdepositor"),
+          signPsbt: mockSignPsbt,
+          deriveContextHash: vi.fn().mockResolvedValue("ab".repeat(32)),
+          approveDepositTerms: vi.fn().mockResolvedValue(undefined),
+        },
+      },
+    } as never);
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCalculateBtcTxHash.mockReturnValue("0xmatching_pre_pegin_hash");
+    mockGetVaultFromChain.mockResolvedValue({
+      prePeginTxHash: "0xmatching_pre_pegin_hash",
+      hashlock: "0xonchain_hashlock",
+      status: OnChainBtcVaultStatus.PENDING,
+    } as never);
+    mockGetVaultRegistryReader.mockReturnValue({
+      getProtocolInfoBatch: makeMatchingProtocolInfoBatch(),
+    } as unknown as ReturnType<typeof getVaultRegistryReader>);
+    mockVerifyResumeParticipantKeys.mockResolvedValue(undefined);
+    vi.mocked(resolveFundedTxFeeAndUtxos).mockResolvedValue(RESOLVED as never);
+    vi.mocked(rebuildDepositTerms).mockResolvedValue(REBUILT_TERMS as never);
+    mockFetchVaultById.mockResolvedValue(baseVault as never);
+  });
+
+  it("rebuilds terms from chain and forwards them (with approval capability) to the broadcast", async () => {
+    connectIntentWallet();
+
+    const { result } = renderHook(() => useVaultActions());
+    await act(async () => {
+      await result.current.handleBroadcast({
+        ...baseBroadcastParams,
+        pendingPegin: { ...basePendingPegin },
+      });
+    });
+
+    expect(result.current.broadcastError).toBeNull();
+    // Prevouts resolved once, mempool-only (no same-device record argument).
+    expect(resolveFundedTxFeeAndUtxos).toHaveBeenCalledWith(TRUSTED_TX_HEX);
+    expect(rebuildDepositTerms).toHaveBeenCalledWith({
+      vaultId: "0xvaultId",
+      fundedPrePeginTxHex: TRUSTED_TX_HEX,
+      connectedDepositorAddress: "0xconnected_depositor",
+      depositorBtcPubkey: "depositorBtcPubkey",
+      fundedTxFee: 1234n,
+    });
+    expect(mockBroadcastPrePeginTransaction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        unsignedTxHex: TRUSTED_TX_HEX,
+        depositTerms: REBUILT_TERMS,
+        expectedUtxos: RESOLVED.expectedUtxos,
+        btcWalletProvider: expect.objectContaining({
+          approveDepositTerms: expect.any(Function),
+          deriveContextHash: expect.any(Function),
+        }),
+      }),
+    );
+  });
+
+  it("does not broadcast (and reports the error) when the rebuild fails", async () => {
+    connectIntentWallet();
+    vi.mocked(rebuildDepositTerms).mockRejectedValue(
+      new Error(
+        "Sibling vaults of this Pre-PegIn disagree on offchainParamsVersion",
+      ),
+    );
+
+    const { result } = renderHook(() => useVaultActions());
+    await act(async () => {
+      await result.current.handleBroadcast({
+        ...baseBroadcastParams,
+        pendingPegin: { ...basePendingPegin },
+      });
+    });
+
+    expect(mockBroadcastPrePeginTransaction).not.toHaveBeenCalled();
+    expect(result.current.broadcastError).toContain("disagree on");
+  });
+
+  it("skips the rebuild entirely for a software (signPsbt-only) wallet", async () => {
+    vi.mocked(useChainConnector).mockReturnValue({
+      connectedWallet: {
+        account: { address: "bc1qdepositor" },
+        provider: {
+          connectWallet: vi.fn().mockResolvedValue(undefined),
+          getAddress: vi.fn().mockResolvedValue("bc1qdepositor"),
+          signPsbt: mockSignPsbt,
+        },
+      },
+    } as never);
+
+    const { result } = renderHook(() => useVaultActions());
+    await act(async () => {
+      await result.current.handleBroadcast({
+        ...baseBroadcastParams,
+        pendingPegin: { ...basePendingPegin },
+      });
+    });
+
+    expect(result.current.broadcastError).toBeNull();
+    expect(rebuildDepositTerms).not.toHaveBeenCalled();
+    expect(resolveFundedTxFeeAndUtxos).not.toHaveBeenCalled();
+    const broadcastArg = mockBroadcastPrePeginTransaction.mock.calls[0][0];
+    expect("depositTerms" in broadcastArg).toBe(false);
   });
 });

--- a/services/vault/src/hooks/deposit/__tests__/useVaultActions.test.ts
+++ b/services/vault/src/hooks/deposit/__tests__/useVaultActions.test.ts
@@ -17,10 +17,21 @@ import { broadcastPrePeginTransaction, fetchVaultById } from "@/services/vault";
 import { rebuildDepositTerms } from "@/services/vault/rebuildDepositTerms";
 import { resolveFundedTxFeeAndUtxos } from "@/services/vault/resolveFundedTxFee";
 import { activateVaultWithSecret } from "@/services/vault/vaultActivationService";
+import { utxosToExpectedRecord } from "@/services/vault/vaultPeginBroadcastService";
 
 import { useVaultActions } from "../useVaultActions";
 
 const mockSignPsbt = vi.hoisted(() => vi.fn().mockResolvedValue("signedPsbt"));
+const makeDefaultChainConnector = vi.hoisted(() => () => ({
+  connectedWallet: {
+    account: { address: "bc1qdepositor" },
+    provider: {
+      connectWallet: vi.fn().mockResolvedValue(undefined),
+      getAddress: vi.fn().mockResolvedValue("bc1qdepositor"),
+      signPsbt: mockSignPsbt,
+    },
+  },
+}));
 const mockCalculateBtcTxHash = vi.hoisted(() =>
   vi.fn(() => "0xmatching_pre_pegin_hash"),
 );
@@ -107,16 +118,7 @@ vi.mock("@/clients/eth-contract/pause-state/query", () => ({
 
 vi.mock("@babylonlabs-io/wallet-connector", () => ({
   getSharedWagmiConfig: vi.fn(() => ({})),
-  useChainConnector: vi.fn(() => ({
-    connectedWallet: {
-      account: { address: "bc1qdepositor" },
-      provider: {
-        connectWallet: vi.fn().mockResolvedValue(undefined),
-        getAddress: vi.fn().mockResolvedValue("bc1qdepositor"),
-        signPsbt: mockSignPsbt,
-      },
-    },
-  })),
+  useChainConnector: vi.fn(makeDefaultChainConnector),
 }));
 
 vi.mock("wagmi/actions", () => ({
@@ -249,6 +251,15 @@ const baseBroadcastParams = {
   onRefetchActivities: vi.fn(),
   onShowSuccessModal: vi.fn(),
 };
+
+// Re-assert the default connector before EVERY test so a describe that
+// overrides useChainConnector's return value cannot leak a stale wallet into
+// later tests. Idempotent for tests that never override it.
+beforeEach(() => {
+  vi.mocked(useChainConnector).mockImplementation(
+    makeDefaultChainConnector as never,
+  );
+});
 
 describe("useVaultActions — handleBroadcast transaction integrity", () => {
   beforeEach(() => {
@@ -1218,8 +1229,6 @@ describe("useVaultActions — handleActivation hashlock source", () => {
   });
 });
 
-// Placed last: these tests override the useChainConnector mock's return value,
-// which persists for the rest of the file.
 describe("useVaultActions — handleBroadcast intent (Ledger) resume branch", () => {
   const RESOLVED = {
     expectedUtxos: {
@@ -1228,6 +1237,13 @@ describe("useVaultActions — handleBroadcast intent (Ledger) resume branch", ()
     fundedTxFee: 1234n,
   };
   const REBUILT_TERMS = { prepeginTxid: "ff".repeat(32) };
+  // Single fixture for the chain read AND the `target` the hook must forward
+  // to the rebuild — the same object, not a re-read.
+  const ONCHAIN_VAULT = {
+    prePeginTxHash: "0xmatching_pre_pegin_hash",
+    hashlock: "0xonchain_hashlock",
+    status: OnChainBtcVaultStatus.PENDING,
+  };
 
   function connectIntentWallet() {
     vi.mocked(useChainConnector).mockReturnValue({
@@ -1247,11 +1263,7 @@ describe("useVaultActions — handleBroadcast intent (Ledger) resume branch", ()
   beforeEach(() => {
     vi.clearAllMocks();
     mockCalculateBtcTxHash.mockReturnValue("0xmatching_pre_pegin_hash");
-    mockGetVaultFromChain.mockResolvedValue({
-      prePeginTxHash: "0xmatching_pre_pegin_hash",
-      hashlock: "0xonchain_hashlock",
-      status: OnChainBtcVaultStatus.PENDING,
-    } as never);
+    mockGetVaultFromChain.mockResolvedValue(ONCHAIN_VAULT as never);
     mockGetVaultRegistryReader.mockReturnValue({
       getProtocolInfoBatch: makeMatchingProtocolInfoBatch(),
     } as unknown as ReturnType<typeof getVaultRegistryReader>);
@@ -1277,6 +1289,7 @@ describe("useVaultActions — handleBroadcast intent (Ledger) resume branch", ()
     expect(resolveFundedTxFeeAndUtxos).toHaveBeenCalledWith(TRUSTED_TX_HEX);
     expect(rebuildDepositTerms).toHaveBeenCalledWith({
       vaultId: "0xvaultId",
+      target: ONCHAIN_VAULT,
       fundedPrePeginTxHex: TRUSTED_TX_HEX,
       connectedDepositorAddress: "0xconnected_depositor",
       depositorBtcPubkey: "depositorBtcPubkey",
@@ -1340,5 +1353,68 @@ describe("useVaultActions — handleBroadcast intent (Ledger) resume branch", ()
     expect(resolveFundedTxFeeAndUtxos).not.toHaveBeenCalled();
     const broadcastArg = mockBroadcastPrePeginTransaction.mock.calls[0][0];
     expect("depositTerms" in broadcastArg).toBe(false);
+  });
+
+  // The seam guard (ensurePrePeginTermsApproval) must see the capability
+  // absent — an always-present wrapper property would turn its typed error
+  // into a mid-ceremony TypeError.
+  it("does not forward deriveContextHash when the intent wallet lacks it", async () => {
+    vi.mocked(useChainConnector).mockReturnValue({
+      connectedWallet: {
+        account: { address: "bc1qdepositor" },
+        provider: {
+          connectWallet: vi.fn().mockResolvedValue(undefined),
+          getAddress: vi.fn().mockResolvedValue("bc1qdepositor"),
+          signPsbt: mockSignPsbt,
+          approveDepositTerms: vi.fn().mockResolvedValue(undefined),
+        },
+      },
+    } as never);
+
+    const { result } = renderHook(() => useVaultActions());
+    await act(async () => {
+      await result.current.handleBroadcast({
+        ...baseBroadcastParams,
+        pendingPegin: { ...basePendingPegin },
+      });
+    });
+
+    expect(result.current.broadcastError).toBeNull();
+    const broadcastArg = mockBroadcastPrePeginTransaction.mock.calls[0][0];
+    expect("deriveContextHash" in broadcastArg.btcWalletProvider).toBe(false);
+    expect("approveDepositTerms" in broadcastArg.btcWalletProvider).toBe(true);
+  });
+
+  // The intent path resolves prevouts mempool-only; the local UTXO record
+  // helper belongs to the software branch and must never run here.
+  it("broadcasts even when the local UTXO record helper would throw", async () => {
+    connectIntentWallet();
+    vi.mocked(utxosToExpectedRecord).mockImplementation(() => {
+      throw new Error("stale local UTXO record");
+    });
+
+    const { result } = renderHook(() => useVaultActions());
+    await act(async () => {
+      await result.current.handleBroadcast({
+        ...baseBroadcastParams,
+        pendingPegin: {
+          ...basePendingPegin,
+          selectedUTXOs: [
+            {
+              txid: "abc123",
+              vout: 0,
+              value: "100000",
+              scriptPubKey: "0014abcdef",
+            },
+          ],
+        },
+      });
+    });
+
+    expect(result.current.broadcastError).toBeNull();
+    expect(rebuildDepositTerms).toHaveBeenCalledTimes(1);
+    expect(mockBroadcastPrePeginTransaction).toHaveBeenCalledTimes(1);
+    // Restore the factory default — implementations survive clearAllMocks.
+    vi.mocked(utxosToExpectedRecord).mockImplementation(() => ({}));
   });
 });

--- a/services/vault/src/hooks/deposit/useBroadcastState.ts
+++ b/services/vault/src/hooks/deposit/useBroadcastState.ts
@@ -72,6 +72,7 @@ export function useBroadcastState({
     try {
       await vaultHandleBroadcast({
         vaultId: activity.id,
+        depositorEthAddress,
         pendingPegin,
         updatePendingPeginStatus,
         removePendingPegin,
@@ -110,6 +111,7 @@ export function useBroadcastState({
   }, [
     activity,
     batchVaultIds,
+    depositorEthAddress,
     pendingPegins,
     updatePendingPeginStatus,
     removePendingPegin,

--- a/services/vault/src/hooks/deposit/useVaultActions.ts
+++ b/services/vault/src/hooks/deposit/useVaultActions.ts
@@ -78,6 +78,12 @@ import {
 
 export interface BroadcastPrePeginParams {
   vaultId: Hex;
+  /**
+   * Connected wallet's ETH address. On the intent (Ledger) path the rebuild
+   * asserts it equals the on-chain depositor before any device interaction —
+   * a stale modal after a wallet switch must fail closed, not re-approve.
+   */
+  depositorEthAddress: string;
   pendingPegin?: PendingPeginRequest;
   updatePendingPeginStatus?: (
     vaultId: string,
@@ -167,6 +173,7 @@ export function useVaultActions(): UseVaultActionsReturn {
   const handleBroadcast = async (params: BroadcastPrePeginParams) => {
     const {
       vaultId,
+      depositorEthAddress,
       pendingPegin,
       updatePendingPeginStatus,
       removePendingPegin,
@@ -364,17 +371,17 @@ export function useVaultActions(): UseVaultActionsReturn {
         });
       }
 
-      // Intent (Ledger) resume: rebuild the approved DepositTerms from chain +
-      // WASM and run the derive→approve ceremony (inside broadcastPrePeginTransaction)
-      // before signing. Software wallets keep the signPsbt-only path unchanged.
-      // Resolve every prevout ONCE so the fee that feeds the rebuilt terms is the
-      // same Σin−Σout the broadcast will sign (no drift).
+      // Intent (Ledger) resume: rebuild the DepositTerms from chain + WASM and
+      // run the derive→approve ceremony before signing. Prevouts are resolved
+      // once, mempool-only (never the local cache), so the fee the device
+      // approves is the fee the broadcast signs. Software wallets unchanged.
       if (supportsDepositApproval(btcWalletProvider)) {
         const { expectedUtxos: resolvedUtxos, fundedTxFee } =
-          await resolveFundedTxFeeAndUtxos(unsignedTxHex, expectedUtxos);
+          await resolveFundedTxFeeAndUtxos(unsignedTxHex);
         const depositTerms = await rebuildDepositTerms({
           vaultId,
           fundedPrePeginTxHex: unsignedTxHex,
+          connectedDepositorAddress: depositorEthAddress as Hex,
           depositorBtcPubkey,
           fundedTxFee,
         });
@@ -423,13 +430,10 @@ export function useVaultActions(): UseVaultActionsReturn {
       if (mountedRef.current) {
         let errorMessage: string;
 
-        // An intent-wallet's DepositTermsRejectedError arrives here with its
-        // message preserved verbatim (no "Failed to broadcast" wrapper), so the
-        // resume UI's mapDepositError classifies it the same as the fresh path
-        // does today. broadcastError is string-typed by contract (its content is
-        // asserted across the hook tests). When #2110 adds a typed
-        // intent-rejection branch to mapDepositError, thread the typed error to
-        // the mapper here as useDepositFlow already does — see #2110.
+        // DepositTermsRejectedError arrives message-preserved, so mapDepositError
+        // classifies it like the fresh path today. broadcastError is string by
+        // contract; when #2110 adds a typed branch, thread the typed error to
+        // the mapper here (as useDepositFlow does).
         if (err instanceof UtxoNotAvailableError) {
           // UTXO not available - provide specific error message
           errorMessage = err.message;

--- a/services/vault/src/hooks/deposit/useVaultActions.ts
+++ b/services/vault/src/hooks/deposit/useVaultActions.ts
@@ -5,6 +5,7 @@
 import {
   ensureHexPrefix,
   forwardDepositApproval,
+  forwardDeriveContextHash,
   isRegisteredVaultVersionMismatchError,
   stripHexPrefix,
   supportsDepositApproval,
@@ -285,19 +286,6 @@ export function useVaultActions(): UseVaultActionsReturn {
       // by unrelated transactions.
       await assertUtxosAvailable(unsignedTxHex, depositorAddress);
 
-      // Use the locally stored UTXO set as trusted construction-time data
-      // ONLY when we're broadcasting the local tx. The stored UTXOs are the
-      // inputs of the local tx, not necessarily of the indexer's tx, so when
-      // we fell back to the indexer copy (`!localUnsignedTxHex`) we must pass
-      // `undefined` and let `broadcastPrePeginTransaction` resolve inputs from
-      // the mempool. `createPsbtFromTransaction` throws if `expectedUtxos` is
-      // supplied but doesn't cover every input, so a stale/partial local set
-      // paired with the indexer tx would dead-end the broadcast.
-      const expectedUtxos =
-        localUnsignedTxHex && pendingPegin?.selectedUTXOs?.length
-          ? utxosToExpectedRecord(pendingPegin.selectedUTXOs)
-          : undefined;
-
       // The integrity guarantee for this broadcast is the on-chain
       // `prePeginTxHash` match asserted above: it commits to every input,
       // output, and script of the registered Pre-PegIn, so a match proves
@@ -380,6 +368,7 @@ export function useVaultActions(): UseVaultActionsReturn {
           await resolveFundedTxFeeAndUtxos(unsignedTxHex);
         const depositTerms = await rebuildDepositTerms({
           vaultId,
+          target: onChainVault,
           fundedPrePeginTxHex: unsignedTxHex,
           connectedDepositorAddress: depositorEthAddress as Hex,
           depositorBtcPubkey,
@@ -389,8 +378,7 @@ export function useVaultActions(): UseVaultActionsReturn {
           unsignedTxHex,
           btcWalletProvider: {
             signPsbt: (psbtHex: string) => btcWalletProvider.signPsbt(psbtHex),
-            deriveContextHash: (appName: string, context: string) =>
-              btcWalletProvider.deriveContextHash(appName, context),
+            ...forwardDeriveContextHash(btcWalletProvider),
             ...forwardDepositApproval(btcWalletProvider),
           },
           depositorBtcPubkey,
@@ -398,6 +386,18 @@ export function useVaultActions(): UseVaultActionsReturn {
           depositTerms,
         });
       } else {
+        // Use the locally stored UTXO set as trusted construction-time data
+        // ONLY when we're broadcasting the local tx. The stored UTXOs are the
+        // inputs of the local tx, not necessarily of the indexer's tx, so when
+        // we fell back to the indexer copy (`!localUnsignedTxHex`) we must pass
+        // `undefined` and let `broadcastPrePeginTransaction` resolve inputs from
+        // the mempool. `createPsbtFromTransaction` throws if `expectedUtxos` is
+        // supplied but doesn't cover every input, so a stale/partial local set
+        // paired with the indexer tx would dead-end the broadcast.
+        const expectedUtxos =
+          localUnsignedTxHex && pendingPegin?.selectedUTXOs?.length
+            ? utxosToExpectedRecord(pendingPegin.selectedUTXOs)
+            : undefined;
         await broadcastPrePeginTransaction({
           unsignedTxHex,
           btcWalletProvider: {

--- a/services/vault/src/hooks/deposit/useVaultActions.ts
+++ b/services/vault/src/hooks/deposit/useVaultActions.ts
@@ -4,8 +4,10 @@
 
 import {
   ensureHexPrefix,
+  forwardDepositApproval,
   isRegisteredVaultVersionMismatchError,
   stripHexPrefix,
+  supportsDepositApproval,
   verifyRegisteredVaultVersions,
 } from "@babylonlabs-io/ts-sdk/tbv/core";
 import {
@@ -60,6 +62,8 @@ import {
   broadcastPrePeginTransaction,
   fetchVaultById,
 } from "../../services/vault";
+import { rebuildDepositTerms } from "../../services/vault/rebuildDepositTerms";
+import { resolveFundedTxFeeAndUtxos } from "../../services/vault/resolveFundedTxFee";
 import {
   activateVaultWithSecret,
   activateVaultWithSecretAndRedeem,
@@ -360,14 +364,42 @@ export function useVaultActions(): UseVaultActionsReturn {
         });
       }
 
-      await broadcastPrePeginTransaction({
-        unsignedTxHex,
-        btcWalletProvider: {
-          signPsbt: (psbtHex: string) => btcWalletProvider.signPsbt(psbtHex),
-        },
-        depositorBtcPubkey,
-        expectedUtxos,
-      });
+      // Intent (Ledger) resume: rebuild the approved DepositTerms from chain +
+      // WASM and run the derive→approve ceremony (inside broadcastPrePeginTransaction)
+      // before signing. Software wallets keep the signPsbt-only path unchanged.
+      // Resolve every prevout ONCE so the fee that feeds the rebuilt terms is the
+      // same Σin−Σout the broadcast will sign (no drift).
+      if (supportsDepositApproval(btcWalletProvider)) {
+        const { expectedUtxos: resolvedUtxos, fundedTxFee } =
+          await resolveFundedTxFeeAndUtxos(unsignedTxHex, expectedUtxos);
+        const depositTerms = await rebuildDepositTerms({
+          vaultId,
+          fundedPrePeginTxHex: unsignedTxHex,
+          depositorBtcPubkey,
+          fundedTxFee,
+        });
+        await broadcastPrePeginTransaction({
+          unsignedTxHex,
+          btcWalletProvider: {
+            signPsbt: (psbtHex: string) => btcWalletProvider.signPsbt(psbtHex),
+            deriveContextHash: (appName: string, context: string) =>
+              btcWalletProvider.deriveContextHash(appName, context),
+            ...forwardDepositApproval(btcWalletProvider),
+          },
+          depositorBtcPubkey,
+          expectedUtxos: resolvedUtxos,
+          depositTerms,
+        });
+      } else {
+        await broadcastPrePeginTransaction({
+          unsignedTxHex,
+          btcWalletProvider: {
+            signPsbt: (psbtHex: string) => btcWalletProvider.signPsbt(psbtHex),
+          },
+          depositorBtcPubkey,
+          expectedUtxos,
+        });
+      }
 
       const nextStatus = getNextLocalStatus(
         PeginAction.SIGN_AND_BROADCAST_TO_BITCOIN,
@@ -391,6 +423,13 @@ export function useVaultActions(): UseVaultActionsReturn {
       if (mountedRef.current) {
         let errorMessage: string;
 
+        // An intent-wallet's DepositTermsRejectedError arrives here with its
+        // message preserved verbatim (no "Failed to broadcast" wrapper), so the
+        // resume UI's mapDepositError classifies it the same as the fresh path
+        // does today. broadcastError is string-typed by contract (its content is
+        // asserted across the hook tests). When #2110 adds a typed
+        // intent-rejection branch to mapDepositError, thread the typed error to
+        // the mapper here as useDepositFlow already does — see #2110.
         if (err instanceof UtxoNotAvailableError) {
           // UTXO not available - provide specific error message
           errorMessage = err.message;

--- a/services/vault/src/services/vault/__tests__/rebuildDepositTerms.test.ts
+++ b/services/vault/src/services/vault/__tests__/rebuildDepositTerms.test.ts
@@ -2,6 +2,7 @@ import {
   rebuildDepositTermsCore,
   resolveParticipantKeysAtEpochs,
 } from "@babylonlabs-io/ts-sdk/tbv/core";
+import { Transaction } from "bitcoinjs-lib";
 import type { Hex } from "viem";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -39,6 +40,7 @@ vi.mock("@/utils/vaultCoreVersionSupport", () => ({
 vi.mock("../../../clients/eth-contract/btc-vault-registry/query", () => ({
   getVaultFromChain: vi.fn(),
   getVaultKeyEpochsFromChain: vi.fn(),
+  getVaultProviderGenesisBtcPubkeyFromChain: vi.fn(),
 }));
 vi.mock("../../../clients/eth-contract/sdk-readers", () => ({
   getOperationKeyReader: vi.fn().mockResolvedValue({}),
@@ -53,7 +55,10 @@ vi.mock("../../../config/pegin", () => ({
 vi.mock("../fetchVaults", () => ({
   fetchVaultIdsByDepositor: vi.fn(),
 }));
-vi.mock("../vaultPayoutSignatureService", () => ({
+// importOriginal keeps the real assertVpCommissionInProtocolRange so the
+// commission-ceiling mapping is exercised end-to-end.
+vi.mock("../vaultPayoutSignatureService", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../vaultPayoutSignatureService")>()),
   resolveVaultProviderBtcPubkey: vi.fn(),
 }));
 
@@ -197,6 +202,7 @@ describe("rebuildDepositTerms orchestrator (mocked chain, real discovery + mappi
   function baseParams() {
     return {
       vaultId: TARGET_ID,
+      target: targetVault,
       fundedPrePeginTxHex: "deadbeef",
       connectedDepositorAddress: DEPOSITOR_ETH.toLowerCase() as `0x${string}`,
       depositorBtcPubkey: DEPOSITOR_BTC,
@@ -228,6 +234,7 @@ describe("rebuildDepositTerms orchestrator (mocked chain, real discovery + mappi
         securityCouncilKeys: ["c1", "c2", "c3"],
         timelockAssert: 150n,
         tRefund: 144,
+        minVpCommissionBps: 10,
       }),
       getTimelockPeginByVersion: vi.fn().mockResolvedValue(100),
     } as never);
@@ -273,7 +280,7 @@ describe("rebuildDepositTerms orchestrator (mocked chain, real discovery + mappi
       timelockRefund: 144, // tRefund mapping
       prepeginTxid: "12".repeat(32), // stripped + lowercased
       prepeginMaxFee: 1234n,
-      maxAcceptableCommissionBps: 250, // interim proxy = stored VP bps (#2252)
+      maxAcceptableCommissionBps: 275, // stored 250 + 25 bps headroom (fresh-path cap policy, #2252 interim)
       network: "signet",
     });
   });
@@ -311,5 +318,53 @@ describe("rebuildDepositTerms orchestrator (mocked chain, real discovery + mappi
       /disagree on offchainParamsVersion/,
     );
     expect(rebuildDepositTermsCore).not.toHaveBeenCalled();
+  });
+
+  /** A funded Pre-PegIn tx with `htlcCount` HTLC outputs and the auth-anchor
+   * OP_RETURN at vout === htlcCount. Uses the GLOBAL native Buffer, not
+   * `import { Buffer } from "buffer"` — the polyfill package's instances fail
+   * bitcoinjs/typeforce's native Buffer.isBuffer check (dual-realm Buffer). */
+  function makeFundedTx(htlcCount: number): string {
+    const tx = new Transaction();
+    tx.version = 2;
+    tx.addInput(Buffer.alloc(32, 0x11), 0);
+    for (let i = 0; i < htlcCount; i++) {
+      tx.addOutput(Buffer.from(`5120${"00".repeat(32)}`, "hex"), 1000);
+    }
+    tx.addOutput(
+      Buffer.concat([Buffer.from([0x6a, 0x20]), Buffer.alloc(32, 0xab)]),
+      0,
+    );
+    return tx.toHex();
+  }
+
+  // Lagging-indexer end-to-end: discovery only enumerates what the indexer
+  // knows, so a truncated sibling set must be caught by the REAL core's
+  // auth-anchor completeness check — not silently rebuilt as a 1-vault batch.
+  it("refuses a truncated sibling set via the real core's auth-anchor check", async () => {
+    const actual = await vi.importActual<
+      typeof import("@babylonlabs-io/ts-sdk/tbv/core")
+    >("@babylonlabs-io/ts-sdk/tbv/core");
+    vi.mocked(rebuildDepositTermsCore).mockImplementation(
+      actual.rebuildDepositTermsCore,
+    );
+
+    // 2-HTLC funded tx (anchor at vout 2), but the indexer returns only the
+    // target vault id — the discovered sibling set covers 1 of 2 HTLCs.
+    const fundedTxHex = makeFundedTx(2);
+    const laggedTarget = {
+      ...targetVault,
+      prePeginTxHash: `0x${Transaction.fromHex(fundedTxHex).getId()}` as Hex,
+    };
+    vi.mocked(fetchVaultIdsByDepositor).mockResolvedValue([TARGET_ID]);
+
+    await expect(
+      rebuildDepositTerms({
+        ...baseParams(),
+        target: laggedTarget,
+        fundedPrePeginTxHex: fundedTxHex,
+      }),
+    ).rejects.toThrow(/does not match the discovered sibling count 1/);
+    expect(rebuildDepositTermsCore).toHaveBeenCalledTimes(1);
   });
 });

--- a/services/vault/src/services/vault/__tests__/rebuildDepositTerms.test.ts
+++ b/services/vault/src/services/vault/__tests__/rebuildDepositTerms.test.ts
@@ -1,0 +1,315 @@
+import {
+  rebuildDepositTermsCore,
+  resolveParticipantKeysAtEpochs,
+} from "@babylonlabs-io/ts-sdk/tbv/core";
+import type { Hex } from "viem";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  getVaultFromChain,
+  getVaultKeyEpochsFromChain,
+  type OnChainVaultData,
+} from "../../../clients/eth-contract/btc-vault-registry/query";
+import {
+  getProtocolParamsReader,
+  getUniversalChallengerReader,
+  getVaultKeeperReader,
+  getVaultRegistryReader,
+} from "../../../clients/eth-contract/sdk-readers";
+import { fetchVaultIdsByDepositor } from "../fetchVaults";
+import {
+  assertContiguousHtlcVector,
+  assertSiblingBatchHomogeneous,
+  rebuildDepositTerms,
+} from "../rebuildDepositTerms";
+import { resolveVaultProviderBtcPubkey } from "../vaultPayoutSignatureService";
+
+// Orchestrator collaborators — mocked (hoisted by vitest above the imports) so
+// `rebuildDepositTerms` runs end-to-end (real discoverSiblings + field mapping)
+// without chain access or WASM. The ts-sdk core is mocked to CAPTURE its input;
+// the mapping IS the behavior under test. The pure-assert describes need none.
+vi.mock("@babylonlabs-io/ts-sdk/tbv/core", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@babylonlabs-io/ts-sdk/tbv/core")>()),
+  rebuildDepositTermsCore: vi.fn(),
+  resolveParticipantKeysAtEpochs: vi.fn(),
+}));
+vi.mock("@/utils/vaultCoreVersionSupport", () => ({
+  assertVaultCoreVersionSupported: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("../../../clients/eth-contract/btc-vault-registry/query", () => ({
+  getVaultFromChain: vi.fn(),
+  getVaultKeyEpochsFromChain: vi.fn(),
+}));
+vi.mock("../../../clients/eth-contract/sdk-readers", () => ({
+  getOperationKeyReader: vi.fn().mockResolvedValue({}),
+  getProtocolParamsReader: vi.fn(),
+  getUniversalChallengerReader: vi.fn(),
+  getVaultKeeperReader: vi.fn(),
+  getVaultRegistryReader: vi.fn(),
+}));
+vi.mock("../../../config/pegin", () => ({
+  getBTCNetworkForWASM: vi.fn(() => "signet"),
+}));
+vi.mock("../fetchVaults", () => ({
+  fetchVaultIdsByDepositor: vi.fn(),
+}));
+vi.mock("../vaultPayoutSignatureService", () => ({
+  resolveVaultProviderBtcPubkey: vi.fn(),
+}));
+
+// Only the fields the homogeneity assert reads matter here; the cast keeps the
+// fixture minimal instead of faking the full on-chain record.
+function makeVault(over: Partial<OnChainVaultData> = {}): OnChainVaultData {
+  return {
+    // OnChainBtcVaultStatus.PENDING — the only broadcastable state.
+    status: 0,
+    vaultCoreVersion: 2,
+    offchainParamsVersion: 3,
+    appVaultKeepersVersion: 4,
+    universalChallengersVersion: 5,
+    vaultProviderCommissionBps: 250,
+    applicationEntryPoint: "0xaaaa000000000000000000000000000000000001",
+    vaultProvider: "0xbbbb000000000000000000000000000000000002",
+    ...over,
+  } as OnChainVaultData;
+}
+
+describe("assertSiblingBatchHomogeneous", () => {
+  it("accepts siblings whose stamps, provider, application, and commission match the target", () => {
+    const target = makeVault();
+    expect(() =>
+      assertSiblingBatchHomogeneous(target, [makeVault(), makeVault()]),
+    ).not.toThrow();
+  });
+
+  it("rejects a sibling that is no longer PENDING (would be silently funded)", () => {
+    const target = makeVault();
+    // On-chain Expired(4) — the indexer-facing gate only checks the target.
+    const sib = makeVault({ status: 4 });
+    expect(() => assertSiblingBatchHomogeneous(target, [sib])).toThrow(
+      /no longer awaiting broadcast/,
+    );
+  });
+
+  it("rejects a non-PENDING target (chain-read authority over the indexer gate)", () => {
+    const target = makeVault({ status: 4 });
+    expect(() => assertSiblingBatchHomogeneous(target, [makeVault()])).toThrow(
+      /no longer awaiting broadcast/,
+    );
+  });
+
+  it("accepts address fields that differ only by case", () => {
+    const target = makeVault();
+    const sib = makeVault({
+      vaultProvider:
+        "0xBBBB000000000000000000000000000000000002" as OnChainVaultData["vaultProvider"],
+    });
+    expect(() => assertSiblingBatchHomogeneous(target, [sib])).not.toThrow();
+  });
+
+  // Each sibling is stamped by its own submitPeginRequest, so any of these can
+  // drift if governance/VP changes land between sibling registrations. Gate 1
+  // cannot see timelockPegin/timelockAssert/commission, so each must fail here.
+  it.each([
+    ["vaultCoreVersion", 1],
+    ["offchainParamsVersion", 9],
+    ["appVaultKeepersVersion", 9],
+    ["universalChallengersVersion", 9],
+    ["vaultProviderCommissionBps", 300],
+  ] as const)("rejects a sibling with a different %s", (field, value) => {
+    const target = makeVault();
+    const sib = makeVault({ [field]: value });
+    expect(() => assertSiblingBatchHomogeneous(target, [sib])).toThrow(
+      new RegExp(`disagree on ${field}`),
+    );
+  });
+
+  it.each([
+    ["applicationEntryPoint", "0xcccc000000000000000000000000000000000003"],
+    ["vaultProvider", "0xcccc000000000000000000000000000000000003"],
+  ] as const)("rejects a sibling with a different %s", (field, value) => {
+    const target = makeVault();
+    const sib = makeVault({
+      [field]: value as OnChainVaultData["vaultProvider"],
+    });
+    expect(() => assertSiblingBatchHomogeneous(target, [sib])).toThrow(
+      new RegExp(`disagree on ${field}`),
+    );
+  });
+});
+
+describe("assertContiguousHtlcVector", () => {
+  const sib = (htlcVout: number) => ({
+    htlcVout,
+    hashlock: "ab".repeat(32),
+    amount: 1_000n,
+  });
+
+  it("accepts a contiguous vector starting at 0", () => {
+    expect(() =>
+      assertContiguousHtlcVector([sib(0), sib(1), sib(2)]),
+    ).not.toThrow();
+  });
+
+  it("rejects a gap (missing sibling would mis-align the funded tx)", () => {
+    expect(() => assertContiguousHtlcVector([sib(0), sib(2)])).toThrow(
+      /non-contiguous/,
+    );
+  });
+
+  it("rejects a duplicate htlcVout", () => {
+    expect(() => assertContiguousHtlcVector([sib(0), sib(1), sib(1)])).toThrow(
+      /non-contiguous/,
+    );
+  });
+
+  it("rejects a vector not starting at vout 0", () => {
+    expect(() => assertContiguousHtlcVector([sib(1), sib(2)])).toThrow(
+      /non-contiguous/,
+    );
+  });
+});
+
+describe("rebuildDepositTerms orchestrator (mocked chain, real discovery + mapping)", () => {
+  const TARGET_ID = "0xtarget_vault_id" as Hex;
+  const SIBLING_ID = "0xsibling_vault_id" as Hex;
+  const DEPOSITOR_ETH = "0xAAAA00000000000000000000000000000000dEAD";
+  const PRE_PEGIN_TX_HASH = `0x${"12".repeat(32)}` as Hex;
+  // secp256k1 G.x — a valid x-only key for the real processPublicKeyToXOnly.
+  const DEPOSITOR_BTC =
+    "79BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798";
+
+  const targetVault = makeVault({
+    depositor: DEPOSITOR_ETH as OnChainVaultData["depositor"],
+    prePeginTxHash: PRE_PEGIN_TX_HASH,
+    hashlock: `0x${"aa".repeat(32)}` as Hex,
+    htlcVout: 0,
+    amount: 90_000n,
+  });
+  const siblingVault = makeVault({
+    depositor: DEPOSITOR_ETH as OnChainVaultData["depositor"],
+    prePeginTxHash: PRE_PEGIN_TX_HASH,
+    hashlock: `0x${"bb".repeat(32)}` as Hex,
+    htlcVout: 1,
+    amount: 120_000n,
+  });
+
+  function baseParams() {
+    return {
+      vaultId: TARGET_ID,
+      fundedPrePeginTxHex: "deadbeef",
+      connectedDepositorAddress: DEPOSITOR_ETH.toLowerCase() as `0x${string}`,
+      depositorBtcPubkey: DEPOSITOR_BTC,
+      fundedTxFee: 1234n,
+    };
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getVaultFromChain).mockImplementation(async (id: Hex) => {
+      if (id === TARGET_ID) return targetVault;
+      if (id === SIBLING_ID) return siblingVault;
+      throw new Error(`unexpected vault id ${id}`);
+    });
+    vi.mocked(fetchVaultIdsByDepositor).mockResolvedValue([
+      TARGET_ID,
+      SIBLING_ID,
+    ]);
+    vi.mocked(getVaultRegistryReader).mockReturnValue({
+      getProtocolInfoBatch: vi
+        .fn()
+        .mockResolvedValue([{ prePeginTxHash: PRE_PEGIN_TX_HASH }]),
+    } as never);
+    vi.mocked(getProtocolParamsReader).mockResolvedValue({
+      getOffchainParamsByVersion: vi.fn().mockResolvedValue({
+        feeRate: 3n,
+        minPeginFeeRate: 7n,
+        councilQuorum: 2,
+        securityCouncilKeys: ["c1", "c2", "c3"],
+        timelockAssert: 150n,
+        tRefund: 144,
+      }),
+      getTimelockPeginByVersion: vi.fn().mockResolvedValue(100),
+    } as never);
+    vi.mocked(getVaultKeeperReader).mockResolvedValue({
+      getVaultKeepersByVersion: vi.fn().mockResolvedValue(["vk-eth-1"]),
+    } as never);
+    vi.mocked(getUniversalChallengerReader).mockResolvedValue({
+      getUniversalChallengersByVersion: vi.fn().mockResolvedValue(["uc-eth-1"]),
+    } as never);
+    vi.mocked(resolveVaultProviderBtcPubkey).mockResolvedValue("cc".repeat(32));
+    vi.mocked(getVaultKeyEpochsFromChain).mockResolvedValue({} as never);
+    vi.mocked(resolveParticipantKeysAtEpochs).mockResolvedValue({
+      vaultProvider: { operationBtcPubkey: "dd".repeat(32) },
+      vaultKeeperOperationKeysSorted: ["ee".repeat(32)],
+      universalChallengerOperationKeysSorted: ["ff".repeat(32)],
+    } as never);
+    vi.mocked(rebuildDepositTermsCore).mockResolvedValue({
+      prepeginTxid: "sentinel",
+    } as never);
+  });
+
+  it("maps stamped chain reads + ordered siblings into the core input", async () => {
+    const result = await rebuildDepositTerms(baseParams());
+
+    expect(result).toEqual({ prepeginTxid: "sentinel" });
+    expect(rebuildDepositTermsCore).toHaveBeenCalledWith({
+      vaultCoreVersion: 2, // stamped, not chain-active
+      siblings: [
+        { hashlock: targetVault.hashlock, amount: 90_000n },
+        { hashlock: siblingVault.hashlock, amount: 120_000n },
+      ],
+      fundedPrePeginTxHex: "deadbeef",
+      depositorBtcPubkey: DEPOSITOR_BTC.toLowerCase(),
+      vaultProviderBtcPubkey: "dd".repeat(32), // OPERATION key, not genesis
+      vaultKeeperBtcPubkeys: ["ee".repeat(32)],
+      universalChallengerBtcPubkeys: ["ff".repeat(32)],
+      protocolFeeRate: 3n,
+      minPeginFeeRate: 7n,
+      councilQuorum: 2,
+      councilSize: 3, // securityCouncilKeys.length
+      timelockPegin: 100,
+      timelockAssert: 150, // Number() of the bigint read
+      timelockRefund: 144, // tRefund mapping
+      prepeginTxid: "12".repeat(32), // stripped + lowercased
+      prepeginMaxFee: 1234n,
+      maxAcceptableCommissionBps: 250, // interim proxy = stored VP bps (#2252)
+      network: "signet",
+    });
+  });
+
+  it("refuses when the connected wallet is not the on-chain depositor", async () => {
+    await expect(
+      rebuildDepositTerms({
+        ...baseParams(),
+        connectedDepositorAddress:
+          "0x9999000000000000000000000000000000000099" as `0x${string}`,
+      }),
+    ).rejects.toThrow(/owned by/);
+    expect(rebuildDepositTermsCore).not.toHaveBeenCalled();
+  });
+
+  it("refuses when a discovered sibling is no longer PENDING", async () => {
+    vi.mocked(getVaultFromChain).mockImplementation(async (id: Hex) => {
+      if (id === TARGET_ID) return targetVault;
+      return { ...siblingVault, status: 4 }; // on-chain Expired
+    });
+
+    await expect(rebuildDepositTerms(baseParams())).rejects.toThrow(
+      /no longer awaiting broadcast/,
+    );
+    expect(rebuildDepositTermsCore).not.toHaveBeenCalled();
+  });
+
+  it("refuses when a sibling carries a different stamped version", async () => {
+    vi.mocked(getVaultFromChain).mockImplementation(async (id: Hex) => {
+      if (id === TARGET_ID) return targetVault;
+      return { ...siblingVault, offchainParamsVersion: 9 };
+    });
+
+    await expect(rebuildDepositTerms(baseParams())).rejects.toThrow(
+      /disagree on offchainParamsVersion/,
+    );
+    expect(rebuildDepositTermsCore).not.toHaveBeenCalled();
+  });
+});

--- a/services/vault/src/services/vault/__tests__/resolveFundedTxFee.test.ts
+++ b/services/vault/src/services/vault/__tests__/resolveFundedTxFee.test.ts
@@ -1,10 +1,6 @@
-import { Buffer } from "buffer";
+import { Transaction } from "bitcoinjs-lib";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { mockFromHex } = vi.hoisted(() => ({ mockFromHex: vi.fn() }));
-vi.mock("bitcoinjs-lib", () => ({
-  Transaction: { fromHex: mockFromHex },
-}));
 vi.mock("../vaultUtxoDerivationService", () => ({
   fetchUTXOFromMempool: vi.fn(),
 }));
@@ -12,79 +8,81 @@ vi.mock("../vaultUtxoDerivationService", () => ({
 import { resolveFundedTxFeeAndUtxos } from "../resolveFundedTxFee";
 import { fetchUTXOFromMempool } from "../vaultUtxoDerivationService";
 
-// Bitcoin stores the prev-txid in reverse (internal) byte order; the display txid
-// is the reverse of what sits in `input.hash`. Non-palindromic txids so a missing
-// reverse in production would produce the wrong key and fail the assertions.
+// NOTE: this file deliberately uses the global (native) Buffer, not
+// `import { Buffer } from "buffer"` — the polyfill package's instances fail
+// bitcoinjs/typeforce's native Buffer.isBuffer check (dual-realm Buffer).
+
+// Non-palindromic display-order txids: a missing byte-reverse in production
+// would produce a different key/lookup and fail the assertions below.
 const TXID_A = "a1".repeat(31) + "b2";
 const TXID_B = "c3".repeat(31) + "d4";
 
-function internalHash(displayTxid: string): Buffer {
-  return Buffer.from(Buffer.from(displayTxid, "hex").reverse());
-}
-
-/** A mock parsed tx with the exact `ins`/`outs` shape resolveFundedTxFee reads. */
-function mockTx(
-  ins: { txid: string; vout: number }[],
-  outValues: number[],
-): void {
-  mockFromHex.mockReturnValue({
-    ins: ins.map((i) => ({ hash: internalHash(i.txid), index: i.vout })),
-    outs: outValues.map((value) => ({ value })),
-  });
+/** Build a real tx spending `inputs` (display-order txids) with `outputs` sat values. */
+function makeTxHex(
+  inputs: { txid: string; vout: number }[],
+  outputs: number[],
+): string {
+  const tx = new Transaction();
+  tx.version = 2;
+  for (const inp of inputs) {
+    // addInput takes the internal (reversed) prev-hash.
+    tx.addInput(Buffer.from(inp.txid, "hex").reverse(), inp.vout);
+  }
+  for (const value of outputs) {
+    tx.addOutput(Buffer.from(`0014${"00".repeat(20)}`, "hex"), value);
+  }
+  return tx.toHex();
 }
 
 describe("resolveFundedTxFeeAndUtxos", () => {
-  beforeEach(() => {
-    mockFromHex.mockReset();
-    vi.mocked(fetchUTXOFromMempool).mockReset();
-  });
+  beforeEach(() => vi.mocked(fetchUTXOFromMempool).mockReset());
 
-  it("computes fee = Σin − Σout, reuses same-device prevouts, mempool-resolves the rest", async () => {
-    mockTx(
+  it("resolves every prevout from the mempool and computes fee = inputs − outputs", async () => {
+    const hex = makeTxHex(
       [
         { txid: TXID_A, vout: 0 },
         { txid: TXID_B, vout: 1 },
       ],
       [1000, 500],
     );
-    const sameDevice = {
-      [`${TXID_A}:0`]: { scriptPubKey: "0014aa", value: 1200 },
-    };
-    vi.mocked(fetchUTXOFromMempool).mockResolvedValue({
-      scriptPubKey: "0014bb",
-      value: 800,
-    });
+    vi.mocked(fetchUTXOFromMempool)
+      .mockResolvedValueOnce({ scriptPubKey: "0014aa", value: 1200 })
+      .mockResolvedValueOnce({ scriptPubKey: "0014bb", value: 800 });
 
-    const { expectedUtxos, fundedTxFee } = await resolveFundedTxFeeAndUtxos(
-      "deadbeef",
-      sameDevice,
-    );
+    const { expectedUtxos, fundedTxFee } =
+      await resolveFundedTxFeeAndUtxos(hex);
 
     // (1200 + 800) − (1000 + 500)
     expect(fundedTxFee).toBe(500n);
-    // Only the input NOT in sameDevice hit the mempool.
-    expect(fetchUTXOFromMempool).toHaveBeenCalledTimes(1);
-    expect(fetchUTXOFromMempool).toHaveBeenCalledWith(TXID_B, 1);
+    // Every input queried with its DISPLAY-order txid (production reverses
+    // the internal input.hash) — the format broadcastPrePeginTransaction's
+    // resolveInputUtxo looks up.
+    expect(fetchUTXOFromMempool).toHaveBeenCalledTimes(2);
+    expect(fetchUTXOFromMempool).toHaveBeenNthCalledWith(1, TXID_A, 0);
+    expect(fetchUTXOFromMempool).toHaveBeenNthCalledWith(2, TXID_B, 1);
     // Complete record so the broadcast never re-resolves.
     expect(Object.keys(expectedUtxos).sort()).toEqual([
       `${TXID_A}:0`,
       `${TXID_B}:1`,
     ]);
+    expect(expectedUtxos[`${TXID_A}:0`]).toEqual({
+      scriptPubKey: "0014aa",
+      value: 1200,
+    });
   });
 
-  it("keys prevouts by display-order txid (the format broadcastPrePeginTransaction looks up)", async () => {
-    mockTx([{ txid: TXID_A, vout: 3 }], [999]);
+  it("accepts 0x-prefixed tx hex", async () => {
+    const hex = makeTxHex([{ txid: TXID_A, vout: 3 }], [999]);
     vi.mocked(fetchUTXOFromMempool).mockResolvedValue({
       scriptPubKey: "0014aa",
       value: 5000,
     });
 
-    const { expectedUtxos } = await resolveFundedTxFeeAndUtxos(
-      "deadbeef",
-      undefined,
+    const { expectedUtxos, fundedTxFee } = await resolveFundedTxFeeAndUtxos(
+      `0x${hex}`,
     );
 
-    // Same key resolveInputUtxo builds: `${reverse(input.hash).toString("hex")}:${vout}`.
+    expect(fundedTxFee).toBe(4001n);
     expect(expectedUtxos[`${TXID_A}:3`]).toEqual({
       scriptPubKey: "0014aa",
       value: 5000,
@@ -92,13 +90,14 @@ describe("resolveFundedTxFeeAndUtxos", () => {
   });
 
   it("throws when the fee is not positive", async () => {
-    mockTx([{ txid: TXID_A, vout: 0 }], [1000]);
-    const sameDevice = {
-      [`${TXID_A}:0`]: { scriptPubKey: "0014aa", value: 1000 },
-    };
+    const hex = makeTxHex([{ txid: TXID_A, vout: 0 }], [1000]);
+    vi.mocked(fetchUTXOFromMempool).mockResolvedValue({
+      scriptPubKey: "0014aa",
+      value: 1000,
+    });
 
-    await expect(
-      resolveFundedTxFeeAndUtxos("deadbeef", sameDevice),
-    ).rejects.toThrow(/fee.*is 0|expected > 0/);
+    await expect(resolveFundedTxFeeAndUtxos(hex)).rejects.toThrow(
+      /do not cover its outputs/,
+    );
   });
 });

--- a/services/vault/src/services/vault/__tests__/resolveFundedTxFee.test.ts
+++ b/services/vault/src/services/vault/__tests__/resolveFundedTxFee.test.ts
@@ -100,4 +100,34 @@ describe("resolveFundedTxFeeAndUtxos", () => {
       /do not cover its outputs/,
     );
   });
+
+  it("rejects when any prevout fetch fails (no partial UTXO record)", async () => {
+    const hex = makeTxHex(
+      [
+        { txid: TXID_A, vout: 0 },
+        { txid: TXID_B, vout: 1 },
+      ],
+      [1000],
+    );
+    vi.mocked(fetchUTXOFromMempool)
+      .mockResolvedValueOnce({ scriptPubKey: "0014aa", value: 1200 })
+      .mockRejectedValueOnce(new Error("mempool 404"));
+
+    await expect(resolveFundedTxFeeAndUtxos(hex)).rejects.toThrow(
+      /mempool 404/,
+    );
+  });
+
+  it("throws when the fee exceeds the maximum reasonable fee cap", async () => {
+    // 2_001_000 in − 1_000_000 out = 1_001_000 fee > the 1_000_000 sat cap.
+    const hex = makeTxHex([{ txid: TXID_A, vout: 0 }], [1_000_000]);
+    vi.mocked(fetchUTXOFromMempool).mockResolvedValue({
+      scriptPubKey: "0014aa",
+      value: 2_001_000,
+    });
+
+    await expect(resolveFundedTxFeeAndUtxos(hex)).rejects.toThrow(
+      /exceeds the maximum reasonable fee/,
+    );
+  });
 });

--- a/services/vault/src/services/vault/__tests__/resolveFundedTxFee.test.ts
+++ b/services/vault/src/services/vault/__tests__/resolveFundedTxFee.test.ts
@@ -1,0 +1,104 @@
+import { Buffer } from "buffer";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockFromHex } = vi.hoisted(() => ({ mockFromHex: vi.fn() }));
+vi.mock("bitcoinjs-lib", () => ({
+  Transaction: { fromHex: mockFromHex },
+}));
+vi.mock("../vaultUtxoDerivationService", () => ({
+  fetchUTXOFromMempool: vi.fn(),
+}));
+
+import { resolveFundedTxFeeAndUtxos } from "../resolveFundedTxFee";
+import { fetchUTXOFromMempool } from "../vaultUtxoDerivationService";
+
+// Bitcoin stores the prev-txid in reverse (internal) byte order; the display txid
+// is the reverse of what sits in `input.hash`. Non-palindromic txids so a missing
+// reverse in production would produce the wrong key and fail the assertions.
+const TXID_A = "a1".repeat(31) + "b2";
+const TXID_B = "c3".repeat(31) + "d4";
+
+function internalHash(displayTxid: string): Buffer {
+  return Buffer.from(Buffer.from(displayTxid, "hex").reverse());
+}
+
+/** A mock parsed tx with the exact `ins`/`outs` shape resolveFundedTxFee reads. */
+function mockTx(
+  ins: { txid: string; vout: number }[],
+  outValues: number[],
+): void {
+  mockFromHex.mockReturnValue({
+    ins: ins.map((i) => ({ hash: internalHash(i.txid), index: i.vout })),
+    outs: outValues.map((value) => ({ value })),
+  });
+}
+
+describe("resolveFundedTxFeeAndUtxos", () => {
+  beforeEach(() => {
+    mockFromHex.mockReset();
+    vi.mocked(fetchUTXOFromMempool).mockReset();
+  });
+
+  it("computes fee = Σin − Σout, reuses same-device prevouts, mempool-resolves the rest", async () => {
+    mockTx(
+      [
+        { txid: TXID_A, vout: 0 },
+        { txid: TXID_B, vout: 1 },
+      ],
+      [1000, 500],
+    );
+    const sameDevice = {
+      [`${TXID_A}:0`]: { scriptPubKey: "0014aa", value: 1200 },
+    };
+    vi.mocked(fetchUTXOFromMempool).mockResolvedValue({
+      scriptPubKey: "0014bb",
+      value: 800,
+    });
+
+    const { expectedUtxos, fundedTxFee } = await resolveFundedTxFeeAndUtxos(
+      "deadbeef",
+      sameDevice,
+    );
+
+    // (1200 + 800) − (1000 + 500)
+    expect(fundedTxFee).toBe(500n);
+    // Only the input NOT in sameDevice hit the mempool.
+    expect(fetchUTXOFromMempool).toHaveBeenCalledTimes(1);
+    expect(fetchUTXOFromMempool).toHaveBeenCalledWith(TXID_B, 1);
+    // Complete record so the broadcast never re-resolves.
+    expect(Object.keys(expectedUtxos).sort()).toEqual([
+      `${TXID_A}:0`,
+      `${TXID_B}:1`,
+    ]);
+  });
+
+  it("keys prevouts by display-order txid (the format broadcastPrePeginTransaction looks up)", async () => {
+    mockTx([{ txid: TXID_A, vout: 3 }], [999]);
+    vi.mocked(fetchUTXOFromMempool).mockResolvedValue({
+      scriptPubKey: "0014aa",
+      value: 5000,
+    });
+
+    const { expectedUtxos } = await resolveFundedTxFeeAndUtxos(
+      "deadbeef",
+      undefined,
+    );
+
+    // Same key resolveInputUtxo builds: `${reverse(input.hash).toString("hex")}:${vout}`.
+    expect(expectedUtxos[`${TXID_A}:3`]).toEqual({
+      scriptPubKey: "0014aa",
+      value: 5000,
+    });
+  });
+
+  it("throws when the fee is not positive", async () => {
+    mockTx([{ txid: TXID_A, vout: 0 }], [1000]);
+    const sameDevice = {
+      [`${TXID_A}:0`]: { scriptPubKey: "0014aa", value: 1000 },
+    };
+
+    await expect(
+      resolveFundedTxFeeAndUtxos("deadbeef", sameDevice),
+    ).rejects.toThrow(/fee.*is 0|expected > 0/);
+  });
+});

--- a/services/vault/src/services/vault/__tests__/resolveMaxAcceptableCommissionBps.test.ts
+++ b/services/vault/src/services/vault/__tests__/resolveMaxAcceptableCommissionBps.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from "vitest";
+
+// The range assert lives in vaultPayoutSignatureService, whose module graph
+// reaches the shared ETH client (config read at construction). Stub the
+// chain-facing modules so the pure helpers under test load without config.
+vi.mock("../../../clients/eth-contract/btc-vault-registry/query", () => ({
+  getVaultFromChain: vi.fn(),
+  getVaultProviderGenesisBtcPubkeyFromChain: vi.fn(),
+  getVaultKeyEpochsFromChain: vi.fn(),
+}));
+vi.mock("../../../clients/eth-contract/sdk-readers", () => ({
+  getOperationKeyReader: vi.fn(),
+  getProtocolParamsReader: vi.fn(),
+  getUniversalChallengerReader: vi.fn(),
+  getVaultKeeperReader: vi.fn(),
+  getVaultRegistryReader: vi.fn(),
+}));
+vi.mock("../../../config/pegin", () => ({
+  getBTCNetworkForWASM: vi.fn(() => "testnet"),
+}));
+
+import { resolveMaxAcceptableCommissionBps } from "../resolveMaxAcceptableCommissionBps";
+
+describe("resolveMaxAcceptableCommissionBps", () => {
+  it("throws when the stored commission is below the protocol floor", () => {
+    expect(() =>
+      resolveMaxAcceptableCommissionBps({ vaultProviderCommissionBps: 5 }, 10),
+    ).toThrow(/VP commission 5 bps out of protocol range \[10, 10000\)/);
+  });
+
+  it("throws on a zero commission (tx-graph builder refuses vp_commission_bps == 0)", () => {
+    expect(() =>
+      resolveMaxAcceptableCommissionBps({ vaultProviderCommissionBps: 0 }, 0),
+    ).toThrow(/VP commission 0 bps out of protocol range \[1, 10000\)/);
+  });
+
+  it("applies the fresh path's +25 bps headroom to an in-range commission", () => {
+    expect(
+      resolveMaxAcceptableCommissionBps(
+        { vaultProviderCommissionBps: 250 },
+        10,
+      ),
+    ).toBe(275);
+  });
+
+  it("caps the ceiling at 9999 so it never reaches the contract's exclusive bound", () => {
+    expect(
+      resolveMaxAcceptableCommissionBps(
+        { vaultProviderCommissionBps: 9990 },
+        10,
+      ),
+    ).toBe(9999);
+  });
+});

--- a/services/vault/src/services/vault/__tests__/resolveMaxAcceptableCommissionBps.test.ts
+++ b/services/vault/src/services/vault/__tests__/resolveMaxAcceptableCommissionBps.test.ts
@@ -51,4 +51,15 @@ describe("resolveMaxAcceptableCommissionBps", () => {
       ),
     ).toBe(9999);
   });
+
+  it("rejects a NaN floor instead of letting it silently disable the range check", () => {
+    // Math.max(NaN, 1) is NaN and every comparison against NaN is false —
+    // without the guard, a commission of 0 would pass.
+    expect(() =>
+      resolveMaxAcceptableCommissionBps(
+        { vaultProviderCommissionBps: 0 },
+        Number.NaN,
+      ),
+    ).toThrow(/non-negative integer/);
+  });
 });

--- a/services/vault/src/services/vault/__tests__/resolveResumeCommissionCeilingBps.test.ts
+++ b/services/vault/src/services/vault/__tests__/resolveResumeCommissionCeilingBps.test.ts
@@ -19,24 +19,24 @@ vi.mock("../../../config/pegin", () => ({
   getBTCNetworkForWASM: vi.fn(() => "testnet"),
 }));
 
-import { resolveMaxAcceptableCommissionBps } from "../resolveMaxAcceptableCommissionBps";
+import { resolveResumeCommissionCeilingBps } from "../resolveResumeCommissionCeilingBps";
 
-describe("resolveMaxAcceptableCommissionBps", () => {
+describe("resolveResumeCommissionCeilingBps", () => {
   it("throws when the stored commission is below the protocol floor", () => {
     expect(() =>
-      resolveMaxAcceptableCommissionBps({ vaultProviderCommissionBps: 5 }, 10),
+      resolveResumeCommissionCeilingBps({ vaultProviderCommissionBps: 5 }, 10),
     ).toThrow(/VP commission 5 bps out of protocol range \[10, 10000\)/);
   });
 
   it("throws on a zero commission (tx-graph builder refuses vp_commission_bps == 0)", () => {
     expect(() =>
-      resolveMaxAcceptableCommissionBps({ vaultProviderCommissionBps: 0 }, 0),
+      resolveResumeCommissionCeilingBps({ vaultProviderCommissionBps: 0 }, 0),
     ).toThrow(/VP commission 0 bps out of protocol range \[1, 10000\)/);
   });
 
   it("applies the fresh path's +25 bps headroom to an in-range commission", () => {
     expect(
-      resolveMaxAcceptableCommissionBps(
+      resolveResumeCommissionCeilingBps(
         { vaultProviderCommissionBps: 250 },
         10,
       ),
@@ -45,7 +45,7 @@ describe("resolveMaxAcceptableCommissionBps", () => {
 
   it("caps the ceiling at 9999 so it never reaches the contract's exclusive bound", () => {
     expect(
-      resolveMaxAcceptableCommissionBps(
+      resolveResumeCommissionCeilingBps(
         { vaultProviderCommissionBps: 9990 },
         10,
       ),
@@ -56,7 +56,7 @@ describe("resolveMaxAcceptableCommissionBps", () => {
     // Math.max(NaN, 1) is NaN and every comparison against NaN is false —
     // without the guard, a commission of 0 would pass.
     expect(() =>
-      resolveMaxAcceptableCommissionBps(
+      resolveResumeCommissionCeilingBps(
         { vaultProviderCommissionBps: 0 },
         Number.NaN,
       ),

--- a/services/vault/src/services/vault/rebuildDepositTerms.ts
+++ b/services/vault/src/services/vault/rebuildDepositTerms.ts
@@ -5,7 +5,7 @@
  * an intent (Ledger) wallet has nothing to approve. Reconstructs them from
  * chain + WASM only — never browser storage — at the vault's STAMPED versions;
  * the one non-chain-derivable field is the commission ceiling (interim proxy,
- * see {@link resolveMaxAcceptableCommissionBps} + #2252). This orchestrator does
+ * see {@link resolveResumeCommissionCeilingBps} + #2252). This orchestrator does
  * the chain reads + sibling discovery (mirrors `discoverBatch` /
  * `prepareSigningContext` — shared-helper dedupe deferred); the WASM recompute +
  * Gate 0/1 byte-checks live in ts-sdk `rebuildDepositTermsCore`.
@@ -39,7 +39,7 @@ import {
 import { getBTCNetworkForWASM } from "../../config/pegin";
 
 import { fetchVaultIdsByDepositor } from "./fetchVaults";
-import { resolveMaxAcceptableCommissionBps } from "./resolveMaxAcceptableCommissionBps";
+import { resolveResumeCommissionCeilingBps } from "./resolveResumeCommissionCeilingBps";
 import { resolveVaultProviderBtcPubkey } from "./vaultPayoutSignatureService";
 
 export interface RebuildDepositTermsParams {
@@ -281,7 +281,7 @@ export async function rebuildDepositTerms(
     timelockRefund: offchainParams.tRefund,
     prepeginTxid: stripHexPrefix(target.prePeginTxHash).toLowerCase(),
     prepeginMaxFee: params.fundedTxFee,
-    maxAcceptableCommissionBps: resolveMaxAcceptableCommissionBps(
+    maxAcceptableCommissionBps: resolveResumeCommissionCeilingBps(
       target,
       offchainParams.minVpCommissionBps,
     ),

--- a/services/vault/src/services/vault/rebuildDepositTerms.ts
+++ b/services/vault/src/services/vault/rebuildDepositTerms.ts
@@ -1,22 +1,15 @@
 /**
  * Rebuild a {@link DepositTerms} on the resume-broadcast path (#2220 Part 2).
  *
- * On a fresh deposit the terms are still in memory from `preparePegin`. On a
- * resume — including a different browser / private mode — they are gone, so an
- * intent (Ledger) wallet has nothing to approve. This reconstructs them from
- * chain + WASM ONLY (never browser storage): every field is chain-derivable at
- * the vault's STAMPED version, except the depositor commission ceiling (interim
- * proxy — see {@link resolveMaxAcceptableCommissionBps} + #2252).
- *
- * This orchestrator does the CHAIN READS + sibling discovery only; the pure
- * WASM-recompute + Gate 1 byte-match + projection live in ts-sdk
- * `rebuildDepositTermsCore` (unit-testable, no chain). btc-vault is the protocol
- * source of truth. Design: `todo/ledger/2220-part2-resume-rebuild-design.md`.
- *
- * NOTE (drift): sibling discovery mirrors `discoverBatch` (vaultRefundService)
- * and the stamped reads mirror `prepareSigningContext` (vaultPayoutSignatureService).
- * A shared helper is the anti-drift move; deferred so this PR does not refactor
- * payout/refund code.
+ * On resume (any browser) the in-memory terms from `preparePegin` are gone, so
+ * an intent (Ledger) wallet has nothing to approve. Reconstructs them from
+ * chain + WASM only — never browser storage — at the vault's STAMPED versions;
+ * the one non-chain-derivable field is the commission ceiling (interim proxy,
+ * see {@link resolveMaxAcceptableCommissionBps} + #2252). This orchestrator does
+ * the chain reads + sibling discovery (mirrors `discoverBatch` /
+ * `prepareSigningContext` — shared-helper dedupe deferred); the WASM recompute +
+ * Gate 0/1 byte-checks live in ts-sdk `rebuildDepositTermsCore`.
+ * Design: `todo/ledger/2220-part2-resume-rebuild-design.md`.
  */
 
 import {
@@ -27,6 +20,7 @@ import {
   type DepositTerms,
   type RebuildSibling,
 } from "@babylonlabs-io/ts-sdk/tbv/core";
+import { OnChainBtcVaultStatus } from "@babylonlabs-io/ts-sdk/tbv/core/clients";
 import type { Address, Hex } from "viem";
 
 import { assertVaultCoreVersionSupported } from "@/utils/vaultCoreVersionSupport";
@@ -34,6 +28,7 @@ import { assertVaultCoreVersionSupported } from "@/utils/vaultCoreVersionSupport
 import {
   getVaultFromChain,
   getVaultKeyEpochsFromChain,
+  type OnChainVaultData,
 } from "../../clients/eth-contract/btc-vault-registry/query";
 import {
   getOperationKeyReader,
@@ -51,21 +46,15 @@ import { resolveVaultProviderBtcPubkey } from "./vaultPayoutSignatureService";
 export interface RebuildDepositTermsParams {
   /** The vault being resumed (any sibling of a batch). */
   vaultId: Hex;
-  /** Funded Pre-PegIn tx hex — already hash-verified against on-chain prePeginTxHash by the caller (Gate 0). */
+  /** Funded Pre-PegIn tx hex — the core re-verifies it against the on-chain hash (Gate 0). */
   fundedPrePeginTxHex: string;
-  /**
-   * Connected wallet's ETH address, when available — a sanity check that it equals
-   * the on-chain depositor (defense-in-depth vs a stale wallet switch). Sibling
-   * enumeration always uses the authoritative on-chain depositor, so this is optional.
-   */
-  connectedDepositorAddress?: Address;
-  /** Depositor BTC pubkey (from the broadcast context) — the identity the HTLC scripts + PSBT are signed with. */
+  /** Connected wallet's ETH address — must equal the on-chain depositor (stale wallet-switch guard). */
+  connectedDepositorAddress: Address;
+  /** Depositor BTC pubkey — the identity the HTLC scripts + PSBT are signed with. */
   depositorBtcPubkey: string;
   /**
-   * The funded Pre-PegIn tx fee (Σ input prevout values − Σ outputs), a WALLET-level
-   * fee distinct from the per-vault graph `peginMaxFee`. The caller computes it from the
-   * prevouts it already resolves for broadcast (Gate 3); it becomes `DepositTerms.prepeginMaxFee`,
-   * the bound the device enforces (`fee ≤ prepegin_max_fee`).
+   * Funded-tx fee (Σ prevouts − Σ outputs), computed by the caller from the same
+   * prevouts the broadcast signs. Becomes the device's `prepegin_max_fee` bound.
    */
   fundedTxFee: bigint;
 }
@@ -75,60 +64,62 @@ interface OrderedSibling extends RebuildSibling {
 }
 
 /**
- * Discover the complete sibling set sharing this vault's Pre-PegIn tx, ordered by
- * on-chain htlcVout, fail-closed. Mirrors `discoverBatch` (vaultRefundService).
- * Membership is by on-chain `prePeginTxHash` equality, not indexer hex — a stale
- * indexer can only enumerate ids, never fabricate/drop a sibling. The OP_RETURN
- * completeness anchor runs in `rebuildDepositTermsCore` (it holds the funded tx).
+ * Fields that must be uniform across the batch: each sibling is stamped by its
+ * own `submitPeginRequest`, so governance/VP changes between registrations can
+ * stamp them differently — and Gate 1 cannot see fields not encoded in the
+ * HTLC outputs (timelockPegin, timelockAssert, commission). Fail closed.
  */
-async function discoverSiblings(
-  targetVaultId: Hex,
-  targetPrePeginTxHash: Hex,
-  connectedDepositor: Address | undefined,
-  onChainDepositor: Address,
-  target: OrderedSibling,
-): Promise<OrderedSibling[]> {
-  if (
-    connectedDepositor !== undefined &&
-    onChainDepositor.toLowerCase() !== connectedDepositor.toLowerCase()
-  ) {
-    throw new Error(
-      `Vault ${targetVaultId} is owned by ${onChainDepositor}, but the connected ` +
-        `wallet is ${connectedDepositor}. Connect with the depositor wallet to resume.`,
-    );
+const SIBLING_HOMOGENEOUS_FIELDS = [
+  "vaultCoreVersion",
+  "offchainParamsVersion",
+  "appVaultKeepersVersion",
+  "universalChallengersVersion",
+  "vaultProviderCommissionBps",
+] as const;
+
+/** Exported for tests — pure, fail-closed. */
+export function assertSiblingBatchHomogeneous(
+  target: OnChainVaultData,
+  siblings: readonly OnChainVaultData[],
+): void {
+  // Chain-read PENDING gate for EVERY member — an expired/liquidated sibling
+  // would otherwise be silently funded by the shared broadcast.
+  for (const vault of [target, ...siblings]) {
+    if (vault.status !== OnChainBtcVaultStatus.PENDING) {
+      throw new Error(
+        `A vault in this Pre-PegIn batch is no longer awaiting broadcast ` +
+          `(on-chain status ${vault.status}); the batch cannot be broadcast ` +
+          `as one transaction. Resume refused.`,
+      );
+    }
   }
-
-  const txHashLower = targetPrePeginTxHash.toLowerCase();
-  const targetIdLower = targetVaultId.toLowerCase();
-  const depositorVaultIds = await fetchVaultIdsByDepositor(onChainDepositor);
-  const candidateIds = depositorVaultIds.filter(
-    (id) => id.toLowerCase() !== targetIdLower,
-  );
-
-  // Lean prePeginTxHash-only multicall first, so the fully-validated read (which
-  // fail-closes on a bad stamped vaultCoreVersion) runs only for actual siblings.
-  const candidateInfos =
-    await getVaultRegistryReader().getProtocolInfoBatch(candidateIds);
-  const siblingIds = candidateIds.filter(
-    (_, i) => candidateInfos[i].prePeginTxHash.toLowerCase() === txHashLower,
-  );
-  const siblingOnChain = await Promise.all(
-    siblingIds.map((id) => getVaultFromChain(id)),
-  );
-
-  const siblings: OrderedSibling[] = [target];
-  for (const sib of siblingOnChain) {
-    if (sib.prePeginTxHash.toLowerCase() !== txHashLower) continue;
-    siblings.push({
-      hashlock: sib.hashlock,
-      amount: sib.amount,
-      htlcVout: sib.htlcVout,
-    });
+  for (const sib of siblings) {
+    for (const field of SIBLING_HOMOGENEOUS_FIELDS) {
+      if (sib[field] !== target[field]) {
+        throw new Error(
+          `Sibling vaults of this Pre-PegIn disagree on ${field} ` +
+            `(${String(sib[field])} vs ${String(target[field])}); the batch ` +
+            `cannot be described by one set of deposit terms. Resume refused.`,
+        );
+      }
+    }
+    for (const field of ["applicationEntryPoint", "vaultProvider"] as const) {
+      if (sib[field].toLowerCase() !== target[field].toLowerCase()) {
+        throw new Error(
+          `Sibling vaults of this Pre-PegIn disagree on ${field} ` +
+            `(${sib[field]} vs ${target[field]}); the batch cannot be ` +
+            `described by one set of deposit terms. Resume refused.`,
+        );
+      }
+    }
   }
-  siblings.sort((a, b) => a.htlcVout - b.htlcVout);
+}
 
-  // Contiguity: cover [0, N-1] with no gaps/dupes — the core (and buildDepositTerms)
-  // derive htlcVout from array position, so a gap would mis-align with the funded tx.
+/** Exported for tests — pure, fail-closed. htlcVout is derived from array
+ * position downstream, so the sorted vector must cover [0, N-1] exactly. */
+export function assertContiguousHtlcVector(
+  siblings: readonly OrderedSibling[],
+): void {
   for (let i = 0; i < siblings.length; i++) {
     if (siblings[i].htlcVout !== i) {
       throw new Error(
@@ -137,33 +128,64 @@ async function discoverSiblings(
       );
     }
   }
+}
+
+/**
+ * Discover the complete sibling set sharing this Pre-PegIn tx, ordered by
+ * htlcVout. Membership is on-chain `prePeginTxHash` equality (a stale indexer
+ * can only enumerate ids); completeness is backstopped by the core's OP_RETURN
+ * anchor check.
+ */
+async function discoverSiblings(
+  targetVaultId: Hex,
+  connectedDepositor: Address,
+  target: OnChainVaultData,
+): Promise<OrderedSibling[]> {
+  if (target.depositor.toLowerCase() !== connectedDepositor.toLowerCase()) {
+    throw new Error(
+      `Vault ${targetVaultId} is owned by ${target.depositor}, but the connected ` +
+        `wallet is ${connectedDepositor}. Connect with the depositor wallet to resume.`,
+    );
+  }
+
+  const txHashLower = target.prePeginTxHash.toLowerCase();
+  const targetIdLower = targetVaultId.toLowerCase();
+  const depositorVaultIds = await fetchVaultIdsByDepositor(target.depositor);
+  const candidateIds = depositorVaultIds.filter(
+    (id) => id.toLowerCase() !== targetIdLower,
+  );
+
+  // Lean hash-only multicall first; the fully-validated read runs only for
+  // actual siblings.
+  const candidateInfos =
+    await getVaultRegistryReader().getProtocolInfoBatch(candidateIds);
+  const siblingIds = candidateIds.filter(
+    (_, i) => candidateInfos[i].prePeginTxHash.toLowerCase() === txHashLower,
+  );
+  const siblingOnChain = (
+    await Promise.all(siblingIds.map((id) => getVaultFromChain(id)))
+  ).filter((sib) => sib.prePeginTxHash.toLowerCase() === txHashLower);
+
+  assertSiblingBatchHomogeneous(target, siblingOnChain);
+
+  const siblings: OrderedSibling[] = [target, ...siblingOnChain].map((v) => ({
+    hashlock: v.hashlock,
+    amount: v.amount,
+    htlcVout: v.htlcVout,
+  }));
+  siblings.sort((a, b) => a.htlcVout - b.htlcVout);
+  assertContiguousHtlcVector(siblings);
 
   return siblings;
 }
 
-export async function rebuildDepositTerms(
-  params: RebuildDepositTermsParams,
-): Promise<DepositTerms> {
-  const target = await getVaultFromChain(params.vaultId);
-
-  // Fail closed with a friendly "update the app" message BEFORE any wallet popup
-  // if this build's WASM cannot construct the vault's stamped version (mirrors the
-  // refund flow). Vendor-neutral — not a Ledger-specific guard.
-  await assertVaultCoreVersionSupported(target.vaultCoreVersion);
-
-  const siblings = await discoverSiblings(
-    params.vaultId,
-    target.prePeginTxHash,
-    params.connectedDepositorAddress,
-    target.depositor,
-    {
-      hashlock: target.hashlock,
-      amount: target.amount,
-      htlcVout: target.htlcVout,
-    },
-  );
-
-  // ---- Shared stamped-version reads (mirror prepareSigningContext) ----
+/**
+ * Read everything version-locked to the vault's stamps (mirrors
+ * `prepareSigningContext`): offchain params + timelocks at
+ * `offchainParamsVersion`, rosters at their stamped versions, operation keys
+ * at the vault's frozen epochs.
+ */
+async function readStampedVaultContext(vaultId: Hex, target: OnChainVaultData) {
   const protocolParamsReader = await getProtocolParamsReader();
   const offchainParams = await protocolParamsReader.getOffchainParamsByVersion(
     target.offchainParamsVersion,
@@ -198,7 +220,7 @@ export async function rebuildDepositTerms(
     undefined,
   );
   const operationKeyReader = await getOperationKeyReader();
-  const epochs = await getVaultKeyEpochsFromChain(params.vaultId);
+  const epochs = await getVaultKeyEpochsFromChain(vaultId);
   const participantKeys = await resolveParticipantKeysAtEpochs({
     operationKeyReader,
     query: {
@@ -210,6 +232,26 @@ export async function rebuildDepositTerms(
     },
     epochs,
   });
+
+  return { offchainParams, timelockPegin, participantKeys };
+}
+
+export async function rebuildDepositTerms(
+  params: RebuildDepositTermsParams,
+): Promise<DepositTerms> {
+  const target = await getVaultFromChain(params.vaultId);
+
+  // Fail closed before any wallet popup if this build's WASM cannot construct
+  // the stamped version. Vendor-neutral, mirrors the refund flow.
+  await assertVaultCoreVersionSupported(target.vaultCoreVersion);
+
+  const siblings = await discoverSiblings(
+    params.vaultId,
+    params.connectedDepositorAddress,
+    target,
+  );
+  const { offchainParams, timelockPegin, participantKeys } =
+    await readStampedVaultContext(params.vaultId, target);
 
   return rebuildDepositTermsCore({
     vaultCoreVersion: target.vaultCoreVersion,

--- a/services/vault/src/services/vault/rebuildDepositTerms.ts
+++ b/services/vault/src/services/vault/rebuildDepositTerms.ts
@@ -1,0 +1,237 @@
+/**
+ * Rebuild a {@link DepositTerms} on the resume-broadcast path (#2220 Part 2).
+ *
+ * On a fresh deposit the terms are still in memory from `preparePegin`. On a
+ * resume — including a different browser / private mode — they are gone, so an
+ * intent (Ledger) wallet has nothing to approve. This reconstructs them from
+ * chain + WASM ONLY (never browser storage): every field is chain-derivable at
+ * the vault's STAMPED version, except the depositor commission ceiling (interim
+ * proxy — see {@link resolveMaxAcceptableCommissionBps} + #2252).
+ *
+ * This orchestrator does the CHAIN READS + sibling discovery only; the pure
+ * WASM-recompute + Gate 1 byte-match + projection live in ts-sdk
+ * `rebuildDepositTermsCore` (unit-testable, no chain). btc-vault is the protocol
+ * source of truth. Design: `todo/ledger/2220-part2-resume-rebuild-design.md`.
+ *
+ * NOTE (drift): sibling discovery mirrors `discoverBatch` (vaultRefundService)
+ * and the stamped reads mirror `prepareSigningContext` (vaultPayoutSignatureService).
+ * A shared helper is the anti-drift move; deferred so this PR does not refactor
+ * payout/refund code.
+ */
+
+import {
+  processPublicKeyToXOnly,
+  rebuildDepositTermsCore,
+  resolveParticipantKeysAtEpochs,
+  stripHexPrefix,
+  type DepositTerms,
+  type RebuildSibling,
+} from "@babylonlabs-io/ts-sdk/tbv/core";
+import type { Address, Hex } from "viem";
+
+import { assertVaultCoreVersionSupported } from "@/utils/vaultCoreVersionSupport";
+
+import {
+  getVaultFromChain,
+  getVaultKeyEpochsFromChain,
+} from "../../clients/eth-contract/btc-vault-registry/query";
+import {
+  getOperationKeyReader,
+  getProtocolParamsReader,
+  getUniversalChallengerReader,
+  getVaultKeeperReader,
+  getVaultRegistryReader,
+} from "../../clients/eth-contract/sdk-readers";
+import { getBTCNetworkForWASM } from "../../config/pegin";
+
+import { fetchVaultIdsByDepositor } from "./fetchVaults";
+import { resolveMaxAcceptableCommissionBps } from "./resolveMaxAcceptableCommissionBps";
+import { resolveVaultProviderBtcPubkey } from "./vaultPayoutSignatureService";
+
+export interface RebuildDepositTermsParams {
+  /** The vault being resumed (any sibling of a batch). */
+  vaultId: Hex;
+  /** Funded Pre-PegIn tx hex — already hash-verified against on-chain prePeginTxHash by the caller (Gate 0). */
+  fundedPrePeginTxHex: string;
+  /**
+   * Connected wallet's ETH address, when available — a sanity check that it equals
+   * the on-chain depositor (defense-in-depth vs a stale wallet switch). Sibling
+   * enumeration always uses the authoritative on-chain depositor, so this is optional.
+   */
+  connectedDepositorAddress?: Address;
+  /** Depositor BTC pubkey (from the broadcast context) — the identity the HTLC scripts + PSBT are signed with. */
+  depositorBtcPubkey: string;
+  /**
+   * The funded Pre-PegIn tx fee (Σ input prevout values − Σ outputs), a WALLET-level
+   * fee distinct from the per-vault graph `peginMaxFee`. The caller computes it from the
+   * prevouts it already resolves for broadcast (Gate 3); it becomes `DepositTerms.prepeginMaxFee`,
+   * the bound the device enforces (`fee ≤ prepegin_max_fee`).
+   */
+  fundedTxFee: bigint;
+}
+
+interface OrderedSibling extends RebuildSibling {
+  htlcVout: number;
+}
+
+/**
+ * Discover the complete sibling set sharing this vault's Pre-PegIn tx, ordered by
+ * on-chain htlcVout, fail-closed. Mirrors `discoverBatch` (vaultRefundService).
+ * Membership is by on-chain `prePeginTxHash` equality, not indexer hex — a stale
+ * indexer can only enumerate ids, never fabricate/drop a sibling. The OP_RETURN
+ * completeness anchor runs in `rebuildDepositTermsCore` (it holds the funded tx).
+ */
+async function discoverSiblings(
+  targetVaultId: Hex,
+  targetPrePeginTxHash: Hex,
+  connectedDepositor: Address | undefined,
+  onChainDepositor: Address,
+  target: OrderedSibling,
+): Promise<OrderedSibling[]> {
+  if (
+    connectedDepositor !== undefined &&
+    onChainDepositor.toLowerCase() !== connectedDepositor.toLowerCase()
+  ) {
+    throw new Error(
+      `Vault ${targetVaultId} is owned by ${onChainDepositor}, but the connected ` +
+        `wallet is ${connectedDepositor}. Connect with the depositor wallet to resume.`,
+    );
+  }
+
+  const txHashLower = targetPrePeginTxHash.toLowerCase();
+  const targetIdLower = targetVaultId.toLowerCase();
+  const depositorVaultIds = await fetchVaultIdsByDepositor(onChainDepositor);
+  const candidateIds = depositorVaultIds.filter(
+    (id) => id.toLowerCase() !== targetIdLower,
+  );
+
+  // Lean prePeginTxHash-only multicall first, so the fully-validated read (which
+  // fail-closes on a bad stamped vaultCoreVersion) runs only for actual siblings.
+  const candidateInfos =
+    await getVaultRegistryReader().getProtocolInfoBatch(candidateIds);
+  const siblingIds = candidateIds.filter(
+    (_, i) => candidateInfos[i].prePeginTxHash.toLowerCase() === txHashLower,
+  );
+  const siblingOnChain = await Promise.all(
+    siblingIds.map((id) => getVaultFromChain(id)),
+  );
+
+  const siblings: OrderedSibling[] = [target];
+  for (const sib of siblingOnChain) {
+    if (sib.prePeginTxHash.toLowerCase() !== txHashLower) continue;
+    siblings.push({
+      hashlock: sib.hashlock,
+      amount: sib.amount,
+      htlcVout: sib.htlcVout,
+    });
+  }
+  siblings.sort((a, b) => a.htlcVout - b.htlcVout);
+
+  // Contiguity: cover [0, N-1] with no gaps/dupes — the core (and buildDepositTerms)
+  // derive htlcVout from array position, so a gap would mis-align with the funded tx.
+  for (let i = 0; i < siblings.length; i++) {
+    if (siblings[i].htlcVout !== i) {
+      throw new Error(
+        `Sibling discovery produced a non-contiguous HTLC vector ` +
+          `(${siblings.map((s) => s.htlcVout).join(", ")}); resume refused.`,
+      );
+    }
+  }
+
+  return siblings;
+}
+
+export async function rebuildDepositTerms(
+  params: RebuildDepositTermsParams,
+): Promise<DepositTerms> {
+  const target = await getVaultFromChain(params.vaultId);
+
+  // Fail closed with a friendly "update the app" message BEFORE any wallet popup
+  // if this build's WASM cannot construct the vault's stamped version (mirrors the
+  // refund flow). Vendor-neutral — not a Ledger-specific guard.
+  await assertVaultCoreVersionSupported(target.vaultCoreVersion);
+
+  const siblings = await discoverSiblings(
+    params.vaultId,
+    target.prePeginTxHash,
+    params.connectedDepositorAddress,
+    target.depositor,
+    {
+      hashlock: target.hashlock,
+      amount: target.amount,
+      htlcVout: target.htlcVout,
+    },
+  );
+
+  // ---- Shared stamped-version reads (mirror prepareSigningContext) ----
+  const protocolParamsReader = await getProtocolParamsReader();
+  const offchainParams = await protocolParamsReader.getOffchainParamsByVersion(
+    target.offchainParamsVersion,
+  );
+  const timelockPegin = await protocolParamsReader.getTimelockPeginByVersion(
+    target.offchainParamsVersion,
+  );
+
+  const vaultKeeperReader = await getVaultKeeperReader();
+  const vaultKeepers = await vaultKeeperReader.getVaultKeepersByVersion(
+    target.applicationEntryPoint,
+    target.appVaultKeepersVersion,
+  );
+  if (vaultKeepers.length === 0) {
+    throw new Error(
+      `No vault keepers for version ${target.appVaultKeepersVersion}`,
+    );
+  }
+  const universalChallengerReader = await getUniversalChallengerReader();
+  const universalChallengers =
+    await universalChallengerReader.getUniversalChallengersByVersion(
+      target.universalChallengersVersion,
+    );
+  if (universalChallengers.length === 0) {
+    throw new Error(
+      `No universal challengers for version ${target.universalChallengersVersion}`,
+    );
+  }
+
+  const registrationVpBtcPubkey = await resolveVaultProviderBtcPubkey(
+    target.vaultProvider,
+    undefined,
+  );
+  const operationKeyReader = await getOperationKeyReader();
+  const epochs = await getVaultKeyEpochsFromChain(params.vaultId);
+  const participantKeys = await resolveParticipantKeysAtEpochs({
+    operationKeyReader,
+    query: {
+      vaultProviderEthAddress: target.vaultProvider,
+      vaultProviderGenesisBtcPubkey: `0x${registrationVpBtcPubkey}` as Hex,
+      applicationEntryPoint: target.applicationEntryPoint,
+      vaultKeepers,
+      universalChallengers,
+    },
+    epochs,
+  });
+
+  return rebuildDepositTermsCore({
+    vaultCoreVersion: target.vaultCoreVersion,
+    siblings: siblings.map((s) => ({ hashlock: s.hashlock, amount: s.amount })),
+    fundedPrePeginTxHex: params.fundedPrePeginTxHex,
+    depositorBtcPubkey: processPublicKeyToXOnly(
+      params.depositorBtcPubkey,
+    ).toLowerCase(),
+    vaultProviderBtcPubkey: participantKeys.vaultProvider.operationBtcPubkey,
+    vaultKeeperBtcPubkeys: participantKeys.vaultKeeperOperationKeysSorted,
+    universalChallengerBtcPubkeys:
+      participantKeys.universalChallengerOperationKeysSorted,
+    protocolFeeRate: offchainParams.feeRate,
+    minPeginFeeRate: offchainParams.minPeginFeeRate,
+    councilQuorum: offchainParams.councilQuorum,
+    councilSize: offchainParams.securityCouncilKeys.length,
+    timelockPegin,
+    timelockAssert: Number(offchainParams.timelockAssert),
+    timelockRefund: offchainParams.tRefund,
+    prepeginTxid: stripHexPrefix(target.prePeginTxHash).toLowerCase(),
+    prepeginMaxFee: params.fundedTxFee,
+    maxAcceptableCommissionBps: resolveMaxAcceptableCommissionBps(target),
+    network: getBTCNetworkForWASM(),
+  });
+}

--- a/services/vault/src/services/vault/rebuildDepositTerms.ts
+++ b/services/vault/src/services/vault/rebuildDepositTerms.ts
@@ -9,7 +9,6 @@
  * the chain reads + sibling discovery (mirrors `discoverBatch` /
  * `prepareSigningContext` — shared-helper dedupe deferred); the WASM recompute +
  * Gate 0/1 byte-checks live in ts-sdk `rebuildDepositTermsCore`.
- * Design: `todo/ledger/2220-part2-resume-rebuild-design.md`.
  */
 
 import {
@@ -46,6 +45,8 @@ import { resolveVaultProviderBtcPubkey } from "./vaultPayoutSignatureService";
 export interface RebuildDepositTermsParams {
   /** The vault being resumed (any sibling of a batch). */
   vaultId: Hex;
+  /** Caller's getVaultFromChain(vaultId) record, already hash-verified against fundedPrePeginTxHex. */
+  target: OnChainVaultData;
   /** Funded Pre-PegIn tx hex — the core re-verifies it against the on-chain hash (Gate 0). */
   fundedPrePeginTxHex: string;
   /** Connected wallet's ETH address — must equal the on-chain depositor (stale wallet-switch guard). */
@@ -186,41 +187,48 @@ async function discoverSiblings(
  * at the vault's frozen epochs.
  */
 async function readStampedVaultContext(vaultId: Hex, target: OnChainVaultData) {
-  const protocolParamsReader = await getProtocolParamsReader();
-  const offchainParams = await protocolParamsReader.getOffchainParamsByVersion(
-    target.offchainParamsVersion,
-  );
-  const timelockPegin = await protocolParamsReader.getTimelockPeginByVersion(
-    target.offchainParamsVersion,
-  );
+  // Reader factories are TTL-cached with in-flight dedupe, so concurrent
+  // acquisition is safe.
+  const [
+    { offchainParams, timelockPegin },
+    vaultKeepers,
+    universalChallengers,
+    registrationVpBtcPubkey,
+    operationKeyReader,
+    epochs,
+  ] = await Promise.all([
+    getProtocolParamsReader().then(async (reader) => {
+      const [offchainParams, timelockPegin] = await Promise.all([
+        reader.getOffchainParamsByVersion(target.offchainParamsVersion),
+        reader.getTimelockPeginByVersion(target.offchainParamsVersion),
+      ]);
+      return { offchainParams, timelockPegin };
+    }),
+    getVaultKeeperReader().then((r) =>
+      r.getVaultKeepersByVersion(
+        target.applicationEntryPoint,
+        target.appVaultKeepersVersion,
+      ),
+    ),
+    getUniversalChallengerReader().then((r) =>
+      r.getUniversalChallengersByVersion(target.universalChallengersVersion),
+    ),
+    resolveVaultProviderBtcPubkey(target.vaultProvider, undefined),
+    getOperationKeyReader(),
+    getVaultKeyEpochsFromChain(vaultId),
+  ]);
 
-  const vaultKeeperReader = await getVaultKeeperReader();
-  const vaultKeepers = await vaultKeeperReader.getVaultKeepersByVersion(
-    target.applicationEntryPoint,
-    target.appVaultKeepersVersion,
-  );
   if (vaultKeepers.length === 0) {
     throw new Error(
       `No vault keepers for version ${target.appVaultKeepersVersion}`,
     );
   }
-  const universalChallengerReader = await getUniversalChallengerReader();
-  const universalChallengers =
-    await universalChallengerReader.getUniversalChallengersByVersion(
-      target.universalChallengersVersion,
-    );
   if (universalChallengers.length === 0) {
     throw new Error(
       `No universal challengers for version ${target.universalChallengersVersion}`,
     );
   }
 
-  const registrationVpBtcPubkey = await resolveVaultProviderBtcPubkey(
-    target.vaultProvider,
-    undefined,
-  );
-  const operationKeyReader = await getOperationKeyReader();
-  const epochs = await getVaultKeyEpochsFromChain(vaultId);
   const participantKeys = await resolveParticipantKeysAtEpochs({
     operationKeyReader,
     query: {
@@ -239,7 +247,7 @@ async function readStampedVaultContext(vaultId: Hex, target: OnChainVaultData) {
 export async function rebuildDepositTerms(
   params: RebuildDepositTermsParams,
 ): Promise<DepositTerms> {
-  const target = await getVaultFromChain(params.vaultId);
+  const { target } = params;
 
   // Fail closed before any wallet popup if this build's WASM cannot construct
   // the stamped version. Vendor-neutral, mirrors the refund flow.
@@ -273,7 +281,10 @@ export async function rebuildDepositTerms(
     timelockRefund: offchainParams.tRefund,
     prepeginTxid: stripHexPrefix(target.prePeginTxHash).toLowerCase(),
     prepeginMaxFee: params.fundedTxFee,
-    maxAcceptableCommissionBps: resolveMaxAcceptableCommissionBps(target),
+    maxAcceptableCommissionBps: resolveMaxAcceptableCommissionBps(
+      target,
+      offchainParams.minVpCommissionBps,
+    ),
     network: getBTCNetworkForWASM(),
   });
 }

--- a/services/vault/src/services/vault/resolveFundedTxFee.ts
+++ b/services/vault/src/services/vault/resolveFundedTxFee.ts
@@ -4,6 +4,10 @@
  * in browser storage (`assertUtxosAvailable` already guarantees the inputs are
  * mempool-visible). Returns a COMPLETE record that the broadcast reuses
  * verbatim, so the fee in the rebuilt terms is the fee it signs (no drift).
+ *
+ * The fee bounds here deliberately overlap `validateInputOutputBalance`
+ * (vaultPeginBroadcastService) — this copy bounds the fee at the terms-minting
+ * site, before the rebuild's chain reads and any device work.
  */
 
 import { MAX_REASONABLE_FEE_SATS } from "@babylonlabs-io/ts-sdk";

--- a/services/vault/src/services/vault/resolveFundedTxFee.ts
+++ b/services/vault/src/services/vault/resolveFundedTxFee.ts
@@ -6,6 +6,7 @@
  * verbatim, so the fee in the rebuilt terms is the fee it signs (no drift).
  */
 
+import { MAX_REASONABLE_FEE_SATS } from "@babylonlabs-io/ts-sdk";
 import { Transaction } from "bitcoinjs-lib";
 import { Buffer } from "buffer";
 
@@ -21,13 +22,19 @@ export async function resolveFundedTxFeeAndUtxos(
     : fundedPrePeginTxHex;
   const tx = Transaction.fromHex(cleanHex);
 
+  const resolvedInputs = await Promise.all(
+    tx.ins.map(async (input) => {
+      // Bitcoin stores the prev-txid in reverse (internal) byte order.
+      const txid = Buffer.from(input.hash).reverse().toString("hex");
+      const key = `${txid}:${input.index}`;
+      const utxo = await fetchUTXOFromMempool(txid, input.index);
+      return { key, utxo };
+    }),
+  );
+
   const expectedUtxos: UtxoRecord = {};
   let totalInputValue = 0n;
-  for (const input of tx.ins) {
-    // Bitcoin stores the prev-txid in reverse (internal) byte order.
-    const txid = Buffer.from(input.hash).reverse().toString("hex");
-    const key = `${txid}:${input.index}`;
-    const utxo = await fetchUTXOFromMempool(txid, input.index);
+  for (const { key, utxo } of resolvedInputs) {
     expectedUtxos[key] = utxo;
     totalInputValue += BigInt(utxo.value);
   }
@@ -41,6 +48,14 @@ export async function resolveFundedTxFeeAndUtxos(
     throw new Error(
       `The funded Pre-PegIn transaction's inputs do not cover its outputs ` +
         `plus a fee (computed fee: ${fundedTxFee} sats). Refusing to resume.`,
+    );
+  }
+  if (fundedTxFee > MAX_REASONABLE_FEE_SATS) {
+    throw new Error(
+      `The funded Pre-PegIn transaction's computed fee (${fundedTxFee} sats) ` +
+        `exceeds the maximum reasonable fee (${MAX_REASONABLE_FEE_SATS} sats). ` +
+        `This may indicate the mempool API returned manipulated UTXO data. ` +
+        `Refusing to resume.`,
     );
   }
 

--- a/services/vault/src/services/vault/resolveFundedTxFee.ts
+++ b/services/vault/src/services/vault/resolveFundedTxFee.ts
@@ -1,0 +1,54 @@
+/**
+ * Resolve every prevout of a funded Pre-PegIn tx once and compute its fee
+ * (Σ input prevout values − Σ outputs).
+ *
+ * Same-device prevouts come from the trusted construction-time set; cross-device
+ * ones from the mempool (safe pre-broadcast — the outpoints are still unspent,
+ * `assertUtxosAvailable` guarantees it). Returns a COMPLETE `expectedUtxos`
+ * record so `broadcastPrePeginTransaction` reuses these exact prevouts and never
+ * re-resolves — the fee that feeds the rebuilt DepositTerms is then the SAME
+ * `Σin − Σout` the broadcast will actually sign (no drift).
+ */
+
+import { Transaction } from "bitcoinjs-lib";
+import { Buffer } from "buffer";
+
+import { fetchUTXOFromMempool } from "./vaultUtxoDerivationService";
+
+type UtxoRecord = Record<string, { scriptPubKey: string; value: number }>;
+
+export async function resolveFundedTxFeeAndUtxos(
+  fundedPrePeginTxHex: string,
+  sameDeviceUtxos: UtxoRecord | undefined,
+): Promise<{ expectedUtxos: UtxoRecord; fundedTxFee: bigint }> {
+  const cleanHex = fundedPrePeginTxHex.startsWith("0x")
+    ? fundedPrePeginTxHex.slice(2)
+    : fundedPrePeginTxHex;
+  const tx = Transaction.fromHex(cleanHex);
+
+  const expectedUtxos: UtxoRecord = {};
+  let totalInputValue = 0n;
+  for (const input of tx.ins) {
+    // Bitcoin stores the prev-txid in reverse (internal) byte order.
+    const txid = Buffer.from(input.hash).reverse().toString("hex");
+    const key = `${txid}:${input.index}`;
+    const utxo =
+      sameDeviceUtxos?.[key] ?? (await fetchUTXOFromMempool(txid, input.index));
+    expectedUtxos[key] = utxo;
+    totalInputValue += BigInt(utxo.value);
+  }
+
+  const totalOutputValue = tx.outs.reduce(
+    (sum, o) => sum + BigInt(o.value),
+    0n,
+  );
+  const fundedTxFee = totalInputValue - totalOutputValue;
+  if (fundedTxFee <= 0n) {
+    throw new Error(
+      `Funded Pre-PegIn tx fee (Σin − Σout) is ${fundedTxFee}; expected > 0. ` +
+        `Refusing to resume.`,
+    );
+  }
+
+  return { expectedUtxos, fundedTxFee };
+}

--- a/services/vault/src/services/vault/resolveFundedTxFee.ts
+++ b/services/vault/src/services/vault/resolveFundedTxFee.ts
@@ -1,13 +1,9 @@
 /**
- * Resolve every prevout of a funded Pre-PegIn tx once and compute its fee
- * (Σ input prevout values − Σ outputs).
- *
- * Same-device prevouts come from the trusted construction-time set; cross-device
- * ones from the mempool (safe pre-broadcast — the outpoints are still unspent,
- * `assertUtxosAvailable` guarantees it). Returns a COMPLETE `expectedUtxos`
- * record so `broadcastPrePeginTransaction` reuses these exact prevouts and never
- * re-resolves — the fee that feeds the rebuilt DepositTerms is then the SAME
- * `Σin − Σout` the broadcast will actually sign (no drift).
+ * Resolve every prevout of a funded Pre-PegIn tx and compute its fee
+ * (inputs − outputs). Mempool-only — nothing the device approves may originate
+ * in browser storage (`assertUtxosAvailable` already guarantees the inputs are
+ * mempool-visible). Returns a COMPLETE record that the broadcast reuses
+ * verbatim, so the fee in the rebuilt terms is the fee it signs (no drift).
  */
 
 import { Transaction } from "bitcoinjs-lib";
@@ -19,7 +15,6 @@ type UtxoRecord = Record<string, { scriptPubKey: string; value: number }>;
 
 export async function resolveFundedTxFeeAndUtxos(
   fundedPrePeginTxHex: string,
-  sameDeviceUtxos: UtxoRecord | undefined,
 ): Promise<{ expectedUtxos: UtxoRecord; fundedTxFee: bigint }> {
   const cleanHex = fundedPrePeginTxHex.startsWith("0x")
     ? fundedPrePeginTxHex.slice(2)
@@ -32,8 +27,7 @@ export async function resolveFundedTxFeeAndUtxos(
     // Bitcoin stores the prev-txid in reverse (internal) byte order.
     const txid = Buffer.from(input.hash).reverse().toString("hex");
     const key = `${txid}:${input.index}`;
-    const utxo =
-      sameDeviceUtxos?.[key] ?? (await fetchUTXOFromMempool(txid, input.index));
+    const utxo = await fetchUTXOFromMempool(txid, input.index);
     expectedUtxos[key] = utxo;
     totalInputValue += BigInt(utxo.value);
   }
@@ -45,8 +39,8 @@ export async function resolveFundedTxFeeAndUtxos(
   const fundedTxFee = totalInputValue - totalOutputValue;
   if (fundedTxFee <= 0n) {
     throw new Error(
-      `Funded Pre-PegIn tx fee (Σin − Σout) is ${fundedTxFee}; expected > 0. ` +
-        `Refusing to resume.`,
+      `The funded Pre-PegIn transaction's inputs do not cover its outputs ` +
+        `plus a fee (computed fee: ${fundedTxFee} sats). Refusing to resume.`,
     );
   }
 

--- a/services/vault/src/services/vault/resolveMaxAcceptableCommissionBps.ts
+++ b/services/vault/src/services/vault/resolveMaxAcceptableCommissionBps.ts
@@ -8,18 +8,31 @@
  * `vaultProviderCommissionBps` (the VP's actual commission); those are different values.
  *
  * TODO(#2252): once btc-vault emits `maxAcceptableCommissionBps` on `PegInSubmitted`
- * and the indexer exposes it, read that field directly. Until then this returns the
- * stored `vaultProviderCommissionBps` as an interim proxy.
+ * and the indexer exposes it, read that field directly. Until then this validates the
+ * stored `vaultProviderCommissionBps` against the protocol range and applies the same
+ * `capMaxAcceptableCommissionBps` policy the fresh path uses, so the rebuilt ceiling
+ * clears the device's dust floor exactly as the original did.
  *
  * Why the proxy is safe for the Pre-PegIn broadcast resume: `commissionFee` is not part
  * of the Pre-PegIn signature, DERIVE_CONTEXT_HASH, or any byte-verification gate — only
  * the device's parse-time dust gate + on-screen display use it. The flow is feature-
- * flagged and pre-mainnet, so no user hits the interim. Caveat: the stored actual can dip
- * below the device dust floor for a very small pegin; the emitted ceiling removes that.
+ * flagged and pre-mainnet, so no user hits the interim. Remaining caveat: if the VP's
+ * commission drifted between quote and registration, the rebuilt ceiling can differ
+ * from the originally submitted one by up to 25 bps until #2252 lands.
  */
-export function resolveMaxAcceptableCommissionBps(vault: {
-  vaultProviderCommissionBps: number;
-}): number {
-  // TODO(#2252): return vault.maxAcceptableCommissionBps once emitted on-chain.
-  return vault.vaultProviderCommissionBps;
+
+import { capMaxAcceptableCommissionBps } from "@babylonlabs-io/ts-sdk/tbv/core";
+
+import { assertVpCommissionInProtocolRange } from "./vaultPayoutSignatureService";
+
+export function resolveMaxAcceptableCommissionBps(
+  vault: { vaultProviderCommissionBps: number },
+  minVpCommissionBps: number,
+): number {
+  assertVpCommissionInProtocolRange(
+    vault.vaultProviderCommissionBps,
+    minVpCommissionBps,
+  );
+  // TODO(#2252): return the emitted maxAcceptableCommissionBps once available.
+  return capMaxAcceptableCommissionBps(vault.vaultProviderCommissionBps);
 }

--- a/services/vault/src/services/vault/resolveMaxAcceptableCommissionBps.ts
+++ b/services/vault/src/services/vault/resolveMaxAcceptableCommissionBps.ts
@@ -1,0 +1,25 @@
+/**
+ * Resolve the depositor's per-deposit commission ceiling (`maxAcceptableCommissionBps`)
+ * for a resume-time DepositTerms rebuild.
+ *
+ * `maxAcceptableCommissionBps` is a `submitPeginRequest` argument that the contract
+ * bound-checks once and discards — it is never stored on-chain and (today) never
+ * emitted. It is NOT the protocol floor `minVpCommissionBps` nor the stored
+ * `vaultProviderCommissionBps` (the VP's actual commission); those are different values.
+ *
+ * TODO(#2252): once btc-vault emits `maxAcceptableCommissionBps` on `PegInSubmitted`
+ * and the indexer exposes it, read that field directly. Until then this returns the
+ * stored `vaultProviderCommissionBps` as an interim proxy.
+ *
+ * Why the proxy is safe for the Pre-PegIn broadcast resume: `commissionFee` is not part
+ * of the Pre-PegIn signature, DERIVE_CONTEXT_HASH, or any byte-verification gate — only
+ * the device's parse-time dust gate + on-screen display use it. The flow is feature-
+ * flagged and pre-mainnet, so no user hits the interim. Caveat: the stored actual can dip
+ * below the device dust floor for a very small pegin; the emitted ceiling removes that.
+ */
+export function resolveMaxAcceptableCommissionBps(vault: {
+  vaultProviderCommissionBps: number;
+}): number {
+  // TODO(#2252): return vault.maxAcceptableCommissionBps once emitted on-chain.
+  return vault.vaultProviderCommissionBps;
+}

--- a/services/vault/src/services/vault/resolveResumeCommissionCeilingBps.ts
+++ b/services/vault/src/services/vault/resolveResumeCommissionCeilingBps.ts
@@ -25,7 +25,7 @@ import { capMaxAcceptableCommissionBps } from "@babylonlabs-io/ts-sdk/tbv/core";
 
 import { assertVpCommissionInProtocolRange } from "./vaultPayoutSignatureService";
 
-export function resolveMaxAcceptableCommissionBps(
+export function resolveResumeCommissionCeilingBps(
   vault: { vaultProviderCommissionBps: number },
   minVpCommissionBps: number,
 ): number {

--- a/services/vault/src/services/vault/vaultPayoutSignatureService.ts
+++ b/services/vault/src/services/vault/vaultPayoutSignatureService.ts
@@ -63,6 +63,13 @@ export function assertVpCommissionInProtocolRange(
   bps: number,
   minVpCommissionBps: number,
 ): void {
+  // NaN/undefined would silently disable the floor (Math.max(NaN, 1) → NaN,
+  // and every < comparison below turns false) — reject the bad read loudly.
+  if (!Number.isInteger(minVpCommissionBps) || minVpCommissionBps < 0) {
+    throw new Error(
+      `minVpCommissionBps must be a non-negative integer, got ${minVpCommissionBps}`,
+    );
+  }
   const minCommissionBps = Math.max(
     minVpCommissionBps,
     MIN_REALIZABLE_VP_COMMISSION_BPS,

--- a/services/vault/src/services/vault/vaultPayoutSignatureService.ts
+++ b/services/vault/src/services/vault/vaultPayoutSignatureService.ts
@@ -54,6 +54,31 @@ const VP_COMMISSION_BPS_EXCLUSIVE_MAX = 10_000;
  */
 const MIN_REALIZABLE_VP_COMMISSION_BPS = 1;
 
+/**
+ * Trust-boundary check on a VP commission read from chain — mirrors
+ * `BTCVaultRegistry._validateCommission` (plus the tx-graph's nonzero floor)
+ * so downstream consumers can trust the value.
+ */
+export function assertVpCommissionInProtocolRange(
+  bps: number,
+  minVpCommissionBps: number,
+): void {
+  const minCommissionBps = Math.max(
+    minVpCommissionBps,
+    MIN_REALIZABLE_VP_COMMISSION_BPS,
+  );
+  if (
+    !Number.isInteger(bps) ||
+    bps < minCommissionBps ||
+    bps >= VP_COMMISSION_BPS_EXCLUSIVE_MAX
+  ) {
+    throw new Error(
+      `VP commission ${bps} bps out of protocol range ` +
+        `[${minCommissionBps}, ${VP_COMMISSION_BPS_EXCLUSIVE_MAX})`,
+    );
+  }
+}
+
 export interface PrepareSigningContextParams {
   /** Derived vault ID (for contract calls) */
   vaultId: string;
@@ -187,23 +212,10 @@ export async function prepareSigningContext(
     vault.offchainParamsVersion,
   );
 
-  // Trust-boundary check on the VP commission read from chain — mirrors
-  // `BTCVaultRegistry._validateCommission` so `buildPayoutPsbt` can trust it.
-  const minCommissionBps = Math.max(
+  assertVpCommissionInProtocolRange(
+    vault.vaultProviderCommissionBps,
     offchainParams.minVpCommissionBps,
-    MIN_REALIZABLE_VP_COMMISSION_BPS,
   );
-  if (
-    !Number.isInteger(vault.vaultProviderCommissionBps) ||
-    vault.vaultProviderCommissionBps < minCommissionBps ||
-    vault.vaultProviderCommissionBps >= VP_COMMISSION_BPS_EXCLUSIVE_MAX
-  ) {
-    throw new Error(
-      `VP commission ${vault.vaultProviderCommissionBps} bps out of protocol ` +
-        `range [${minCommissionBps}, ${VP_COMMISSION_BPS_EXCLUSIVE_MAX}) ` +
-        `for offchain params version ${vault.offchainParamsVersion}`,
-    );
-  }
 
   const councilMembers = offchainParams.securityCouncilKeys
     .map((k) => stripHexPrefix(k))

--- a/services/vault/src/services/vault/vaultPayoutSignatureService.ts
+++ b/services/vault/src/services/vault/vaultPayoutSignatureService.ts
@@ -41,9 +41,9 @@ import {
 import { getBTCNetworkForWASM } from "../../config/pegin";
 
 /**
- * Exclusive upper bound on VP commission (bps) — `BTCVaultRegistry._validateCommission`
- * ceiling. Local literal by design: the SDK's `MAX_VP_COMMISSION_BPS_EXCLUSIVE`
- * is an internal module, not public API.
+ * Exclusive upper bound on VP commission (bps) — mirrors `VPKeyRegistryLogic.sol`
+ * (registerVaultProvider / updateCommission bounds). Local literal by design:
+ * the SDK's `MAX_VP_COMMISSION_BPS_EXCLUSIVE` is an internal module, not public API.
  */
 const VP_COMMISSION_BPS_EXCLUSIVE_MAX = 10_000;
 
@@ -56,8 +56,8 @@ const MIN_REALIZABLE_VP_COMMISSION_BPS = 1;
 
 /**
  * Trust-boundary check on a VP commission read from chain — mirrors
- * `BTCVaultRegistry._validateCommission` (plus the tx-graph's nonzero floor)
- * so downstream consumers can trust the value.
+ * `VPKeyRegistryLogic.sol`'s registration/update bounds (plus the tx-graph's
+ * nonzero floor) so downstream consumers can trust the value.
  */
 export function assertVpCommissionInProtocolRange(
   bps: number,

--- a/services/vault/src/services/vault/vaultPeginBroadcastService.ts
+++ b/services/vault/src/services/vault/vaultPeginBroadcastService.ts
@@ -80,8 +80,8 @@ export interface BroadcastPrePeginParams {
   /**
    * Approved deposit terms — required when `btcWalletProvider` supports deposit
    * approval. Fresh flows pass `PreparePeginResult.depositTerms`; the resume
-   * path will rebuild them from chain state (Part 2). Ignored (but still
-   * txid-validated) for non-approval wallets.
+   * path rebuilds them from chain state via `rebuildDepositTerms`. Ignored
+   * (but still txid-validated) for non-approval wallets.
    */
   depositTerms?: DepositTerms;
 


### PR DESCRIPTION
- Part 2 of #2220. On resume-broadcast an intent (Ledger) wallet must re-approve the Pre-PegIn, but the in-memory DepositTerms from preparePegin are gone after a browser switch / private mode. This rebuilds them from chain + WASM only — never browser storage.
- rebuildDepositTermsCore (ts-sdk, pure): fails closed at four choke points — Gate 0 (funded tx hashes to the on-chain prePeginTxHash), auth-anchor OP_RETURN completeness (vout === siblingCount), independent bounds on the WASM sizing outputs, Gate 1 (per-sibling HTLC value + scriptPubKey byte-match) — then projects via buildDepositTerms.
- rebuildDepositTerms (vault): stamped-version chain reads + sibling discovery by on-chain prePeginTxHash, with contiguity, batch-wide PENDING, and sibling-homogeneity asserts (stamps/provider/application/commission must match the target — the fields Gate 1 can't see), plus a connected-wallet ownership check.
- resolveFundedTxFeeAndUtxos: mempool-only prevout resolution; the same record feeds the broadcast PSBT, so the fee the device bounds is the fee it signs.
- handleBroadcast branches on supportsDepositApproval; the software-wallet path is byte-identical to before.
- Commission ceiling uses an interim proxy (vaultProviderCommissionBps) until the contract emits maxAcceptableCommissionBps — #2252.