### PR TITLE
feat(vault): align tooltip copy

### DIFF
--- a/services/vault/src/applications/aave/components/LoanCard/Borrow/BorrowMetricsCard/BorrowMetricsCard.tsx
+++ b/services/vault/src/applications/aave/components/LoanCard/Borrow/BorrowMetricsCard/BorrowMetricsCard.tsx
@@ -115,7 +115,7 @@ export function BorrowMetricsCard({
       <div className={ROW_CLASS}>
         <div className="flex items-center gap-1 text-accent-secondary">
           {COPY.loans.healthFactorLabel}
-          <Hint tooltip={COPY.loans.healthFactorTooltip} />
+          <Hint tooltip={COPY.tooltips.healthFactor} />
         </div>
         <span className="flex items-center gap-2 text-accent-primary">
           {healthFactorOriginal && originalColor ? (

--- a/services/vault/src/applications/aave/components/LoanCard/Repay/RepayDetailsCard/RepayDetailsCard.tsx
+++ b/services/vault/src/applications/aave/components/LoanCard/Repay/RepayDetailsCard/RepayDetailsCard.tsx
@@ -68,7 +68,7 @@ export function RepayDetailsCard({
       <div className={ROW_CLASS}>
         <div className="flex items-center gap-1 text-accent-secondary">
           {COPY.loans.healthFactorLabel}
-          <Hint tooltip={COPY.loans.healthFactorTooltip} />
+          <Hint tooltip={COPY.tooltips.healthFactor} />
         </div>
         <span className="flex items-center gap-2 text-accent-primary">
           {healthFactorOriginal && originalColor ? (

--- a/services/vault/src/components/pages/BorrowingMarketsData/CollateralInfoCard.tsx
+++ b/services/vault/src/components/pages/BorrowingMarketsData/CollateralInfoCard.tsx
@@ -39,7 +39,7 @@ export function CollateralInfoCard({
           <span className="text-base leading-[1.5] tracking-[0.15px] text-accent-secondary">
             {COPY.marketData.collateral.factorLabel}
           </span>
-          <Hint tooltip={COPY.marketData.collateral.factorTooltip} />
+          <Hint tooltip={COPY.tooltips.collateralFactor} />
         </div>
         <span className="text-base leading-[1.5] tracking-[0.15px] text-accent-primary">
           {collateralFactor}

--- a/services/vault/src/components/pages/BorrowingMarketsData/__tests__/BorrowingMarketsData.test.tsx
+++ b/services/vault/src/components/pages/BorrowingMarketsData/__tests__/BorrowingMarketsData.test.tsx
@@ -28,7 +28,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 // consistent with BorrowMarketsTable.test.tsx / CollateralInfoCard.test.tsx.
 vi.mock("@babylonlabs-io/core-ui", () => ({
   Avatar: ({ alt }: { alt: string }) => <img alt={alt} />,
-  Hint: () => null,
+  Hint: ({ tooltip }: { tooltip?: string }) => <span>{tooltip}</span>,
   Container: ({
     children,
     className,
@@ -333,6 +333,24 @@ describe("BorrowingMarketsData", () => {
     expect(statsBar.getByText("$35.5M")).toBeInTheDocument(); // supplied
     expect(statsBar.getByText("$24.1M")).toBeInTheDocument(); // total borrowed
     expect(statsBar.getByText("68%")).toBeInTheDocument(); // market utilization
+  });
+
+  it("explains every stats-bar figure with its own tooltip", () => {
+    setUpHooks();
+
+    renderPage("1");
+
+    const statsBar = within(screen.getByTestId("market-stats-bar"));
+    const { stats } = COPY.marketData;
+    for (const tooltip of [
+      stats.availableLiquidityTooltip,
+      COPY.loans.borrowAprTooltip,
+      stats.suppliedTooltip,
+      stats.totalBorrowedTooltip,
+      stats.marketUtilizationTooltip,
+    ]) {
+      expect(statsBar.getByText(tooltip)).toBeInTheDocument();
+    }
   });
 
   it("shows the on-chain collateral factor as a percentage", () => {

--- a/services/vault/src/components/pages/BorrowingMarketsData/index.tsx
+++ b/services/vault/src/components/pages/BorrowingMarketsData/index.tsx
@@ -251,6 +251,7 @@ export default function BorrowingMarketsData() {
       {
         label: COPY.marketData.stats.availableLiquidity,
         value: compactUsdLabel(liquidity?.availableLiquidity, priceUsd),
+        tooltip: COPY.marketData.stats.availableLiquidityTooltip,
       },
       {
         label: COPY.marketData.stats.borrowApr,
@@ -268,6 +269,7 @@ export default function BorrowingMarketsData() {
       {
         label: COPY.marketData.stats.totalBorrowed,
         value: compactUsdLabel(liquidity?.totalBorrowed, priceUsd),
+        tooltip: COPY.marketData.stats.totalBorrowedTooltip,
       },
       {
         label: COPY.marketData.stats.marketUtilization,
@@ -275,6 +277,7 @@ export default function BorrowingMarketsData() {
           liquidity?.utilizationBps == null
             ? COPY.common.emptyValue
             : formatBasisPointsAsPercent(liquidity.utilizationBps),
+        tooltip: COPY.marketData.stats.marketUtilizationTooltip,
       },
     ];
   }, [

--- a/services/vault/src/components/pages/Liquidations/LiquidationEventCard.tsx
+++ b/services/vault/src/components/pages/Liquidations/LiquidationEventCard.tsx
@@ -1,3 +1,4 @@
+import { Hint } from "@babylonlabs-io/core-ui";
 import type { ReactNode } from "react";
 import { twJoin } from "tailwind-merge";
 
@@ -23,21 +24,33 @@ const SECTION_TITLE_CLASS =
   "text-base uppercase leading-[1.5] tracking-[0.15px] text-accent-secondary";
 const ROW_CLASS = "flex w-full items-center justify-between text-sm";
 const DIVIDER_CLASS = "h-px w-full bg-secondary-strokeLight";
+// `Hint` renders a block-level wrapper, so a label that carries one must be a
+// block element itself.
+const HINTED_LABEL_CLASS = "flex items-center gap-1";
 
 function DetailRow({
   label,
   value,
   labelClassName,
+  tooltip,
 }: {
   label: string;
   value: string;
   labelClassName?: string;
+  tooltip?: string;
 }) {
   return (
     <div className={ROW_CLASS}>
-      <span className={twJoin("text-accent-primary", labelClassName)}>
+      <div
+        className={twJoin(
+          HINTED_LABEL_CLASS,
+          "text-accent-primary",
+          labelClassName,
+        )}
+      >
         {label}
-      </span>
+        {tooltip ? <Hint tooltip={tooltip} /> : null}
+      </div>
       <span className="text-accent-primary">{value}</span>
     </div>
   );
@@ -69,11 +82,13 @@ function SeizureRow({
   amount,
   unit,
   emphasis,
+  tooltip,
 }: {
   label: string;
   amount: string;
   unit: string;
   emphasis?: boolean;
+  tooltip?: string;
 }) {
   return (
     <div
@@ -83,15 +98,17 @@ function SeizureRow({
           "border-t border-secondary-strokeLight bg-background-contrast",
       )}
     >
-      <span
+      <div
         className={twJoin(
+          HINTED_LABEL_CLASS,
           emphasis
             ? "text-base leading-[1.5] tracking-[0.15px] text-accent-primary"
             : "text-sm leading-[1.43] tracking-[0.17px] text-accent-secondary",
         )}
       >
         {label}
-      </span>
+        {tooltip ? <Hint tooltip={tooltip} /> : null}
+      </div>
       <span className="text-base leading-[1.5] tracking-[0.15px] text-accent-primary">
         {amount} <span className="text-accent-secondary">{unit}</span>
       </span>
@@ -174,11 +191,13 @@ export function LiquidationEventCard({ card }: { card: EventCardData }) {
           ))}
           <SeizureRow
             label={COPY.liquidations.events.targetSeizure}
+            tooltip={COPY.liquidations.events.targetSeizureTooltip}
             amount={card.targetSeizure.amount}
             unit={card.targetSeizure.unit}
           />
           <SeizureRow
             label={COPY.liquidations.events.overSeizure}
+            tooltip={COPY.liquidations.events.overSeizureTooltip}
             amount={card.overSeizure.amount}
             unit={card.overSeizure.unit}
           />
@@ -208,6 +227,7 @@ export function LiquidationEventCard({ card }: { card: EventCardData }) {
           <DetailRow
             label={card.fairness.label}
             value={card.fairness.value}
+            tooltip={card.fairness.tooltip}
             labelClassName="text-info-light"
           />
         </div>

--- a/services/vault/src/components/pages/Liquidations/PositionOverview.tsx
+++ b/services/vault/src/components/pages/Liquidations/PositionOverview.tsx
@@ -73,7 +73,7 @@ export function PositionOverview({
       },
       {
         label: COPY.liquidations.position.healthFactor,
-        tooltip: COPY.overview.healthFactorTooltip,
+        tooltip: COPY.tooltips.healthFactor,
         value: healthFactorText,
         valueNode: (
           <span className="flex items-center gap-2">
@@ -81,7 +81,6 @@ export function PositionOverview({
             <HeartIcon color={healthFactorColor} />
           </span>
         ),
-        caption: COPY.risk.healthFactorDescription,
       },
     ],
     [

--- a/services/vault/src/components/pages/Liquidations/__tests__/LiquidationEventCard.test.tsx
+++ b/services/vault/src/components/pages/Liquidations/__tests__/LiquidationEventCard.test.tsx
@@ -1,0 +1,78 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { COPY } from "@/copy";
+
+// Component tests mock core-ui (its dist isn't built in the test run) —
+// the mock surfaces the tooltip text so it can be asserted against its row.
+vi.mock("@babylonlabs-io/core-ui", () => ({
+  Hint: ({ tooltip }: { tooltip?: string }) => <span>{tooltip}</span>,
+}));
+
+import { LiquidationEventCard } from "../LiquidationEventCard";
+import type { LiquidationEventCard as EventCardData } from "../liquidationChartData";
+
+const CARD: EventCardData = {
+  key: "0",
+  title: "Liq Event 1",
+  badge: "sacrificial",
+  tone: "1",
+  triggered: false,
+  collateralLabel: "0.42 BTC",
+  liqPriceLabel: "$60,000",
+  distanceLabel: "-10%",
+  distanceNegative: true,
+  seizedVaults: [{ name: "Vault 1", amount: "0.42", unit: "BTC" }],
+  targetSeizure: { amount: "0.40", unit: "BTC" },
+  overSeizure: { amount: "0.02", unit: "BTC" },
+  collateralLiquidatedLabel: "0.42 BTC",
+  debtRepaidLabel: "$1,000",
+  liquidatorProfitLabel: "$100",
+  fairness: {
+    label: COPY.liquidations.events.fairnessPaymentWbtc,
+    value: "$81 (0.002 BTC)",
+    tooltip: COPY.liquidations.events.fairnessPaymentTooltip,
+  },
+  btcRemainingLabel: "0.5 BTC",
+  debtRemainingLabel: "$5,000",
+  hfAfterLabel: "1.20",
+};
+
+describe("LiquidationEventCard", () => {
+  it("explains the target and over seizure rows with the design's tooltips", () => {
+    render(<LiquidationEventCard card={CARD} />);
+
+    expect(
+      screen.getByText(COPY.liquidations.events.targetSeizureTooltip),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(COPY.liquidations.events.overSeizureTooltip),
+    ).toBeInTheDocument();
+  });
+
+  it("shows the fairness tooltip supplied by the card", () => {
+    render(<LiquidationEventCard card={CARD} />);
+
+    expect(
+      screen.getByText(COPY.liquidations.events.fairnessPaymentTooltip),
+    ).toBeInTheDocument();
+  });
+
+  it("shows no fairness tooltip when the card supplies none", () => {
+    render(
+      <LiquidationEventCard
+        card={{
+          ...CARD,
+          fairness: {
+            label: COPY.liquidations.events.fairnessDebtRepaid,
+            value: "$50",
+          },
+        }}
+      />,
+    );
+
+    expect(
+      screen.queryByText(COPY.liquidations.events.fairnessPaymentTooltip),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/services/vault/src/components/pages/Liquidations/__tests__/liquidationChartData.test.ts
+++ b/services/vault/src/components/pages/Liquidations/__tests__/liquidationChartData.test.ts
@@ -6,6 +6,7 @@ import type {
   LiquidationGroup,
   Vault,
 } from "@/applications/aave/positionNotifications/types";
+import { COPY } from "@/copy";
 
 import {
   buildLiquidationChartData,
@@ -466,6 +467,31 @@ describe("buildLiquidationChartData", () => {
     expect(cards[0].fairness.value).toContain("$81");
     // Converted at the event's trigger price: 81 / 40500 = 0.002 BTC.
     expect(cards[0].fairness.value).toContain("0.002");
+  });
+
+  // The tooltip describes a payment to the user's wallet, which only the
+  // full-liquidation variant makes — the debt-repaid row must not claim it.
+  it("carries the fairness tooltip on the payment variant only", () => {
+    const paymentResult = makeResult([
+      makeGroup(1, { isFullLiquidation: true, fairnessPaymentUsd: 81 }),
+    ]);
+    const debtRepaidResult = makeResult([
+      makeGroup(1, { isFullLiquidation: false }),
+    ]);
+    const options = {
+      vaultsTotal: 1,
+      btcPrice: 90000,
+      collateralFactor: CF,
+    };
+
+    expect(
+      buildLiquidationChartData(paymentResult, options).cards[0].fairness
+        .tooltip,
+    ).toBe(COPY.liquidations.events.fairnessPaymentTooltip);
+    expect(
+      buildLiquidationChartData(debtRepaidResult, options).cards[0].fairness
+        .tooltip,
+    ).toBeUndefined();
   });
 
   // The card colour used to key off `badge` (array position), so a protected

--- a/services/vault/src/components/pages/Liquidations/liquidationChartData.ts
+++ b/services/vault/src/components/pages/Liquidations/liquidationChartData.ts
@@ -72,7 +72,7 @@ export interface LiquidationEventCard {
   debtRepaidLabel: string;
   liquidatorProfitLabel: string;
   /** Full group shows a wBTC fairness payment; safe groups show fairness debt repaid. */
-  fairness: { label: string; value: string };
+  fairness: { label: string; value: string; tooltip?: string };
   btcRemainingLabel: string;
   debtRemainingLabel: string;
   hfAfterLabel: string;
@@ -234,6 +234,7 @@ function toCard(
     ? {
         label: COPY.liquidations.events.fairnessPaymentWbtc,
         value: `${formatUsd(group.fairnessPaymentUsd)} (${formatBtcAmount(group.fairnessPaymentUsd / group.liquidationPrice)})`,
+        tooltip: COPY.liquidations.events.fairnessPaymentTooltip,
       }
     : {
         label: COPY.liquidations.events.fairnessDebtRepaid,

--- a/services/vault/src/components/simple/LoansSummary.tsx
+++ b/services/vault/src/components/simple/LoansSummary.tsx
@@ -71,7 +71,7 @@ export function LoansSummary({
     }),
     {
       label: COPY.loans.healthFactorLabel,
-      tooltip: COPY.loans.healthFactorTooltip,
+      tooltip: COPY.tooltips.healthFactor,
       value: healthFactorText,
       valueNode: (
         <>

--- a/services/vault/src/components/simple/RiskSection/RiskSection.tsx
+++ b/services/vault/src/components/simple/RiskSection/RiskSection.tsx
@@ -127,7 +127,7 @@ export function RiskSection({
                   {COPY.risk.healthFactorTitle}
                 </span>
                 <span className="max-w-[442px] text-sm leading-[1.43] tracking-[0.17px] text-accent-secondary">
-                  {COPY.risk.healthFactorDescription}
+                  {COPY.tooltips.healthFactor}
                 </span>
               </div>
               <div className="mt-3 flex shrink-0 items-center gap-2">
@@ -166,7 +166,7 @@ export function RiskSection({
               <StatCell
                 label={COPY.risk.collateralFactorLabel}
                 value={collateralFactorText}
-                tooltip={COPY.risk.collateralFactorTooltip}
+                tooltip={COPY.tooltips.collateralFactor}
                 loading={collateralFactorLoading}
               />
             </div>

--- a/services/vault/src/components/simple/SplitTooLowHint.tsx
+++ b/services/vault/src/components/simple/SplitTooLowHint.tsx
@@ -1,3 +1,4 @@
+import { Hint } from "@babylonlabs-io/core-ui";
 import { IoInformationCircle } from "react-icons/io5";
 
 import { COPY } from "@/copy";
@@ -16,16 +17,25 @@ export function SplitTooLowHint({ minDepositForSplit }: SplitTooLowHintProps) {
   // Centered hint that sizes to its content, wrapping to a second line when the
   // message is too long for the row.
   return (
-    <div
-      role="status"
-      aria-live="polite"
-      className="flex w-full items-center justify-center gap-2 rounded-lg border border-secondary-strokeLight px-3 py-2 text-center"
-    >
-      <IoInformationCircle
-        size={18}
-        className="mt-px shrink-0 text-accent-primary"
+    <div className="flex w-full items-center justify-center gap-2 rounded-lg border border-secondary-strokeLight px-3 py-2 text-center">
+      <Hint
+        className="shrink-0"
+        tooltip={COPY.deposit.form.splitTooLowTooltip}
+        icon={
+          <IoInformationCircle
+            size={18}
+            className="mt-px shrink-0 text-accent-primary"
+          />
+        }
       />
-      <span className="min-w-0 text-sm text-accent-secondary">
+      {/* The live region wraps only the message. `Hint` renders its tooltip
+          inline, so keeping it outside stops an open tooltip from re-announcing
+          the whole hint. */}
+      <span
+        role="status"
+        aria-live="polite"
+        className="min-w-0 text-sm text-accent-secondary"
+      >
         {hint.prefix}{" "}
         <span className="text-accent-primary">{hint.splitName}</span>
         {hint.middle}{" "}

--- a/services/vault/src/components/vaults/VaultsSummaryCard.tsx
+++ b/services/vault/src/components/vaults/VaultsSummaryCard.tsx
@@ -74,7 +74,7 @@ export function VaultsSummaryCard({
     },
     {
       label: COPY.vaults.summary.healthFactorLabel,
-      tooltip: COPY.overview.healthFactorTooltip,
+      tooltip: COPY.tooltips.healthFactor,
       value: healthFactorText,
       valueNode: (
         <span

--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -91,6 +91,16 @@ export interface EmphasisBodySegment {
 }
 
 export const COPY = {
+  // Tooltips whose concept appears on more than one screen. One key per
+  // concept, referenced from every surface, so the screens can't drift apart.
+  tooltips: {
+    // Risk card, markets collateral card, protocol parameters (LTV).
+    collateralFactor:
+      "The maximum percentage of borrowing power from the total collateral value.",
+    // Overview position cards, risk card body, borrow / repay detail cards.
+    healthFactor:
+      "Indicates the health of your position. If it falls below 1.0, your position may be liquidated.",
+  },
   pegin: {
     labels: {
       PENDING: "Pending",
@@ -586,7 +596,7 @@ export const COPY = {
     },
     form: {
       computingAllocation: "Computing allocation...",
-      transactionReserveLabel: "Transaction Reserve",
+      transactionReserveLabel: "Reserve Claimer UTXO",
       transactionReserveTooltip:
         "A small portion of your deposit is reserved in a dedicated output to fund a future protocol claim transaction. It remains locked until claim conditions are met and is returned to you if unused.",
       // The depositable maximum is labelled as the balance, with `maxTooltip`
@@ -655,6 +665,8 @@ export const COPY = {
       // minimum are
       // emphasized (primary text) by the component; the rest stays secondary.
       // The component joins these fragments with explicit `{" "}` separators.
+      splitTooLowTooltip:
+        "Deposits below this amount may be fully liquidated in a single event.",
       splitTooLowHint: (minBtc: string) => ({
         prefix: "To use",
         splitName: TWO_VAULT_SPLIT_NAME,
@@ -1072,14 +1084,11 @@ export const COPY = {
     // Repay amount slider: prefixes the user's wallet balance shown beside Max.
     balanceLabel: "Balance",
     atRiskOfLiquidation: "At risk of liquidation",
-    borrowAprTooltip:
-      "The annual interest rate charged on your borrowed amount.",
+    borrowAprTooltip: "Borrow APR currently offered on this market",
     utilizationTooltip:
-      "The share of this market's supplied liquidity currently borrowed.",
+      "Percentage of deposited assets currently being borrowed on this market.",
     debtTooltip:
       "The total amount you currently owe for this asset, including accrued interest.",
-    healthFactorTooltip:
-      "Your position's safety margin. If it falls below 1.0, your collateral can be liquidated.",
     borrowingUnavailable:
       "Borrowing is temporarily unavailable. Please check back later.",
     priceUnavailable:
@@ -1245,12 +1254,17 @@ export const COPY = {
     // "Utilisation" is respelled to the American form this file mandates.
     stats: {
       availableLiquidity: "Available Liquidity",
+      availableLiquidityTooltip: "Available liquidity to borrow on this market",
       borrowApr: "Borrow APR",
       supplied: "Supplied",
-      suppliedTooltip:
-        "Total liquidity supplied to this market — the borrowed amount plus what is still available.",
+      suppliedTooltip: "Provided liquidity on this market",
       totalBorrowed: "Total Borrowed",
+      totalBorrowedTooltip: "Borrowed liquidity on this market",
       marketUtilization: "Market Utilization",
+      // Deliberately not the charts' `utilizationRateTooltip`: that one
+      // explains the interest-rate curve, this one the headline figure.
+      marketUtilizationTooltip:
+        "Percentage of deposited assets currently being borrowed",
     },
     collateral: {
       assetLabel: "Collateral Asset",
@@ -1258,8 +1272,6 @@ export const COPY = {
       // what the depositor supplied, not for the vaultBTC reserve token.
       assetName: "Native BTC",
       factorLabel: "Collateral Factor",
-      factorTooltip:
-        "The share of your collateral's value you can borrow against before liquidation applies.",
     },
     interestRateModel: {
       title: "Interest rate model",
@@ -1390,13 +1402,21 @@ export const COPY = {
       distance: "Distance",
       seizedVaultsSection: "Seized Vaults",
       targetSeizure: "Target seizure",
+      targetSeizureTooltip:
+        "The collateral value that the liquidator may receive during the liquidation process.",
       overSeizure: "Over seizure",
+      overSeizureTooltip:
+        "An additional portion of the collateral value that the liquidator may seize due to the nature of indivisible BTC Vaults.",
       estimatedLiquidationSection: "Estimated Liquidation",
       collateralLiquidated: "Collateral liquidated",
       debtRepaid: "Debt Repaid",
       liquidatorProfit: "Liquidator profit",
       fairnessDebtRepaid: "Fairness Debt Repaid",
       fairnessPaymentWbtc: "Fairness Payment (wBTC)",
+      // Describes the payment variant only; the debt-repaid variant of the
+      // row carries no tooltip.
+      fairnessPaymentTooltip:
+        "Payment by the liquidator to the user's wallet due to over seizure of collateral.",
       positionAfterSection: "Position After Liquidation",
       btcRemaining: "BTC remaining",
       debtRemaining: "Debt remaining",
@@ -1418,8 +1438,6 @@ export const COPY = {
     heading: "Overview",
     positionTitle: "Position",
     healthFactorLabel: "Health factor",
-    healthFactorTooltip:
-      "Your position's safety margin. If it falls below 1.0, your collateral can be liquidated.",
     totalCollateralValueLabel: "Total collateral value",
     totalCollateralValueTooltip:
       "The total value of assets used as collateral.",
@@ -1542,8 +1560,6 @@ export const COPY = {
   risk: {
     title: "Risk",
     healthFactorTitle: "Health Factor",
-    healthFactorDescription:
-      "Indicates the health of your position. When the ratio falls below 1.0, liquidation may occur.",
     healthFactorInfinity: "∞",
     status: {
       noPosition: "No Position",
@@ -1555,8 +1571,6 @@ export const COPY = {
     liquidationBtcPriceLabel: "Liquidation BTC Price",
     currentBtcPriceLabel: "Current BTC Price",
     collateralFactorLabel: "Collateral Factor",
-    collateralFactorTooltip:
-      "The maximum share of your collateral's value that can be borrowed against.",
     chart: {
       pairLabel: "BTC/USD",
       liquidationPriceLabel: "Liquidation Price",
@@ -1634,22 +1648,19 @@ export const COPY = {
     sectionTitle: "Protocol Parameters",
     minDeposit: {
       label: "Min deposit",
-      tooltip:
-        "Minimum BTC deposit required to create a BTC Vault, set by the protocol.",
+      tooltip: "The minimum amount of BTC required to make a deposit.",
     },
     minForSplit: {
       label: "Effective minimum for split",
       tooltip:
-        "Minimum deposit to split into 2 BTC Vaults. Both BTC Vaults must meet the minimum deposit requirement.",
+        "The minimum amount of BTC required to enable partial liquidation by splitting a deposit into two BTC Vaults.",
     },
     ltv: {
       label: "LTV / Collateral Factor",
-      tooltip:
-        "Maximum percentage of collateral value that can be borrowed against.",
     },
     liquidationThreshold: {
       label: "Liquidation threshold (THF)",
-      tooltip: "Target health factor at which liquidation becomes profitable.",
+      tooltip: "The ideal health factor to restore during liquidation",
     },
     liquidationBonus: {
       label: "Liquidation Bonus (LB)",

--- a/services/vault/src/hooks/useProtocolFeeRows.ts
+++ b/services/vault/src/hooks/useProtocolFeeRows.ts
@@ -62,7 +62,7 @@ function buildFeeRows(
     rows.push({
       label: COPY.protocolFees.ltv.label,
       value: `${(CF * PERCENT_SCALE).toFixed(0)}%`,
-      tooltip: COPY.protocolFees.ltv.tooltip,
+      tooltip: COPY.tooltips.collateralFactor,
     });
 
     rows.push({


### PR DESCRIPTION
Aligns every vault tooltip with the new Figma **💬 Tooltips** page. 18 tooltips were audited: 1 already matched, 9 are reworded, 8 are new.

## Shared copy keys

Collateral factor and health factor had drifted into 3 and 2 separate phrasings across the app. Both now have a single key in `copy.ts` — `tooltips.collateralFactor` and `tooltips.healthFactor` — referenced from every surface, so the screens cannot drift apart again. The per-screen duplicates are deleted.

## New tooltips

- **Liquidation event cards** — target seizure, over seizure, fairness payment.
- **Markets stat bar** — available liquidity, total borrowed, market utilization.
- **Deposit form** — small-amount warning (`splitTooLowTooltip`).

## Reworded to match Figma

Supplied, borrow-flow APR and utilization, and the protocol parameters (min deposit, effective minimum for split, liquidation threshold, liquidation bonus).

## Label rename

"Transaction Reserve" becomes "Reserve Claimer UTXO", per the Figma fee panel.

## Deliberate deltas from Figma

Three places where the implementation does not copy Figma verbatim, so reviewers diffing against the design know they are intentional:

| Figma | Implemented | Why |
| --- | --- | --- |
| "liquidty" | "liquidity" | Typo in the design. |
| "the liquidator is  seize" | "the liquidator may seize" | Typo in the design. |
| APY (borrow-flow tooltip) | APR | The app uses APR everywhere else; the underlying figure is a rate, not a yield. |
| "The penalty range applied during the liquidation." (LB) | "Bonus percentage awarded to liquidators on seized collateral." | The row renders one number, `(LB - 1) x 100`, not a range — and it is the liquidator's premium, which the label "Liquidation Bonus (LB)" already says. The Figma wording would tell the reader something untrue. |
| "…if the margin ratio falls below 1.0…" | "…if it falls below 1.0…" | "Margin ratio" appears nowhere else in the app and has no antecedent in its own sentence. Since this key is the single wording across six surfaces, the orphan term would propagate to all of them. |
| "BTCVaults" | "BTC Vaults" | `copy.ts` mandates the two-word form, used 75 times elsewhere in the file. |

The two typos are raised with design separately — the app should not ship them.

## Accessibility and markup

Two fixes that came out of wiring the tooltips in:

- `LiquidationEventCard` label wrappers are now `<div>`, matching every other label-plus-`Hint` site. `Hint` renders a block-level wrapper, so the previous `<span>` produced invalid nesting.
- `SplitTooLowHint`'s live region now wraps only the message rather than the whole row. `Hint` renders its tooltip inline with no portal, so a tooltip inside a `role="status"` region made a screen reader re-announce the entire hint on hover.

## Testing

- `tsc --noEmit -p tsconfig.lib.json` — clean.
- `eslint` on all touched files — clean.
- `vitest` on the touched suites — 47 tests passing, including new coverage for the liquidation event card tooltips and the fairness-payment tooltip variant.
