### PR TITLE
refactor(vault): move god mode behind a production-owned override seam

### DIFF
--- a/services/vault/src/components/pages/BorrowingMarketsData/__tests__/BorrowingMarketsData.test.tsx
+++ b/services/vault/src/components/pages/BorrowingMarketsData/__tests__/BorrowingMarketsData.test.tsx
@@ -67,10 +67,10 @@ vi.mock("@/config", () => ({
   getNetworkConfigBTC: () => ({ icon: "btc-icon.svg" }),
 }));
 
-const useDemoMarketDataMock = vi.fn();
+const useMarketDataOverrideMock = vi.fn();
 
-vi.mock("@/dev/demoMarketData", () => ({
-  useDemoMarketData: () => useDemoMarketDataMock(),
+vi.mock("@/overrides/marketData", () => ({
+  useMarketDataOverride: () => useMarketDataOverrideMock(),
 }));
 
 // The two chart cards have their own dedicated test files (chart internals,
@@ -232,7 +232,7 @@ function setUpHooks({
   identityError = null,
   isIntegrityViolation = false,
 }: HookOverrides = {}) {
-  useDemoMarketDataMock.mockReturnValue(demoMarketData);
+  useMarketDataOverrideMock.mockReturnValue(demoMarketData);
   useAaveConfigMock.mockReturnValue({
     config: { coreSpokeAddress: "0xspoke000000000000000000000000000000000" },
     borrowableReserves,

--- a/services/vault/src/components/pages/BorrowingMarketsData/__tests__/identity.test.tsx
+++ b/services/vault/src/components/pages/BorrowingMarketsData/__tests__/identity.test.tsx
@@ -88,11 +88,6 @@ vi.mock("@/applications/aave/hooks", () => ({
   useInterestRateModelCurve: () => mockUseInterestRateModelCurve(),
 }));
 
-const mockUseDemoMarketData = vi.fn();
-vi.mock("@/dev/demoMarketData", () => ({
-  useDemoMarketData: () => mockUseDemoMarketData(),
-}));
-
 const WETH_IDENTITY = {
   address: "0xWETH" as Address,
   symbol: "WETH",
@@ -122,7 +117,6 @@ describe("BorrowingMarketsData", () => {
     mockUseAaveReserveLiquidity.mockReturnValue({ liquidityByReserveId: {} });
     mockUseAaveReservesPrices.mockReturnValue({ pricesByReserveId: {} });
     mockUseVaultSplitParams.mockReturnValue({ params: null });
-    mockUseDemoMarketData.mockReturnValue(null);
     mockUseBorrowRateHistory.mockReturnValue({
       points: [],
       isLoading: false,

--- a/services/vault/src/components/pages/BorrowingMarketsData/index.tsx
+++ b/services/vault/src/components/pages/BorrowingMarketsData/index.tsx
@@ -28,7 +28,7 @@ import { NEUTRAL_BUTTON_CLASS } from "@/components/shared/buttonClasses";
 import { PAGE_CONTENT_CLASS } from "@/components/shared/layoutClasses";
 import { getNetworkConfigBTC } from "@/config";
 import { COPY } from "@/copy";
-import { useDemoMarketData } from "@/dev/demoMarketData";
+import { useMarketDataOverride } from "@/overrides/marketData";
 import { getAssetPickerRoute, getMarketSlug, MARKET_PARAM } from "@/routes";
 import {
   getCurrencyIconWithFallback,
@@ -125,7 +125,7 @@ export default function BorrowingMarketsData() {
   // God-mode demo data (dev only; null unless the panel's toggle is on).
   // Substituted at the raw-hook layer, so the derivation below formats demo
   // figures exactly as it formats live ones. Inert in production.
-  const demoMarketData = useDemoMarketData();
+  const demoMarketData = useMarketDataOverride();
   const isDemo = demoMarketData !== null;
   const effectiveReserves = demoMarketData?.reserves ?? borrowableReserves;
   const effectiveLiquidityByReserveId =
@@ -170,9 +170,9 @@ export default function BorrowingMarketsData() {
     underlying: isDemo ? undefined : selectedReserve?.reserve.underlying,
   });
 
-  // Dev-only (`useDemoMarketData` is null in production): the fixture's own
-  // label stands in for a verified identity. The F7 gate below still governs
-  // every live reserve.
+  // Dev-only (`useMarketDataOverride` is null in production): the fixture's
+  // own label stands in for a verified identity. The F7 gate below still
+  // governs every live reserve.
   const demoIdentity = isDemo ? selectedReserve?.token : undefined;
   const symbol = demoIdentity?.symbol ?? identity?.symbol ?? "";
   const name = demoIdentity?.name ?? identity?.name ?? symbol;

--- a/services/vault/src/components/pages/Liquidations/__tests__/Liquidations.test.tsx
+++ b/services/vault/src/components/pages/Liquidations/__tests__/Liquidations.test.tsx
@@ -6,7 +6,7 @@ import { calculate } from "@/applications/aave/positionNotifications";
 import type { CalculatorParams } from "@/applications/aave/positionNotifications/types";
 import { formatHealthFactor } from "@/applications/aave/utils";
 import { COPY } from "@/copy";
-import type { LiquidationPositionOverride } from "@/dev/liquidationDebugStore";
+import type { LiquidationPositionOverride } from "@/overrides/liquidations";
 import { formatBtcAmount, formatUsd } from "@/utils/formatting";
 
 /**
@@ -22,9 +22,7 @@ const useConnectionMock = vi.fn();
 const useETHWalletMock = vi.fn();
 const useDashboardStateMock = vi.fn();
 const usePositionNotificationsMock = vi.fn();
-const useDebugManualModeMock = vi.fn();
-const useDebugPositionOverrideMock = vi.fn();
-const useDebugManualParamsMock = vi.fn();
+const usePositionCascadeOverrideMock = vi.fn();
 const useLiquidationPositionOverrideMock = vi.fn();
 
 vi.mock("@/context/wallet", () => ({
@@ -40,13 +38,11 @@ vi.mock("@/applications/aave/hooks/usePositionNotifications", () => ({
   usePositionNotifications: () => usePositionNotificationsMock(),
 }));
 
-vi.mock("@/dev/debugPositionStore", () => ({
-  useDebugManualMode: () => useDebugManualModeMock(),
-  useDebugPositionOverride: () => useDebugPositionOverrideMock(),
-  useDebugManualParams: () => useDebugManualParamsMock(),
+vi.mock("@/overrides/position", () => ({
+  usePositionCascadeOverride: () => usePositionCascadeOverrideMock(),
 }));
 
-vi.mock("@/dev/liquidationDebugStore", () => ({
+vi.mock("@/overrides/liquidations", () => ({
   useLiquidationPositionOverride: () => useLiquidationPositionOverrideMock(),
 }));
 
@@ -180,18 +176,15 @@ function connectWallet() {
 
 /** Manual mode off, matching the real store's default (untouched in production). */
 function disableGodMode() {
-  useDebugManualModeMock.mockReturnValue(false);
-  useDebugPositionOverrideMock.mockReturnValue({ result: null, status: null });
-  useDebugManualParamsMock.mockReturnValue(GOD_MODE_PARAMS);
+  usePositionCascadeOverrideMock.mockReturnValue(null);
 }
 
 function enableGodMode() {
-  useDebugManualModeMock.mockReturnValue(true);
-  useDebugPositionOverrideMock.mockReturnValue({
+  usePositionCascadeOverrideMock.mockReturnValue({
     result: GOD_MODE_RESULT,
     status: null,
+    params: GOD_MODE_PARAMS,
   });
-  useDebugManualParamsMock.mockReturnValue(GOD_MODE_PARAMS);
 }
 
 /** Position override off, matching the real store's default (untouched in production). */

--- a/services/vault/src/components/pages/Liquidations/index.tsx
+++ b/services/vault/src/components/pages/Liquidations/index.tsx
@@ -2,27 +2,13 @@ import { Container, Loader, SeizureMap } from "@babylonlabs-io/core-ui";
 import { useDeferredValue, useMemo, useState } from "react";
 import { useOutletContext } from "react-router";
 
-import {
-  BPS_SCALE,
-  MIN_HEALTH_FACTOR_FOR_BORROW,
-} from "@/applications/aave/constants";
-import { usePositionNotifications } from "@/applications/aave/hooks/usePositionNotifications";
+import { BPS_SCALE } from "@/applications/aave/constants";
 import { calculate } from "@/applications/aave/positionNotifications";
-import {
-  calculateBorrowCapacityUsd,
-  getHealthFactorStatusFromValue,
-} from "@/applications/aave/utils";
 import type { RootLayoutContext } from "@/components/pages/RootLayout";
 import { EmptyState } from "@/components/shared";
 import { PAGE_CONTENT_CLASS } from "@/components/shared/layoutClasses";
 import { useConnection, useETHWallet } from "@/context/wallet";
 import { COPY } from "@/copy";
-import {
-  useDebugManualMode,
-  useDebugManualParams,
-  useDebugPositionOverride,
-} from "@/dev/debugPositionStore";
-import { useLiquidationPositionOverride } from "@/dev/liquidationDebugStore";
 import { useDashboardState } from "@/hooks/useDashboardState";
 import { useLoanActions } from "@/hooks/useLoanActions";
 import { formatPriceUsd } from "@/utils/formatting";
@@ -34,6 +20,7 @@ import {
 import { LiquidationEventCard } from "./LiquidationEventCard";
 import { PositionOverview } from "./PositionOverview";
 import { SimulationToolbar } from "./SimulationToolbar";
+import { useLiquidationsPageState } from "./useLiquidationsPageState";
 
 /**
  * Liquidation Dashboard (issue #2043, Figma node 10209:67763).
@@ -46,8 +33,8 @@ import { SimulationToolbar } from "./SimulationToolbar";
  * cascade, this page charts THAT cascade instead — and every position stat
  * derives from it too, never from the live `useDashboardState`, so a
  * fabricated demo can never be shown as if it were the depositor's real
- * position. See `src/dev/debugPositionStore.ts`. A separate position override
- * (`src/dev/liquidationDebugStore.ts`) can additionally force the stat cards'
+ * position. See `src/overrides/position.ts`. A separate position override
+ * (`src/overrides/liquidations.ts`) can additionally force the stat cards'
  * own figures independent of the cascade — it wins over both the live
  * position and the cascade for those cards, while the cascade keeps driving
  * the event cards.
@@ -80,15 +67,7 @@ export default function Liquidations() {
   const { isConnected } = useConnection();
   const account = isConnected ? address : undefined;
 
-  const { result: liveResult, params: liveParams } =
-    usePositionNotifications(account);
   const {
-    collateralBtc,
-    collateralValueUsd,
-    debtValueUsd,
-    maxTotalDebtUsd,
-    healthFactor,
-    healthFactorStatus,
     hasCollateral,
     hasLoans,
     collateralFactorBps,
@@ -98,104 +77,13 @@ export default function Liquidations() {
 
   const { openBorrowPicker, openRepay } = useLoanActions({ borrowedAssets });
 
-  // God-mode override (dev only): manual mode drives this page's whole
-  // cascade, bypassing the connection/empty-state ladder below, the way
-  // `DashboardPage.tsx` drives its overview card. Compile-time dead in
-  // production, like the other debug hooks (debugPositionStore.ts) — nothing
-  // ever sets `manualMode` outside the debug panel, which is only imported
-  // behind `import.meta.env.DEV`.
-  const debugManualMode = useDebugManualMode();
-  const { result: debugResultOverride } = useDebugPositionOverride();
-  const debugManualParams = useDebugManualParams();
-  const godMode = useMemo(
-    () =>
-      debugManualMode && debugResultOverride
-        ? { result: debugResultOverride, params: debugManualParams }
-        : null,
-    [debugManualMode, debugResultOverride, debugManualParams],
-  );
-
-  // Position override (dev only): a lighter-weight god-mode control that sets
-  // this page's stat cards directly, without needing a real position or a
-  // Manual Mode cascade. It wins for the stat cards even over an active
-  // cascade above — see the `position` derivation below — while the cascade
-  // (godMode/`result`) keeps driving the event cards untouched.
-  const positionOverride = useLiquidationPositionOverride();
-  const isGodMode = godMode !== null || positionOverride !== null;
-
-  const result = godMode?.result ?? liveResult;
-  const params = godMode?.params ?? liveParams;
-
-  // Position stats shown above the chart. Precedence: the position override,
-  // then the god-mode cascade's own numbers, then the live `useDashboardState`
-  // figures — a mocked stat must never render mixed with a real one, so each
-  // branch is self-contained rather than layering overrides on a live base.
-  const position = useMemo(() => {
-    if (positionOverride) {
-      const {
-        collateralBtc: overrideCollateralBtc,
-        debtUsd,
-        healthFactor: overrideHealthFactor,
-      } = positionOverride;
-      // Price: the active cascade's if Manual Mode is on, else the live oracle
-      // price — `params` already resolves that precedence. No price available
-      // = an absent caption, not a fabricated "$0.00 USD".
-      // `maxTotalDebtUsd = debtUsd * HF / MIN_HEALTH_FACTOR_FOR_BORROW` mirrors
-      // `calculateBorrowCapacityUsd`: live HF = collateralValueUsd * LT /
-      // (BPS_SCALE * debtUsd), and maxTotalDebtUsd = collateralValueUsd * LT /
-      // BPS_SCALE / MIN_HEALTH_FACTOR_FOR_BORROW, so substituting collapses to
-      // this — guarded so a non-positive HF can't divide by zero or produce a
-      // negative denominator.
-      const btcPrice = params?.btcPrice ?? null;
-      return {
-        collateralBtc: overrideCollateralBtc,
-        collateralValueUsd:
-          btcPrice !== null ? overrideCollateralBtc * btcPrice : null,
-        debtValueUsd: debtUsd,
-        maxTotalDebtUsd:
-          overrideHealthFactor > 0
-            ? (debtUsd * overrideHealthFactor) / MIN_HEALTH_FACTOR_FOR_BORROW
-            : 0,
-        healthFactor: overrideHealthFactor,
-        healthFactorStatus:
-          getHealthFactorStatusFromValue(overrideHealthFactor),
-      };
-    }
-    if (!godMode) {
-      return {
-        collateralBtc,
-        collateralValueUsd,
-        debtValueUsd,
-        maxTotalDebtUsd,
-        healthFactor,
-        healthFactorStatus,
-      };
-    }
-    const { result: gmResult, params: gmParams } = godMode;
-    const { maxTotalDebtUsd: gmMaxTotalDebtUsd } = calculateBorrowCapacityUsd({
-      collateralValueUsd: gmResult.collateralValue,
-      currentDebtUsd: gmParams.totalDebtUsd,
-      liquidationThresholdBps: Math.round(gmParams.CF * BPS_SCALE),
-    });
-    return {
-      collateralBtc: gmParams.vaults.reduce((sum, v) => sum + v.btc, 0),
-      collateralValueUsd: gmResult.collateralValue,
-      debtValueUsd: gmParams.totalDebtUsd,
-      maxTotalDebtUsd: gmMaxTotalDebtUsd,
-      healthFactor: gmResult.currentHF,
-      healthFactorStatus: getHealthFactorStatusFromValue(gmResult.currentHF),
-    };
-  }, [
-    positionOverride,
+  const {
+    position,
     params,
-    godMode,
-    collateralBtc,
-    collateralValueUsd,
-    debtValueUsd,
-    maxTotalDebtUsd,
-    healthFactor,
-    healthFactorStatus,
-  ]);
+    result,
+    isGodMode,
+    cascade: cascadeOverride,
+  } = useLiquidationsPageState(account);
 
   const livePrice = params?.btcPrice ?? null;
   // `null` = "track the live price" — the slider hasn't diverged from it (or
@@ -228,8 +116,8 @@ export default function Liquidations() {
     return calculate({ ...params, btcPrice: projectedPrice });
   }, [params, result, projectedPrice]);
 
-  const collateralFactor = godMode
-    ? godMode.params.CF
+  const collateralFactor = cascadeOverride
+    ? cascadeOverride.params.CF
     : collateralFactorBps !== null
       ? collateralFactorBps / BPS_SCALE
       : null;

--- a/services/vault/src/components/pages/Liquidations/useLiquidationsPageState.ts
+++ b/services/vault/src/components/pages/Liquidations/useLiquidationsPageState.ts
@@ -1,0 +1,161 @@
+import { useMemo } from "react";
+
+import {
+  BPS_SCALE,
+  MIN_HEALTH_FACTOR_FOR_BORROW,
+} from "@/applications/aave/constants";
+import { usePositionNotifications } from "@/applications/aave/hooks/usePositionNotifications";
+import type {
+  CalculatorParams,
+  CalculatorResult,
+} from "@/applications/aave/positionNotifications";
+import {
+  calculateBorrowCapacityUsd,
+  getHealthFactorStatusFromValue,
+  type HealthFactorStatus,
+} from "@/applications/aave/utils";
+import { useDashboardState } from "@/hooks/useDashboardState";
+import { useLiquidationPositionOverride } from "@/overrides/liquidations";
+import { usePositionCascadeOverride } from "@/overrides/position";
+
+export interface LiquidationsPagePosition {
+  collateralBtc: number;
+  collateralValueUsd: number | null;
+  debtValueUsd: number;
+  maxTotalDebtUsd: number;
+  healthFactor: number | null;
+  healthFactorStatus: HealthFactorStatus;
+}
+
+export interface LiquidationsPageState {
+  position: LiquidationsPagePosition;
+  params: CalculatorParams | null;
+  result: CalculatorResult | null;
+  isGodMode: boolean;
+  /** The cascade override alone, or null. Distinct from `isGodMode`, which
+   *  also flips on for a position-override-only state that never touches the
+   *  chart — the chart's collateral factor must track the cascade. */
+  cascade: { result: CalculatorResult; params: CalculatorParams } | null;
+}
+
+/**
+ * The Liquidations page's precedence ladder for its position stats — the
+ * position override, then the god-mode cascade's own numbers, then the live
+ * `useDashboardState` figures — relocated out of the page component.
+ */
+export function useLiquidationsPageState(
+  account: string | undefined,
+): LiquidationsPageState {
+  const { result: liveResult, params: liveParams } =
+    usePositionNotifications(account);
+  const {
+    collateralBtc,
+    collateralValueUsd,
+    debtValueUsd,
+    maxTotalDebtUsd,
+    healthFactor,
+    healthFactorStatus,
+  } = useDashboardState(account);
+
+  // God-mode override (dev only): manual mode drives this page's whole
+  // cascade, bypassing the connection/empty-state ladder below, the way
+  // `DashboardPage.tsx` drives its overview card. Compile-time dead in
+  // production, like the other override reads (overrides/store.ts) — nothing
+  // ever sets this outside the debug panel, which is only imported behind
+  // `import.meta.env.DEV`.
+  // A status-only override (stale price) carries no cascade to chart, so it
+  // must not put this page into god mode — it falls through to live, exactly
+  // as a live stale price would.
+  const cascadeOverride = usePositionCascadeOverride();
+  const godMode = useMemo(
+    () =>
+      cascadeOverride?.result
+        ? { result: cascadeOverride.result, params: cascadeOverride.params }
+        : null,
+    [cascadeOverride],
+  );
+
+  // Position override (dev only): a lighter-weight god-mode control that sets
+  // this page's stat cards directly, without needing a real position or a
+  // Manual Mode cascade. It wins for the stat cards even over an active
+  // cascade above — see the `position` derivation below — while the cascade
+  // (godMode/`result`) keeps driving the event cards untouched.
+  const positionOverride = useLiquidationPositionOverride();
+  const isGodMode = godMode !== null || positionOverride !== null;
+
+  const result = godMode?.result ?? liveResult;
+  const params = godMode?.params ?? liveParams;
+
+  // Position stats shown above the chart. Precedence: the position override,
+  // then the god-mode cascade's own numbers, then the live `useDashboardState`
+  // figures — a mocked stat must never render mixed with a real one, so each
+  // branch is self-contained rather than layering overrides on a live base.
+  const position = useMemo((): LiquidationsPagePosition => {
+    if (positionOverride) {
+      const {
+        collateralBtc: overrideCollateralBtc,
+        debtUsd,
+        healthFactor: overrideHealthFactor,
+      } = positionOverride;
+      // Price: the active cascade's if Manual Mode is on, else the live oracle
+      // price — `params` already resolves that precedence. No price available
+      // = an absent caption, not a fabricated "$0.00 USD".
+      // `maxTotalDebtUsd = debtUsd * HF / MIN_HEALTH_FACTOR_FOR_BORROW` mirrors
+      // `calculateBorrowCapacityUsd`: live HF = collateralValueUsd * LT /
+      // (BPS_SCALE * debtUsd), and maxTotalDebtUsd = collateralValueUsd * LT /
+      // BPS_SCALE / MIN_HEALTH_FACTOR_FOR_BORROW, so substituting collapses to
+      // this — guarded so a non-positive HF can't divide by zero or produce a
+      // negative denominator.
+      const btcPrice = params?.btcPrice ?? null;
+      return {
+        collateralBtc: overrideCollateralBtc,
+        collateralValueUsd:
+          btcPrice !== null ? overrideCollateralBtc * btcPrice : null,
+        debtValueUsd: debtUsd,
+        maxTotalDebtUsd:
+          overrideHealthFactor > 0
+            ? (debtUsd * overrideHealthFactor) / MIN_HEALTH_FACTOR_FOR_BORROW
+            : 0,
+        healthFactor: overrideHealthFactor,
+        healthFactorStatus:
+          getHealthFactorStatusFromValue(overrideHealthFactor),
+      };
+    }
+    if (!godMode) {
+      return {
+        collateralBtc,
+        collateralValueUsd,
+        debtValueUsd,
+        maxTotalDebtUsd,
+        healthFactor,
+        healthFactorStatus,
+      };
+    }
+    const { result: gmResult, params: gmParams } = godMode;
+    const { maxTotalDebtUsd: gmMaxTotalDebtUsd } = calculateBorrowCapacityUsd({
+      collateralValueUsd: gmResult.collateralValue,
+      currentDebtUsd: gmParams.totalDebtUsd,
+      liquidationThresholdBps: Math.round(gmParams.CF * BPS_SCALE),
+    });
+    return {
+      collateralBtc: gmParams.vaults.reduce((sum, v) => sum + v.btc, 0),
+      collateralValueUsd: gmResult.collateralValue,
+      debtValueUsd: gmParams.totalDebtUsd,
+      maxTotalDebtUsd: gmMaxTotalDebtUsd,
+      healthFactor: gmResult.currentHF,
+      healthFactorStatus: getHealthFactorStatusFromValue(gmResult.currentHF),
+    };
+  }, [
+    positionOverride,
+    params,
+    godMode,
+    collateralBtc,
+    collateralValueUsd,
+    debtValueUsd,
+    maxTotalDebtUsd,
+    healthFactor,
+    healthFactorStatus,
+  ]);
+
+  return { position, params, result, isGodMode, cascade: godMode };
+}

--- a/services/vault/src/components/pages/Loans.tsx
+++ b/services/vault/src/components/pages/Loans.tsx
@@ -16,14 +16,14 @@ import { EmptyState } from "@/components/shared";
 import { PAGE_CONTENT_CLASS } from "@/components/shared/layoutClasses";
 import { useConnection, useETHWallet } from "@/context/wallet";
 import { COPY } from "@/copy";
-import {
-  resolveShownHealthFactor,
-  useDebugBorrowCapacity,
-  useDebugHealthFactorOverride,
-} from "@/dev/debugPositionStore";
-import { useDemoLoan } from "@/dev/demoDeposit";
 import { useDashboardState } from "@/hooks/useDashboardState";
 import { useLoanActions } from "@/hooks/useLoanActions";
+import {
+  resolveShownHealthFactor,
+  useBorrowCapacityOverride,
+  useHealthFactorOverride,
+} from "@/overrides/borrowCapacity";
+import { useLoanOverride } from "@/overrides/loans";
 import { parseReserveId } from "@/routes";
 import { formatUsdValue } from "@/utils/formatting";
 
@@ -69,7 +69,7 @@ export default function Loans() {
   // is set — so the Loans page can be exercised without a borrow position, or
   // a wallet. Every mock row is `displayOnly`, so ActiveLoansList disables its
   // actions and the real borrow/repay flows never see one. Inert in production.
-  const demoLoans = useDemoLoan();
+  const demoLoans = useLoanOverride();
   const displayLoans = useMemo(() => {
     if (!demoLoans) return activeLoans;
     return [...demoLoans.rows, ...(demoLoans.hideReal ? [] : activeLoans)];
@@ -79,8 +79,8 @@ export default function Loans() {
 
   // God-mode summary overrides (dev only; null unless the panel forces them,
   // compile-time null in production builds).
-  const healthFactorOverride = useDebugHealthFactorOverride();
-  const borrowCapacityOverride = useDebugBorrowCapacity();
+  const healthFactorOverride = useHealthFactorOverride();
+  const borrowCapacityOverride = useBorrowCapacityOverride();
   const {
     healthFactor: shownHealthFactor,
     healthFactorStatus: shownHealthFactorStatus,

--- a/services/vault/src/components/pages/RootLayout.tsx
+++ b/services/vault/src/components/pages/RootLayout.tsx
@@ -34,9 +34,9 @@ import { useAddressType } from "@/context/addressType";
 import { AppPeginPollingProvider } from "@/context/deposit/AppPeginPollingProvider";
 import { useGeoFencing } from "@/context/geofencing";
 import { COPY } from "@/copy";
-import { useDebugProtocolStatusOverride } from "@/dev/debugPositionStore";
 import { usePageTitle } from "@/hooks/usePageTitle";
 import { useProtocolGateState } from "@/hooks/useProtocolGate";
+import { useProtocolStatusOverride } from "@/overrides/protocolStatus";
 
 import {
   AaveConfigProvider,
@@ -98,7 +98,7 @@ export default function RootLayout() {
   // override (compile-time null in production) wins over the live gate, so a
   // forced frozen/paused preview drives banner suppression here too and can't
   // leave a second banner visible.
-  const statusOverride = useDebugProtocolStatusOverride();
+  const statusOverride = useProtocolStatusOverride();
   const hasProtocolStatus =
     (statusOverride ?? resolveBannerStatus(gate)) !== null;
   // Deposit kill-switch banner. Suppressed when a frozen/paused status banner is

--- a/services/vault/src/components/pages/VaultsPage.tsx
+++ b/services/vault/src/components/pages/VaultsPage.tsx
@@ -33,11 +33,11 @@ import { VaultsSummaryCard } from "@/components/vaults/VaultsSummaryCard";
 import { FeatureFlags } from "@/config";
 import { useConnection, useETHWallet } from "@/context/wallet";
 import { COPY } from "@/copy";
-import { useDemoDeposit } from "@/dev/demoDeposit";
 import { usePendingDeposits } from "@/hooks/usePendingDeposits";
 import { useProtocolGateState } from "@/hooks/useProtocolGate";
 import { useVaultsPageData } from "@/hooks/useVaultsPageData";
 import { useVaultsPageEmptiness } from "@/hooks/useVaultsPageEmptiness";
+import { useDepositOverride } from "@/overrides/deposits";
 import { invalidateVaultQueries, vaultOrderQueryKey } from "@/utils/queryKeys";
 
 export default function VaultsPage() {
@@ -63,7 +63,7 @@ export default function VaultsPage() {
   // God-mode demo aggregate (dev only; null unless the panel's "Inject demo"
   // toggle is on). Routes the page to the populated layout even while
   // disconnected, so the sections can be exercised without a wallet.
-  const demo = useDemoDeposit();
+  const demo = useDepositOverride();
 
   // Withdraw flow, opened per-row with that vault preselected. Only the
   // demo-free list ever reaches it; its optimistic activating entries are
@@ -112,11 +112,6 @@ export default function VaultsPage() {
     }
   }, [address, queryClient]);
 
-  // The god-mode panel itself is mounted once by the route layout (see
-  // dev/GodModeMount); this only gates the demo-driven body below.
-  const isDevToolingEnabled =
-    import.meta.env.DEV && FeatureFlags.isGodModePanelEnabled;
-
   const populatedBody = (
     <div className="flex flex-col gap-8">
       {/* One of the two data sources failed while the other still has rows —
@@ -164,7 +159,7 @@ export default function VaultsPage() {
   const renderBody = () => {
     // Dev-only: with demo injection on, always show the populated layout —
     // even while disconnected — so the page can be exercised without a wallet.
-    if (isDevToolingEnabled && demo) return populatedBody;
+    if (demo) return populatedBody;
     if (isLoading) {
       return (
         <div className="flex items-center justify-center py-12">

--- a/services/vault/src/components/pages/__tests__/Loans.test.tsx
+++ b/services/vault/src/components/pages/__tests__/Loans.test.tsx
@@ -19,9 +19,9 @@ import { COPY } from "@/copy";
 const useConnectionMock = vi.fn();
 const useETHWalletMock = vi.fn();
 const useDashboardStateMock = vi.fn();
-const useDemoLoanMock = vi.fn();
-const useDebugHealthFactorOverrideMock = vi.fn();
-const useDebugBorrowCapacityMock = vi.fn();
+const useLoanOverrideMock = vi.fn();
+const useHealthFactorOverrideMock = vi.fn();
+const useBorrowCapacityOverrideMock = vi.fn();
 
 vi.mock("@/context/wallet", () => ({
   useConnection: () => useConnectionMock(),
@@ -51,14 +51,14 @@ vi.mock("@/applications/aave/hooks", () => ({
   useActiveLoans: () => [],
 }));
 
-vi.mock("@/dev/demoDeposit", () => ({
-  useDemoLoan: () => useDemoLoanMock(),
+vi.mock("@/overrides/loans", () => ({
+  useLoanOverride: () => useLoanOverrideMock(),
 }));
 
-vi.mock("@/dev/debugPositionStore", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("@/dev/debugPositionStore")>()),
-  useDebugHealthFactorOverride: () => useDebugHealthFactorOverrideMock(),
-  useDebugBorrowCapacity: () => useDebugBorrowCapacityMock(),
+vi.mock("@/overrides/borrowCapacity", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/overrides/borrowCapacity")>()),
+  useHealthFactorOverride: () => useHealthFactorOverrideMock(),
+  useBorrowCapacityOverride: () => useBorrowCapacityOverrideMock(),
 }));
 
 vi.mock("react-router", () => ({
@@ -141,9 +141,9 @@ const DEMO_LOAN_ROW = {
 describe("Loans page — loading gate", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    useDemoLoanMock.mockReturnValue(null);
-    useDebugHealthFactorOverrideMock.mockReturnValue(null);
-    useDebugBorrowCapacityMock.mockReturnValue(null);
+    useLoanOverrideMock.mockReturnValue(null);
+    useHealthFactorOverrideMock.mockReturnValue(null);
+    useBorrowCapacityOverrideMock.mockReturnValue(null);
   });
 
   it("shows a spinner (not the deposit CTA) while a connected depositor's position loads", () => {
@@ -191,7 +191,7 @@ describe("Loans page — loading gate", () => {
       ...CONNECTED_LOADED,
       hasCollateral: false,
     });
-    useDemoLoanMock.mockReturnValue({
+    useLoanOverrideMock.mockReturnValue({
       rows: [DEMO_LOAN_ROW],
       debtUsd: 1500,
       hideReal: false,
@@ -211,7 +211,11 @@ describe("Loans page — loading gate", () => {
       ...CONNECTED_LOADED,
       hasCollateral: false,
     });
-    useDemoLoanMock.mockReturnValue({ rows: [], debtUsd: 0, hideReal: false });
+    useLoanOverrideMock.mockReturnValue({
+      rows: [],
+      debtUsd: 0,
+      hideReal: false,
+    });
 
     render(<Loans />);
 
@@ -232,9 +236,9 @@ describe("Loans page — loading gate", () => {
 describe("Loans page — god-mode summary overrides", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    useDemoLoanMock.mockReturnValue(null);
-    useDebugHealthFactorOverrideMock.mockReturnValue(null);
-    useDebugBorrowCapacityMock.mockReturnValue(null);
+    useLoanOverrideMock.mockReturnValue(null);
+    useHealthFactorOverrideMock.mockReturnValue(null);
+    useBorrowCapacityOverrideMock.mockReturnValue(null);
     useConnectionMock.mockReturnValue({ isConnected: true });
     useETHWalletMock.mockReturnValue({ address: "0xabc" });
   });
@@ -246,7 +250,7 @@ describe("Loans page — god-mode summary overrides", () => {
       ...CONNECTED_LOADED,
       isBorrowCapacityLoading: true,
     });
-    useDebugBorrowCapacityMock.mockReturnValue({
+    useBorrowCapacityOverrideMock.mockReturnValue({
       loading: false,
       error: new Error("forced"),
     });
@@ -263,7 +267,10 @@ describe("Loans page — god-mode summary overrides", () => {
       ...CONNECTED_LOADED,
       borrowCapacityError: new Error("live failure"),
     });
-    useDebugBorrowCapacityMock.mockReturnValue({ loading: true, error: null });
+    useBorrowCapacityOverrideMock.mockReturnValue({
+      loading: true,
+      error: null,
+    });
 
     render(<Loans />);
 
@@ -278,7 +285,7 @@ describe("Loans page — god-mode summary overrides", () => {
       healthFactor: 5,
       healthFactorStatus: "safe",
     });
-    useDebugHealthFactorOverrideMock.mockReturnValue(0.95);
+    useHealthFactorOverrideMock.mockReturnValue(0.95);
 
     render(<Loans />);
 
@@ -294,7 +301,7 @@ describe("Loans page — god-mode summary overrides", () => {
       ...CONNECTED_LOADED,
       hasCollateral: false,
     });
-    useDebugHealthFactorOverrideMock.mockReturnValue(1.25);
+    useHealthFactorOverrideMock.mockReturnValue(1.25);
 
     render(<Loans />);
 

--- a/services/vault/src/components/pages/__tests__/RootLayout.test.tsx
+++ b/services/vault/src/components/pages/__tests__/RootLayout.test.tsx
@@ -60,12 +60,12 @@ vi.mock("@/context/wallet", () => ({
 const debugStatusMock = vi.hoisted(
   () => ({ value: null }) as { value: "frozen" | "paused" | null },
 );
-vi.mock("@/dev/debugPositionStore", async (importOriginal) => {
+vi.mock("@/overrides/protocolStatus", async (importOriginal) => {
   const actual =
-    await importOriginal<typeof import("@/dev/debugPositionStore")>();
+    await importOriginal<typeof import("@/overrides/protocolStatus")>();
   return {
     ...actual,
-    useDebugProtocolStatusOverride: () => debugStatusMock.value,
+    useProtocolStatusOverride: () => debugStatusMock.value,
   };
 });
 

--- a/services/vault/src/components/pages/__tests__/VaultsPage.test.tsx
+++ b/services/vault/src/components/pages/__tests__/VaultsPage.test.tsx
@@ -75,10 +75,6 @@ vi.mock("@/hooks/useVaultsPageData", () => ({
   }),
 }));
 
-vi.mock("@/dev/demoDeposit", () => ({
-  useDemoDeposit: () => null,
-}));
-
 vi.mock("@/components/vaults/VaultsSummaryCard", () => ({
   VaultsSummaryCard: () => <div data-testid="vaults-summary-card" />,
 }));

--- a/services/vault/src/components/shared/ProtocolStatusBanner.tsx
+++ b/services/vault/src/components/shared/ProtocolStatusBanner.tsx
@@ -11,8 +11,8 @@ import {
 } from "@/components/shared/protocolStatus";
 import featureFlags from "@/config/featureFlags";
 import { COPY } from "@/copy";
-import { useDebugProtocolStatusOverride } from "@/dev/debugPositionStore";
 import { useProtocolGateState } from "@/hooks/useProtocolGate";
+import { useProtocolStatusOverride } from "@/overrides/protocolStatus";
 
 // tone per status — exhaustive over ProtocolStatus so a new ScopeStatus fails
 // the typecheck instead of silently falling through.
@@ -30,9 +30,9 @@ const STATUS_TONE: Record<ProtocolStatus, NotificationCardTone> = {
 export function ProtocolStatusBanner() {
   const gate = useProtocolGateState();
   // Dev-only god-mode override (compile-time null in production, see
-  // debugPositionStore) — forcing "healthy" is not a scenario, so releasing the
-  // override (null) is how you go back to the live gate state.
-  const statusOverride = useDebugProtocolStatusOverride();
+  // overrides/protocolStatus) — forcing "healthy" is not a scenario, so
+  // releasing the override (null) is how you go back to the live gate state.
+  const statusOverride = useProtocolStatusOverride();
   const status = statusOverride ?? resolveBannerStatus(gate);
   if (!status) {
     return null;

--- a/services/vault/src/components/shared/__tests__/ProtocolStatusBanner.test.tsx
+++ b/services/vault/src/components/shared/__tests__/ProtocolStatusBanner.test.tsx
@@ -22,7 +22,7 @@ vi.mock("@/hooks/useProtocolGate", () => ({
   useProtocolGateState: () => gateMock.value,
 }));
 
-import { setDebugProtocolStatusOverride } from "@/dev/debugPositionStore";
+import { setProtocolStatusOverride } from "@/overrides/protocolStatus";
 
 import { ProtocolStatusBanner } from "../ProtocolStatusBanner";
 
@@ -30,7 +30,7 @@ beforeEach(() => {
   featureFlagsMock.noticeBannerMessage = undefined;
   featureFlagsMock.isGodModePanelEnabled = true;
   gateMock.value = { protocol: null, aave: null };
-  setDebugProtocolStatusOverride(null);
+  setProtocolStatusOverride(null);
 });
 
 describe("ProtocolStatusBanner", () => {
@@ -90,19 +90,19 @@ describe("ProtocolStatusBanner", () => {
   });
 
   it("forces each paused card from the god-mode override while the gate is healthy", () => {
-    setDebugProtocolStatusOverride("frozen");
+    setProtocolStatusOverride("frozen");
     const soft = render(<ProtocolStatusBanner />);
     expect(screen.getByText("Protocol is soft-paused")).toBeInTheDocument();
     soft.unmount();
 
-    setDebugProtocolStatusOverride("paused");
+    setProtocolStatusOverride("paused");
     render(<ProtocolStatusBanner />);
     expect(screen.getByText("Protocol is fully paused")).toBeInTheDocument();
   });
 
   it("falls back to the live gate once the override is released", () => {
-    setDebugProtocolStatusOverride("paused");
-    setDebugProtocolStatusOverride(null);
+    setProtocolStatusOverride("paused");
+    setProtocolStatusOverride(null);
 
     const { container } = render(<ProtocolStatusBanner />);
 

--- a/services/vault/src/components/simple/DashboardPage.tsx
+++ b/services/vault/src/components/simple/DashboardPage.tsx
@@ -19,21 +19,19 @@ import {
 import featureFlags from "@/config/featureFlags";
 import { useConnection, useETHWallet } from "@/context/wallet";
 import { COPY } from "@/copy";
-import {
-  resolveShownHealthFactor,
-  useDebugHealthFactorOverride,
-  useDebugManualMode,
-  useDebugManualParams,
-  useDebugPositionOverride,
-} from "@/dev/debugPositionStore";
-import {
-  resolveLiquidationCardState,
-  useLiquidationDebugState,
-} from "@/dev/liquidationDebugStore";
 import { useApplicationCap } from "@/hooks/useApplicationCap";
 import { useDashboardState } from "@/hooks/useDashboardState";
 import { useLoanActions } from "@/hooks/useLoanActions";
 import { usePrices } from "@/hooks/usePrices";
+import {
+  resolveShownHealthFactor,
+  useHealthFactorOverride,
+} from "@/overrides/borrowCapacity";
+import {
+  resolveLiquidationCardState,
+  useLiquidationCardOverride,
+} from "@/overrides/liquidations";
+import { usePositionCascadeOverride } from "@/overrides/position";
 import {
   formatBasisPointsAsPercent,
   formatBtcAmount,
@@ -56,31 +54,25 @@ export function DashboardPage() {
   const { isConnected } = useConnection();
 
   // Dev-only banner override driven by the position-notifications section of
-  // the god-mode panel (see debugPositionStore). Always null in production, so
-  // the banners fall back to the live calculation with no behavioural change.
-  const { result: debugResultOverride, status: debugStatusOverride } =
-    useDebugPositionOverride();
-  // Manual mode only: live mode republishes the live result as a no-op
-  // override, which is not a simulation.
-  const debugManualMode = useDebugManualMode();
-  const debugManualParams = useDebugManualParams();
-  const liquidationDebugState = useLiquidationDebugState();
+  // the god-mode panel (see @/overrides/position). Always null in production,
+  // so the banners fall back to the live calculation with no behavioural
+  // change.
+  const cascadeOverride = usePositionCascadeOverride();
+  const liquidationCardOverride = useLiquidationCardOverride();
   // No live source yet: the chart renders only from the god-mode cascade,
   // behind its own flag. Elsewhere it stays absent rather than charting a real
   // position from placeholder numbers.
   const liquidationCascade = useMemo(
     () =>
-      featureFlags.isLiquidationAnalysisChartEnabled &&
-      debugManualMode &&
-      debugResultOverride
+      featureFlags.isLiquidationAnalysisChartEnabled && cascadeOverride?.result
         ? {
-            result: debugResultOverride,
-            btcPrice: debugManualParams.btcPrice,
-            collateralFactor: debugManualParams.CF,
-            vaultsTotal: debugManualParams.vaults.length,
+            result: cascadeOverride.result,
+            btcPrice: cascadeOverride.params.btcPrice,
+            collateralFactor: cascadeOverride.params.CF,
+            vaultsTotal: cascadeOverride.params.vaults.length,
           }
         : null,
-    [debugManualMode, debugResultOverride, debugManualParams],
+    [cascadeOverride],
   );
   const {
     collateralBtc,
@@ -118,7 +110,7 @@ export function DashboardPage() {
 
   // Feed the critical top banner the same debug-aware result the mid-page banner
   // uses: the debug override when set, otherwise the live calculation.
-  const criticalBannerResult = debugResultOverride ?? positionNotifications;
+  const criticalBannerResult = cascadeOverride?.result ?? positionNotifications;
 
   const { vaults: aaveVaults } = useAaveVaults(
     isConnected ? address : undefined,
@@ -139,7 +131,7 @@ export function DashboardPage() {
   // vault, whose values are still $0, doesn't surface an empty panel.
   const hasOverviewData = hasCollateral || hasLoans;
   const liquidationCardState = resolveLiquidationCardState(
-    liquidationDebugState,
+    liquidationCardOverride,
     { hasCollateral: hasDisplayCollateral, hasLoans },
   );
 
@@ -179,7 +171,7 @@ export function DashboardPage() {
   // price there is nothing to imply a liquidation price from, and the stats
   // read as placeholders rather than mixing a forced HF with live liquidation
   // numbers (the case you hit inspecting the stale-price path).
-  const healthFactorOverride = useDebugHealthFactorOverride();
+  const healthFactorOverride = useHealthFactorOverride();
   const {
     healthFactor: shownHealthFactor,
     healthFactorStatus: shownHealthFactorStatus,
@@ -224,8 +216,8 @@ export function DashboardPage() {
       connectedAddress={address}
       onDeposit={openDeposit}
       onRepay={openRepay}
-      result={debugResultOverride ?? undefined}
-      statusOverride={debugStatusOverride ?? undefined}
+      result={cascadeOverride?.result ?? undefined}
+      statusOverride={cascadeOverride?.status ?? undefined}
     />
   ) : null;
 

--- a/services/vault/src/components/simple/MaxVaultsNotification.tsx
+++ b/services/vault/src/components/simple/MaxVaultsNotification.tsx
@@ -1,7 +1,7 @@
 import { NotificationCard } from "@/components/shared/NotificationCard";
 import { COPY } from "@/copy";
-import { useDebugMaxVaultsOverride } from "@/dev/debugPositionStore";
 import { useVaultCountCap } from "@/hooks/useVaultCountCap";
+import { useMaxVaultsOverride } from "@/overrides/protocolStatus";
 
 const TEST_ID = "max-vaults-notification";
 
@@ -23,9 +23,10 @@ export function MaxVaultsNotification({
 }: MaxVaultsNotificationProps) {
   const { isAtCap, maxVaults } = useVaultCountCap(connectedAddress);
   // Dev-only god-mode override (compile-time null in production, see
-  // debugPositionStore). It carries the cap NUMBER, not a boolean: the live
-  // `maxVaults` read is null while disconnected and the copy interpolates it.
-  const capOverride = useDebugMaxVaultsOverride();
+  // overrides/protocolStatus). It carries the cap NUMBER, not a boolean: the
+  // live `maxVaults` read is null while disconnected and the copy
+  // interpolates it.
+  const capOverride = useMaxVaultsOverride();
 
   const cap = capOverride ?? maxVaults;
   const atCap = capOverride !== null || isAtCap;

--- a/services/vault/src/components/simple/PostDepositContinuationContent.tsx
+++ b/services/vault/src/components/simple/PostDepositContinuationContent.tsx
@@ -12,10 +12,10 @@ import { useMemo } from "react";
 import type { Address, Hex } from "viem";
 
 import { useBTCWallet } from "@/context/wallet";
-import { useDemoDeposit } from "@/dev/demoDeposit";
 import type { DepositWarning } from "@/hooks/deposit/depositWarnings";
 import { useBtcPublicKey } from "@/hooks/useBtcPublicKey";
 import { useVaultDeposits } from "@/hooks/useVaultDeposits";
+import { useDepositOverride } from "@/overrides/deposits";
 
 import { ContinuationWarnings } from "./ContinuationWarnings";
 import { PostDepositContinuationView } from "./PostDepositContinuationView";
@@ -55,7 +55,7 @@ export function PostDepositContinuationContent({
   // is what lets PostDepositContinuationView find the demo VaultActivity and
   // mount the activation branch; the app provider resolves demo polling results
   // by id via `demo.resultsById`. Inert in production.
-  const demo = useDemoDeposit();
+  const demo = useDepositOverride();
 
   const scoped = useMemo(() => {
     const ids = new Set<string>(vaultIds);

--- a/services/vault/src/components/simple/__tests__/DashboardPage.test.tsx
+++ b/services/vault/src/components/simple/__tests__/DashboardPage.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { COPY } from "@/copy";
-import { setDebugHealthFactorOverride } from "@/dev/debugPositionStore";
+import { setHealthFactorOverride } from "@/overrides/borrowCapacity";
 
 import { DashboardPage } from "../DashboardPage";
 
@@ -66,15 +66,8 @@ vi.mock("@/hooks/usePrices", () => ({
   usePrices: () => pricesMock,
 }));
 
-vi.mock("@/dev/debugPositionStore", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("@/dev/debugPositionStore")>()),
-  useDebugPositionOverride: () => ({ result: null, status: null }),
-  useDebugManualMode: () => false,
-}));
-
 vi.mock("@/dev/demoDeposit", () => ({
   useDemoCollateral: () => null,
-  useDemoWithdrawal: () => null,
 }));
 
 vi.mock("@/applications/aave/context", () => ({
@@ -114,7 +107,7 @@ beforeEach(() => {
   featureFlagsMock.isGodModePanelEnabled = false;
   pricesMock.prices = {};
   pricesMock.metadata = {};
-  setDebugHealthFactorOverride(null);
+  setHealthFactorOverride(null);
 });
 
 describe("DashboardPage composition", () => {
@@ -139,7 +132,7 @@ describe("DashboardPage risk card under a forced health factor", () => {
   });
 
   it("charts the liquidation price and distance implied by the forced value", () => {
-    setDebugHealthFactorOverride(2.4);
+    setHealthFactorOverride(2.4);
 
     render(<DashboardPage />);
 
@@ -150,7 +143,7 @@ describe("DashboardPage risk card under a forced health factor", () => {
   });
 
   it("clamps the distance to zero when the forced value is below 1", () => {
-    setDebugHealthFactorOverride(0.95);
+    setHealthFactorOverride(0.95);
 
     render(<DashboardPage />);
 
@@ -160,7 +153,7 @@ describe("DashboardPage risk card under a forced health factor", () => {
 
   it("shows placeholders rather than live stats when no usable BTC price backs the forced value", () => {
     pricesMock.metadata = { BTC: { isStale: true, fetchFailed: false } };
-    setDebugHealthFactorOverride(2.4);
+    setHealthFactorOverride(2.4);
 
     render(<DashboardPage />);
 

--- a/services/vault/src/components/simple/__tests__/MaxVaultsNotification.test.tsx
+++ b/services/vault/src/components/simple/__tests__/MaxVaultsNotification.test.tsx
@@ -11,12 +11,11 @@ const featureFlagsMock = vi.hoisted(() => ({
 }));
 vi.mock("@/config/featureFlags", () => ({ default: featureFlagsMock }));
 
-import {
-  DEBUG_FORCED_MAX_VAULTS,
-  setDebugMaxVaultsOverride,
-} from "@/dev/debugPositionStore";
+import { setMaxVaultsOverride } from "@/overrides/protocolStatus";
 
 import { MaxVaultsNotification } from "../MaxVaultsNotification";
+
+const FORCED_MAX_VAULTS = 10;
 
 const BELOW_CAP = {
   isAtCap: false,
@@ -27,7 +26,7 @@ const BELOW_CAP = {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  setDebugMaxVaultsOverride(null);
+  setMaxVaultsOverride(null);
 });
 
 describe("MaxVaultsNotification", () => {
@@ -86,7 +85,7 @@ describe("MaxVaultsNotification", () => {
   it("shows the card from the god-mode override while below the live cap", () => {
     mockUseVaultCountCap.mockReturnValue(BELOW_CAP);
 
-    setDebugMaxVaultsOverride(DEBUG_FORCED_MAX_VAULTS);
+    setMaxVaultsOverride(FORCED_MAX_VAULTS);
     render(<MaxVaultsNotification connectedAddress="0xuser" />);
 
     expect(screen.getByTestId("max-vaults-notification")).toHaveAttribute(
@@ -95,9 +94,7 @@ describe("MaxVaultsNotification", () => {
     );
     expect(
       screen.getByText(
-        new RegExp(
-          `maximum number of BTC Vaults \\(${DEBUG_FORCED_MAX_VAULTS}\\)`,
-        ),
+        new RegExp(`maximum number of BTC Vaults \\(${FORCED_MAX_VAULTS}\\)`),
       ),
     ).toBeInTheDocument();
   });
@@ -105,8 +102,8 @@ describe("MaxVaultsNotification", () => {
   it("renders nothing once the god-mode override is released", () => {
     mockUseVaultCountCap.mockReturnValue(BELOW_CAP);
 
-    setDebugMaxVaultsOverride(DEBUG_FORCED_MAX_VAULTS);
-    setDebugMaxVaultsOverride(null);
+    setMaxVaultsOverride(FORCED_MAX_VAULTS);
+    setMaxVaultsOverride(null);
     const { container } = render(
       <MaxVaultsNotification connectedAddress="0xuser" />,
     );

--- a/services/vault/src/components/simple/__tests__/PostDepositContinuationContent.test.tsx
+++ b/services/vault/src/components/simple/__tests__/PostDepositContinuationContent.test.tsx
@@ -39,8 +39,8 @@ vi.mock("@/hooks/useVaultDeposits", () => ({
   }),
 }));
 
-vi.mock("@/dev/demoDeposit", () => ({
-  useDemoDeposit: () => ({
+vi.mock("@/overrides/deposits", () => ({
+  useDepositOverride: () => ({
     pendingActivities: [{ id: DEMO_ID }],
     resultsById: new Map(),
   }),

--- a/services/vault/src/components/vaults/VaultsLifecycleSections.tsx
+++ b/services/vault/src/components/vaults/VaultsLifecycleSections.tsx
@@ -45,7 +45,6 @@ import { PostDepositContinuationContent } from "@/components/simple/PostDepositC
 import { ProtocolParamsProvider } from "@/context/ProtocolParamsContext";
 import { useDepositPollingResult } from "@/context/deposit/PeginPollingContext";
 import { COPY } from "@/copy";
-import { getDemoStepperBatch } from "@/dev/demoDeposit";
 import { useRefundRowAction } from "@/hooks/deposit/useRefundRowAction";
 import type { usePendingDeposits } from "@/hooks/usePendingDeposits";
 import {
@@ -54,6 +53,7 @@ import {
   PeginAction,
   type PeginState,
 } from "@/models/peginStateMachine";
+import { getDemoStepperBatch } from "@/overrides/deposits";
 import type { VaultActivity } from "@/types/activity";
 import type { VaultProvider } from "@/types/vaultProvider";
 import { truncateHash } from "@/utils/addressUtils";
@@ -429,12 +429,10 @@ export function VaultsLifecycleSections({
       const activity = allActivities.find((a) => a.id === depositId);
       if (!activity) {
         // God-mode: an owned flow-state demo card opens the multistepper so
-        // the whole flow can be walked. `import.meta.env.DEV` tree-shakes
-        // this from production, where `demo` is always null.
-        if (import.meta.env.DEV) {
-          const demoBatch = getDemoStepperBatch(demo, depositId);
-          if (demoBatch) setViewingBatch(demoBatch);
-        }
+        // the whole flow can be walked. `getDemoStepperBatch` is null-safe
+        // and gated at source, so this is a no-op in production.
+        const demoBatch = getDemoStepperBatch(demo, depositId);
+        if (demoBatch) setViewingBatch(demoBatch);
         return;
       }
       const siblings = getBatchSiblings(allActivities, activity);

--- a/services/vault/src/context/deposit/PeginPollingContext.tsx
+++ b/services/vault/src/context/deposit/PeginPollingContext.tsx
@@ -22,9 +22,9 @@ import {
 } from "react";
 import type { Hex } from "viem";
 
-import { useDemoDeposit } from "@/dev/demoDeposit";
 import { logger } from "@/infrastructure";
 import { shortId, TELEMETRY_EVENT } from "@/infrastructure/telemetryEvents";
+import { useDepositOverride } from "@/overrides/deposits";
 
 import { usePeginPollingProtocolParams } from "../../hooks/deposit/usePeginPollingProtocolParams";
 import { usePeginPollingQuery } from "../../hooks/deposit/usePeginPollingQuery";
@@ -193,7 +193,7 @@ export function PeginPollingProvider({
   // God-mode demo deposit (dev only; null unless NEXT_PUBLIC_FF_GOD_MODE_PANEL
   // is on and the panel toggle is enabled). When present, its ids resolve to
   // controlled results below instead of the live polling decision tree.
-  const demo = useDemoDeposit();
+  const demo = useDepositOverride();
 
   // Optimistic step completions (for immediate UI feedback after an action).
   // App-scoped, not provider-scoped: the writers run outside the context

--- a/services/vault/src/context/deposit/__tests__/AppPeginPollingProvider.test.tsx
+++ b/services/vault/src/context/deposit/__tests__/AppPeginPollingProvider.test.tsx
@@ -46,8 +46,8 @@ vi.mock("@/hooks/useVaultDeposits", () => ({
 }));
 
 // A demo aggregate exists, but the provider must not be fed from it.
-vi.mock("@/dev/demoDeposit", () => ({
-  useDemoDeposit: () => ({
+vi.mock("@/overrides/deposits", () => ({
+  useDepositOverride: () => ({
     pendingActivities: [{ id: DEMO_ID }],
     resultsById: new Map(),
   }),

--- a/services/vault/src/dev/GodModePanel.tsx
+++ b/services/vault/src/dev/GodModePanel.tsx
@@ -7,9 +7,9 @@
  * app — no cross-window plumbing).
  *
  * It is a controller only: it never renders the cards itself. It manages a list
- * of mock items (each a deposit / withdrawal / collateral / loan at some state)
- * that render inside the REAL dashboard, vaults and loans sections (see
- * demoDeposit.ts). It is mounted once for those routes (see dev/GodModeMount).
+ * of mock items (each a deposit / collateral / loan at some state) that render
+ * inside the REAL dashboard, vaults and loans sections (see demoDeposit.ts).
+ * It is mounted once for those routes (see dev/GodModeMount).
  *
  * Chrome is intentionally theme-independent (fixed zinc colors) and inline, not
  * routed through copy.ts — none of it is shown to depositors.
@@ -26,6 +26,19 @@ import {
 import { createPortal } from "react-dom";
 
 import type { ProtocolStatus } from "@/components/shared/protocolStatus";
+import { setActivityOverride } from "@/overrides/activity";
+import { setArtifactDownloadOverride } from "@/overrides/artifactDownload";
+import {
+  setBorrowCapacityOverride,
+  setHealthFactorOverride,
+} from "@/overrides/borrowCapacity";
+import { setCollateralOverride } from "@/overrides/collateral";
+import { setDepositOverride } from "@/overrides/deposits";
+import { setLoanOverride } from "@/overrides/loans";
+import {
+  setMaxVaultsOverride,
+  setProtocolStatusOverride,
+} from "@/overrides/protocolStatus";
 import { clearArtifactDownloadReceipts } from "@/utils/artifactDownloadStorage";
 
 import {
@@ -36,6 +49,7 @@ import {
   setDebugHealthFactorOverride,
   setDebugMaxVaultsOverride,
   setDebugProtocolStatusOverride,
+  useDebugBorrowCapacity,
   useDebugBorrowCapacityStateOverride,
   useDebugHealthFactorOverride,
   useDebugMaxVaultsOverride,
@@ -45,6 +59,7 @@ import {
   DEMO_ARTIFACT_SCENARIO_LABELS,
   DEMO_ARTIFACT_SCENARIOS,
   type DemoArtifactScenario,
+  demoFetchAndDownloadArtifacts,
   setArtifactDownloadMockEnabled,
   setArtifactDownloadScenario,
   useArtifactDownloadMockEnabled,
@@ -53,6 +68,10 @@ import {
 import {
   addDemoItem,
   amountUnitFor,
+  buildActivitiesDemo,
+  buildCollateralsDemo,
+  buildDepositsDemo,
+  buildLoansDemo,
   DEMO_BORROW_SYMBOL_OPTIONS,
   type DemoBorrowSymbol,
   type DemoCta,
@@ -85,7 +104,6 @@ import {
 
 const TYPE_LABELS: Record<DemoType, string> = {
   deposit: "Deposit",
-  withdrawal: "Withdrawal",
   collateral: "Collateral",
   loan: "Loan",
   activity: "Activity",
@@ -302,6 +320,38 @@ function DemoControls() {
   const [clearedReceipts, setClearedReceipts] = useState<number | null>(null);
   const borrowSymbol = useDemoBorrowSymbol();
 
+  // Publish the resolved deposit-family aggregates for the real dashboard
+  // sections to read. "Inject demo" gates all four: merely adding a mock item
+  // must not inject it until the toggle opts in.
+  useEffect(() => {
+    setDepositOverride(enabled ? buildDepositsDemo(items, hideReal) : null);
+  }, [enabled, items, hideReal]);
+
+  useEffect(() => {
+    setActivityOverride(
+      enabled ? buildActivitiesDemo(items, hideReal, borrowSymbol) : null,
+    );
+  }, [enabled, items, hideReal, borrowSymbol]);
+
+  useEffect(() => {
+    setCollateralOverride(
+      enabled ? buildCollateralsDemo(items, hideReal) : null,
+    );
+  }, [enabled, items, hideReal]);
+
+  useEffect(() => {
+    setLoanOverride(
+      enabled ? buildLoansDemo(items, hideReal, borrowSymbol) : null,
+    );
+  }, [enabled, items, hideReal, borrowSymbol]);
+
+  // Independent of "Inject demo" — see the toggle's own label below.
+  useEffect(() => {
+    setArtifactDownloadOverride(
+      mockArtifactDownload ? demoFetchAndDownloadArtifacts : null,
+    );
+  }, [mockArtifactDownload]);
+
   return (
     <div className="space-y-3">
       <label className="flex cursor-pointer items-center justify-between gap-2 text-sm">
@@ -479,6 +529,14 @@ function NotificationOverrideControls() {
   const maxVaultsOverride = useDebugMaxVaultsOverride();
   const protocolStatusOverride = useDebugProtocolStatusOverride();
 
+  useEffect(() => {
+    setMaxVaultsOverride(maxVaultsOverride);
+  }, [maxVaultsOverride]);
+
+  useEffect(() => {
+    setProtocolStatusOverride(protocolStatusOverride);
+  }, [protocolStatusOverride]);
+
   return (
     <div className="space-y-2">
       <div className={PANEL_SECTION_TITLE_CLASS}>Notifications</div>
@@ -534,6 +592,17 @@ const BORROW_CAPACITY_LABELS: Record<DebugBorrowCapacityState, string> = {
 function LoansOverrideControls() {
   const healthFactorOverride = useDebugHealthFactorOverride();
   const borrowCapacityOverride = useDebugBorrowCapacityStateOverride();
+  // Resolved {loading, error} | null snapshot — see debugPositionStore's
+  // DEBUG_BORROW_CAPACITY_SNAPSHOTS for why the Error stays dev-only there.
+  const resolvedBorrowCapacity = useDebugBorrowCapacity();
+
+  useEffect(() => {
+    setHealthFactorOverride(healthFactorOverride);
+  }, [healthFactorOverride]);
+
+  useEffect(() => {
+    setBorrowCapacityOverride(resolvedBorrowCapacity);
+  }, [resolvedBorrowCapacity]);
 
   return (
     <div className="space-y-2">

--- a/services/vault/src/dev/LiquidationAnalysisDebugPanel.tsx
+++ b/services/vault/src/dev/LiquidationAnalysisDebugPanel.tsx
@@ -14,6 +14,13 @@
  * independently, so both can be on at once.
  */
 
+import { useEffect } from "react";
+
+import {
+  setLiquidationCardOverride,
+  setLiquidationPositionOverride,
+} from "@/overrides/liquidations";
+
 import {
   LIQUIDATION_DEBUG_STATES,
   setLiquidationDebugState,
@@ -38,6 +45,10 @@ const POSITION_FIELD_GRID_CLASS = "grid grid-cols-3 gap-x-3 gap-y-2";
 function PositionOverrideControls() {
   const enabled = useLiquidationPositionOverrideEnabled();
   const values = useLiquidationPositionOverrideValues();
+
+  useEffect(() => {
+    setLiquidationPositionOverride(enabled ? values : null);
+  }, [enabled, values]);
 
   const updateField = (
     field: keyof LiquidationPositionOverride,
@@ -108,6 +119,10 @@ function PositionOverrideControls() {
 
 export function LiquidationAnalysisDebugPanel() {
   const state = useLiquidationDebugState();
+
+  useEffect(() => {
+    setLiquidationCardOverride(state === "auto" ? null : state);
+  }, [state]);
 
   return (
     <details className={PANEL_SECTION_CLASS}>

--- a/services/vault/src/dev/MarketDataDebugPanel.tsx
+++ b/services/vault/src/dev/MarketDataDebugPanel.tsx
@@ -8,6 +8,10 @@
  * data.
  */
 
+import { useEffect } from "react";
+
+import { setMarketDataOverride } from "@/overrides/marketData";
+
 import { setDemoMarketDataEnabled, useDemoMarketData } from "./demoMarketData";
 import {
   PANEL_HINT_CLASS,
@@ -19,6 +23,10 @@ import {
 export function MarketDataDebugPanel() {
   const demoMarketData = useDemoMarketData();
   const enabled = demoMarketData !== null;
+
+  useEffect(() => {
+    setMarketDataOverride(demoMarketData);
+  }, [demoMarketData]);
 
   return (
     <details className={PANEL_SECTION_CLASS}>

--- a/services/vault/src/dev/PositionNotificationsDebugPanel.tsx
+++ b/services/vault/src/dev/PositionNotificationsDebugPanel.tsx
@@ -28,12 +28,12 @@ import {
   resetDebugManualParams,
   setDebugManualMode,
   setDebugManualParams,
-  setDebugPositionOverride,
   setDebugSimulateStalePrice,
   useDebugManualMode,
   useDebugManualParams,
   useDebugSimulateStalePrice,
 } from "@/dev/debugPositionStore";
+import { setPositionCascadeOverride } from "@/overrides/position";
 
 import {
   PANEL_BUTTON_CLASS,
@@ -468,20 +468,31 @@ export function PositionNotificationsDebugPanel() {
   const displayResult = manualMode ? manualResult : hookResult;
 
   // Publish the derived override so the dashboard banner reflects the debug
-  // state. Live mode publishes the live result (a no-op override); manual mode
-  // publishes the simulated result; stale-price publishes the status only.
+  // state. Live mode publishes nothing (every consumer already falls back to
+  // the live calculation); manual mode publishes the simulated cascade;
+  // stale-price publishes the status with no cascade to chart.
   useEffect(() => {
     if (simulateStalePrice) {
-      setDebugPositionOverride(null, "stale-price");
+      setPositionCascadeOverride({
+        result: null,
+        status: "stale-price",
+        params: manualParams,
+      });
+    } else if (manualMode && manualResult) {
+      setPositionCascadeOverride({
+        result: manualResult,
+        status: null,
+        params: manualParams,
+      });
     } else {
-      setDebugPositionOverride(displayResult, null);
+      setPositionCascadeOverride(null);
     }
-  }, [displayResult, simulateStalePrice]);
+  }, [manualMode, manualResult, manualParams, simulateStalePrice]);
 
   // Stop overriding the banner once this panel unmounts (god-mode hidden or the
   // popped-out window closed) — otherwise the last manual / stale-price override
   // would linger in the module store and keep driving the dashboard banner.
-  useEffect(() => () => setDebugPositionOverride(null, null), []);
+  useEffect(() => () => setPositionCascadeOverride(null), []);
 
   return (
     <details className={PANEL_SECTION_CLASS}>

--- a/services/vault/src/dev/__tests__/GodModePanel.test.tsx
+++ b/services/vault/src/dev/__tests__/GodModePanel.test.tsx
@@ -19,7 +19,6 @@ import {
   buildCollateralsDemo,
   buildDepositsDemo,
   buildLoansDemo,
-  buildWithdrawalsDemo,
   COLLATERAL_SCENARIOS,
   type DemoBorrowSymbol,
   type DemoItem,
@@ -33,7 +32,6 @@ import {
   submitDemoVaultActivation,
   useDemoBorrowSymbol,
   useDemoItems,
-  WITHDRAWAL_SCENARIOS,
 } from "../demoDeposit";
 import { GodModePanel } from "../GodModePanel";
 
@@ -137,21 +135,6 @@ describe("demoDeposit builders", () => {
     );
     expect(deposits.pendingActivities[0].collateral.amount).toBe("1.2345");
     expect(deposits.hideReal).toBe(true);
-
-    const withdrawals = buildWithdrawalsDemo(
-      [
-        {
-          key: 2,
-          type: "withdrawal",
-          stateIndex: 0,
-          amount: "0.5",
-          batched: false,
-        },
-      ],
-      true,
-    );
-    expect(withdrawals.vaults[0].amountBtc).toBe(0.5);
-    expect(withdrawals.statuses.size).toBe(1);
 
     const collateral = buildCollateralsDemo(
       [
@@ -505,17 +488,6 @@ describe("GodModePanel", () => {
     ).not.toBeInTheDocument();
   });
 
-  it("switches a mock to a different type and shows that type's states", () => {
-    renderExpanded();
-
-    fireEvent.change(screen.getByRole("combobox", { name: "Mock 1 type" }), {
-      target: { value: "withdrawal" },
-    });
-
-    // The readout reflects the first state of the newly selected type.
-    expect(screen.getByText(WITHDRAWAL_SCENARIOS[0].label)).toBeInTheDocument();
-  });
-
   it("switches a mock to a loan and re-labels its amount in the borrowed asset", () => {
     renderExpanded();
 
@@ -726,7 +698,6 @@ describe("GodModePanel", () => {
 describe("demoDeposit scenario lists", () => {
   it("exposes non-empty scenario lists per type", () => {
     expect(DEPOSIT_SCENARIOS.length).toBeGreaterThan(0);
-    expect(WITHDRAWAL_SCENARIOS.length).toBeGreaterThan(0);
     expect(COLLATERAL_SCENARIOS.length).toBeGreaterThan(0);
     expect(loanScenarios(TEST_SYMBOL).length).toBeGreaterThan(0);
     expect(activityScenarios(TEST_SYMBOL).length).toBeGreaterThan(0);

--- a/services/vault/src/dev/__tests__/debugPositionStore.test.ts
+++ b/services/vault/src/dev/__tests__/debugPositionStore.test.ts
@@ -1,17 +1,11 @@
 import { act, renderHook } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 
 import {
   calculate,
   deriveBannerState,
-  type CalculatorResult,
 } from "@/applications/aave/positionNotifications";
 import { getHealthFactorStatusFromValue } from "@/applications/aave/utils";
-
-// The two non-cascade overrides are read by production components, so the store
-// additionally gates them on the god-mode flag (see debugPositionStore).
-const featureFlagsMock = vi.hoisted(() => ({ isGodModePanelEnabled: true }));
-vi.mock("@/config/featureFlags", () => ({ default: featureFlagsMock }));
 
 import {
   applyDebugPreset,
@@ -25,7 +19,6 @@ import {
   setDebugManualMode,
   setDebugManualParams,
   setDebugMaxVaultsOverride,
-  setDebugPositionOverride,
   setDebugProtocolStatusOverride,
   setDebugSimulateStalePrice,
   useDebugBorrowCapacityStateOverride,
@@ -33,14 +26,9 @@ import {
   useDebugManualMode,
   useDebugManualParams,
   useDebugMaxVaultsOverride,
-  useDebugPositionOverride,
   useDebugProtocolStatusOverride,
   useDebugSimulateStalePrice,
 } from "../debugPositionStore";
-
-// Opaque identity token — the store only stores/compares the reference, so the
-// full CalculatorResult shape is irrelevant to these tests.
-const RESULT_DOUBLE = { currentHF: 1.23 } as unknown as CalculatorResult;
 
 describe("debugPositionStore", () => {
   // Reset through the same setters production uses — the store is a module
@@ -49,7 +37,6 @@ describe("debugPositionStore", () => {
     setDebugManualMode(false);
     setDebugSimulateStalePrice(false);
     resetDebugManualParams();
-    setDebugPositionOverride(null, null);
   });
 
   it("reflects the manual-mode and stale-price toggles", () => {
@@ -77,38 +64,10 @@ describe("debugPositionStore", () => {
     act(() => resetDebugManualParams());
     expect(result.current.btcPrice).toBe(defaultBtcPrice);
   });
-
-  it("publishes the banner override for the dashboard to read", () => {
-    const { result } = renderHook(() => useDebugPositionOverride());
-    expect(result.current).toEqual({ result: null, status: null });
-
-    act(() => setDebugPositionOverride(RESULT_DOUBLE, null));
-    expect(result.current).toEqual({ result: RESULT_DOUBLE, status: null });
-
-    act(() => setDebugPositionOverride(null, "stale-price"));
-    expect(result.current).toEqual({ result: null, status: "stale-price" });
-  });
-
-  it("keeps the same snapshot when the override is unchanged (reference guard)", () => {
-    const { result } = renderHook(() => useDebugPositionOverride());
-
-    act(() => setDebugPositionOverride(null, "stale-price"));
-    const first = result.current;
-
-    // Same values → identical snapshot, so subscribers don't churn.
-    act(() => setDebugPositionOverride(null, "stale-price"));
-    expect(result.current).toBe(first);
-
-    // A changed value → a fresh snapshot.
-    act(() => setDebugPositionOverride(null, "loading"));
-    expect(result.current).not.toBe(first);
-    expect(result.current.status).toBe("loading");
-  });
 });
 
 describe("non-cascade notification overrides", () => {
   afterEach(() => {
-    featureFlagsMock.isGodModePanelEnabled = true;
     act(() => setDebugMaxVaultsOverride(null));
     act(() => setDebugProtocolStatusOverride(null));
   });
@@ -137,23 +96,10 @@ describe("non-cascade notification overrides", () => {
     act(() => setDebugProtocolStatusOverride(null));
     expect(result.current).toBeNull();
   });
-
-  it("reports no override when god mode is off, whatever was written", () => {
-    act(() => setDebugMaxVaultsOverride(DEBUG_FORCED_MAX_VAULTS));
-    act(() => setDebugProtocolStatusOverride("paused"));
-
-    featureFlagsMock.isGodModePanelEnabled = false;
-
-    const cap = renderHook(() => useDebugMaxVaultsOverride());
-    const status = renderHook(() => useDebugProtocolStatusOverride());
-    expect(cap.result.current).toBeNull();
-    expect(status.result.current).toBeNull();
-  });
 });
 
 describe("loans summary overrides", () => {
   afterEach(() => {
-    featureFlagsMock.isGodModePanelEnabled = true;
     act(() => setDebugHealthFactorOverride(null));
     act(() => setDebugBorrowCapacityStateOverride(null));
   });
@@ -180,20 +126,6 @@ describe("loans summary overrides", () => {
 
     act(() => setDebugBorrowCapacityStateOverride(null));
     expect(result.current).toBeNull();
-  });
-
-  // These feed a PRODUCTION page (the v3 Loans summary), so the flag gate is
-  // what keeps a stale override out of a real build.
-  it("reports no override when god mode is off, whatever was written", () => {
-    act(() => setDebugHealthFactorOverride(1.02));
-    act(() => setDebugBorrowCapacityStateOverride("error"));
-
-    featureFlagsMock.isGodModePanelEnabled = false;
-
-    const hf = renderHook(() => useDebugHealthFactorOverride());
-    const capacity = renderHook(() => useDebugBorrowCapacityStateOverride());
-    expect(hf.result.current).toBeNull();
-    expect(capacity.result.current).toBeNull();
   });
 
   it("bands every offered health factor into a distinct status", () => {

--- a/services/vault/src/dev/debugPositionStore.ts
+++ b/services/vault/src/dev/debugPositionStore.ts
@@ -15,24 +15,11 @@
 
 import { useSyncExternalStore } from "react";
 
-import type { PositionNotificationsStatus } from "@/applications/aave/hooks/usePositionNotifications";
 import type {
   BannerSeverity,
   CalculatorParams,
-  CalculatorResult,
 } from "@/applications/aave/positionNotifications";
-import {
-  getHealthFactorStatusFromValue,
-  type HealthFactorStatus,
-} from "@/applications/aave/utils";
 import type { ProtocolStatus } from "@/components/shared/protocolStatus";
-import featureFlags from "@/config/featureFlags";
-
-/** Derived banner override the dashboard reads: null result/status = use live. */
-export interface DebugPositionOverride {
-  result: CalculatorResult | null;
-  status: PositionNotificationsStatus | null;
-}
 
 // Representative sample inputs for manual mode — a realistic starting point,
 // NOT protocol parameters. The ratio defaults are exported so the panel's
@@ -191,8 +178,6 @@ export function applyDebugPreset(preset: DebugPreset) {
   emit();
 }
 
-const NO_OVERRIDE: DebugPositionOverride = { result: null, status: null };
-
 /**
  * Cap used when "maximum vaults reached" is forced from the panel — the
  * on-chain governance value at the time of writing, so the forced card reads
@@ -240,7 +225,6 @@ const DEBUG_BORROW_CAPACITY_SNAPSHOTS: Record<
 let manualMode = false;
 let simulateStalePrice = false;
 let manualParams: CalculatorParams = makeDefaultDebugParams();
-let override: DebugPositionOverride = NO_OVERRIDE;
 // Non-cascade notification overrides (Figma v3 §7 / §8 / §9). null = no
 // override, i.e. the component uses live chain state.
 let maxVaultsOverride: number | null = null;
@@ -285,20 +269,6 @@ export function resetDebugManualParams() {
   emit();
 }
 
-/**
- * Publish the derived banner override. Written by the debug panel's effect and
- * read by the dashboard. Reference-guarded so an unchanged override doesn't
- * churn subscribers (mirrors React's setState bailout).
- */
-export function setDebugPositionOverride(
-  result: CalculatorResult | null,
-  status: PositionNotificationsStatus | null,
-) {
-  if (override.result === result && override.status === status) return;
-  override = { result, status };
-  emit();
-}
-
 /** Force (a cap number) or release (null) the "maximum vaults reached" card. */
 export function setDebugMaxVaultsOverride(cap: number | null) {
   maxVaultsOverride = cap;
@@ -334,10 +304,6 @@ function getSimulateStalePrice() {
 function getManualParams() {
   return manualParams;
 }
-function getOverride() {
-  return override;
-}
-
 export function useDebugManualMode(): boolean {
   return useSyncExternalStore(subscribe, getManualMode, getManualMode);
 }
@@ -354,31 +320,23 @@ export function useDebugManualParams(): CalculatorParams {
   return useSyncExternalStore(subscribe, getManualParams, getManualParams);
 }
 
-export function useDebugPositionOverride(): DebugPositionOverride {
-  return useSyncExternalStore(subscribe, getOverride, getOverride);
-}
-
-// The two overrides below are read by PRODUCTION components (the max-vaults
-// notice and the protocol banner), so they are additionally gated on the
-// god-mode flag — which is itself hard-gated on `import.meta.env.DEV`. In a
-// production build these getters are compile-time constant `null`, exactly like
-// demoArtifactDownload's mock gate, so the components always see live state.
+// Plain getters for the panel's own display hooks below. The god-mode gate
+// for PRODUCTION consumers now lives solely in `overrides/store.ts` (read via
+// the matching `@/overrides/*` store), so these no longer re-check the flag.
 function getMaxVaultsOverride(): number | null {
-  return featureFlags.isGodModePanelEnabled ? maxVaultsOverride : null;
+  return maxVaultsOverride;
 }
 
 function getProtocolStatusOverride(): ProtocolStatus | null {
-  return featureFlags.isGodModePanelEnabled ? protocolStatusOverride : null;
+  return protocolStatusOverride;
 }
 
 function getHealthFactorOverride(): number | null {
-  return featureFlags.isGodModePanelEnabled ? healthFactorOverride : null;
+  return healthFactorOverride;
 }
 
 function getBorrowCapacityStateOverride(): DebugBorrowCapacityState | null {
-  return featureFlags.isGodModePanelEnabled
-    ? borrowCapacityStateOverride
-    : null;
+  return borrowCapacityStateOverride;
 }
 
 function getBorrowCapacity(): DebugBorrowCapacity | null {
@@ -421,27 +379,10 @@ export function useDebugBorrowCapacityStateOverride(): DebugBorrowCapacityState 
 
 /**
  * The forced borrow-capacity rendering state for the v3 Loans summary, or null
- * to use the live read. Production reads THIS (not the raw state or the Error
- * constant) so the simulated-failure message never enters a production build.
+ * to use the live read. The panel publishes THIS (not the raw state or the
+ * Error constant) to `@/overrides/borrowCapacity`, so the simulated-failure
+ * message never enters a production build.
  */
 export function useDebugBorrowCapacity(): DebugBorrowCapacity | null {
   return useSyncExternalStore(subscribe, getBorrowCapacity, getBorrowCapacity);
-}
-
-/**
- * What a page should render for the health factor given a forced value. Shared
- * by every god-mode consumer so they can't drift on how a forced value maps to
- * a status: the status is always re-derived with the production banding
- * function, never carried over from the live read.
- */
-export function resolveShownHealthFactor(
-  override: number | null,
-  healthFactor: number | null,
-  healthFactorStatus: HealthFactorStatus,
-): { healthFactor: number | null; healthFactorStatus: HealthFactorStatus } {
-  if (override === null) return { healthFactor, healthFactorStatus };
-  return {
-    healthFactor: override,
-    healthFactorStatus: getHealthFactorStatusFromValue(override),
-  };
 }

--- a/services/vault/src/dev/demoDeposit.ts
+++ b/services/vault/src/dev/demoDeposit.ts
@@ -3,15 +3,14 @@
  *
  * The god-mode panel builds a LIST of mock items that render inside the REAL
  * dashboard sections, so you can preview many states at once. Each item has a
- * TYPE (deposit / withdrawal / collateral / loan / activity) and a STATE; the
- * state decides which section it lands in (e.g. a deposit in an expired state
- * renders under Expired Deposits; a withdrawal in the payout-sent state under
- * Withdrawals; a loan under Active Loans on the v3 Loans page; an activity row
- * in the v3 Activity feed).
+ * TYPE (deposit / collateral / loan / activity) and a STATE; the state decides
+ * which section it lands in (e.g. a deposit in an expired state renders under
+ * Expired Deposits; a loan under Active Loans on the v3 Loans page; an
+ * activity row in the v3 Activity feed).
  *
  * How it stays safe and fully inert when off:
- *  - States are built by the REAL state machines (getPeginState /
- *    getPegoutDisplayState), so the gallery can't drift from production.
+ *  - States are built by the REAL state machine (getPeginState), so the
+ *    gallery can't drift from production.
  *  - Demo activities are injected ONLY into the section render lists (never into
  *    `allActivities`), so they are never polled. Click handlers no-op for them,
  *    with one deliberate exception: owned flow-state deposit cards open the real
@@ -26,7 +25,6 @@
 import { useMemo, useSyncExternalStore } from "react";
 import type { Hex } from "viem";
 
-import type { RedeemedVaultInfo } from "@/applications/aave/hooks/useAaveVaults";
 import type { ActiveLoanRow } from "@/applications/aave/hooks/useActiveLoans";
 import {
   getStepLabel,
@@ -35,18 +33,12 @@ import {
 import featureFlags from "@/config/featureFlags";
 import { COPY } from "@/copy";
 import { DepositFlowStep } from "@/hooks/deposit/depositFlowSteps/types";
-import type { PegoutPollingResult } from "@/hooks/usePegoutPolling";
 import {
   ContractStatus,
   getPeginState,
   type GetPeginStateOptions,
   LocalStorageStatus,
 } from "@/models/peginStateMachine";
-import {
-  ClaimerPegoutStatusValue,
-  getPegoutDisplayState,
-  TIMED_OUT_STATE,
-} from "@/models/pegoutStateMachine";
 import { VAULT_COLLATERAL_ASSET } from "@/services/activity/projection";
 import { getCurrencyIconWithFallback } from "@/services/token/tokenService";
 import type { VaultActivity } from "@/types/activity";
@@ -63,19 +55,14 @@ export type DemoCta = "primary" | "outlined" | "none";
  *  with, and the unit of the value that mock actually renders. */
 export type DemoAmountUnit = string;
 
-/** Deposit / withdrawal / collateral cards render the literal "BTC" (see
- *  `buildActivity`), while activity rows render the network-aware collateral
- *  symbol ("sBTC" on signet) — so the label a mock's amount field carries has
- *  to follow whichever list builds it, not one global spelling. */
+/** Deposit / collateral cards render the literal "BTC" (see `buildActivity`),
+ *  while activity rows render the network-aware collateral symbol ("sBTC" on
+ *  signet) — so the label a mock's amount field carries has to follow
+ *  whichever list builds it, not one global spelling. */
 const BTC_AMOUNT_UNIT = "BTC";
 
 /** The kind of thing a mock item represents. */
-export type DemoType =
-  | "deposit"
-  | "withdrawal"
-  | "collateral"
-  | "loan"
-  | "activity";
+export type DemoType = "deposit" | "collateral" | "loan" | "activity";
 
 /** One mock item the panel manages. `batched` only applies to deposits. */
 export interface DemoItem {
@@ -110,9 +97,6 @@ const DEMO_BATCH_PREPEGIN = `0x${"bc".repeat(32)}`;
 const DEMO_OWNER_PUBKEY = "a".repeat(64);
 const DEMO_PEGIN_TX = `0x${"d1".repeat(32)}` as Hex;
 const DEMO_PREPEGIN_TX = `0x${"e1".repeat(32)}` as Hex;
-const DEMO_CLAIM_TXID = "c".repeat(64);
-const DEMO_ASSERT_TXID = "a2".repeat(32);
-const DEMO_PEGOUT_PEGIN_TXID = "d1".repeat(32);
 const DEFAULT_DEMO_AMOUNT = "0.0375";
 const DEMO_REQUIRED_DEPTH = 6;
 /** Fixed timestamp (2025-10-16 11:48:47 UTC) so date rows are stable. */
@@ -389,66 +373,6 @@ export const ACTIVATION_CONFIRMING_SCENARIO_INDEX = flowScenarioIndex(
 /** Terminal ACTIVE state the simulated confirmation lands on. */
 export const ACTIVATED_SCENARIO_INDEX =
   DEPOSIT_SCENARIOS.indexOf(ACTIVATED_SCENARIO);
-
-// --- Withdrawal (peg-out) scenarios ----------------------------------------
-
-/** One controllable withdrawal (peg-out) state. Withdrawals never show a CTA. */
-export interface WithdrawalScenario extends BaseScenario {
-  claimerStatus?: ClaimerPegoutStatusValue;
-  found: boolean;
-  timedOut?: boolean;
-}
-
-export const WITHDRAWAL_SCENARIOS: WithdrawalScenario[] = [
-  {
-    key: "wd-initiating",
-    label: "Initiating",
-    expectedCta: "none",
-    found: false,
-  },
-  {
-    key: "wd-claim-received",
-    label: "Submitted (claim received)",
-    expectedCta: "none",
-    claimerStatus: ClaimerPegoutStatusValue.CLAIM_EVENT_RECEIVED,
-    found: true,
-  },
-  {
-    key: "wd-claim-broadcast",
-    label: "In progress (claim broadcast)",
-    expectedCta: "none",
-    claimerStatus: ClaimerPegoutStatusValue.CLAIM_BROADCAST,
-    found: true,
-  },
-  {
-    key: "wd-assert-broadcast",
-    label: "Challenge period (assert broadcast)",
-    expectedCta: "none",
-    claimerStatus: ClaimerPegoutStatusValue.ASSERT_BROADCAST,
-    found: true,
-  },
-  {
-    key: "wd-payout-sent",
-    label: "Payout sent",
-    expectedCta: "none",
-    claimerStatus: ClaimerPegoutStatusValue.PAYOUT_BROADCAST,
-    found: true,
-  },
-  {
-    key: "wd-blocked",
-    label: "Blocked (contact support)",
-    expectedCta: "none",
-    claimerStatus: ClaimerPegoutStatusValue.PAYOUT_BLOCKED,
-    found: true,
-  },
-  {
-    key: "wd-timed-out",
-    label: "Status unavailable (timed out)",
-    expectedCta: "none",
-    found: false,
-    timedOut: true,
-  },
-];
 
 // --- Collateral (active vault) scenarios -----------------------------------
 
@@ -803,7 +727,6 @@ export function scenariosForType(
   type: DemoType,
   borrowSymbol: DemoBorrowSymbol,
 ): BaseScenario[] {
-  if (type === "withdrawal") return WITHDRAWAL_SCENARIOS;
   if (type === "collateral") return COLLATERAL_SCENARIOS;
   if (type === "loan") return loanScenarios(borrowSymbol);
   if (type === "activity") return activityScenarios(borrowSymbol);
@@ -832,14 +755,6 @@ export function amountUnitFor(
 /** Which dashboard section a mock item renders in (panel hint, derived from
  *  type + state). */
 export function itemSectionHint(item: DemoItem): string {
-  if (item.type === "withdrawal") {
-    // v2 only: the v3 /vaults page has no withdrawal section yet (the
-    // relocation step of #2041), so a withdrawal mock renders nothing there.
-    const scenario = WITHDRAWAL_SCENARIOS[item.stateIndex];
-    return scenario?.claimerStatus === ClaimerPegoutStatusValue.PAYOUT_BROADCAST
-      ? "Withdrawals (v2 only)"
-      : "Pending Withdrawals (v2 only)";
-  }
   if (item.type === "collateral") {
     return "BTC Vaults (v2) / Active Vaults (v3 Vaults)";
   }
@@ -892,54 +807,6 @@ function buildActivity(
   };
 }
 
-function buildWithdrawVault(id: Hex, amount: string): RedeemedVaultInfo {
-  return {
-    id,
-    peginTxHash: DEMO_PEGIN_TX,
-    prePeginTxHash: DEMO_PREPEGIN_TX,
-    amountBtc: Number.parseFloat(amount) || 0,
-    providerName: DEMO_VAULT_PROVIDER.name ?? "demo-vault-provider",
-    vaultProviderAddress: DEMO_PROVIDER_ID,
-    createdAt: DEMO_TIMESTAMP,
-    offchainParamsVersion: 0,
-  };
-}
-
-function buildPegoutResult(scenario: WithdrawalScenario): PegoutPollingResult {
-  if (scenario.timedOut) {
-    return { displayState: TIMED_OUT_STATE };
-  }
-  if (!scenario.claimerStatus) {
-    return {
-      displayState: getPegoutDisplayState(undefined, false),
-      response: {
-        pegin_txid: DEMO_PEGOUT_PEGIN_TXID,
-        found: false,
-        claimer: null,
-        challengers: [],
-      },
-    };
-  }
-  return {
-    displayState: getPegoutDisplayState(scenario.claimerStatus, true),
-    response: {
-      pegin_txid: DEMO_PEGOUT_PEGIN_TXID,
-      found: true,
-      claimer: {
-        status: scenario.claimerStatus,
-        failed:
-          scenario.claimerStatus === ClaimerPegoutStatusValue.PAYOUT_BLOCKED,
-        claim_txid: DEMO_CLAIM_TXID,
-        claimer_pubkey: DEMO_OWNER_PUBKEY,
-        assert_txid: DEMO_ASSERT_TXID,
-        created_at: DEMO_AT_SECONDS,
-        updated_at: DEMO_AT_SECONDS,
-      },
-      challengers: [],
-    },
-  };
-}
-
 function buildCollateralEntry(
   id: Hex,
   scenario: CollateralScenario,
@@ -970,12 +837,6 @@ export interface ActiveDemo {
   expiredActivities: VaultActivity[];
   resultsById: Map<string, DepositPollingResult>;
   provider: VaultProvider;
-  hideReal: boolean;
-}
-
-export interface ActiveDemoWithdrawal {
-  vaults: RedeemedVaultInfo[];
-  statuses: Map<string, PegoutPollingResult>;
   hideReal: boolean;
 }
 
@@ -1028,23 +889,6 @@ export function buildDepositsDemo(
     provider: DEMO_VAULT_PROVIDER,
     hideReal,
   };
-}
-
-export function buildWithdrawalsDemo(
-  items: DemoItem[],
-  hideReal: boolean,
-): ActiveDemoWithdrawal {
-  const vaults: RedeemedVaultInfo[] = [];
-  const statuses = new Map<string, PegoutPollingResult>();
-  for (const item of items) {
-    if (item.type !== "withdrawal") continue;
-    const scenario =
-      WITHDRAWAL_SCENARIOS[item.stateIndex] ?? WITHDRAWAL_SCENARIOS[0];
-    const id = itemHexId(item.key);
-    vaults.push(buildWithdrawVault(id, safeAmount(item.amount)));
-    statuses.set(id, buildPegoutResult(scenario));
-  }
-  return { vaults, statuses, hideReal };
 }
 
 export function buildCollateralsDemo(
@@ -1370,21 +1214,6 @@ export function useDemoDeposit(): ActiveDemo | null {
     () =>
       import.meta.env.DEV && flagOn && enabled
         ? buildDepositsDemo(items, hideReal)
-        : null,
-    [flagOn, enabled, items, hideReal],
-  );
-}
-
-/** Aggregate demo withdrawals to inject, or null when off. */
-export function useDemoWithdrawal(): ActiveDemoWithdrawal | null {
-  const enabled = useDemoEnabled();
-  const hideReal = useDemoHideReal();
-  const items = useDemoItems();
-  const flagOn = featureFlags.isGodModePanelEnabled;
-  return useMemo(
-    () =>
-      import.meta.env.DEV && flagOn && enabled
-        ? buildWithdrawalsDemo(items, hideReal)
         : null,
     [flagOn, enabled, items, hideReal],
   );

--- a/services/vault/src/dev/liquidationDebugStore.ts
+++ b/services/vault/src/dev/liquidationDebugStore.ts
@@ -61,26 +61,6 @@ export function useLiquidationDebugState(): LiquidationDebugState {
   return useSyncExternalStore(subscribe, getState, getState);
 }
 
-/**
- * Resolve the card's two flags from the live position and the debug state, so
- * the forcing rule lives next to the store instead of in the dashboard's JSX.
- */
-export function resolveLiquidationCardState(
-  debugState: LiquidationDebugState,
-  live: { hasCollateral: boolean; hasLoans: boolean },
-): { hasCollateral: boolean; hasLoans: boolean } {
-  switch (debugState) {
-    case "no-deposit":
-      return { hasCollateral: false, hasLoans: false };
-    case "no-loan":
-      return { hasCollateral: true, hasLoans: false };
-    case "position":
-      return { hasCollateral: true, hasLoans: true };
-    case "auto":
-      return live;
-  }
-}
-
 /** The `/liquidations` page's stat-card figures, set directly from the panel. */
 export interface LiquidationPositionOverride {
   collateralBtc: number;
@@ -136,15 +116,4 @@ export function useLiquidationPositionOverrideValues(): LiquidationPositionOverr
     getPositionOverrideValues,
     getPositionOverrideValues,
   );
-}
-
-/**
- * The position override for consumers: null means use the live (or cascade)
- * figures. Mock is all-or-nothing, like the rest of god mode — a consumer
- * never blends `positionOverrideValues` with live data.
- */
-export function useLiquidationPositionOverride(): LiquidationPositionOverride | null {
-  const enabled = useLiquidationPositionOverrideEnabled();
-  const values = useLiquidationPositionOverrideValues();
-  return enabled ? values : null;
 }

--- a/services/vault/src/hooks/__tests__/useActivitiesWithPending.test.tsx
+++ b/services/vault/src/hooks/__tests__/useActivitiesWithPending.test.tsx
@@ -14,7 +14,7 @@ import { useActivitiesWithPending } from "../useActivitiesWithPending";
 
 const useActivitiesMock = vi.fn();
 const getPendingActivitiesMock = vi.fn();
-const useDemoActivityMock = vi.fn();
+const useActivityOverrideMock = vi.fn();
 
 vi.mock("../useActivities", () => ({
   useActivities: (arg: unknown) => useActivitiesMock(arg),
@@ -24,8 +24,8 @@ vi.mock("../../services/activity", () => ({
   getPendingActivities: (arg: unknown) => getPendingActivitiesMock(arg),
 }));
 
-vi.mock("../../dev/demoDeposit", () => ({
-  useDemoActivity: () => useDemoActivityMock(),
+vi.mock("../../overrides/activity", () => ({
+  useActivityOverride: () => useActivityOverrideMock(),
 }));
 
 const ADDR = "0xabc0000000000000000000000000000000000001" as const;
@@ -47,7 +47,7 @@ describe("useActivitiesWithPending", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     useActivitiesMock.mockReturnValue({ data: [], isLoading: false });
-    useDemoActivityMock.mockReturnValue(null);
+    useActivityOverrideMock.mockReturnValue(null);
   });
 
   it("returns [] synchronously when userAddress is undefined, even if pending activities exist for a prior address", () => {
@@ -91,13 +91,16 @@ describe("useActivitiesWithPending — god-mode demo rows", () => {
     vi.clearAllMocks();
     getPendingActivitiesMock.mockReturnValue([]);
     useActivitiesMock.mockReturnValue({ data: [], isLoading: false });
-    useDemoActivityMock.mockReturnValue(null);
+    useActivityOverrideMock.mockReturnValue(null);
   });
 
   it("renders demo rows while disconnected, without waiting on the live query", () => {
     useActivitiesMock.mockReturnValue({ data: [], isLoading: true });
     const demoRow = makePending("demo-activity-1", 5_000);
-    useDemoActivityMock.mockReturnValue({ rows: [demoRow], hideReal: false });
+    useActivityOverrideMock.mockReturnValue({
+      rows: [demoRow],
+      hideReal: false,
+    });
 
     const { result } = renderHook(() => useActivitiesWithPending(undefined));
 
@@ -112,7 +115,7 @@ describe("useActivitiesWithPending — god-mode demo rows", () => {
       data: [makePending("confirmed-1", 1_000)],
       isLoading: true,
     });
-    useDemoActivityMock.mockReturnValue({ rows: [], hideReal: true });
+    useActivityOverrideMock.mockReturnValue({ rows: [], hideReal: true });
 
     const { result } = renderHook(() => useActivitiesWithPending(ADDR));
 
@@ -122,7 +125,7 @@ describe("useActivitiesWithPending — god-mode demo rows", () => {
 
   it("keeps the live loading state when the demo adds nothing to the feed", () => {
     useActivitiesMock.mockReturnValue({ data: [], isLoading: true });
-    useDemoActivityMock.mockReturnValue({ rows: [], hideReal: false });
+    useActivityOverrideMock.mockReturnValue({ rows: [], hideReal: false });
 
     const { result } = renderHook(() => useActivitiesWithPending(ADDR));
 
@@ -133,7 +136,7 @@ describe("useActivitiesWithPending — god-mode demo rows", () => {
     const confirmed = makePending("confirmed-1", 3_000);
     const demoOlder = makePending("demo-activity-1", 2_000);
     useActivitiesMock.mockReturnValue({ data: [confirmed], isLoading: false });
-    useDemoActivityMock.mockReturnValue({
+    useActivityOverrideMock.mockReturnValue({
       rows: [demoOlder],
       hideReal: false,
     });

--- a/services/vault/src/hooks/__tests__/useVaultsPageData.test.ts
+++ b/services/vault/src/hooks/__tests__/useVaultsPageData.test.ts
@@ -39,8 +39,8 @@ const demoState = vi.hoisted(() => ({
   } | null,
 }));
 
-vi.mock("@/dev/demoDeposit", () => ({
-  useDemoCollateral: () => demoState.current,
+vi.mock("@/overrides/collateral", () => ({
+  useCollateralOverride: () => demoState.current,
 }));
 
 describe("useVaultsPageData", () => {

--- a/services/vault/src/hooks/deposit/__tests__/useArtifactDownload.test.tsx
+++ b/services/vault/src/hooks/deposit/__tests__/useArtifactDownload.test.tsx
@@ -8,6 +8,13 @@ import {
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+const featureFlagsMock = vi.hoisted(() => ({
+  // The artifact-download override is itself gated on this flag; the
+  // god-mode test flips it on to exercise the gated path.
+  isGodModePanelEnabled: false,
+}));
+vi.mock("@/config/featureFlags", () => ({ default: featureFlagsMock }));
+
 vi.mock("@/services/artifacts", async () => {
   // Re-export the real cancellation sentinel so the hook's
   // `err instanceof ArtifactDownloadCancelledError` check matches the
@@ -44,17 +51,7 @@ vi.mock("@/hooks/deposit/depositFlowSteps/ensureAuthenticatedVpClient", () => ({
   ensureAuthenticatedVpClient: vi.fn(),
 }));
 
-vi.mock("@/dev/demoArtifactDownload", () => ({
-  // Default OFF so every existing test exercises the real download path; the
-  // one demo test below flips it on.
-  isArtifactDownloadDemoEnabled: vi.fn(() => false),
-  demoFetchAndDownloadArtifacts: vi.fn(),
-}));
-
-import {
-  demoFetchAndDownloadArtifacts,
-  isArtifactDownloadDemoEnabled,
-} from "@/dev/demoArtifactDownload";
+import { setArtifactDownloadOverride } from "@/overrides/artifactDownload";
 import {
   ArtifactDownloadCancelledError,
   type ArtifactDownloadOutcome,
@@ -75,8 +72,6 @@ import { useArtifactDownload } from "../useArtifactDownload";
 const fetchMock = vi.mocked(fetchAndDownloadArtifacts);
 const openTargetMock = vi.mocked(openArtifactSaveTarget);
 const ensureAuthMock = vi.mocked(ensureAuthenticatedVpClient);
-const demoEnabledMock = vi.mocked(isArtifactDownloadDemoEnabled);
-const demoFetchMock = vi.mocked(demoFetchAndDownloadArtifacts);
 const saveReceiptMock = vi.mocked(saveArtifactDownloadReceipt);
 const hasDownloadedMock = vi.mocked(hasArtifactsDownloaded);
 
@@ -133,8 +128,8 @@ describe("useArtifactDownload — prime then fetch", () => {
   beforeEach(() => {
     fetchMock.mockReset();
     ensureAuthMock.mockReset();
-    demoEnabledMock.mockReturnValue(false);
-    demoFetchMock.mockReset();
+    featureFlagsMock.isGodModePanelEnabled = false;
+    setArtifactDownloadOverride(null);
     saveReceiptMock.mockReset();
     hasDownloadedMock.mockReturnValue(false);
     openTargetMock.mockReset();
@@ -144,6 +139,8 @@ describe("useArtifactDownload — prime then fetch", () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+    featureFlagsMock.isGodModePanelEnabled = false;
+    setArtifactDownloadOverride(null);
   });
 
   it("primes the bearer upfront when the registry is cold, then fetches once", async () => {
@@ -303,8 +300,9 @@ describe("useArtifactDownload — prime then fetch", () => {
     // gate: the file it wrote is synthetic, so mocking a download on a real
     // vault must not leave that vault looking recoverable, so it reports
     // `delivered` (which drives the UI) and never `downloaded`.
-    demoEnabledMock.mockReturnValue(true);
-    demoFetchMock.mockResolvedValueOnce(undefined);
+    featureFlagsMock.isGodModePanelEnabled = true;
+    const overrideFn = vi.fn().mockResolvedValueOnce(undefined);
+    setArtifactDownloadOverride(overrideFn);
 
     const { result } = renderHook(() =>
       useArtifactDownload({ vaultId: VAULT_ID }),
@@ -316,8 +314,8 @@ describe("useArtifactDownload — prime then fetch", () => {
 
     await waitFor(() => expect(result.current.delivered).toBe(true));
     expect(result.current.downloaded).toBe(false);
-    expect(demoFetchMock).toHaveBeenCalledTimes(1);
-    expect(demoFetchMock).toHaveBeenCalledWith(
+    expect(overrideFn).toHaveBeenCalledTimes(1);
+    expect(overrideFn).toHaveBeenCalledWith(
       SAVE_TARGET,
       { peginTxid: PEGIN_TXID, depositorPk: DEPOSITOR_PK },
       expect.anything(),
@@ -712,7 +710,8 @@ describe("useArtifactDownload — funnel telemetry", () => {
   beforeEach(() => {
     fetchMock.mockReset();
     ensureAuthMock.mockReset();
-    demoEnabledMock.mockReturnValue(false);
+    featureFlagsMock.isGodModePanelEnabled = false;
+    setArtifactDownloadOverride(null);
     saveReceiptMock.mockReset();
     hasDownloadedMock.mockReset();
     hasDownloadedMock.mockReturnValue(false);

--- a/services/vault/src/hooks/deposit/useArtifactDownload.ts
+++ b/services/vault/src/hooks/deposit/useArtifactDownload.ts
@@ -8,10 +8,6 @@ import { useCallback, useRef, useState } from "react";
 import type { Hex } from "viem";
 
 import { COPY } from "@/copy";
-import {
-  demoFetchAndDownloadArtifacts,
-  isArtifactDownloadDemoEnabled,
-} from "@/dev/demoArtifactDownload";
 import { ensureAuthenticatedVpClient } from "@/hooks/deposit/depositFlowSteps/ensureAuthenticatedVpClient";
 import { logger } from "@/infrastructure";
 import {
@@ -21,6 +17,7 @@ import {
   TELEMETRY_STAGE,
 } from "@/infrastructure/telemetryEvents";
 import { isPreDepositorSignaturesError } from "@/models/peginStateMachine";
+import { getArtifactDownloadOverride } from "@/overrides/artifactDownload";
 import {
   ArtifactDownloadCancelledError,
   type ArtifactDownloadOutcome,
@@ -143,7 +140,7 @@ export function useArtifactDownload(options?: {
       // so the dialogs' progress states can be exercised. Opted into via the
       // god-mode panel's "Mock artifact download" toggle; off in production
       // builds, where the god-mode gate is compile-time false.
-      const demoDownload = isArtifactDownloadDemoEnabled();
+      const demoDownload = getArtifactDownloadOverride();
 
       // DO NOT REORDER: showSaveFilePicker() requires transient user
       // activation, which any preceding `await` destroys. Opening the save
@@ -225,7 +222,7 @@ export function useArtifactDownload(options?: {
         fetchOptions: FetchArtifactsOptions,
       ): Promise<ArtifactDownloadOutcome | null> =>
         demoDownload
-          ? demoFetchAndDownloadArtifacts(
+          ? demoDownload(
               saveTarget,
               { peginTxid: normalizedPeginTxid, depositorPk },
               fetchOptions,

--- a/services/vault/src/hooks/useActivitiesWithPending.ts
+++ b/services/vault/src/hooks/useActivitiesWithPending.ts
@@ -9,7 +9,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import type { Address } from "viem";
 
 import { STORAGE_UPDATE_EVENT } from "../constants";
-import { useDemoActivity } from "../dev/demoDeposit";
+import { useActivityOverride } from "../overrides/activity";
 import { getPendingActivities } from "../services/activity";
 import type { ActivityLog, ActivityRow } from "../types/activityLog";
 
@@ -38,7 +38,7 @@ export function useActivitiesWithPending(userAddress: Address | undefined) {
   // indexed history. Read-only display rows: nothing here is ever polled,
   // written to localStorage, or deduplicated against real ids. Inert in
   // production.
-  const demo = useDemoActivity();
+  const demo = useActivityOverride();
 
   // Load pending activities from localStorage
   const loadPendingActivities = useCallback(() => {

--- a/services/vault/src/hooks/usePendingDeposits.ts
+++ b/services/vault/src/hooks/usePendingDeposits.ts
@@ -18,13 +18,13 @@ import { useMemo } from "react";
 import type { Address } from "viem";
 
 import { useBTCWallet, useETHWallet } from "@/context/wallet";
-import { useDemoDeposit } from "@/dev/demoDeposit";
 import { useAllDepositProviders } from "@/hooks/deposit/useAllDepositProviders";
 import { useBroadcastModal } from "@/hooks/deposit/useBroadcastModal";
 import { useEmergencyWithdrawModal } from "@/hooks/deposit/useEmergencyWithdrawModal";
 import { useRefundModal } from "@/hooks/deposit/useRefundModal";
 import { useVaultDeposits } from "@/hooks/useVaultDeposits";
 import { ContractStatus } from "@/models/peginStateMachine";
+import { useDepositOverride } from "@/overrides/deposits";
 
 export function usePendingDeposits() {
   const { connected: btcConnected, address: btcAddress } = useBTCWallet();
@@ -44,7 +44,7 @@ export function usePendingDeposits() {
   // the `demo` aggregate returned below (see PendingDepositSection). When
   // `demo.hideReal` is set, the real deposits are dropped from the render lists
   // so only the demo shows. Inert in production.
-  const demo = useDemoDeposit();
+  const demo = useDepositOverride();
 
   const pendingActivities = useMemo(() => {
     const real = activities.filter(

--- a/services/vault/src/hooks/useVaultsPageData.ts
+++ b/services/vault/src/hooks/useVaultsPageData.ts
@@ -13,8 +13,8 @@ import { useMemo } from "react";
 
 import { getNetworkConfigBTC } from "@/config";
 import { COPY } from "@/copy";
-import { useDemoCollateral } from "@/dev/demoDeposit";
 import { useDashboardState } from "@/hooks/useDashboardState";
+import { useCollateralOverride } from "@/overrides/collateral";
 import type { CollateralVaultEntry } from "@/types/collateral";
 import {
   formatBtcAmount,
@@ -34,7 +34,7 @@ export function useVaultsPageData(connectedAddress: string | undefined) {
     collateralVaults,
   } = useDashboardState(connectedAddress);
 
-  const demoCollateral = useDemoCollateral();
+  const demoCollateral = useCollateralOverride();
   const displayVaults = useMemo((): CollateralVaultEntry[] => {
     if (!demoCollateral) return collateralVaults;
     return [

--- a/services/vault/src/overrides/__tests__/borrowCapacity.test.ts
+++ b/services/vault/src/overrides/__tests__/borrowCapacity.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveShownHealthFactor } from "../borrowCapacity";
+
+describe("resolveShownHealthFactor", () => {
+  it("passes the live health factor and status through when there is no override", () => {
+    expect(resolveShownHealthFactor(null, 2.4, "safe")).toEqual({
+      healthFactor: 2.4,
+      healthFactorStatus: "safe",
+    });
+  });
+
+  it("substitutes the forced value and re-derives its status from production banding", () => {
+    // Live status is "safe", but the forced value bands as "danger" — the
+    // status must follow the forced value, never the live read.
+    expect(resolveShownHealthFactor(0.5, 2.4, "safe")).toEqual({
+      healthFactor: 0.5,
+      healthFactorStatus: "danger",
+    });
+  });
+
+  it("re-derives warning and safe bands for their respective forced values", () => {
+    expect(resolveShownHealthFactor(1.25, null, "no_debt")).toEqual({
+      healthFactor: 1.25,
+      healthFactorStatus: "warning",
+    });
+    expect(resolveShownHealthFactor(2.0, null, "no_debt")).toEqual({
+      healthFactor: 2.0,
+      healthFactorStatus: "safe",
+    });
+  });
+});

--- a/services/vault/src/overrides/__tests__/deposits.test.ts
+++ b/services/vault/src/overrides/__tests__/deposits.test.ts
@@ -1,0 +1,86 @@
+import type { Hex } from "viem";
+import { describe, expect, it } from "vitest";
+
+import { ContractStatus, getPeginState } from "@/models/peginStateMachine";
+import type { VaultActivity } from "@/types/activity";
+import type { DepositPollingResult } from "@/types/peginPolling";
+
+import type { DepositOverride } from "../deposits";
+import { getDemoStepperBatch } from "../deposits";
+
+const PEGIN_STATE = getPeginState(ContractStatus.PENDING, {});
+
+function makeActivity(id: Hex, unsignedPrePeginTx: string): VaultActivity {
+  return {
+    id,
+    collateral: { amount: "0.1", symbol: "BTC" },
+    providers: [{ id: "0xprovider" }],
+    displayLabel: PEGIN_STATE.displayLabel,
+    unsignedPrePeginTx,
+    depositorWotsPkHash: "",
+  };
+}
+
+function makeResult(
+  id: string,
+  isOwnedByCurrentWallet: boolean,
+): DepositPollingResult {
+  return {
+    depositId: id,
+    loading: false,
+    error: null,
+    peginState: PEGIN_STATE,
+    isOwnedByCurrentWallet,
+    depositorBtcPubkey: "a".repeat(64),
+    prePeginConfirmations: null,
+    requiredPrePeginDepth: 6,
+  };
+}
+
+const OWNED_ID = `0x${"1".repeat(40)}` as Hex;
+const SIBLING_ID = `0x${"2".repeat(40)}` as Hex;
+const UNOWNED_ID = `0x${"3".repeat(40)}` as Hex;
+const SHARED_PREPEGIN = `0x${"bc".repeat(32)}`;
+
+function makeOverride(): DepositOverride {
+  const owned = makeActivity(OWNED_ID, SHARED_PREPEGIN);
+  const sibling = makeActivity(SIBLING_ID, SHARED_PREPEGIN);
+  const unowned = makeActivity(UNOWNED_ID, "");
+  return {
+    pendingActivities: [owned, sibling, unowned],
+    expiredActivities: [],
+    resultsById: new Map([
+      [OWNED_ID, makeResult(OWNED_ID, true)],
+      [SIBLING_ID, makeResult(SIBLING_ID, true)],
+      [UNOWNED_ID, makeResult(UNOWNED_ID, false)],
+    ]),
+    provider: {
+      id: "0xprovider",
+      btcPubKey: `0x${"f".repeat(64)}`,
+      name: "demo-vault-provider",
+      url: "https://demo-vault-provider.invalid",
+      metadataStatus: "ok",
+    },
+    hideReal: false,
+  };
+}
+
+describe("getDemoStepperBatch", () => {
+  it("returns null when there is no override", () => {
+    expect(getDemoStepperBatch(null, OWNED_ID)).toBeNull();
+  });
+
+  it("returns null when the deposit id is not a pending demo activity", () => {
+    expect(getDemoStepperBatch(makeOverride(), "0xmissing")).toBeNull();
+  });
+
+  it("returns null for an unowned (different-wallet) demo deposit", () => {
+    expect(getDemoStepperBatch(makeOverride(), UNOWNED_ID)).toBeNull();
+  });
+
+  it("returns every owned sibling sharing the same Pre-PegIn batch", () => {
+    const batch = getDemoStepperBatch(makeOverride(), OWNED_ID);
+    expect(batch).not.toBeNull();
+    expect(new Set(batch)).toEqual(new Set([OWNED_ID, SIBLING_ID]));
+  });
+});

--- a/services/vault/src/overrides/__tests__/liquidations.test.ts
+++ b/services/vault/src/overrides/__tests__/liquidations.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, it } from "vitest";
 
-import { resolveLiquidationCardState } from "../liquidationDebugStore";
+import { resolveLiquidationCardState } from "../liquidations";
 
 const live = { hasCollateral: true, hasLoans: false };
 
 describe("resolveLiquidationCardState", () => {
-  it("passes the live position through untouched on auto", () => {
-    expect(resolveLiquidationCardState("auto", live)).toBe(live);
+  it("passes the live position through untouched when there is no override", () => {
+    expect(resolveLiquidationCardState(null, live)).toBe(live);
   });
 
   it("forces each card state regardless of the live position", () => {

--- a/services/vault/src/overrides/__tests__/store.test.ts
+++ b/services/vault/src/overrides/__tests__/store.test.ts
@@ -1,0 +1,53 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const featureFlagsMock = vi.hoisted(() => ({ isGodModePanelEnabled: true }));
+vi.mock("@/config/featureFlags", () => ({ default: featureFlagsMock }));
+
+import { createOverrideStore } from "../store";
+
+interface TestValue {
+  value: number;
+}
+
+describe("createOverrideStore", () => {
+  afterEach(() => {
+    featureFlagsMock.isGodModePanelEnabled = true;
+  });
+
+  it("returns null from get()/useValue() when the god-mode flag is off", () => {
+    const store = createOverrideStore<TestValue>();
+    store.set({ value: 1 });
+    featureFlagsMock.isGodModePanelEnabled = false;
+
+    expect(store.get()).toBeNull();
+    const { result } = renderHook(() => store.useValue());
+    expect(result.current).toBeNull();
+  });
+
+  it("returns the stored value from get()/useValue() when the flag is on", () => {
+    const store = createOverrideStore<TestValue>();
+    const value = { value: 1 };
+    store.set(value);
+
+    expect(store.get()).toBe(value);
+    const { result } = renderHook(() => store.useValue());
+    expect(result.current).toBe(value);
+  });
+
+  it("set() is a no-op for an identical value — subscribers are not re-notified", () => {
+    const store = createOverrideStore<TestValue>();
+    let renderCount = 0;
+    renderHook(() => {
+      renderCount += 1;
+      return store.useValue();
+    });
+    const value = { value: 1 };
+
+    act(() => store.set(value));
+    expect(renderCount).toBe(2);
+
+    act(() => store.set(value));
+    expect(renderCount).toBe(2);
+  });
+});

--- a/services/vault/src/overrides/activity.ts
+++ b/services/vault/src/overrides/activity.ts
@@ -1,0 +1,13 @@
+import type { ActivityRow } from "@/types/activityLog";
+
+import { createOverrideStore } from "./store";
+
+export interface ActivityOverride {
+  rows: ActivityRow[];
+  hideReal: boolean;
+}
+
+const activityOverrideStore = createOverrideStore<ActivityOverride>();
+
+export const useActivityOverride = activityOverrideStore.useValue;
+export const setActivityOverride = activityOverrideStore.set;

--- a/services/vault/src/overrides/artifactDownload.ts
+++ b/services/vault/src/overrides/artifactDownload.ts
@@ -1,0 +1,25 @@
+import type {
+  ArtifactSaveTarget,
+  FetchArtifactsOptions,
+  VaultBindingContext,
+} from "@/services/artifacts";
+
+import { createOverrideStore } from "./store";
+
+/**
+ * Stands in for the real `fetchAndDownloadArtifacts`. Resolves to nothing
+ * rather than an outcome: the activation gate is satisfied only by a receipt,
+ * and a receipt is written only from an outcome, so no simulated download can
+ * unlock a real vault's activation.
+ */
+export type ArtifactDownloadFn = (
+  target: ArtifactSaveTarget,
+  binding: VaultBindingContext,
+  options?: FetchArtifactsOptions,
+) => Promise<void>;
+
+const artifactDownloadOverrideStore = createOverrideStore<ArtifactDownloadFn>();
+
+/** Imperative: read at interaction time (download start), not in render. */
+export const getArtifactDownloadOverride = artifactDownloadOverrideStore.get;
+export const setArtifactDownloadOverride = artifactDownloadOverrideStore.set;

--- a/services/vault/src/overrides/borrowCapacity.ts
+++ b/services/vault/src/overrides/borrowCapacity.ts
@@ -1,0 +1,42 @@
+import {
+  getHealthFactorStatusFromValue,
+  type HealthFactorStatus,
+} from "@/applications/aave/utils";
+
+import { createOverrideStore } from "./store";
+
+/** What the Loans summary should render for a forced borrow-capacity state. */
+export interface BorrowCapacityOverride {
+  loading: boolean;
+  error: Error | null;
+}
+
+const healthFactorOverrideStore = createOverrideStore<number>();
+const borrowCapacityOverrideStore =
+  createOverrideStore<BorrowCapacityOverride>();
+
+/** Force (a value) or release (null) the Loans summary health factor. */
+export const useHealthFactorOverride = healthFactorOverrideStore.useValue;
+export const setHealthFactorOverride = healthFactorOverrideStore.set;
+
+/** Force (loading / error) or release (null) the borrow-capacity cards. */
+export const useBorrowCapacityOverride = borrowCapacityOverrideStore.useValue;
+export const setBorrowCapacityOverride = borrowCapacityOverrideStore.set;
+
+/**
+ * What a page should render for the health factor given a forced value. Shared
+ * by every god-mode consumer so they can't drift on how a forced value maps to
+ * a status: the status is always re-derived with the production banding
+ * function, never carried over from the live read.
+ */
+export function resolveShownHealthFactor(
+  override: number | null,
+  healthFactor: number | null,
+  healthFactorStatus: HealthFactorStatus,
+): { healthFactor: number | null; healthFactorStatus: HealthFactorStatus } {
+  if (override === null) return { healthFactor, healthFactorStatus };
+  return {
+    healthFactor: override,
+    healthFactorStatus: getHealthFactorStatusFromValue(override),
+  };
+}

--- a/services/vault/src/overrides/collateral.ts
+++ b/services/vault/src/overrides/collateral.ts
@@ -1,0 +1,13 @@
+import type { CollateralVaultEntry } from "@/types/collateral";
+
+import { createOverrideStore } from "./store";
+
+export interface CollateralOverride {
+  vaults: CollateralVaultEntry[];
+  hideReal: boolean;
+}
+
+const collateralOverrideStore = createOverrideStore<CollateralOverride>();
+
+export const useCollateralOverride = collateralOverrideStore.useValue;
+export const setCollateralOverride = collateralOverrideStore.set;

--- a/services/vault/src/overrides/deposits.ts
+++ b/services/vault/src/overrides/deposits.ts
@@ -1,0 +1,48 @@
+import type { Hex } from "viem";
+
+import type { VaultActivity } from "@/types/activity";
+import type { DepositPollingResult } from "@/types/peginPolling";
+import type { VaultProvider } from "@/types/vaultProvider";
+import { getBatchSiblings } from "@/utils/batchedPegin";
+
+import { createOverrideStore } from "./store";
+
+export interface DepositOverride {
+  pendingActivities: VaultActivity[];
+  expiredActivities: VaultActivity[];
+  resultsById: Map<string, DepositPollingResult>;
+  provider: VaultProvider;
+  hideReal: boolean;
+}
+
+const depositOverrideStore = createOverrideStore<DepositOverride>();
+
+export const useDepositOverride = depositOverrideStore.useValue;
+export const setDepositOverride = depositOverrideStore.set;
+
+/**
+ * Resolve a clicked demo deposit to the batch of owned vault ids the deposit
+ * multistepper should open with, or `null` when the click must stay a no-op.
+ *
+ * Opens for any OWNED flow-state demo deposit (the 15 flow steps + the
+ * activated terminal), so the whole Deposit Progress view can be walked with
+ * god mode. Stays inert for a different-wallet (unowned) preview and for
+ * expired deposits (those live in `expiredActivities`, not the pending list).
+ *
+ * There is no "would this auto-run real signing?" guard: for every demo id
+ * PostDepositContinuationView renders a SAFE view (read-only progress, or the
+ * simulated activation walk) — the real signing/registry branches never mount.
+ */
+export function getDemoStepperBatch(
+  override: DepositOverride | null,
+  depositId: string,
+): Hex[] | null {
+  if (!override) return null;
+  const activity = override.pendingActivities.find((a) => a.id === depositId);
+  if (!activity) return null;
+  // Different-wallet demo cards are disabled previews — never open.
+  if (!override.resultsById.get(depositId)?.isOwnedByCurrentWallet) return null;
+  return getBatchSiblings(override.pendingActivities, activity)
+    .filter((s) => override.resultsById.get(s.id)?.isOwnedByCurrentWallet)
+    .map((s) => s.id as Hex);
+}

--- a/services/vault/src/overrides/liquidations.ts
+++ b/services/vault/src/overrides/liquidations.ts
@@ -1,0 +1,50 @@
+import { createOverrideStore } from "./store";
+
+/** Which of the `/liquidations` card's mutually exclusive states to force.
+ *  `null` (the default, and the only value production can ever see) leaves
+ *  it derived from the live position. */
+export type LiquidationCardOverride =
+  | "no-deposit"
+  | "no-loan"
+  | "position"
+  | null;
+
+/** The `/liquidations` page's stat-card figures, set directly from the panel. */
+export interface LiquidationPositionOverride {
+  collateralBtc: number;
+  debtUsd: number;
+  healthFactor: number;
+}
+
+const liquidationCardOverrideStore =
+  createOverrideStore<LiquidationCardOverride>();
+const liquidationPositionOverrideStore =
+  createOverrideStore<LiquidationPositionOverride>();
+
+export const useLiquidationCardOverride = liquidationCardOverrideStore.useValue;
+export const setLiquidationCardOverride = liquidationCardOverrideStore.set;
+
+export const useLiquidationPositionOverride =
+  liquidationPositionOverrideStore.useValue;
+export const setLiquidationPositionOverride =
+  liquidationPositionOverrideStore.set;
+
+/**
+ * Resolve the card's two flags from the live position and the override, so
+ * the forcing rule lives next to the store instead of in the dashboard's JSX.
+ */
+export function resolveLiquidationCardState(
+  override: LiquidationCardOverride,
+  live: { hasCollateral: boolean; hasLoans: boolean },
+): { hasCollateral: boolean; hasLoans: boolean } {
+  switch (override) {
+    case "no-deposit":
+      return { hasCollateral: false, hasLoans: false };
+    case "no-loan":
+      return { hasCollateral: true, hasLoans: false };
+    case "position":
+      return { hasCollateral: true, hasLoans: true };
+    case null:
+      return live;
+  }
+}

--- a/services/vault/src/overrides/loans.ts
+++ b/services/vault/src/overrides/loans.ts
@@ -1,0 +1,15 @@
+import type { ActiveLoanRow } from "@/applications/aave/hooks/useActiveLoans";
+
+import { createOverrideStore } from "./store";
+
+export interface LoanOverride {
+  rows: ActiveLoanRow[];
+  /** Total mock debt in USD — the Loans summary totals the rendered rows. */
+  debtUsd: number;
+  hideReal: boolean;
+}
+
+const loanOverrideStore = createOverrideStore<LoanOverride>();
+
+export const useLoanOverride = loanOverrideStore.useValue;
+export const setLoanOverride = loanOverrideStore.set;

--- a/services/vault/src/overrides/marketData.ts
+++ b/services/vault/src/overrides/marketData.ts
@@ -1,0 +1,20 @@
+import type { ReserveLiquidity } from "@/applications/aave/hooks";
+import type { AaveReserveConfig } from "@/applications/aave/services/fetchConfig";
+
+import { createOverrideStore } from "./store";
+
+/** Everything the Borrowing Markets Data page derives `rows` / `stats` /
+ *  the collateral card from. */
+export interface MarketDataOverride {
+  reserves: AaveReserveConfig[];
+  liquidityByReserveId: Record<string, ReserveLiquidity | null>;
+  aprPercentByReserveId: Record<string, number | null>;
+  pricesByReserveId: Record<string, number | null>;
+  /** Decimal fraction (e.g. 0.75), same unit as `useVaultSplitParams`'s `CF`. */
+  collateralFactor: number;
+}
+
+const marketDataOverrideStore = createOverrideStore<MarketDataOverride>();
+
+export const useMarketDataOverride = marketDataOverrideStore.useValue;
+export const setMarketDataOverride = marketDataOverrideStore.set;

--- a/services/vault/src/overrides/position.ts
+++ b/services/vault/src/overrides/position.ts
@@ -1,0 +1,27 @@
+import type { PositionNotificationsStatus } from "@/applications/aave/hooks/usePositionNotifications";
+import type {
+  CalculatorParams,
+  CalculatorResult,
+} from "@/applications/aave/positionNotifications";
+
+import { createOverrideStore } from "./store";
+
+/** The already-resolved manual-mode cascade: whether this override is
+ *  "active" is decided once at publish time (null = not active), never
+ *  re-derived per consumer.
+ *
+ *  `result` is null when the panel is simulating a STATUS rather than a
+ *  cascade (stale price): the banner takes the status, but there is no
+ *  simulated cascade to chart, so a consumer that charts the cascade must
+ *  treat a null result as "no cascade" and fall back to live. */
+export interface PositionCascadeOverride {
+  result: CalculatorResult | null;
+  status: PositionNotificationsStatus | null;
+  params: CalculatorParams;
+}
+
+const positionCascadeOverrideStore =
+  createOverrideStore<PositionCascadeOverride>();
+
+export const usePositionCascadeOverride = positionCascadeOverrideStore.useValue;
+export const setPositionCascadeOverride = positionCascadeOverrideStore.set;

--- a/services/vault/src/overrides/protocolStatus.ts
+++ b/services/vault/src/overrides/protocolStatus.ts
@@ -1,0 +1,14 @@
+import type { ProtocolStatus } from "@/components/shared/protocolStatus";
+
+import { createOverrideStore } from "./store";
+
+const maxVaultsOverrideStore = createOverrideStore<number>();
+const protocolStatusOverrideStore = createOverrideStore<ProtocolStatus>();
+
+/** Force (a cap number) or release (null) the "maximum vaults reached" card. */
+export const useMaxVaultsOverride = maxVaultsOverrideStore.useValue;
+export const setMaxVaultsOverride = maxVaultsOverrideStore.set;
+
+/** Force (a status) or release (null) the protocol soft/fully-paused banner. */
+export const useProtocolStatusOverride = protocolStatusOverrideStore.useValue;
+export const setProtocolStatusOverride = protocolStatusOverrideStore.set;

--- a/services/vault/src/overrides/store.ts
+++ b/services/vault/src/overrides/store.ts
@@ -1,0 +1,52 @@
+/**
+ * Shared factory for the production-owned god-mode override seam
+ * (dev / QA only — gated behind NEXT_PUBLIC_FF_GOD_MODE_PANEL).
+ *
+ * Each domain in `src/overrides/` builds its store from this factory, so the
+ * god-mode flag is checked in exactly one place: here. No domain file
+ * re-checks `featureFlags.isGodModePanelEnabled`.
+ */
+
+import { useSyncExternalStore } from "react";
+
+import featureFlags from "@/config/featureFlags";
+
+export interface OverrideStore<T> {
+  /** Imperative, gated — read outside render (event handlers). */
+  get(): T | null;
+  /** Reactive, gated — useSyncExternalStore. */
+  useValue(): T | null;
+  /** Reference-guarded: setting an identical value is a no-op. */
+  set(value: T | null): void;
+}
+
+export function createOverrideStore<T>(): OverrideStore<T> {
+  let value: T | null = null;
+  const listeners = new Set<() => void>();
+
+  function subscribe(listener: () => void): () => void {
+    listeners.add(listener);
+    return () => {
+      listeners.delete(listener);
+    };
+  }
+
+  // Never allocates a fresh object: the gate returns the stored reference
+  // or null, so useSyncExternalStore never sees a "changed" snapshot from
+  // the gate itself.
+  function getSnapshot(): T | null {
+    return featureFlags.isGodModePanelEnabled ? value : null;
+  }
+
+  return {
+    get: getSnapshot,
+    useValue(): T | null {
+      return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+    },
+    set(next: T | null) {
+      if (value === next) return;
+      value = next;
+      for (const listener of listeners) listener();
+    },
+  };
+}


### PR DESCRIPTION
Production code imported `@/dev/*` directly to read demo state. That pointed the dependency the wrong way and spread the god-mode flag check across every consumer.

`src/overrides/` now owns the seam. Each domain exposes a store built from `createOverrideStore`, which checks
`featureFlags.isGodModePanelEnabled` in one place and returns `null` everywhere else. The dev panels publish resolved whole objects into those stores; production reads them and keeps its existing merge logic unchanged. No static `@/dev/*` import remains outside `src/dev/`; the two lazy DEV-gated mounts stay as they were.

The Liquidations precedence ladder moves verbatim into `useLiquidationsPageState`, and the dead demo-withdrawal seam is deleted, so the panel loses its withdrawal item type.