### PR TITLE
ci(release): retry manifest verify probe to absorb release CDN propagation (#253)

### DIFF
--- a/.github/actions/publish-integrity-manifest/action.yml
+++ b/.github/actions/publish-integrity-manifest/action.yml
@@ -39,9 +39,19 @@ runs:
                --title "Frontend manifest ${PREFIX}" \
                --notes "sha256 manifest for the frontend integrity checker (devops-backlog#253). Do not delete." \
                --latest=false 2>&1); then
-            curl -sfIL -o /dev/null "$URL" || { echo "::error::manifest not retrievable at $URL"; exit 1; }
-            echo "published ${TAG}"
-            exit 0
+            # The public download URL is eventually consistent — Immutable
+            # Releases finalizes after create returns, so the asset can 404
+            # for a few seconds even though the upload succeeded. Give the
+            # CDN a bounded window before declaring the publish broken.
+            for _ in 1 2 3 4 5 6; do
+              if curl -sfIL -o /dev/null "$URL"; then
+                echo "published ${TAG}"
+                exit 0
+              fi
+              sleep 5
+            done
+            echo "::error::manifest not retrievable at ${URL} 30s after create"
+            exit 1
           fi
           # Failed create: re-probe the public URL the checker reads. Only a
           # slot PUBLISHED by a concurrent run is a race worth advancing past —


### PR DESCRIPTION
## Problem

The first monitored-env deploy after #2168 landed went red: [run 31775552723](https://github.com/babylonlabs-io/babylon-toolkit/actions/runs/31775552723/job/94691275337), `s3_publish (vault-testnet)`, step *Publish checksum manifest as an immutable per-sha release*.

The publish itself **succeeded** — the failure was the action's own verification probe:

- `06:24:48Z` — `gh release create fm-vault-vault-testnet-23d78882…` succeeds; API shows the release published with both assets `state: uploaded`
- `06:24:49Z` — the single `curl -sfIL` HEAD probe of the public download URL fails → `::error::manifest not retrievable` → exit 1
- moments later — the same URL serves 200 (and the checker has since downloaded the manifest)

The public `releases/download/…` URL is eventually consistent, and this repo has Immutable Releases enabled which adds a finalization pass after create returns — so the asset can 404 on the CDN for a few seconds even though the upload succeeded. The fail-loud branch (built for drafts / permission errors / numbering gaps) can't distinguish *not yet visible* from *not there* with a single probe.

## Fix

Retry the post-create probe for up to 30s (6×5s) before failing. Still fail-closed: an asset that genuinely never appears reds the job exactly as before.

Deliberately **not** changed: the pre-create probe and the create-race re-probe stay single-shot. A transient false 404 there is self-correcting (create fails on the existing tag → falls through to the loud branch), and same-sha runs are already serialized by the per-(workflow, env, sha) concurrency group, so the seconds-after-create window doesn't apply to them in practice.

## Impact of the original failure

None beyond the red run: the S3 upload steps completed before the manifest step, and the slot-1 manifest is published and retrievable. Attempt 2 of the run re-published into the sanctioned `-r2` slot.