### PR TITLE
Feat/ledger sign psbt e2e

### DIFF
--- a/packages/babylon-ledger-vault-signer/THIRD-PARTY-NOTICES.md
+++ b/packages/babylon-ledger-vault-signer/THIRD-PARTY-NOTICES.md
@@ -18,11 +18,20 @@ their own license files. Vendored source:
   section of that directory's README)
 - License: Apache License 2.0
 - Modifications: see the per-file provenance headers in the vendored source
-  (explicit Buffer import, defensive strict-null guards, formatting; psbtv2.ts
-  additionally drops `fromBitcoinJS`, unifies the serialization key comparator
-  to byte-lexicographic order, and adds two BIP-371 `psbtIn` enum members plus
-  a public `getInputEntriesOfType` reader; clientCommands.ts adds an optional
-  `onYield` validator hook to `YieldCommand` / `ClientCommandInterpreter`).
+  (explicit Buffer import, defensive strict-null guards, formatting; varint.ts
+  additionally makes `parseVarint` reject the non-minimal "overlong" CompactSize
+  encodings upstream accepts; psbtv2.ts additionally drops `fromBitcoinJS`,
+  unifies the serialization key comparator to byte-lexicographic order, rejects
+  repeated keypairs and trailing bytes on deserialize, and adds two BIP-371
+  `psbtIn` enum members plus a public `getInputEntriesOfType` reader;
+  clientCommands.ts adds an optional `onYield` validator hook to `YieldCommand`
+  / `ClientCommandInterpreter`; buffertools.ts additionally makes
+  `unsafeTo64bitLE` reject input that is not a non-negative safe integer, which
+  upstream wrapped or encoded as zero; merkelizedPsbt.ts additionally requires
+  the input/output map counts to equal the declared `PSBT_GLOBAL_*_COUNT`s in
+  both directions, where upstream ignored surplus maps; merkle.ts additionally
+  throws a typed `Error` rather than a raw `TypeError` on an out-of-bounds leaf
+  index).
 
 ### Apache License 2.0
 

--- a/packages/babylon-ledger-vault-signer/THIRD-PARTY-NOTICES.md
+++ b/packages/babylon-ledger-vault-signer/THIRD-PARTY-NOTICES.md
@@ -12,12 +12,16 @@ their own license files. Vendored source:
 - Source: https://github.com/LedgerHQ/app-bitcoin
 - Version: ledger-bitcoin@0.3.0 (commit 0a9e9e141f3340d29e7c6181177d4e5e9483a9f7)
 - Files: vendored under packages/babylon-ledger-vault-signer/src/vendor/ledger-bitcoin/
-  (source-in-tree; not yet reachable from the published bundle)
+  — the source is in-tree and, from #2219 onward, the compiled vendored code is
+  also bundled into the published dist/ (build strips the per-file provenance
+  headers, so this notice is the redistribution record; see the audit-boundary
+  section of that directory's README)
 - License: Apache License 2.0
 - Modifications: see the per-file provenance headers in the vendored source
   (explicit Buffer import, defensive strict-null guards, formatting; psbtv2.ts
-  additionally drops `fromBitcoinJS` and unifies the serialization key
-  comparator to byte-lexicographic order; clientCommands.ts adds an optional
+  additionally drops `fromBitcoinJS`, unifies the serialization key comparator
+  to byte-lexicographic order, and adds two BIP-371 `psbtIn` enum members plus
+  a public `getInputEntriesOfType` reader; clientCommands.ts adds an optional
   `onYield` validator hook to `YieldCommand` / `ClientCommandInterpreter`).
 
 ### Apache License 2.0

--- a/packages/babylon-ledger-vault-signer/package.json
+++ b/packages/babylon-ledger-vault-signer/package.json
@@ -17,7 +17,7 @@
     }
   },
   "scripts": {
-    "build": "tsc -b --noEmit tsconfig.lib.json && vite build && node -e \"if (!require('node:fs').existsSync('dist/index.d.ts')) { console.error('Build emitted no dist/index.d.ts, so the published types entry would 404. Check the beforeWriteFile filter in vite.config.ts.'); process.exit(1); }\"",
+    "build": "tsc -b --noEmit tsconfig.lib.json && vite build && node scripts/check-dist-types.cjs",
     "format": "prettier --check \"src/**/*.ts\"",
     "format:fix": "prettier --write \"src/**/*.ts\"",
     "lint": "eslint .",

--- a/packages/babylon-ledger-vault-signer/package.json
+++ b/packages/babylon-ledger-vault-signer/package.json
@@ -17,7 +17,7 @@
     }
   },
   "scripts": {
-    "build": "tsc -b --noEmit tsconfig.lib.json && vite build",
+    "build": "tsc -b --noEmit tsconfig.lib.json && vite build && node -e \"if (!require('node:fs').existsSync('dist/index.d.ts')) { console.error('Build emitted no dist/index.d.ts, so the published types entry would 404. Check the beforeWriteFile filter in vite.config.ts.'); process.exit(1); }\"",
     "format": "prettier --check \"src/**/*.ts\"",
     "format:fix": "prettier --write \"src/**/*.ts\"",
     "lint": "eslint .",

--- a/packages/babylon-ledger-vault-signer/package.json
+++ b/packages/babylon-ledger-vault-signer/package.json
@@ -35,6 +35,7 @@
   },
   "description": "Host-side client for the Ledger Babylon Vault app: DMK session lifecycle, raw APDU framing, key reads, and the vault intent ceremony",
   "dependencies": {
+    "@bitcoin-js/tiny-secp256k1-asmjs": "2.2.3",
     "@ledgerhq/device-management-kit": "1.7.1",
     "@ledgerhq/device-transport-kit-web-hid": "1.2.4",
     "@scure/bip32": "1.4.0",

--- a/packages/babylon-ledger-vault-signer/scripts/check-dist-types.cjs
+++ b/packages/babylon-ledger-vault-signer/scripts/check-dist-types.cjs
@@ -1,0 +1,37 @@
+// Post-build gate for the published types: dist/index.d.ts must exist (a
+// broken beforeWriteFile filter in vite.config.ts once dropped every
+// declaration), and no emitted declaration may import from a vendor path —
+// vendor d.ts is excluded from dist, so such a reference would 404 for
+// consumers.
+const { existsSync, readdirSync, readFileSync } = require("node:fs");
+const { join } = require("node:path");
+
+const DIST = join(__dirname, "..", "dist");
+
+if (!existsSync(join(DIST, "index.d.ts"))) {
+  console.error(
+    "Build emitted no dist/index.d.ts, so the published types entry would 404. " +
+      "Check the beforeWriteFile filter in vite.config.ts.",
+  );
+  process.exit(1);
+}
+
+// `from "…vendor/…"` (static import/re-export) or `import("…vendor/…")` (type import).
+const VENDOR_REF = /(?:from\s+["'][^"']*vendor\/|import\(\s*["'][^"']*vendor\/)/;
+const offenders = [];
+const walk = (dir) => {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) walk(path);
+    else if (entry.name.endsWith(".d.ts") && VENDOR_REF.test(readFileSync(path, "utf8"))) offenders.push(path);
+  }
+};
+walk(DIST);
+
+if (offenders.length > 0) {
+  console.error(
+    "Emitted declarations reference vendor paths (vendor d.ts is not shipped, so these imports would 404):\n" +
+      offenders.join("\n"),
+  );
+  process.exit(1);
+}

--- a/packages/babylon-ledger-vault-signer/src/__tests__/e2e/peginFixture.ts
+++ b/packages/babylon-ledger-vault-signer/src/__tests__/e2e/peginFixture.ts
@@ -1,0 +1,398 @@
+/**
+ * Signable PegIn fixture for the Speculos e2e suite.
+ *
+ * The committed SIGN_PSBT vectors were generated from foreign seeds, so this
+ * builder replicates the firmware's own signable test path byte-for-byte:
+ * `tests/test_sign_psbt_validate.py` (`_build_pegin_psbt`:309 and the leaf
+ * builders at :142-221) and `tests/vault_client.py` (test constants at
+ * :99-127, `_vault_expand_commitment`:262) at the fw rev the container runs
+ * (v0.9.5). Every constant below cites its source line.
+ *
+ * @module ledger-vault-signer/__tests__/e2e/peginFixture
+ */
+
+import * as ecc from "@bitcoin-js/tiny-secp256k1-asmjs";
+import { crypto as bcrypto, Psbt, Transaction } from "bitcoinjs-lib";
+import { Buffer } from "buffer";
+import { createHash, createHmac } from "node:crypto";
+
+import type { IntentScalars, IntentVaultGroup } from "../../intentTlv";
+import { tapLeafHash } from "../../tapLeafHash";
+import type { DepositTerms } from "../../types";
+
+/** BIP-341 tapscript leaf version — the only one the vault graph uses. */
+const TAPSCRIPT_LEAF_VERSION = 0xc0;
+
+// ---------------------------------------------------------------------------
+// Firmware test constants (tests/test_sign_psbt_validate.py:105-135 and
+// tests/vault_client.py:99-127). The depositor key is the device's own
+// m/86'/1'/0'/0/0 for the shared firmware-test mnemonic — verified live
+// against the running container via GET_EXTENDED_PUBKEY.
+// ---------------------------------------------------------------------------
+
+export const DEPOSITOR_XONLY_HEX = "dc8d2f9eff0c4f4dbde070a48e330efc908b62a766568d91e658f284b324b878";
+/** TEST_VP_KEY (vault_client.py:99) — the secp256k1 generator's x. */
+export const VP_KEY_HEX = "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798";
+/** TEST_VALID_KEYS[0] (vault_client.py:105). */
+export const KEEPER_KEY_HEX = "25d1dff95105f5253c4022f628a996ad3a0d95fbf21d468a1b33f8c160d8f517";
+/** TEST_VALID_KEYS[1] (vault_client.py:106). */
+export const CHALLENGER_KEY_HEX = "2f01e5e15cca351daff3843fb70f3c2f0a1bdd05e5af888a67784ef3e10a2a01";
+/** VAULT_NUMS_XONLY (test_sign_psbt_validate.py:63). */
+const NUMS_XONLY_HEX = "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0";
+
+export const VAULT_AMOUNT_SATS = 9_876_543;
+export const COMMISSION_FEE_SATS = 54_321;
+export const DEPOSITOR_CLAIM_VALUE_SATS = 12_345;
+export const BASE_FEE_RATE = 1;
+export const PEGIN_MAX_FEE_SATS = 567_891;
+export const PEGIN_CSV_TIMELOCK = 144;
+export const PAYOUT_TIMELOCK = 200;
+export const HTLC_REFUND_TIMELOCK = 144;
+export const HTLC_VOUT = 0;
+/** P2A anchor value — must match P2A_ANCHOR_VALUE in fw vault_constants.h. */
+export const PEGIN_ANCHOR_VALUE_SATS = 240;
+export const PREPEGIN_MAX_FEE_SATS = 500_000;
+
+/**
+ * htlc_value must land in [amount + claim + anchor, … + pegin_max_fee]
+ * (test_sign_psbt_validate.py:117-119): the +234 567 fee term keeps it inside.
+ */
+export const HTLC_VALUE_SATS = VAULT_AMOUNT_SATS + DEPOSITOR_CLAIM_VALUE_SATS + PEGIN_ANCHOR_VALUE_SATS + 234_567;
+
+/** _PREPEGIN_TXID = bytes(range(32)) (test_sign_psbt_validate.py:135), INTERNAL order. */
+export const PREPEGIN_TXID_INTERNAL = Buffer.from(Array.from({ length: 32 }, (_, i) => i));
+
+/** _DERIVE_CONTEXT = bytes(range(72)) (test_sign_psbt_validate.py:591). */
+export const DERIVE_CONTEXT = Uint8Array.from(Array.from({ length: 72 }, (_, i) => i));
+
+/** DERIVE_CONTEXT_HASH app name (vault_client.py:258). */
+export const VAULT_APP_NAME = "babylon-btc-vault";
+
+const HARDENED = 0x80000000;
+/** m/86'/1'/0'/0/0 — depositor_path(coin_type=1) (vault_client.py:279). */
+export const DEPOSITOR_PATH: readonly number[] = [HARDENED | 86, HARDENED | 1, HARDENED | 0, 0, 0];
+const TESTNET_COIN_TYPE = 1;
+
+/** P2A anchor scriptPubKey `51 02 4e 73` (test_sign_psbt_validate.py:349). */
+const P2A_SCRIPT_PUB_KEY = Buffer.from([0x51, 0x02, 0x4e, 0x73]);
+
+const hexToBuffer = (hex: string): Buffer => Buffer.from(hex, "hex");
+const NUMS_XONLY = hexToBuffer(NUMS_XONLY_HEX);
+
+// ---------------------------------------------------------------------------
+// Script builders — TS replicas of the fw test's Python replicas of
+// vault_script.c (test_sign_psbt_validate.py:142-221).
+// ---------------------------------------------------------------------------
+
+const OP_NUMEQUAL = 0x9c;
+const OP_NUMEQUALVERIFY = 0x9d;
+const OP_SIZE = 0x82;
+const OP_EQUALVERIFY = 0x88;
+const OP_SHA256 = 0xa8;
+const OP_CHECKSIG = 0xac;
+const OP_CHECKSIGVERIFY = 0xad;
+const OP_CHECKSIGADD = 0xba;
+const OP_CSV = 0xb2;
+const PUSH_32 = 0x20;
+
+/** Minimal script-number push (test_sign_psbt_validate.py:73). */
+function encodeScriptNum(n: number): Buffer {
+  if (n === 0) return Buffer.from([0x00]);
+  if (n >= 1 && n <= 16) return Buffer.from([0x51 + n - 1]);
+  const bytes: number[] = [];
+  let v = n;
+  while (v > 0) {
+    bytes.push(v & 0xff);
+    v >>= 8;
+  }
+  if ((bytes[bytes.length - 1] & 0x80) !== 0) bytes.push(0x00);
+  return Buffer.from([bytes.length, ...bytes]);
+}
+
+/** N-of-N multisig fragment (test_sign_psbt_validate.py:142). */
+function multisigGroup(keys: readonly Buffer[], isFinal: boolean): Buffer {
+  if (keys.length === 1) {
+    return Buffer.concat([Buffer.from([PUSH_32]), keys[0], Buffer.from([isFinal ? OP_CHECKSIG : OP_CHECKSIGVERIFY])]);
+  }
+  const parts: Buffer[] = [Buffer.concat([Buffer.from([PUSH_32]), keys[0], Buffer.from([OP_CHECKSIG])])];
+  for (const key of keys.slice(1)) {
+    parts.push(Buffer.concat([Buffer.from([PUSH_32]), key, Buffer.from([OP_CHECKSIGADD])]));
+  }
+  parts.push(encodeScriptNum(keys.length));
+  parts.push(Buffer.from([isFinal ? OP_NUMEQUAL : OP_NUMEQUALVERIFY]));
+  return Buffer.concat(parts);
+}
+
+/** HTLC Leaf 0 — hashlock + all-parties leaf (test_sign_psbt_validate.py:154). */
+function htlcLeaf0(
+  depositorPk: Buffer,
+  vpPk: Buffer,
+  keeperPks: readonly Buffer[],
+  challengerPks: readonly Buffer[],
+  hashlock: Buffer,
+): Buffer {
+  return Buffer.concat([
+    Buffer.from([OP_SIZE]),
+    encodeScriptNum(32),
+    Buffer.from([OP_EQUALVERIFY]),
+    Buffer.from([OP_SHA256, PUSH_32]),
+    hashlock,
+    Buffer.from([OP_EQUALVERIFY]),
+    Buffer.from([PUSH_32]),
+    depositorPk,
+    Buffer.from([OP_CHECKSIGVERIFY]),
+    Buffer.from([PUSH_32]),
+    vpPk,
+    Buffer.from([OP_CHECKSIGVERIFY]),
+    multisigGroup(keeperPks, false),
+    multisigGroup(challengerPks, true),
+  ]);
+}
+
+/** HTLC Leaf 1 — depositor refund with CSV (test_sign_psbt_validate.py:169). */
+function htlcLeaf1(depositorPk: Buffer, refundTimelock: number): Buffer {
+  return Buffer.concat([
+    Buffer.from([PUSH_32]),
+    depositorPk,
+    Buffer.from([OP_CHECKSIGVERIFY]),
+    encodeScriptNum(refundTimelock),
+    Buffer.from([OP_CSV]),
+  ]);
+}
+
+/** Vault UTXO leaf (test_sign_psbt_validate.py:175). */
+function vaultUtxoLeaf(
+  depositorPk: Buffer,
+  vpPk: Buffer,
+  keeperPks: readonly Buffer[],
+  challengerPks: readonly Buffer[],
+  peginCsvTimelock: number,
+): Buffer {
+  return Buffer.concat([
+    Buffer.from([PUSH_32]),
+    depositorPk,
+    Buffer.from([OP_CHECKSIGVERIFY]),
+    Buffer.from([PUSH_32]),
+    vpPk,
+    Buffer.from([OP_CHECKSIGVERIFY]),
+    multisigGroup(keeperPks, false),
+    multisigGroup(challengerPks, false),
+    encodeScriptNum(peginCsvTimelock),
+    Buffer.from([OP_CSV]),
+  ]);
+}
+
+/** Depositor Claim leaf `<D> OP_CHECKSIG` (test_sign_psbt_validate.py:188). */
+function depositorClaimLeaf(depositorPk: Buffer): Buffer {
+  return Buffer.concat([Buffer.from([PUSH_32]), depositorPk, Buffer.from([OP_CHECKSIG])]);
+}
+
+// ---------------------------------------------------------------------------
+// Taproot helpers (BIP-341; mirror test_utils.taproot as used by the fw test)
+// ---------------------------------------------------------------------------
+
+function tapBranch(a: Buffer, b: Buffer): Buffer {
+  const [left, right] = Buffer.compare(a, b) <= 0 ? [a, b] : [b, a];
+  return bcrypto.taggedHash("TapBranch", Buffer.concat([left, right]));
+}
+
+function tweakNums(merkleRoot: Buffer): { parity: 0 | 1; xOnly: Buffer } {
+  const tweak = bcrypto.taggedHash("TapTweak", Buffer.concat([NUMS_XONLY, merkleRoot]));
+  const tweaked = ecc.xOnlyPointAddTweak(NUMS_XONLY, tweak);
+  if (tweaked === null) {
+    throw new Error("NUMS taptweak produced no point");
+  }
+  return { parity: tweaked.parity, xOnly: Buffer.from(tweaked.xOnlyPubkey) };
+}
+
+function p2trFromSingleLeaf(leaf: Buffer): Buffer {
+  const { xOnly } = tweakNums(tapLeafHash(TAPSCRIPT_LEAF_VERSION, leaf));
+  return Buffer.concat([Buffer.from([0x51, PUSH_32]), xOnly]);
+}
+
+// ---------------------------------------------------------------------------
+// Hashlock from the device-returned root — host-side mirror of fw
+// derive_vault_secrets_core.h (vault_client.py:262-271):
+// h = SHA256(HKDF-Expand-SHA256(root, "babylonbtcvault" ‖ len ‖ label ‖
+//     u16be(len(ctx)) ‖ ctx, 32)), single block.
+// ---------------------------------------------------------------------------
+
+const VAULT_SECRETS_DOMAIN_TAG = "babylonbtcvault";
+const HKDF_SINGLE_BLOCK_COUNTER = 0x01;
+
+function vaultExpandCommitment(root: Buffer, label: string, ctx: Buffer): Buffer {
+  const labelBytes = Buffer.from(label, "ascii");
+  const ctxLen = Buffer.alloc(2);
+  ctxLen.writeUInt16BE(ctx.length);
+  const info = Buffer.concat([
+    Buffer.from(VAULT_SECRETS_DOMAIN_TAG, "ascii"),
+    Buffer.from([labelBytes.length]),
+    labelBytes,
+    ctxLen,
+    ctx,
+  ]);
+  const secret = createHmac("sha256", root)
+    .update(Buffer.concat([info, Buffer.from([HKDF_SINGLE_BLOCK_COUNTER])]))
+    .digest();
+  return createHash("sha256").update(secret).digest();
+}
+
+/** On-chain HTLC hashlock h for one vault (vault_client.py:269). */
+export function vaultHashlock(root: Uint8Array, htlcVout: number): Buffer {
+  const ctx = Buffer.alloc(4);
+  ctx.writeUInt32BE(htlcVout);
+  return vaultExpandCommitment(Buffer.from(root), "hashlock", ctx);
+}
+
+// ---------------------------------------------------------------------------
+// Deposit terms + intent mapping
+// ---------------------------------------------------------------------------
+
+/**
+ * The e2e deposit terms, matching the fw test intent (`_setup_s2_state` with
+ * `_PREPEGIN_TXID`). `prepeginTxid` is DISPLAY order — the seam converts
+ * display → internal exactly like wallet-connector's provider, and the wire
+ * carries the internal-order bytes the firmware compares against the PSBT.
+ * `vaultCoreVersion` is 2: the device-supported tx-graph version gate — the
+ * TLV's structure/version constants (both 1) are pinned inside the encoder.
+ */
+export function buildDepositTerms(): DepositTerms {
+  return {
+    vaultCoreVersion: 2,
+    protocolFeeRate: BigInt(BASE_FEE_RATE),
+    timelockPegin: PEGIN_CSV_TIMELOCK,
+    timelockAssert: PAYOUT_TIMELOCK,
+    timelockRefund: HTLC_REFUND_TIMELOCK,
+    prepeginTxid: Buffer.from(PREPEGIN_TXID_INTERNAL).reverse().toString("hex"),
+    prepeginMaxFee: BigInt(PREPEGIN_MAX_FEE_SATS),
+    vaultKeeperBtcPubkeys: [KEEPER_KEY_HEX],
+    universalChallengerBtcPubkeys: [CHALLENGER_KEY_HEX],
+    vaults: [
+      {
+        htlcVout: HTLC_VOUT,
+        vaultProviderBtcPubkey: VP_KEY_HEX,
+        peginAmount: BigInt(VAULT_AMOUNT_SATS),
+        commissionFee: BigInt(COMMISSION_FEE_SATS),
+        depositorClaimValue: BigInt(DEPOSITOR_CLAIM_VALUE_SATS),
+        peginMaxFee: BigInt(PEGIN_MAX_FEE_SATS),
+      },
+    ],
+  };
+}
+
+export interface IntentFixture {
+  scalars: IntentScalars;
+  groups: IntentVaultGroup[];
+  keeperPubkeys: Uint8Array[];
+  challengerPubkeys: Uint8Array[];
+}
+
+/**
+ * DepositTerms → APPROVE_VAULT_INTENT inputs, mirroring wallet-connector's
+ * `LedgerVaultProvider.approveDepositTerms` mapping (provider.ts:318-363),
+ * including the display→internal txid flip.
+ */
+export function termsToIntent(terms: DepositTerms): IntentFixture {
+  return {
+    scalars: {
+      coinType: TESTNET_COIN_TYPE,
+      baseFeeRate: terms.protocolFeeRate,
+      peginCsvTimelock: terms.timelockPegin,
+      payoutTimelock: terms.timelockAssert,
+      prepeginTxidInternal: Uint8Array.from(Buffer.from(terms.prepeginTxid, "hex")).reverse(),
+      htlcRefundTimelock: terms.timelockRefund,
+      depositorPath: DEPOSITOR_PATH,
+      keeperCount: terms.vaultKeeperBtcPubkeys.length,
+      challengerCount: terms.universalChallengerBtcPubkeys.length,
+      vaultCount: terms.vaults.length,
+      prepeginMaxFee: terms.prepeginMaxFee,
+    },
+    groups: terms.vaults.map((vault) => ({
+      htlcVout: vault.htlcVout,
+      vaultProviderPubkey: Uint8Array.from(hexToBuffer(vault.vaultProviderBtcPubkey)),
+      vaultAmount: vault.peginAmount,
+      commissionFee: vault.commissionFee,
+      depositorClaimValue: vault.depositorClaimValue,
+      peginMaxFee: vault.peginMaxFee,
+    })),
+    keeperPubkeys: terms.vaultKeeperBtcPubkeys.map((k) => Uint8Array.from(hexToBuffer(k))),
+    challengerPubkeys: terms.universalChallengerBtcPubkeys.map((k) => Uint8Array.from(hexToBuffer(k))),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// PegIn PSBT (test_sign_psbt_validate.py:309 `_build_pegin_psbt`)
+// ---------------------------------------------------------------------------
+
+export interface PeginPsbtFixture {
+  readonly psbtHex: string;
+  readonly htlcScriptPubKey: Buffer;
+  readonly leaf0Script: Buffer;
+  readonly leaf0Hash: Buffer;
+  readonly controlBlock: Buffer;
+}
+
+/**
+ * PegIn PSBTv0: input 0 spends the HTLC at (prepegin_txid, vout 0) via
+ * Leaf 0; outputs are Vault, Depositor Claim, and the P2A anchor. Tx v3
+ * (TRUC), locktime 0, sequence 0xFFFFFFFE — all per the fw builder.
+ */
+export function buildPeginPsbt(hashlock: Buffer): PeginPsbtFixture {
+  const depositor = hexToBuffer(DEPOSITOR_XONLY_HEX);
+  const vp = hexToBuffer(VP_KEY_HEX);
+  const keepers = [hexToBuffer(KEEPER_KEY_HEX)];
+  const challengers = [hexToBuffer(CHALLENGER_KEY_HEX)];
+
+  const leaf0 = htlcLeaf0(depositor, vp, keepers, challengers, hashlock);
+  const leaf1 = htlcLeaf1(depositor, HTLC_REFUND_TIMELOCK);
+  const leaf0Hash = tapLeafHash(TAPSCRIPT_LEAF_VERSION, leaf0);
+  const leaf1Hash = tapLeafHash(TAPSCRIPT_LEAF_VERSION, leaf1);
+  const merkleRoot = tapBranch(leaf0Hash, leaf1Hash);
+  const { parity, xOnly: htlcTweaked } = tweakNums(merkleRoot);
+  const htlcScriptPubKey = Buffer.concat([Buffer.from([0x51, PUSH_32]), htlcTweaked]);
+  // Control block for spending Leaf 0: sibling hash is Leaf 1's hash.
+  const controlBlock = Buffer.concat([Buffer.from([TAPSCRIPT_LEAF_VERSION | parity]), NUMS_XONLY, leaf1Hash]);
+
+  const vaultSpk = p2trFromSingleLeaf(vaultUtxoLeaf(depositor, vp, keepers, challengers, PEGIN_CSV_TIMELOCK));
+  const claimSpk = p2trFromSingleLeaf(depositorClaimLeaf(depositor));
+
+  const psbt = new Psbt();
+  psbt.setVersion(3); // TRUC (BIP-431)
+  psbt.setLocktime(0);
+  psbt.addInput({
+    hash: PREPEGIN_TXID_INTERNAL, // Buffer form: used as-is (internal order)
+    index: HTLC_VOUT,
+    sequence: 0xfffffffe,
+    witnessUtxo: { script: htlcScriptPubKey, value: HTLC_VALUE_SATS },
+    tapInternalKey: NUMS_XONLY,
+    tapMerkleRoot: merkleRoot,
+    tapLeafScript: [{ leafVersion: TAPSCRIPT_LEAF_VERSION, script: leaf0, controlBlock }],
+  });
+  psbt.addOutput({ script: vaultSpk, value: VAULT_AMOUNT_SATS });
+  psbt.addOutput({ script: claimSpk, value: DEPOSITOR_CLAIM_VALUE_SATS });
+  psbt.addOutput({ script: P2A_SCRIPT_PUB_KEY, value: PEGIN_ANCHOR_VALUE_SATS });
+
+  return { psbtHex: psbt.toHex(), htlcScriptPubKey, leaf0Script: leaf0, leaf0Hash, controlBlock };
+}
+
+/**
+ * BIP-341 script-path sighash for input 0 at SIGHASH_DEFAULT over the
+ * fixture's unsigned tx — the message the device's Schnorr signature must
+ * verify against.
+ */
+export function computePeginSighash(psbtHex: string, fixture: PeginPsbtFixture): Buffer {
+  const psbt = Psbt.fromHex(psbtHex);
+  const tx = Transaction.fromBuffer(psbt.data.globalMap.unsignedTx.toBuffer());
+  return tx.hashForWitnessV1(
+    0,
+    [fixture.htlcScriptPubKey],
+    [HTLC_VALUE_SATS],
+    Transaction.SIGHASH_DEFAULT,
+    fixture.leaf0Hash,
+  );
+}
+
+/** BIP-340 verification via the package's own ecc backend. */
+export function verifySchnorrSignature(sighash: Buffer, xOnlyKeyHex: string, signature: Uint8Array): boolean {
+  return ecc.verifySchnorr(sighash, hexToBuffer(xOnlyKeyHex), signature);
+}

--- a/packages/babylon-ledger-vault-signer/src/__tests__/e2e/speculos.e2e.test.ts
+++ b/packages/babylon-ledger-vault-signer/src/__tests__/e2e/speculos.e2e.test.ts
@@ -100,8 +100,10 @@ describe.skipIf(SPECULOS_URL === "")("Speculos end-to-end vault signing", () => 
       const deriveScreens = await approveOnScreen(SPECULOS_URL, DERIVE_APPROVAL_TEXT);
       contextRoot = await rootPending;
       expect(contextRoot).toHaveLength(32);
+      // NB: never log the context root, sighash or signature — CLAUDE.md #7
+      // ("never log payload bytes") is unconditional here, and this suite can
+      // be pointed at a real device. Assertions below pin the values instead.
       console.log(`[speculos-e2e] derive screens: ${deriveScreens.join(" || ")}`);
-      console.log(`[speculos-e2e] context root: ${Buffer.from(contextRoot).toString("hex")}`);
 
       // Scalars and group APDUs answer immediately; the final key batch blocks
       // on the intent review screen — drive it concurrently too.
@@ -139,7 +141,6 @@ describe.skipIf(SPECULOS_URL === "")("Speculos end-to-end vault signing", () => 
       expect(yielded.signerXOnlyHex).toBe(DEPOSITOR_XONLY_HEX);
       expect(yielded.leafHashHex).toBe(fixture.leaf0Hash.toString("hex"));
       expect(yielded.signature).toHaveLength(SCHNORR_SIG_BYTES);
-      console.log(`[speculos-e2e] schnorr signature: ${Buffer.from(yielded.signature).toString("hex")}`);
     },
     SIGNING_TIMEOUT_MS,
   );
@@ -155,7 +156,6 @@ describe.skipIf(SPECULOS_URL === "")("Speculos end-to-end vault signing", () => 
 
       const sighash = computePeginSighash(psbtFixture.psbtHex, psbtFixture);
       const valid = verifySchnorrSignature(sighash, DEPOSITOR_XONLY_HEX, yielded.signature);
-      console.log(`[speculos-e2e] sighash: ${sighash.toString("hex")}`);
       console.log(`[speculos-e2e] verifySchnorr(depositor key): ${valid}`);
       expect(valid).toBe(true);
 

--- a/packages/babylon-ledger-vault-signer/src/__tests__/e2e/speculos.e2e.test.ts
+++ b/packages/babylon-ledger-vault-signer/src/__tests__/e2e/speculos.e2e.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Speculos end-to-end signing test (#2219 B2): the full production path —
+ * envelope gate → DERIVE_CONTEXT_HASH → APPROVE_VAULT_INTENT → signVaultPsbt —
+ * against the real vault app in a Speculos container, ending in cryptographic
+ * verification of the device's Schnorr signature.
+ *
+ * Requires a running container with the vault app (nanosp, testnet build,
+ * firmware-test mnemonic). Skipped unless SPECULOS_URL is set:
+ *
+ *   SPECULOS_URL=http://127.0.0.1:5055 pnpm exec vitest run src/__tests__/e2e/
+ *
+ * The suite is stateful and ordered: the ceremony arms the device state the
+ * signing stage consumes. Each run re-runs the full ceremony, so the container
+ * does not need restarting between runs.
+ */
+
+import { Psbt } from "bitcoinjs-lib";
+import { Buffer } from "buffer";
+import { describe, expect, it } from "vitest";
+
+import { assertDepositTermsDeviceCompatible } from "../../envelope";
+import { signVaultPsbt, type SignVaultPsbtResult } from "../../signPsbt";
+import { approveVaultIntent, deriveContextHash } from "../../vaultCommands";
+import {
+  buildDepositTerms,
+  buildPeginPsbt,
+  computePeginSighash,
+  DEPOSITOR_PATH,
+  DEPOSITOR_XONLY_HEX,
+  DERIVE_CONTEXT,
+  HTLC_VOUT,
+  PREPEGIN_TXID_INTERNAL,
+  termsToIntent,
+  VAULT_APP_NAME,
+  vaultHashlock,
+  verifySchnorrSignature,
+  type PeginPsbtFixture,
+} from "./peginFixture";
+import {
+  approveOnScreen,
+  createSpeculosApduSender,
+  createSpeculosRawApduSender,
+  getAppAndVersion,
+  readScreenText,
+  sleep,
+} from "./speculosClient";
+
+const SPECULOS_URL = process.env.SPECULOS_URL ?? "";
+
+/** Live-verified nanosp review-screen texts (reference driver `lsk_ceremony2.py`). */
+const DERIVE_APPROVAL_TEXT = "Allow derivation";
+const INTENT_APPROVAL_TEXT = "Approve intent";
+
+/** Ceremony = APDUs + human-speed screen navigation; signing = ~40 APDU rounds. */
+const CEREMONY_TIMEOUT_MS = 120_000;
+const SIGNING_TIMEOUT_MS = 60_000;
+const SANITY_TIMEOUT_MS = 30_000;
+
+const SCHNORR_SIG_BYTES = 64;
+
+describe.skipIf(SPECULOS_URL === "")("Speculos end-to-end vault signing", () => {
+  const sendRaw = createSpeculosRawApduSender(SPECULOS_URL);
+  const send = createSpeculosApduSender(SPECULOS_URL);
+
+  // Ordered stages share state; a later stage failing on `undefined` means an
+  // earlier stage failed first — read its failure, not this one.
+  let contextRoot: Uint8Array | undefined;
+  let fixture: PeginPsbtFixture | undefined;
+  let signResult: SignVaultPsbtResult | undefined;
+
+  it(
+    "(1) reports the vault app name and version",
+    async () => {
+      const app = await getAppAndVersion(sendRaw);
+      expect(app.name).toContain("Babylon Vault");
+      expect(app.version).toMatch(/^\d+\.\d+\.\d+$/);
+      console.log(`[speculos-e2e] app: ${app.name} v${app.version}`);
+    },
+    SANITY_TIMEOUT_MS,
+  );
+
+  it(
+    "(2) ceremony: envelope gate, DERIVE_CONTEXT_HASH, APPROVE_VAULT_INTENT via the production encoders",
+    async () => {
+      const terms = buildDepositTerms();
+      // The envelope gate must accept these terms with zero device I/O.
+      assertDepositTermsDeviceCompatible(terms);
+      const intent = termsToIntent(terms);
+      // Byte-order seam: display-order terms txid maps to the internal-order
+      // prevout the PSBT carries and the firmware compares against.
+      expect(Buffer.from(intent.scalars.prepeginTxidInternal).equals(PREPEGIN_TXID_INTERNAL)).toBe(true);
+
+      // The final DERIVE APDU blocks on the review screen — drive it concurrently.
+      const rootPending = deriveContextHash(send, {
+        appName: VAULT_APP_NAME,
+        derivationPath: DEPOSITOR_PATH,
+        context: DERIVE_CONTEXT,
+      });
+      rootPending.catch(() => undefined); // handled at the await below
+      const deriveScreens = await approveOnScreen(SPECULOS_URL, DERIVE_APPROVAL_TEXT);
+      contextRoot = await rootPending;
+      expect(contextRoot).toHaveLength(32);
+      console.log(`[speculos-e2e] derive screens: ${deriveScreens.join(" || ")}`);
+      console.log(`[speculos-e2e] context root: ${Buffer.from(contextRoot).toString("hex")}`);
+
+      // Scalars and group APDUs answer immediately; the final key batch blocks
+      // on the intent review screen — drive it concurrently too.
+      await waitForIdleScreen();
+      const approvePending = approveVaultIntent(send, intent);
+      approvePending.catch(() => undefined); // handled at the await below
+      const intentScreens = await approveOnScreen(SPECULOS_URL, INTENT_APPROVAL_TEXT);
+      await approvePending;
+      console.log(`[speculos-e2e] intent screens: ${intentScreens.join(" || ")}`);
+    },
+    CEREMONY_TIMEOUT_MS,
+  );
+
+  it(
+    "(3) signVaultPsbt signs the PegIn PSBT on the device",
+    async () => {
+      expect(contextRoot, "ceremony stage must have produced a root").toBeDefined();
+      const hashlock = vaultHashlock(contextRoot as Uint8Array, HTLC_VOUT);
+      fixture = buildPeginPsbt(hashlock);
+
+      // PegIn signing is silent (fw test_sign_psbt_validate.py header) — the
+      // approved intent authorizes it, so no screen driving here.
+      // Shorter than the test timeout so the typed abort surfaces first.
+      signResult = await signVaultPsbt(sendRaw, {
+        psbtHex: fixture.psbtHex,
+        depositorXOnlyHex: DEPOSITOR_XONLY_HEX,
+        signal: AbortSignal.timeout(SIGNING_TIMEOUT_MS - 10_000),
+      });
+
+      expect(signResult.yields).toHaveLength(1);
+      const yielded = signResult.yields[0];
+      expect(yielded.kind).toBe("tapscript");
+      if (yielded.kind !== "tapscript") throw new Error("unreachable");
+      expect(yielded.inputIndex).toBe(0);
+      expect(yielded.signerXOnlyHex).toBe(DEPOSITOR_XONLY_HEX);
+      expect(yielded.leafHashHex).toBe(fixture.leaf0Hash.toString("hex"));
+      expect(yielded.signature).toHaveLength(SCHNORR_SIG_BYTES);
+      console.log(`[speculos-e2e] schnorr signature: ${Buffer.from(yielded.signature).toString("hex")}`);
+    },
+    SIGNING_TIMEOUT_MS,
+  );
+
+  it(
+    "(4) the device signature verifies against the BIP-341 script-path sighash",
+    () => {
+      expect(fixture, "signing stage must have built the fixture").toBeDefined();
+      expect(signResult, "signing stage must have produced yields").toBeDefined();
+      const psbtFixture = fixture as PeginPsbtFixture;
+      const yielded = (signResult as SignVaultPsbtResult).yields[0];
+      if (yielded.kind !== "tapscript") throw new Error("stage (3) asserted tapscript");
+
+      const sighash = computePeginSighash(psbtFixture.psbtHex, psbtFixture);
+      const valid = verifySchnorrSignature(sighash, DEPOSITOR_XONLY_HEX, yielded.signature);
+      console.log(`[speculos-e2e] sighash: ${sighash.toString("hex")}`);
+      console.log(`[speculos-e2e] verifySchnorr(depositor key): ${valid}`);
+      expect(valid).toBe(true);
+
+      // Negative control: a different message must not verify.
+      const tampered = Buffer.from(sighash);
+      tampered[0] ^= 0x01;
+      expect(verifySchnorrSignature(tampered, DEPOSITOR_XONLY_HEX, yielded.signature)).toBe(false);
+    },
+    SANITY_TIMEOUT_MS,
+  );
+
+  it(
+    "(5) the merged PSBT carries the tapScriptSig and finalizes",
+    () => {
+      expect(fixture, "signing stage must have built the fixture").toBeDefined();
+      expect(signResult, "signing stage must have produced a merged PSBT").toBeDefined();
+      const psbtFixture = fixture as PeginPsbtFixture;
+      const result = signResult as SignVaultPsbtResult;
+
+      const original = Psbt.fromHex(psbtFixture.psbtHex);
+      const merged = Psbt.fromHex(result.signedPsbtHex);
+      // Merge writes signature fields only — the unsigned tx is byte-identical.
+      expect(merged.data.globalMap.unsignedTx.toBuffer().equals(original.data.globalMap.unsignedTx.toBuffer())).toBe(
+        true,
+      );
+
+      const tapScriptSig = merged.data.inputs[0].tapScriptSig;
+      expect(tapScriptSig).toBeDefined();
+      expect(tapScriptSig).toHaveLength(1);
+      const entry = (tapScriptSig ?? [])[0];
+      expect(entry.pubkey.toString("hex")).toBe(DEPOSITOR_XONLY_HEX);
+      expect(entry.leafHash.toString("hex")).toBe(psbtFixture.leaf0Hash.toString("hex"));
+      expect(entry.signature).toHaveLength(SCHNORR_SIG_BYTES);
+
+      // Structural finalizability: bitcoinjs accepts the script-path input and
+      // assembles witness = [sig, leaf script, control block]. (Consensus
+      // validity additionally needs the co-signers + preimage — out of scope.)
+      merged.finalizeInput(0);
+      const witness = merged.data.inputs[0].finalScriptWitness;
+      expect(witness).toBeDefined();
+      expect((witness ?? Buffer.alloc(0)).includes(psbtFixture.leaf0Script)).toBe(true);
+      expect((witness ?? Buffer.alloc(0)).includes(psbtFixture.controlBlock)).toBe(true);
+    },
+    SANITY_TIMEOUT_MS,
+  );
+
+  /** Best-effort settle back to the dashboard between the two approval flows. */
+  async function waitForIdleScreen(): Promise<void> {
+    const deadline = Date.now() + 5_000;
+    while (Date.now() < deadline) {
+      const screen = await readScreenText(SPECULOS_URL);
+      if (screen.includes("app is ready")) return;
+      await sleep(150);
+    }
+  }
+});

--- a/packages/babylon-ledger-vault-signer/src/__tests__/e2e/speculosClient.test.ts
+++ b/packages/babylon-ledger-vault-signer/src/__tests__/e2e/speculosClient.test.ts
@@ -3,20 +3,47 @@
  *
  * `getAppAndVersion` parses a length-prefixed device response, so every length
  * byte is attacker/emulator-controlled — the truncation guards are the only
- * thing between a malformed frame and a silently wrong result.
+ * thing between a malformed frame and a silently wrong result. Every rejection
+ * case matches the message of the one guard it pins, so collapsing two guards
+ * onto a shared message fails here rather than passing on a sibling's throw.
+ *
+ * The transport tests pin the posted wire bytes for a NON-EMPTY payload: this
+ * sender carries the SIGN_PSBT cdata (built in `signPsbtPrepare.ts` — a
+ * 65-byte global commitment `varint(n) ‖ keysRoot(32) ‖ valuesRoot(32)`, two
+ * count varints, and four 32-byte fields: inputsRoot, outputsRoot, walletId,
+ * walletHmac; 195 bytes across every committed signpsbt vector) and every
+ * CONTINUE payload, and a zero-length APDU cannot distinguish a correct frame
+ * from an all-zero buffer.
  */
 
-import { describe, expect, it } from "vitest";
+import { Buffer } from "buffer";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
-import type { RawApduSender } from "../../rawApdu";
-import { getAppAndVersion } from "./speculosClient";
+import { LEDGER_USER_REFUSED_ERROR_NAME } from "../../errors";
+import type { Apdu, RawApduSender } from "../../rawApdu";
+import { createSpeculosApduSender, createSpeculosRawApduSender, getAppAndVersion, SW_OK } from "./speculosClient";
 
-/** A sender that answers 0x9000 with the given response body. */
+/** A sender that answers success with the given response body. */
 function senderReturning(dataHex: string): RawApduSender {
-  return async () => ({ sw: 0x9000, data: Buffer.from(dataHex, "hex") });
+  return async () => ({ sw: SW_OK, data: Buffer.from(dataHex, "hex") });
 }
 
 describe("getAppAndVersion", () => {
+  it("asks for the BOLOS GET_APP_AND_VERSION with no data", async () => {
+    const sent: Apdu[] = [];
+    const send: RawApduSender = async (apdu) => {
+      sent.push(apdu);
+      return { sw: SW_OK, data: Buffer.from("010361707003312e30", "hex") };
+    };
+
+    await getAppAndVersion(send);
+
+    // B0 01 00 00 (Lc 0) per the reference client LedgerHQ/ledger-live@2ec1cda
+    // `libs/ledger-live-common/src/hw/getAppAndVersion.ts` — `transport.send(0xb0, 0x01, 0x00, 0x00)`.
+    expect(sent).toHaveLength(1);
+    expect(sent[0]).toEqual({ cla: 0xb0, ins: 0x01, p1: 0x00, p2: 0x00, data: new Uint8Array(0) });
+  });
+
   it("parses a well-formed response", async () => {
     // format(01) ‖ len(03) ‖ "app" ‖ len(03) ‖ "1.0"
     const app = await getAppAndVersion(senderReturning("010361707003312e30"));
@@ -24,20 +51,156 @@ describe("getAppAndVersion", () => {
     expect(app).toEqual({ name: "app", version: "1.0" });
   });
 
+  it("rejects a status word other than success", async () => {
+    // The body is well-formed, so only the status-word check can reject it.
+    const send: RawApduSender = async () => ({ sw: 0x6d00, data: Buffer.from("010361707003312e30", "hex") });
+
+    await expect(getAppAndVersion(send)).rejects.toThrow(/answered sw 0x6d00/);
+  });
+
+  it("rejects a response too short to hold the format and length prefixes", async () => {
+    // format ‖ len(03) and nothing else — one byte under the 3-byte minimum.
+    await expect(getAppAndVersion(senderReturning("0103"))).rejects.toThrow(/answered 2 bytes/);
+  });
+
+  it("rejects an unknown format byte", async () => {
+    // The well-formed response byte for byte, with format 0x02 instead of 0x01.
+    await expect(getAppAndVersion(senderReturning("020361707003312e30"))).rejects.toThrow(
+      /answered format 0x02, expected 0x01/,
+    );
+  });
+
   it("rejects a name length that runs past the response", async () => {
     // Claims a 9-byte name in a 6-byte body: the version-length byte is absent,
     // so reading it yields undefined and every later bound becomes NaN — which
     // compares false against any length and would slip through unguarded.
-    await expect(getAppAndVersion(senderReturning("010961707003"))).rejects.toThrow(/truncated/);
+    await expect(getAppAndVersion(senderReturning("010961707003"))).rejects.toThrow(
+      /name length 9 leaves no version-length byte in 6 bytes/,
+    );
   });
 
   it("rejects a name that ends exactly at the response end (no version-length byte)", async () => {
-    // format ‖ len(03) ‖ "app" and nothing else.
-    await expect(getAppAndVersion(senderReturning("0103617070"))).rejects.toThrow(/truncated/);
+    // format ‖ len(03) ‖ "app" and nothing else — the exact `>=` boundary.
+    await expect(getAppAndVersion(senderReturning("0103617070"))).rejects.toThrow(
+      /name length 3 leaves no version-length byte in 5 bytes/,
+    );
   });
 
-  it("rejects a version length that runs past the response", async () => {
-    // format ‖ len(03) ‖ "app" ‖ len(09) ‖ only 2 bytes of version
-    await expect(getAppAndVersion(senderReturning("0103617070093132"))).rejects.toThrow(/truncated/);
+  it("rejects a version one byte shorter than its length claims", async () => {
+    // format ‖ len(03) ‖ "app" ‖ len(03) ‖ "12": the tightest witness for the
+    // bound — a body missing more bytes still passes a bound relaxed by one.
+    await expect(getAppAndVersion(senderReturning("0103617070033132"))).rejects.toThrow(
+      /version length 3 needs 9 bytes, response has 8/,
+    );
+  });
+});
+
+describe("createSpeculosRawApduSender", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("posts the header of an empty-payload APDU and strips the trailing status word", async () => {
+    const posts: { url: string; body: string }[] = [];
+    vi.stubGlobal("fetch", async (url: string, init: RequestInit) => {
+      posts.push({ url, body: String(init.body) });
+      // "app" / "1.0" ‖ 9000 — Speculos appends the status word to the data.
+      return { ok: true, json: async () => ({ data: "010361707003312e309000" }) };
+    });
+
+    const app = await getAppAndVersion(createSpeculosRawApduSender("http://speculos.test"));
+
+    expect(posts).toHaveLength(1);
+    expect(posts[0].url).toBe("http://speculos.test/apdu");
+    expect(JSON.parse(posts[0].body)).toEqual({ data: "b001000000" });
+    expect(app).toEqual({ name: "app", version: "1.0" });
+  });
+
+  it("posts the payload after a one-byte length, per the reference transport framing", async () => {
+    const posts: string[] = [];
+    vi.stubGlobal("fetch", async (_url: string, init: RequestInit) => {
+      posts.push(String(init.body));
+      return { ok: true, json: async () => ({ data: "9000" }) };
+    });
+
+    await createSpeculosRawApduSender("http://speculos.test")({
+      cla: 0xe1,
+      ins: 0x80,
+      p1: 0x02,
+      p2: 0x00,
+      data: new Uint8Array([0xde, 0xad, 0xbe, 0xef]),
+    });
+
+    // Framing per hw-transport `Transport.send` (LedgerHQ/ledger-live@427ed59
+    // `libs/ledgerjs/packages/hw-transport/src/Transport.ts:269-272`): the data
+    // length goes in one byte just before the data. Non-empty payload on
+    // purpose — a zero-length APDU cannot tell the frame from a zeroed buffer.
+    expect(posts).toEqual([JSON.stringify({ data: "e180020004deadbeef" })]);
+  });
+
+  it("accepts the largest payload a single-byte Lc can carry", async () => {
+    const posts: string[] = [];
+    vi.stubGlobal("fetch", async (_url: string, init: RequestInit) => {
+      posts.push(String(init.body));
+      return { ok: true, json: async () => ({ data: "9000" }) };
+    });
+
+    await createSpeculosRawApduSender("http://speculos.test")({
+      cla: 0xe1,
+      ins: 0x80,
+      p1: 0x02,
+      p2: 0x00,
+      data: new Uint8Array(255).fill(0xab),
+    });
+
+    // 255 is the last accepted length — the reference transport rejects at
+    // `data.length >= 256` (LedgerHQ/ledger-live@427ed59 `Transport.ts:261-267`).
+    expect(posts).toEqual([JSON.stringify({ data: `e1800200ff${"ab".repeat(255)}` })]);
+  });
+
+  it("rejects a payload one byte too long for Lc before issuing any request", async () => {
+    const posts: string[] = [];
+    vi.stubGlobal("fetch", async (_url: string, init: RequestInit) => {
+      posts.push(String(init.body));
+      return { ok: true, json: async () => ({ data: "9000" }) };
+    });
+
+    // Lc truncates mod-256, so an unguarded 256-byte payload would post Lc 00
+    // and the device would parse the frame short instead of failing.
+    await expect(
+      createSpeculosRawApduSender("http://speculos.test")({
+        cla: 0xe1,
+        ins: 0x80,
+        p1: 0x02,
+        p2: 0x00,
+        data: new Uint8Array(256),
+      }),
+    ).rejects.toThrow(/APDU data is 256 bytes; Lc is a single byte \(max 255\)/);
+    expect(posts).toEqual([]);
+  });
+});
+
+describe("createSpeculosApduSender", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  const apdu: Apdu = { cla: 0xe1, ins: 0x80, p1: 0x02, p2: 0x00, data: new Uint8Array(0) };
+
+  it("returns the response data without the status word on 0x9000", async () => {
+    vi.stubGlobal("fetch", async () => ({ ok: true, json: async () => ({ data: "aabb9000" }) }));
+
+    const data = await createSpeculosApduSender("http://speculos.test")(apdu);
+
+    expect(Array.from(data)).toEqual([0xaa, 0xbb]);
+  });
+
+  it("raises the shared typed error on a device refusal, exactly as the DMK sender does", async () => {
+    vi.stubGlobal("fetch", async () => ({ ok: true, json: async () => ({ data: "6985" }) }));
+
+    await expect(createSpeculosApduSender("http://speculos.test")(apdu)).rejects.toMatchObject({
+      name: LEDGER_USER_REFUSED_ERROR_NAME,
+      statusWord: 0x6985,
+    });
   });
 });

--- a/packages/babylon-ledger-vault-signer/src/__tests__/e2e/speculosClient.test.ts
+++ b/packages/babylon-ledger-vault-signer/src/__tests__/e2e/speculosClient.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Unit tests for the Speculos e2e helpers that need no emulator.
+ *
+ * `getAppAndVersion` parses a length-prefixed device response, so every length
+ * byte is attacker/emulator-controlled — the truncation guards are the only
+ * thing between a malformed frame and a silently wrong result.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import type { RawApduSender } from "../../rawApdu";
+import { getAppAndVersion } from "./speculosClient";
+
+/** A sender that answers 0x9000 with the given response body. */
+function senderReturning(dataHex: string): RawApduSender {
+  return async () => ({ sw: 0x9000, data: Buffer.from(dataHex, "hex") });
+}
+
+describe("getAppAndVersion", () => {
+  it("parses a well-formed response", async () => {
+    // format(01) ‖ len(03) ‖ "app" ‖ len(03) ‖ "1.0"
+    const app = await getAppAndVersion(senderReturning("010361707003312e30"));
+
+    expect(app).toEqual({ name: "app", version: "1.0" });
+  });
+
+  it("rejects a name length that runs past the response", async () => {
+    // Claims a 9-byte name in a 6-byte body: the version-length byte is absent,
+    // so reading it yields undefined and every later bound becomes NaN — which
+    // compares false against any length and would slip through unguarded.
+    await expect(getAppAndVersion(senderReturning("010961707003"))).rejects.toThrow(/truncated/);
+  });
+
+  it("rejects a name that ends exactly at the response end (no version-length byte)", async () => {
+    // format ‖ len(03) ‖ "app" and nothing else.
+    await expect(getAppAndVersion(senderReturning("0103617070"))).rejects.toThrow(/truncated/);
+  });
+
+  it("rejects a version length that runs past the response", async () => {
+    // format ‖ len(03) ‖ "app" ‖ len(09) ‖ only 2 bytes of version
+    await expect(getAppAndVersion(senderReturning("0103617070093132"))).rejects.toThrow(/truncated/);
+  });
+});

--- a/packages/babylon-ledger-vault-signer/src/__tests__/e2e/speculosClient.ts
+++ b/packages/babylon-ledger-vault-signer/src/__tests__/e2e/speculosClient.ts
@@ -10,15 +10,18 @@
  * @module ledger-vault-signer/__tests__/e2e/speculosClient
  */
 
-import { classifyStatusWord, type RawApduSender } from "../../rawApdu";
+import { createThrowingApduSender, hex2, hex4, type RawApduSender } from "../../rawApdu";
 import type { ApduSender } from "../../vaultCommands";
 
 /** BOLOS-level GET_APP_AND_VERSION (any app answers it). */
 const CLA_BOLOS = 0xb0;
 const INS_GET_APP_AND_VERSION = 0x01;
-const SW_OK = 0x9000;
+/** ISO-7816 success; exported so tests build responses without a bare literal. */
+export const SW_OK = 0x9000;
 /** `format(1)=0x01 ‖ nameLen ‖ name ‖ versionLen ‖ version …` (verified live). */
 const APP_AND_VERSION_FORMAT = 0x01;
+/** Shortest legal response: format byte + both length bytes, name and version empty. */
+const MIN_APP_AND_VERSION_BYTES = 3;
 
 const MAX_APDU_DATA_BYTES = 0xff;
 const STATUS_WORD_HEX_CHARS = 4;
@@ -89,15 +92,13 @@ export function createSpeculosRawApduSender(baseUrl: string): RawApduSender {
   };
 }
 
-/** The ceremony's throwing sender: raw sender + the shared SW classification. */
+/**
+ * The ceremony's throwing sender, built by the same shared helper the DMK
+ * transport uses so both raise identical typed errors. No app identity: this
+ * client reads the app separately via {@link getAppAndVersion}.
+ */
 export function createSpeculosApduSender(baseUrl: string): ApduSender {
-  const sendRaw = createSpeculosRawApduSender(baseUrl);
-  return async (apdu) => {
-    const { sw, data } = await sendRaw(apdu);
-    const error = classifyStatusWord(sw, { ins: apdu.ins, p1: apdu.p1 });
-    if (error) throw error;
-    return data;
-  };
+  return createThrowingApduSender(createSpeculosRawApduSender(baseUrl));
 }
 
 /** All text lines of the currently displayed screen, joined with " | ". */
@@ -156,7 +157,12 @@ export interface AppAndVersion {
   readonly version: string;
 }
 
-/** GET_APP_AND_VERSION (`B0 01 00 00 00`), parsed per the live byte layout. */
+/**
+ * GET_APP_AND_VERSION (`B0 01 00 00 00`), parsed per the live byte layout.
+ * Reference client: LedgerHQ/ledger-live@2ec1cda
+ * `libs/ledger-live-common/src/hw/getAppAndVersion.ts`. Each rejection carries
+ * its own message so no two guards are indistinguishable to a caller or a test.
+ */
 export async function getAppAndVersion(sendRaw: RawApduSender): Promise<AppAndVersion> {
   const { sw, data } = await sendRaw({
     cla: CLA_BOLOS,
@@ -166,22 +172,34 @@ export async function getAppAndVersion(sendRaw: RawApduSender): Promise<AppAndVe
     data: new Uint8Array(0),
   });
   if (sw !== SW_OK) {
-    throw new Error(`GET_APP_AND_VERSION answered sw 0x${sw.toString(16)}`);
+    throw new Error(`GET_APP_AND_VERSION answered sw 0x${hex4(sw)}`);
   }
-  if (data.length < 3 || data[0] !== APP_AND_VERSION_FORMAT) {
-    throw new Error(`GET_APP_AND_VERSION answered an unknown format (${toHex(data)})`);
+  // Lengths only, never the response bytes: this client also drives real devices.
+  if (data.length < MIN_APP_AND_VERSION_BYTES) {
+    throw new Error(
+      `GET_APP_AND_VERSION answered ${data.length} bytes; the format and length prefixes alone need ${MIN_APP_AND_VERSION_BYTES}`,
+    );
+  }
+  if (data[0] !== APP_AND_VERSION_FORMAT) {
+    throw new Error(
+      `GET_APP_AND_VERSION answered format 0x${hex2(data[0])}, expected 0x${hex2(APP_AND_VERSION_FORMAT)}`,
+    );
   }
   const nameLen = data[1];
   const nameEnd = 2 + nameLen;
   // Check BEFORE reading the version-length byte: an out-of-range read yields
   // undefined, and the NaN that follows makes every `>` bound below false.
   if (nameEnd >= data.length) {
-    throw new Error(`GET_APP_AND_VERSION response truncated (${toHex(data)})`);
+    throw new Error(
+      `GET_APP_AND_VERSION response truncated: name length ${nameLen} leaves no version-length byte in ${data.length} bytes`,
+    );
   }
   const versionLen = data[nameEnd];
   const versionEnd = nameEnd + 1 + versionLen;
   if (versionEnd > data.length) {
-    throw new Error(`GET_APP_AND_VERSION response truncated (${toHex(data)})`);
+    throw new Error(
+      `GET_APP_AND_VERSION response truncated: version length ${versionLen} needs ${versionEnd} bytes, response has ${data.length}`,
+    );
   }
   const decoder = new TextDecoder();
   return {

--- a/packages/babylon-ledger-vault-signer/src/__tests__/e2e/speculosClient.ts
+++ b/packages/babylon-ledger-vault-signer/src/__tests__/e2e/speculosClient.ts
@@ -1,0 +1,186 @@
+/**
+ * Speculos REST transport + nanosp screen driver for the e2e suite.
+ *
+ * REST surface (speculos `api/`): POST /apdu {"data": hex} → {"data": hex}
+ * where the response hex is data ‖ 2-byte status word; POST /button/{b}
+ * {"action": "press-and-release"}; GET /events?currentscreenonly=true.
+ * Navigation recipe mirrors the live-verified reference driver
+ * (`lsk_ceremony2.py`): press right until the target text shows, then both.
+ *
+ * @module ledger-vault-signer/__tests__/e2e/speculosClient
+ */
+
+import { classifyStatusWord, type RawApduSender } from "../../rawApdu";
+import type { ApduSender } from "../../vaultCommands";
+
+/** BOLOS-level GET_APP_AND_VERSION (any app answers it). */
+const CLA_BOLOS = 0xb0;
+const INS_GET_APP_AND_VERSION = 0x01;
+const SW_OK = 0x9000;
+/** `format(1)=0x01 ‖ nameLen ‖ name ‖ versionLen ‖ version …` (verified live). */
+const APP_AND_VERSION_FORMAT = 0x01;
+
+const MAX_APDU_DATA_BYTES = 0xff;
+const STATUS_WORD_HEX_CHARS = 4;
+
+/** One press per ~150 ms is enough for Speculos to settle each redraw. */
+const PRESS_SETTLE_MS = 150;
+/** Upper bound on right-presses while hunting the approval screen. */
+const MAX_NAV_PRESSES = 40;
+/** How long to wait for a blocking APDU to put its review screen up. */
+const REVIEW_SCREEN_WAIT_MS = 15_000;
+/** The vault app's idle dashboard shows this line ("… app is ready"). */
+const IDLE_SCREEN_TEXT = "app is ready";
+
+function toHex(bytes: Uint8Array): string {
+  return Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+function fromHex(hex: string): Uint8Array {
+  const out = new Uint8Array(hex.length / 2);
+  for (let i = 0; i < out.length; i++) {
+    out[i] = parseInt(hex.slice(i * 2, i * 2 + 2), 16);
+  }
+  return out;
+}
+
+export function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function postJson(baseUrl: string, path: string, body: unknown): Promise<unknown> {
+  // No client-side timeout: screen-triggering APDUs block until approved;
+  // the vitest per-test timeout is the outer bound.
+  const response = await fetch(`${baseUrl}${path}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+  if (!response.ok) {
+    throw new Error(`Speculos POST ${path} answered HTTP ${response.status}`);
+  }
+  return response.json();
+}
+
+/**
+ * Non-throwing sender over the Speculos REST API — the response hex always
+ * ends in the 2-byte status word, so every SW (0xE000 included) comes back
+ * as data, exactly the {@link RawApduSender} contract.
+ */
+export function createSpeculosRawApduSender(baseUrl: string): RawApduSender {
+  return async (apdu) => {
+    if (apdu.data.length > MAX_APDU_DATA_BYTES) {
+      throw new Error(`APDU data is ${apdu.data.length} bytes; Lc is a single byte (max ${MAX_APDU_DATA_BYTES})`);
+    }
+    const wire = new Uint8Array(5 + apdu.data.length);
+    wire[0] = apdu.cla;
+    wire[1] = apdu.ins;
+    wire[2] = apdu.p1;
+    wire[3] = apdu.p2;
+    wire[4] = apdu.data.length;
+    wire.set(apdu.data, 5);
+    const body = (await postJson(baseUrl, "/apdu", { data: toHex(wire) })) as { data?: unknown };
+    if (typeof body.data !== "string" || body.data.length < STATUS_WORD_HEX_CHARS || body.data.length % 2 !== 0) {
+      throw new Error(`Speculos /apdu answered without a status word: ${JSON.stringify(body)}`);
+    }
+    const raw = fromHex(body.data);
+    const sw = (raw[raw.length - 2] << 8) | raw[raw.length - 1];
+    return { sw, data: raw.subarray(0, raw.length - 2) };
+  };
+}
+
+/** The ceremony's throwing sender: raw sender + the shared SW classification. */
+export function createSpeculosApduSender(baseUrl: string): ApduSender {
+  const sendRaw = createSpeculosRawApduSender(baseUrl);
+  return async (apdu) => {
+    const { sw, data } = await sendRaw(apdu);
+    const error = classifyStatusWord(sw, { ins: apdu.ins, p1: apdu.p1 });
+    if (error) throw error;
+    return data;
+  };
+}
+
+/** All text lines of the currently displayed screen, joined with " | ". */
+export async function readScreenText(baseUrl: string): Promise<string> {
+  const response = await fetch(`${baseUrl}/events?currentscreenonly=true`, { signal: AbortSignal.timeout(10_000) });
+  if (!response.ok) {
+    throw new Error(`Speculos GET /events answered HTTP ${response.status}`);
+  }
+  const body = (await response.json()) as { events?: { text?: string }[] };
+  return (body.events ?? []).map((event) => event.text ?? "").join(" | ");
+}
+
+export async function pressButton(baseUrl: string, button: "left" | "right" | "both"): Promise<void> {
+  await postJson(baseUrl, `/button/${button}`, { action: "press-and-release" });
+}
+
+/**
+ * Drive a nanosp approval flow for a review screen a concurrently-pending
+ * APDU has put up (or is about to): wait for the dashboard to be replaced,
+ * press right until `targetText` shows, then press both to confirm.
+ *
+ * @returns the screens visited, for failure diagnostics
+ */
+export async function approveOnScreen(baseUrl: string, targetText: string): Promise<string[]> {
+  const visited: string[] = [];
+
+  // Never blind-press the idle dashboard: right/both there navigates the app
+  // menu (worst case confirming "Quit"). Wait for the review flow to appear.
+  const waitDeadline = Date.now() + REVIEW_SCREEN_WAIT_MS;
+  let screen = await readScreenText(baseUrl);
+  while ((screen.length === 0 || screen.includes(IDLE_SCREEN_TEXT)) && Date.now() < waitDeadline) {
+    await sleep(PRESS_SETTLE_MS);
+    screen = await readScreenText(baseUrl);
+  }
+  if (screen.length === 0 || screen.includes(IDLE_SCREEN_TEXT)) {
+    throw new Error(`No review screen appeared within ${REVIEW_SCREEN_WAIT_MS} ms (still: "${screen}")`);
+  }
+
+  visited.push(screen);
+  for (let press = 0; press < MAX_NAV_PRESSES; press++) {
+    if (screen.includes(targetText)) {
+      await pressButton(baseUrl, "both");
+      await sleep(PRESS_SETTLE_MS);
+      return visited;
+    }
+    await pressButton(baseUrl, "right");
+    await sleep(PRESS_SETTLE_MS);
+    screen = await readScreenText(baseUrl);
+    visited.push(screen);
+  }
+  throw new Error(`"${targetText}" not reached in ${MAX_NAV_PRESSES} presses; screens: ${visited.join(" || ")}`);
+}
+
+export interface AppAndVersion {
+  readonly name: string;
+  readonly version: string;
+}
+
+/** GET_APP_AND_VERSION (`B0 01 00 00 00`), parsed per the live byte layout. */
+export async function getAppAndVersion(sendRaw: RawApduSender): Promise<AppAndVersion> {
+  const { sw, data } = await sendRaw({
+    cla: CLA_BOLOS,
+    ins: INS_GET_APP_AND_VERSION,
+    p1: 0x00,
+    p2: 0x00,
+    data: new Uint8Array(0),
+  });
+  if (sw !== SW_OK) {
+    throw new Error(`GET_APP_AND_VERSION answered sw 0x${sw.toString(16)}`);
+  }
+  if (data.length < 3 || data[0] !== APP_AND_VERSION_FORMAT) {
+    throw new Error(`GET_APP_AND_VERSION answered an unknown format (${toHex(data)})`);
+  }
+  const nameLen = data[1];
+  const nameEnd = 2 + nameLen;
+  const versionLen = data[nameEnd];
+  const versionEnd = nameEnd + 1 + versionLen;
+  if (versionEnd > data.length) {
+    throw new Error(`GET_APP_AND_VERSION response truncated (${toHex(data)})`);
+  }
+  const decoder = new TextDecoder();
+  return {
+    name: decoder.decode(data.subarray(2, nameEnd)),
+    version: decoder.decode(data.subarray(nameEnd + 1, versionEnd)),
+  };
+}

--- a/packages/babylon-ledger-vault-signer/src/__tests__/e2e/speculosClient.ts
+++ b/packages/babylon-ledger-vault-signer/src/__tests__/e2e/speculosClient.ts
@@ -32,6 +32,8 @@ const PRESS_SETTLE_MS = 150;
 const MAX_NAV_PRESSES = 40;
 /** How long to wait for a blocking APDU to put its review screen up. */
 const REVIEW_SCREEN_WAIT_MS = 15_000;
+/** Timeout for one events-poll fetch against the Speculos REST API. */
+const EVENTS_POLL_TIMEOUT_MS = 10_000;
 /** The vault app's idle dashboard shows this line ("… app is ready"). */
 const IDLE_SCREEN_TEXT = "app is ready";
 
@@ -103,7 +105,9 @@ export function createSpeculosApduSender(baseUrl: string): ApduSender {
 
 /** All text lines of the currently displayed screen, joined with " | ". */
 export async function readScreenText(baseUrl: string): Promise<string> {
-  const response = await fetch(`${baseUrl}/events?currentscreenonly=true`, { signal: AbortSignal.timeout(10_000) });
+  const response = await fetch(`${baseUrl}/events?currentscreenonly=true`, {
+    signal: AbortSignal.timeout(EVENTS_POLL_TIMEOUT_MS),
+  });
   if (!response.ok) {
     throw new Error(`Speculos GET /events answered HTTP ${response.status}`);
   }

--- a/packages/babylon-ledger-vault-signer/src/__tests__/e2e/speculosClient.ts
+++ b/packages/babylon-ledger-vault-signer/src/__tests__/e2e/speculosClient.ts
@@ -173,6 +173,11 @@ export async function getAppAndVersion(sendRaw: RawApduSender): Promise<AppAndVe
   }
   const nameLen = data[1];
   const nameEnd = 2 + nameLen;
+  // Check BEFORE reading the version-length byte: an out-of-range read yields
+  // undefined, and the NaN that follows makes every `>` bound below false.
+  if (nameEnd >= data.length) {
+    throw new Error(`GET_APP_AND_VERSION response truncated (${toHex(data)})`);
+  }
   const versionLen = data[nameEnd];
   const versionEnd = nameEnd + 1 + versionLen;
   if (versionEnd > data.length) {

--- a/packages/babylon-ledger-vault-signer/src/__tests__/expectedSignatures.test.ts
+++ b/packages/babylon-ledger-vault-signer/src/__tests__/expectedSignatures.test.ts
@@ -5,8 +5,10 @@
  * prepare pipeline: which inputs are tapscript / taproot-keypath / absent,
  * the tapleaf hashes (cross-checked against bip341.tapleafHash — an
  * independent oracle), and the expected yield count, matching the per-flow
- * table of the B1-c spec §3.1. Rejections use synthetic PSBTs built with
- * bitcoinjs so each violated rule is visible in the test body.
+ * table of the B1-c spec §3.1. Rejections come in two shapes: rules a synthetic
+ * bitcoinjs PSBT can express directly, and rules that need a real fixture with
+ * one field rewritten — the control-block commitment and the wallet-metadata
+ * rules only mean anything against genuine PegIn / Pre-PegIn material.
  */
 
 import * as ecc from "@bitcoin-js/tiny-secp256k1-asmjs";
@@ -18,6 +20,7 @@ import { join } from "path";
 import { describe, expect, it } from "vitest";
 
 import { isLedgerSignPsbtProtocolError } from "../errors";
+import { buildExpectedSignatureTable, type ExpectedSignaturePsbt } from "../expectedSignatures";
 import { prepareSignPsbt } from "../signPsbtPrepare";
 
 initEccLib(ecc);
@@ -180,39 +183,6 @@ describe("table build rules reject malformed PSBTs before any device I/O", () =>
     expectPrepareRejects(psbt.toHex(), /leaf version 0xc2/);
   });
 
-  it("rejects a keypath input whose internal key is not the depositor key", () => {
-    const psbt = psbtWithOneInput();
-    psbt.updateInput(0, {
-      tapInternalKey: Buffer.from(OTHER_KEY_HEX, "hex"),
-      witnessUtxo: { script: p2trOutput(OTHER_KEY_HEX), value: 5000 },
-    });
-    expectPrepareRejects(psbt.toHex(), /not the connected depositor key/);
-  });
-
-  it("rejects a keypath input with no witnessUtxo", () => {
-    const psbt = psbtWithOneInput();
-    psbt.updateInput(0, { tapInternalKey: Buffer.from(TEST_DEPOSITOR_KEY_HEX, "hex") });
-    expectPrepareRejects(psbt.toHex(), /keypath but has no witnessUtxo/);
-  });
-
-  it("rejects a keypath input whose witnessUtxo script is not P2TR", () => {
-    const psbt = psbtWithOneInput();
-    psbt.updateInput(0, {
-      tapInternalKey: Buffer.from(TEST_DEPOSITOR_KEY_HEX, "hex"),
-      witnessUtxo: { script: Buffer.concat([Buffer.from([0x00, 0x14]), Buffer.alloc(20, 0x2c)]), value: 5000 },
-    });
-    expectPrepareRejects(psbt.toHex(), /witnessUtxo script is not P2TR/);
-  });
-
-  it("rejects a keypath input whose witness program is not the BIP-86 tweak of the depositor key", () => {
-    const psbt = psbtWithOneInput();
-    psbt.updateInput(0, {
-      tapInternalKey: Buffer.from(TEST_DEPOSITOR_KEY_HEX, "hex"),
-      witnessUtxo: { script: P2TR_RANDOM_SCRIPT, value: 5000 },
-    });
-    expectPrepareRejects(psbt.toHex(), /not the BIP-86 P2TR of the depositor key/);
-  });
-
   it("ownership scan: rejects an unsigned input spending the depositor's P2TR UTXO", () => {
     const psbt = psbtWithOneInput();
     psbt.updateInput(0, { witnessUtxo: { script: p2trOutput(TEST_DEPOSITOR_KEY_HEX), value: 5000 } });
@@ -225,5 +195,276 @@ describe("table build rules reject malformed PSBTs before any device I/O", () =>
     const p2wpkhScript = Buffer.concat([Buffer.from([0x00, 0x14]), bcrypto.hash160(compressed)]);
     psbt.updateInput(0, { witnessUtxo: { script: p2wpkhScript, value: 5000 } });
     expectPrepareRejects(psbt.toHex(), /depositor-owned UTXO but carries no signing metadata/);
+  });
+});
+
+/** PSBT_IN key types the fixture-mutation helpers below address by key hex. */
+const WITNESS_UTXO_KEY = "01";
+const INTERNAL_KEY_KEY = "17";
+const LEAF_SCRIPT_KEY_PREFIX = "15";
+
+/** `keyLen ‖ key ‖ valueLen ‖ value` — one PSBT map record as it sits in a fixture's hex. */
+function recordHex(keyHex: string, valueHex: string): string {
+  const byteLen = (hex: string): string => {
+    // Every record we rewrite here is < 0xfd bytes, so the varints stay 1 byte.
+    expect(hex.length / 2).toBeLessThan(0xfd);
+    return (hex.length / 2).toString(16).padStart(2, "0");
+  };
+  return byteLen(keyHex) + keyHex + byteLen(valueHex) + valueHex;
+}
+
+/** Rewrite the one occurrence of `from` in a fixture's PSBT hex; fails if it is not unique. */
+function replaceOnce(psbtHex: string, from: string, to: string): string {
+  const at = psbtHex.indexOf(from);
+  expect(at).toBeGreaterThanOrEqual(0);
+  expect(psbtHex.indexOf(from, at + from.length)).toBe(-1);
+  return psbtHex.slice(0, at) + to + psbtHex.slice(at + from.length);
+}
+
+function inputEntryHex(vector: SignPsbtVector, inputIndex: number, keyPrefix: string): [string, string] {
+  const entry = vector.input_maps[inputIndex].find(([key]) => key.startsWith(keyPrefix));
+  if (!entry) throw new Error(`fixture input ${inputIndex} has no 0x${keyPrefix} entry`);
+  return entry;
+}
+
+/**
+ * A fixture's `[keyHex, valueHex]` input maps as the structural surface the
+ * table builder reads — the way to reach build rules that bip174 rejects at
+ * prepare's merge-target parse gate.
+ */
+function inputMapSurface(inputMaps: readonly (readonly [string, string])[][]): ExpectedSignaturePsbt {
+  return {
+    getGlobalInputCount: () => inputMaps.length,
+    getInputEntriesOfType: (inputIndex, keyType) =>
+      inputMaps[inputIndex]
+        .filter(([key]) => parseInt(key.slice(0, 2), 16) === keyType)
+        .map(([key, value]) => ({ keyData: Buffer.from(key.slice(2), "hex"), value: Buffer.from(value, "hex") })),
+    getInputWitnessUtxo: (inputIndex) => {
+      const entry = inputMaps[inputIndex].find(([key]) => key === WITNESS_UTXO_KEY);
+      if (!entry) return undefined;
+      // value = amount(8) ‖ varint(script len) ‖ script; fixture scripts are < 0xfd bytes.
+      const value = Buffer.from(entry[1], "hex");
+      return { amount: Number(value.readBigUInt64LE(0)), scriptPubKey: value.subarray(9, 9 + value[8]) };
+    },
+  };
+}
+
+function expectRejects(run: () => void, messagePattern: RegExp): void {
+  try {
+    run();
+    throw new Error("expected a LedgerSignPsbtProtocolError, nothing was thrown");
+  } catch (error) {
+    expect(isLedgerSignPsbtProtocolError(error)).toBe(true);
+    expect((error as Error).message).toMatch(messagePattern);
+  }
+}
+
+describe("keypath build rules, driven by mutations of the committed Pre-PegIn fixture", () => {
+  const FIXTURE = "deposit-flow__pre_pegin__0";
+
+  /** Input 0's witnessUtxo record, exactly as it appears in the fixture's PSBT hex. */
+  function witnessUtxoRecordHex(vector: SignPsbtVector): string {
+    return recordHex(WITNESS_UTXO_KEY, inputEntryHex(vector, 0, WITNESS_UTXO_KEY)[1]);
+  }
+
+  /** The fixture's amount(8) prefix, so a rewritten witnessUtxo keeps its real value. */
+  function witnessUtxoAmountHex(vector: SignPsbtVector): string {
+    return inputEntryHex(vector, 0, WITNESS_UTXO_KEY)[1].slice(0, 16);
+  }
+
+  function expectPrepareRejects(psbtHex: string, depositorXOnlyHex: string, messagePattern: RegExp): void {
+    expectRejects(() => prepareSignPsbt({ psbtHex, depositorXOnlyHex }), messagePattern);
+  }
+
+  it("rejects a TAP_INTERNAL_KEY value that is not 32 bytes", () => {
+    // Driven through the table builder directly: bip174 rejects a short
+    // tapInternalKey at prepare's merge-target parse gate, so no PSBT hex can
+    // carry this shape as far as the builder.
+    const vector = loadVector(FIXTURE);
+    const depositorXOnlyHex = fixtureInternalKeyHex(vector);
+    const maps = vector.input_maps.map((entries) => entries.map(([key, value]): [string, string] => [key, value]));
+    maps[0] = maps[0].map(([key, value]): [string, string] =>
+      key === INTERNAL_KEY_KEY ? [key, value.slice(0, 62)] : [key, value],
+    );
+
+    expectRejects(
+      () => buildExpectedSignatureTable({ psbt: inputMapSurface(maps), depositorXOnlyHex }),
+      /malformed TAP_INTERNAL_KEY entry/,
+    );
+  });
+
+  it("rejects a TAP_INTERNAL_KEY entry whose key carries trailing keydata", () => {
+    // Without the empty-keyData rule, a 0x17-typed key with trailing keydata has
+    // its value read as the internal key. Driven through the builder directly:
+    // bip174 rejects a non-1-byte key at prepare's merge-target parse gate
+    // (`bip174@2.1.1 converter/shared/tapInternalKey.js:5`).
+    const vector = loadVector(FIXTURE);
+    const depositorXOnlyHex = fixtureInternalKeyHex(vector);
+    const maps = vector.input_maps.map((entries) => entries.map(([key, value]): [string, string] => [key, value]));
+    maps[0] = maps[0].map(([key, value]): [string, string] =>
+      key === INTERNAL_KEY_KEY ? [`${key}00`, value] : [key, value],
+    );
+
+    expectRejects(
+      () => buildExpectedSignatureTable({ psbt: inputMapSurface(maps), depositorXOnlyHex }),
+      /malformed TAP_INTERNAL_KEY entry/,
+    );
+  });
+
+  it("rejects a keypath input whose internal key is not the connected depositor key", () => {
+    const vector = loadVector(FIXTURE);
+    const depositorXOnlyHex = fixtureInternalKeyHex(vector);
+    // Both fixture inputs share one internal key, so swapping in the other
+    // input's key would be a no-op — flip a byte of the key instead.
+    const flipped = ((parseInt(depositorXOnlyHex.slice(0, 2), 16) ^ 0xff) & 0xff).toString(16).padStart(2, "0");
+    const psbtHex = vector.psbt_hex
+      .split(recordHex(INTERNAL_KEY_KEY, depositorXOnlyHex))
+      .join(recordHex(INTERNAL_KEY_KEY, flipped + depositorXOnlyHex.slice(2)));
+
+    expectPrepareRejects(psbtHex, depositorXOnlyHex, /internal key is not the connected depositor key/);
+  });
+
+  it("rejects a keypath input with no witnessUtxo", () => {
+    const vector = loadVector(FIXTURE);
+    const psbtHex = replaceOnce(vector.psbt_hex, witnessUtxoRecordHex(vector), "");
+
+    expectPrepareRejects(psbtHex, fixtureInternalKeyHex(vector), /keypath but has no witnessUtxo/);
+  });
+
+  it("rejects a keypath input whose witnessUtxo script is not P2TR", () => {
+    const vector = loadVector(FIXTURE);
+    // P2WPKH: amount(8) ‖ varint(22) ‖ OP_0 ‖ push-20 ‖ hash160.
+    const p2wpkhUtxo = `${witnessUtxoAmountHex(vector)}16` + "0014" + "2c".repeat(20);
+    const psbtHex = replaceOnce(vector.psbt_hex, witnessUtxoRecordHex(vector), recordHex(WITNESS_UTXO_KEY, p2wpkhUtxo));
+
+    expectPrepareRejects(psbtHex, fixtureInternalKeyHex(vector), /witnessUtxo script is not P2TR/);
+  });
+
+  it("rejects a keypath input whose witness program is not the BIP-86 tweak of the depositor key", () => {
+    const vector = loadVector(FIXTURE);
+    const foreignUtxo = `${witnessUtxoAmountHex(vector)}225120` + "2b".repeat(32);
+    const psbtHex = replaceOnce(
+      vector.psbt_hex,
+      witnessUtxoRecordHex(vector),
+      recordHex(WITNESS_UTXO_KEY, foreignUtxo),
+    );
+
+    expectPrepareRejects(psbtHex, fixtureInternalKeyHex(vector), /not the BIP-86 P2TR of the depositor key/);
+  });
+});
+
+describe("tapscript control block must commit to its leaf, driven by PegIn fixture mutations", () => {
+  const FIXTURE = "generated__deposit-flow__pegin__0";
+  /** Offsets into the TAP_LEAF_SCRIPT key hex: `15` ‖ parity|version(1) ‖ internal key(32) ‖ path. */
+  const PARITY_BYTE_AT = 2;
+  const INTERNAL_KEY_AT = 4;
+  const MERKLE_PATH_AT = 68;
+  /**
+   * Sibling byte that re-folds this fixture to a DIFFERENT output key whose
+   * y-parity still equals the control block's bit 0 — so the output-key check
+   * is the only one that can fire. The fixture's own byte is 0xa6, and 0xff
+   * (the obvious mutation) flips parity as a side effect.
+   */
+  const PARITY_PRESERVING_SIBLING_BYTE = "00";
+
+  function expectPrepareRejects(psbtHex: string, messagePattern: RegExp): void {
+    expectRejects(() => prepareSignPsbt({ psbtHex, depositorXOnlyHex: TEST_DEPOSITOR_KEY_HEX }), messagePattern);
+  }
+
+  /** Rewrite input 0's TAP_LEAF_SCRIPT record with a mutated control block and/or value. */
+  function mutatedLeafPsbtHex(vector: SignPsbtVector, controlBlockKeyHex: string, valueHex: string): string {
+    const [keyHex, originalValueHex] = inputEntryHex(vector, 0, LEAF_SCRIPT_KEY_PREFIX);
+    return replaceOnce(vector.psbt_hex, recordHex(keyHex, originalValueHex), recordHex(controlBlockKeyHex, valueHex));
+  }
+
+  it("rejects a TAP_LEAF_SCRIPT value holding only the leaf-version byte", () => {
+    const vector = loadVector(FIXTURE);
+    const psbtHex = mutatedLeafPsbtHex(vector, inputEntryHex(vector, 0, LEAF_SCRIPT_KEY_PREFIX)[0], "c0");
+
+    expectPrepareRejects(psbtHex, /TAP_LEAF_SCRIPT value length 1 is below the 2-byte minimum/);
+  });
+
+  it("rejects a control block whose merkle path no longer folds to the witnessUtxo output key", () => {
+    const vector = loadVector(FIXTURE);
+    const [keyHex, valueHex] = inputEntryHex(vector, 0, LEAF_SCRIPT_KEY_PREFIX);
+    const mutatedKey =
+      keyHex.slice(0, MERKLE_PATH_AT) + PARITY_PRESERVING_SIBLING_BYTE + keyHex.slice(MERKLE_PATH_AT + 2);
+
+    expectPrepareRejects(
+      mutatedLeafPsbtHex(vector, mutatedKey, valueHex),
+      /recomputed taproot output key differs from the witnessUtxo witness program/,
+    );
+  });
+
+  it("rejects a control block whose parity bit disagrees with the recomputed output key", () => {
+    const vector = loadVector(FIXTURE);
+    const [keyHex, valueHex] = inputEntryHex(vector, 0, LEAF_SCRIPT_KEY_PREFIX);
+    // Flipping bit 0 keeps the leaf version (bits 1-7) that bip174 cross-checks,
+    // and leaves the merkle path — hence the recomputed output key — untouched.
+    const flipped = (parseInt(keyHex.slice(PARITY_BYTE_AT, PARITY_BYTE_AT + 2), 16) ^ 0x01)
+      .toString(16)
+      .padStart(2, "0");
+    const mutatedKey = keyHex.slice(0, PARITY_BYTE_AT) + flipped + keyHex.slice(PARITY_BYTE_AT + 2);
+
+    expectPrepareRejects(
+      mutatedLeafPsbtHex(vector, mutatedKey, valueHex),
+      /control block parity bit disagrees with the recomputed taproot output key/,
+    );
+  });
+
+  it("rejects a control block that is too short to carry an internal key", () => {
+    const vector = loadVector(FIXTURE);
+    const [keyHex, valueHex] = inputEntryHex(vector, 0, LEAF_SCRIPT_KEY_PREFIX);
+    const mutatedKey = keyHex.slice(0, INTERNAL_KEY_AT);
+
+    expectPrepareRejects(
+      mutatedLeafPsbtHex(vector, mutatedKey, valueHex),
+      /control block length 1 is not 33 plus a multiple of 32/,
+    );
+  });
+
+  it("rejects a control block whose internal key is not an x-only point", () => {
+    const vector = loadVector(FIXTURE);
+    const [keyHex, valueHex] = inputEntryHex(vector, 0, LEAF_SCRIPT_KEY_PREFIX);
+    // 32 × 0xff is above the field prime, so it is on no curve.
+    const mutatedKey = keyHex.slice(0, INTERNAL_KEY_AT) + "ff".repeat(32) + keyHex.slice(MERKLE_PATH_AT);
+
+    expectPrepareRejects(mutatedLeafPsbtHex(vector, mutatedKey, valueHex), /internal key is not an x-only point/);
+  });
+
+  it("rejects a tapscript input whose witnessUtxo script is not P2TR", () => {
+    const vector = loadVector(FIXTURE);
+    const witnessUtxoHex = inputEntryHex(vector, 0, WITNESS_UTXO_KEY)[1];
+    const p2wpkhUtxo = `${witnessUtxoHex.slice(0, 16)}16` + "0014" + "2c".repeat(20);
+    const psbtHex = replaceOnce(
+      vector.psbt_hex,
+      recordHex(WITNESS_UTXO_KEY, witnessUtxoHex),
+      recordHex(WITNESS_UTXO_KEY, p2wpkhUtxo),
+    );
+
+    expectPrepareRejects(psbtHex, /is tapscript but its witnessUtxo script is not P2TR/);
+  });
+});
+
+describe("YieldCollector treats a short signature as a malformed payload", () => {
+  it("raises a protocol error, not a yield mismatch, for a signature shorter than 64 bytes", () => {
+    const vector = loadVector("generated__deposit-flow__pegin__0");
+    const { collector, table } = prepareSignPsbt({
+      psbtHex: vector.psbt_hex,
+      depositorXOnlyHex: TEST_DEPOSITOR_KEY_HEX,
+    });
+    const expectation = table.byInput.get(0);
+    if (expectation?.kind !== "tapscript") throw new Error("input 0 must classify tapscript");
+    // Tapscript YIELD payload (0x10 code byte already stripped by the interpreter):
+    // varint(input 0) ‖ augmLen(0x40) ‖ signer key(32) ‖ leaf hash(32) ‖ signature.
+    const payload = Buffer.from(
+      "00" + "40" + TEST_DEPOSITOR_KEY_HEX + [...expectation.expectedLeafHashHexes][0] + "ab".repeat(63),
+      "hex",
+    );
+
+    expectRejects(
+      () => collector.assertAndRecord(payload),
+      /YIELD payload truncated inside the signature \(63 of 64 bytes on input 0\)/,
+    );
   });
 });

--- a/packages/babylon-ledger-vault-signer/src/__tests__/expectedSignatures.test.ts
+++ b/packages/babylon-ledger-vault-signer/src/__tests__/expectedSignatures.test.ts
@@ -1,0 +1,229 @@
+/**
+ * G2 gate + build-rule rejections for the SIGN_PSBT expected-signature table.
+ *
+ * Classification runs over all 22 firmware-fixture vectors through the real
+ * prepare pipeline: which inputs are tapscript / taproot-keypath / absent,
+ * the tapleaf hashes (cross-checked against bip341.tapleafHash — an
+ * independent oracle), and the expected yield count, matching the per-flow
+ * table of the B1-c spec §3.1. Rejections use synthetic PSBTs built with
+ * bitcoinjs so each violated rule is visible in the test body.
+ */
+
+import * as ecc from "@bitcoin-js/tiny-secp256k1-asmjs";
+import { crypto as bcrypto, initEccLib, payments, Psbt } from "bitcoinjs-lib";
+import { tapleafHash as bip341TapleafHash } from "bitcoinjs-lib/src/payments/bip341";
+import { Buffer } from "buffer";
+import { readFileSync } from "fs";
+import { join } from "path";
+import { describe, expect, it } from "vitest";
+
+import { isLedgerSignPsbtProtocolError } from "../errors";
+import { prepareSignPsbt } from "../signPsbtPrepare";
+
+initEccLib(ecc);
+
+const VECTORS_DIR = join(__dirname, "..", "vendor", "ledger-bitcoin", "__tests__", "vectors", "signpsbt");
+
+interface SignPsbtVector {
+  fixture: string;
+  batch_index: number;
+  psbt_hex: string;
+  n_inputs: number;
+  /** [keyHex, valueHex] pairs per input map, straight from the oracle. */
+  input_maps: [string, string][][];
+}
+
+function loadVector(name: string): SignPsbtVector {
+  return JSON.parse(readFileSync(join(VECTORS_DIR, `${name}.json`), "utf8")) as SignPsbtVector;
+}
+
+const TAPSCRIPT_VECTOR_NAMES = [
+  "deposit-flow__claimer_payout__0",
+  "deposit-flow__claimer_payout__1",
+  "deposit-flow__claimer_payout__2",
+  "deposit-flow__claimer_payout__3",
+  "deposit-flow__claimer_payout__4",
+  "deposit-flow__depositor_graph__0",
+  "deposit-flow__depositor_graph__1",
+  "deposit-flow__depositor_graph__2",
+  "deposit-flow__depositor_graph__3",
+  "deposit-flow__depositor_graph__4",
+  "deposit-flow__depositor_graph__5",
+  "deposit-flow__depositor_graph__6",
+  "deposit-flow__depositor_graph__7",
+  "deposit-flow__depositor_graph__8",
+  "deposit-flow__pegin__0",
+  "generated__deposit-flow__claimer_payout__0",
+  "generated__deposit-flow__depositor_graph__0",
+  "generated__deposit-flow__depositor_graph__1",
+  "generated__deposit-flow__depositor_graph__2",
+  "generated__deposit-flow__pegin__0",
+];
+const KEYPATH_VECTOR_NAMES = ["deposit-flow__pre_pegin__0", "generated__deposit-flow__pre_pegin__0"];
+
+// Valid x-only point (the generated fixtures' depositor key). For tapscript
+// classification the depositor key is a free parameter — expectation is pure
+// passthrough — but the ownership scan tweaks it, so it must be on-curve.
+const TEST_DEPOSITOR_KEY_HEX = "e49662aea97a89551401ce54de10474b24b4ab71383b69cf164ea59b3a209e0d";
+// A second valid point (the signet pre_pegin fixture's depositor key).
+const OTHER_KEY_HEX = "8156406fa3a7e73ff514a9051c0a4554a7142524a41aaaaafc879c6897021167";
+
+/** Fixture input-0 TAP_INTERNAL_KEY — the connected key the keypath table pins. */
+function fixtureInternalKeyHex(vector: SignPsbtVector): string {
+  const entry = vector.input_maps[0].find(([key]) => key === "17");
+  if (!entry) throw new Error("fixture has no TAP_INTERNAL_KEY on input 0");
+  return entry[1];
+}
+
+/** Witness program from the vector's raw witnessUtxo value: amount(8) ‖ varint(34) ‖ 5120‖program. */
+function fixtureWitnessProgramHex(vector: SignPsbtVector, inputIndex: number): string {
+  const entry = vector.input_maps[inputIndex].find(([key]) => key === "01");
+  if (!entry) throw new Error(`fixture input ${inputIndex} has no witnessUtxo`);
+  const value = Buffer.from(entry[1], "hex");
+  expect(value[8]).toBe(34); // varint script length
+  expect(value.subarray(9, 11).toString("hex")).toBe("5120");
+  return value.subarray(11, 43).toString("hex");
+}
+
+/** The fixture's TAP_LEAF_SCRIPT script (value minus the trailing version byte). */
+function fixtureLeafScript(vector: SignPsbtVector, inputIndex: number): Buffer {
+  const entry = vector.input_maps[inputIndex].find(([key]) => key.startsWith("15"));
+  if (!entry) throw new Error(`fixture input ${inputIndex} has no TAP_LEAF_SCRIPT`);
+  const value = Buffer.from(entry[1], "hex");
+  expect(value[value.length - 1]).toBe(0xc0);
+  return Buffer.from(value.subarray(0, value.length - 1));
+}
+
+describe("expected-signature table classification (G2, 22 fixtures)", () => {
+  it.each(TAPSCRIPT_VECTOR_NAMES.map((name) => [name]))("%s: input 0 tapscript, other inputs absent", (name) => {
+    const vector = loadVector(name);
+    const { table } = prepareSignPsbt({ psbtHex: vector.psbt_hex, depositorXOnlyHex: TEST_DEPOSITOR_KEY_HEX });
+
+    expect(table.expectedYieldCount).toBe(1);
+    expect([...table.byInput.keys()]).toEqual([0]);
+    const expectation = table.byInput.get(0);
+    if (expectation?.kind !== "tapscript") throw new Error("input 0 must classify tapscript");
+    expect(expectation.expectedSignerXOnlyHex).toBe(TEST_DEPOSITOR_KEY_HEX);
+    // Independent oracle for the leaf hash the device will echo in its YIELD.
+    const expectedLeafHex = bip341TapleafHash({ output: fixtureLeafScript(vector, 0), version: 0xc0 }).toString("hex");
+    expect([...expectation.expectedLeafHashHexes]).toEqual([expectedLeafHex]);
+  });
+
+  it.each(KEYPATH_VECTOR_NAMES.map((name) => [name]))("%s: every wallet input keypath", (name) => {
+    const vector = loadVector(name);
+    const depositorXOnlyHex = fixtureInternalKeyHex(vector);
+    const { table } = prepareSignPsbt({ psbtHex: vector.psbt_hex, depositorXOnlyHex });
+
+    expect(table.expectedYieldCount).toBe(vector.n_inputs);
+    expect([...table.byInput.keys()]).toEqual([...Array(vector.n_inputs).keys()]);
+    for (let inputIndex = 0; inputIndex < vector.n_inputs; inputIndex++) {
+      const expectation = table.byInput.get(inputIndex);
+      if (expectation?.kind !== "taproot-keypath") throw new Error(`input ${inputIndex} must classify keypath`);
+      expect(expectation.expectedOutputKeyHex).toBe(fixtureWitnessProgramHex(vector, inputIndex));
+    }
+  });
+});
+
+describe("table build rules reject malformed PSBTs before any device I/O", () => {
+  const P2TR_RANDOM_SCRIPT = Buffer.concat([Buffer.from([0x51, 0x20]), Buffer.alloc(32, 0x2b)]);
+  const CONTROL_BLOCK = Buffer.concat([Buffer.from([0xc0]), Buffer.from(OTHER_KEY_HEX, "hex")]);
+  const LEAF_SCRIPT = Buffer.from([0x51]);
+
+  function p2trOutput(xOnlyHex: string): Buffer {
+    const output = payments.p2tr({ internalPubkey: Buffer.from(xOnlyHex, "hex") }).output;
+    if (!output) throw new Error("p2tr produced no output");
+    return output;
+  }
+
+  function psbtWithOneInput(): Psbt {
+    const psbt = new Psbt();
+    psbt.addInput({ hash: Buffer.alloc(32, 0x01), index: 0 });
+    psbt.addOutput({ script: P2TR_RANDOM_SCRIPT, value: 1000 });
+    return psbt;
+  }
+
+  function expectPrepareRejects(psbtHex: string, messagePattern: RegExp): void {
+    try {
+      prepareSignPsbt({ psbtHex, depositorXOnlyHex: TEST_DEPOSITOR_KEY_HEX });
+      throw new Error("prepareSignPsbt did not throw");
+    } catch (error) {
+      expect(isLedgerSignPsbtProtocolError(error)).toBe(true);
+      expect((error as Error).message).toMatch(messagePattern);
+    }
+  }
+
+  it("rejects a PSBT with no depositor-signable input", () => {
+    const psbt = psbtWithOneInput();
+    psbt.updateInput(0, { witnessUtxo: { script: P2TR_RANDOM_SCRIPT, value: 5000 } });
+    expectPrepareRejects(psbt.toHex(), /no depositor-signable input/);
+  });
+
+  it("rejects an ambiguous leaf set (two TAP_LEAF_SCRIPT entries)", () => {
+    const psbt = psbtWithOneInput();
+    // Distinct control blocks (parity bit) — the PSBT map key is the control block.
+    const secondControlBlock = Buffer.from(CONTROL_BLOCK);
+    secondControlBlock[0] = 0xc1;
+    psbt.updateInput(0, {
+      tapLeafScript: [
+        { leafVersion: 0xc0, script: LEAF_SCRIPT, controlBlock: CONTROL_BLOCK },
+        { leafVersion: 0xc0, script: Buffer.from([0x52]), controlBlock: secondControlBlock },
+      ],
+    });
+    expectPrepareRejects(psbt.toHex(), /ambiguous leaf set/);
+  });
+
+  it("rejects a non-tapscript leaf version", () => {
+    const psbt = psbtWithOneInput();
+    const controlBlock = Buffer.from(CONTROL_BLOCK);
+    controlBlock[0] = 0xc2;
+    psbt.updateInput(0, { tapLeafScript: [{ leafVersion: 0xc2, script: LEAF_SCRIPT, controlBlock }] });
+    expectPrepareRejects(psbt.toHex(), /leaf version 0xc2/);
+  });
+
+  it("rejects a keypath input whose internal key is not the depositor key", () => {
+    const psbt = psbtWithOneInput();
+    psbt.updateInput(0, {
+      tapInternalKey: Buffer.from(OTHER_KEY_HEX, "hex"),
+      witnessUtxo: { script: p2trOutput(OTHER_KEY_HEX), value: 5000 },
+    });
+    expectPrepareRejects(psbt.toHex(), /not the connected depositor key/);
+  });
+
+  it("rejects a keypath input with no witnessUtxo", () => {
+    const psbt = psbtWithOneInput();
+    psbt.updateInput(0, { tapInternalKey: Buffer.from(TEST_DEPOSITOR_KEY_HEX, "hex") });
+    expectPrepareRejects(psbt.toHex(), /keypath but has no witnessUtxo/);
+  });
+
+  it("rejects a keypath input whose witnessUtxo script is not P2TR", () => {
+    const psbt = psbtWithOneInput();
+    psbt.updateInput(0, {
+      tapInternalKey: Buffer.from(TEST_DEPOSITOR_KEY_HEX, "hex"),
+      witnessUtxo: { script: Buffer.concat([Buffer.from([0x00, 0x14]), Buffer.alloc(20, 0x2c)]), value: 5000 },
+    });
+    expectPrepareRejects(psbt.toHex(), /witnessUtxo script is not P2TR/);
+  });
+
+  it("rejects a keypath input whose witness program is not the BIP-86 tweak of the depositor key", () => {
+    const psbt = psbtWithOneInput();
+    psbt.updateInput(0, {
+      tapInternalKey: Buffer.from(TEST_DEPOSITOR_KEY_HEX, "hex"),
+      witnessUtxo: { script: P2TR_RANDOM_SCRIPT, value: 5000 },
+    });
+    expectPrepareRejects(psbt.toHex(), /not the BIP-86 P2TR of the depositor key/);
+  });
+
+  it("ownership scan: rejects an unsigned input spending the depositor's P2TR UTXO", () => {
+    const psbt = psbtWithOneInput();
+    psbt.updateInput(0, { witnessUtxo: { script: p2trOutput(TEST_DEPOSITOR_KEY_HEX), value: 5000 } });
+    expectPrepareRejects(psbt.toHex(), /depositor-owned UTXO but carries no signing metadata/);
+  });
+
+  it("ownership scan: rejects an unsigned input spending the depositor's P2WPKH UTXO", () => {
+    const psbt = psbtWithOneInput();
+    const compressed = Buffer.concat([Buffer.from([0x02]), Buffer.from(TEST_DEPOSITOR_KEY_HEX, "hex")]);
+    const p2wpkhScript = Buffer.concat([Buffer.from([0x00, 0x14]), bcrypto.hash160(compressed)]);
+    psbt.updateInput(0, { witnessUtxo: { script: p2wpkhScript, value: 5000 } });
+    expectPrepareRejects(psbt.toHex(), /depositor-owned UTXO but carries no signing metadata/);
+  });
+});

--- a/packages/babylon-ledger-vault-signer/src/__tests__/rawApdu.test.ts
+++ b/packages/babylon-ledger-vault-signer/src/__tests__/rawApdu.test.ts
@@ -8,9 +8,14 @@
 import { describe, expect, it } from "vitest";
 
 import { LEDGER_DEVICE_ERROR_NAME, LEDGER_DEVICE_LOCKED_ERROR_NAME, LEDGER_USER_REFUSED_ERROR_NAME } from "../errors";
-import { classifyStatusWord } from "../rawApdu";
+import { classifyStatusWord, createThrowingApduSender, type Apdu, type RawApduSender } from "../rawApdu";
 
 const context = { ins: 0x80, p1: 0x02 };
+const apdu: Apdu = { cla: 0xe1, ins: 0x80, p1: 0x02, p2: 0x00, data: new Uint8Array() };
+
+function rawSenderAnswering(sw: number, data = new Uint8Array()): RawApduSender {
+  return async () => ({ sw, data });
+}
 
 describe("classifyStatusWord", () => {
   it("returns undefined for 0x9000 — success is not an error", () => {
@@ -65,5 +70,41 @@ describe("classifyStatusWord", () => {
     const error = classifyStatusWord(0x6e00, context);
     expect(error?.message).toMatch(/open the Babylon Vault app/);
     expect(error?.message).not.toMatch(/app at connect time/);
+  });
+});
+
+describe("createThrowingApduSender", () => {
+  it("returns the response data on 0x9000", async () => {
+    const root = new Uint8Array(32).fill(7);
+
+    await expect(createThrowingApduSender(rawSenderAnswering(0x9000, root))(apdu)).resolves.toEqual(root);
+  });
+
+  it("throws the shared typed error on a terminal status word", async () => {
+    // `createDmkApduSender` and `createSpeculosApduSender` both re-base on this
+    // helper, so a decline reads identically over either transport.
+    await expect(createThrowingApduSender(rawSenderAnswering(0x6985))(apdu)).rejects.toMatchObject({
+      name: LEDGER_USER_REFUSED_ERROR_NAME,
+      statusWord: 0x6985,
+    });
+  });
+
+  it("weaves the supplied app identity into the 0x6E00 hint", async () => {
+    const send = createThrowingApduSender(rawSenderAnswering(0x6e00), { appName: "BOLOS", appVersion: "1.6.0" });
+
+    await expect(send(apdu)).rejects.toThrow(/app at connect time: "BOLOS" v1\.6\.0/);
+  });
+
+  it("omits the app hint when built without an app identity", async () => {
+    const send = createThrowingApduSender(rawSenderAnswering(0x6e00));
+
+    const outcome = await send(apdu).then(
+      () => undefined,
+      (error: unknown) => error,
+    );
+
+    expect(outcome).toBeInstanceOf(Error);
+    expect((outcome as Error).message).toMatch(/open the Babylon Vault app/);
+    expect((outcome as Error).message).not.toMatch(/app at connect time/);
   });
 });

--- a/packages/babylon-ledger-vault-signer/src/__tests__/signPsbt.test.ts
+++ b/packages/babylon-ledger-vault-signer/src/__tests__/signPsbt.test.ts
@@ -17,7 +17,7 @@ import { describe, expect, it } from "vitest";
 
 import { isLedgerSignPsbtAbortedError } from "../errors";
 import type { RawApduSender } from "../rawApdu";
-import { signVaultPsbt } from "../signPsbt";
+import { signVaultPsbt, type SignVaultPsbtParams } from "../signPsbt";
 import { tapLeafHash } from "../tapLeafHash";
 
 const VECTORS_DIR = join(__dirname, "..", "vendor", "ledger-bitcoin", "__tests__", "vectors", "signpsbt");
@@ -137,6 +137,7 @@ describe("signVaultPsbt", () => {
       onProgress: () => {
         throw new Error("caller's progress handler is broken");
       },
+      signal: new AbortController().signal,
     });
 
     expect(sent()).toBe(script.length);
@@ -185,5 +186,32 @@ describe("signVaultPsbt", () => {
 
     expect(isLedgerSignPsbtAbortedError(outcome)).toBe(true);
     expect(sent()).toBe(1);
+  });
+
+  it("requires a signal — params without one must not typecheck", () => {
+    // @ts-expect-error `signal` is required; the loop has no round cap and no
+    // internal timeout, so a caller without a signal cannot bound the ceremony.
+    const withoutSignal: SignVaultPsbtParams = {
+      psbtHex: vector.psbt_hex,
+      depositorXOnlyHex: TEST_DEPOSITOR_KEY_HEX,
+    };
+
+    expect(withoutSignal.depositorXOnlyHex).toBe(TEST_DEPOSITOR_KEY_HEX);
+  });
+
+  it("threads the connect-time app identity into terminal status-word diagnostics", async () => {
+    const script: ScriptedExchange[] = [
+      { expectApduHex: SIGN_PSBT_HEADER_HEX + vector.sign_psbt_cdata_hex, respondSw: 0x6e00, respondDataHex: "" },
+    ];
+    const { send } = createScriptedSender(script);
+
+    await expect(
+      signVaultPsbt(send, {
+        psbtHex: vector.psbt_hex,
+        depositorXOnlyHex: TEST_DEPOSITOR_KEY_HEX,
+        signal: new AbortController().signal,
+        appIdentity: { appName: "Babylon Vault", appVersion: "0.1.0" },
+      }),
+    ).rejects.toThrow(/app at connect time: "Babylon Vault" v0\.1\.0/);
   });
 });

--- a/packages/babylon-ledger-vault-signer/src/__tests__/signPsbt.test.ts
+++ b/packages/babylon-ledger-vault-signer/src/__tests__/signPsbt.test.ts
@@ -1,0 +1,189 @@
+/**
+ * `signVaultPsbt` composition: prepare → loop → merge over a scripted device.
+ *
+ * The sender is an ordered script of { expectApduHex, respondSw,
+ * respondDataHex }; any out-of-order or extra APDU fails the test, so "no
+ * further sends" is proven by the sender itself. The PegIn transcript is the
+ * committed Python-oracle trace with its synthetic YIELD replaced by a payload
+ * built from the fixture's own tapleaf (the placeholder's key/leaf bytes are
+ * sha256-derived and no table accepts them).
+ */
+
+import { Psbt } from "bitcoinjs-lib";
+import { Buffer } from "buffer";
+import { readFileSync } from "fs";
+import { join } from "path";
+import { describe, expect, it } from "vitest";
+
+import { isLedgerSignPsbtAbortedError } from "../errors";
+import type { RawApduSender } from "../rawApdu";
+import { signVaultPsbt } from "../signPsbt";
+import { tapLeafHash } from "../tapLeafHash";
+
+const VECTORS_DIR = join(__dirname, "..", "vendor", "ledger-bitcoin", "__tests__", "vectors", "signpsbt");
+const TRACES_DIR = join(__dirname, "..", "vendor", "ledger-bitcoin", "__tests__", "vectors", "command-traces");
+const FIXTURE = "generated__deposit-flow__pegin__0";
+
+// Valid x-only point (the generated fixtures' depositor key).
+const TEST_DEPOSITOR_KEY_HEX = "e49662aea97a89551401ce54de10474b24b4ab71383b69cf164ea59b3a209e0d";
+const TEST_SIG_HEX = "cd".repeat(64);
+const SIGN_PSBT_HEADER_HEX = "e1040001";
+const CONTINUE_HEADER_HEX = "f8010000";
+const TAPSCRIPT_LEAF_VERSION = 0xc0;
+
+interface Trace {
+  command_name: string;
+  request_hex: string;
+  response_hex: string;
+}
+
+const vector = JSON.parse(readFileSync(join(VECTORS_DIR, `${FIXTURE}.json`), "utf8")) as {
+  psbt_hex: string;
+  sign_psbt_cdata_hex: string;
+  input_maps: [string, string][][];
+};
+const traceFile = JSON.parse(readFileSync(join(TRACES_DIR, `${FIXTURE}.json`), "utf8")) as { traces: Trace[] };
+
+/** The fixture's own input-0 tapleaf: BIP-371 value = script ‖ leaf_version(1B). */
+function fixtureLeafHashHex(): string {
+  const entry = vector.input_maps[0].find(([keyHex]) => keyHex.startsWith("15"));
+  if (!entry) throw new Error("fixture input 0 has no TAP_LEAF_SCRIPT entry");
+  const value = Buffer.from(entry[1], "hex");
+  expect(value[value.length - 1]).toBe(TAPSCRIPT_LEAF_VERSION);
+  return tapLeafHash(TAPSCRIPT_LEAF_VERSION, value.subarray(0, value.length - 1)).toString("hex");
+}
+
+interface ScriptedExchange {
+  readonly expectApduHex: string;
+  readonly respondSw: number;
+  readonly respondDataHex: string;
+  /** Side effect fired when this exchange answers (e.g. abort mid-loop). */
+  readonly onRespond?: () => void;
+}
+
+function createScriptedSender(script: readonly ScriptedExchange[]): { send: RawApduSender; sent: () => number } {
+  let calls = 0;
+  const send: RawApduSender = async (apdu) => {
+    const apduHex =
+      [apdu.cla, apdu.ins, apdu.p1, apdu.p2].map((byte) => byte.toString(16).padStart(2, "0")).join("") +
+      Buffer.from(apdu.data).toString("hex");
+    const expected = script[calls];
+    if (!expected) throw new Error(`unexpected extra APDU #${calls}: ${apduHex}`);
+    expect(apduHex, `APDU #${calls}`).toBe(expected.expectApduHex);
+    calls += 1;
+    expected.onRespond?.();
+    return { sw: expected.respondSw, data: Uint8Array.from(Buffer.from(expected.respondDataHex, "hex")) };
+  };
+  return { send, sent: () => calls };
+}
+
+/** `0x10 ‖ varint(0) ‖ 0x40 ‖ signer(32) ‖ leaf(32) ‖ sig(64)` — wire-spec §5 tapscript YIELD. */
+function peginYieldRequestHex(leafHashHex: string): string {
+  return "10" + "00" + "40" + TEST_DEPOSITOR_KEY_HEX + leafHashHex + TEST_SIG_HEX;
+}
+
+/** Each oracle request rides a 0xE000; its response rides the next CONTINUE. */
+function peginScript(leafHashHex: string): ScriptedExchange[] {
+  const exchanges: ScriptedExchange[] = [];
+  let expectApduHex = SIGN_PSBT_HEADER_HEX + vector.sign_psbt_cdata_hex;
+  for (const trace of traceFile.traces) {
+    const requestHex = trace.command_name === "YIELD" ? peginYieldRequestHex(leafHashHex) : trace.request_hex;
+    exchanges.push({ expectApduHex, respondSw: 0xe000, respondDataHex: requestHex });
+    expectApduHex = CONTINUE_HEADER_HEX + trace.response_hex;
+  }
+  exchanges.push({ expectApduHex, respondSw: 0x9000, respondDataHex: "" });
+  return exchanges;
+}
+
+function unsignedTxHex(psbtHex: string): string {
+  return Psbt.fromHex(psbtHex).data.globalMap.unsignedTx.toBuffer().toString("hex");
+}
+
+describe("signVaultPsbt", () => {
+  it("signs a PegIn PSBT end-to-end: yields collected, signature merged, nothing finalized", async () => {
+    const leafHashHex = fixtureLeafHashHex();
+    const script = peginScript(leafHashHex);
+    const { send, sent } = createScriptedSender(script);
+    const progress: { inputIndex: number; yieldedCount: number; expectedYieldCount: number }[] = [];
+
+    const result = await signVaultPsbt(send, {
+      psbtHex: vector.psbt_hex,
+      depositorXOnlyHex: TEST_DEPOSITOR_KEY_HEX,
+      onProgress: (p) => progress.push(p),
+      signal: new AbortController().signal,
+    });
+
+    expect(sent()).toBe(script.length);
+    expect(result.yields).toHaveLength(1);
+    expect(result.yields[0]).toMatchObject({ kind: "tapscript", inputIndex: 0, leafHashHex });
+    expect(progress).toEqual([{ inputIndex: 0, yieldedCount: 1, expectedYieldCount: 1 }]);
+
+    expect(unsignedTxHex(result.signedPsbtHex)).toBe(unsignedTxHex(vector.psbt_hex));
+    const signedInput = Psbt.fromHex(result.signedPsbtHex).data.inputs[0];
+    expect(signedInput.tapScriptSig).toHaveLength(1);
+    expect(signedInput.tapScriptSig?.[0].leafHash.toString("hex")).toBe(leafHashHex);
+    expect(signedInput.tapScriptSig?.[0].signature.toString("hex")).toBe(TEST_SIG_HEX);
+    expect(signedInput.finalScriptWitness).toBeUndefined();
+  });
+
+  it("completes the ceremony when onProgress throws", async () => {
+    const leafHashHex = fixtureLeafHashHex();
+    const script = peginScript(leafHashHex);
+    const { send, sent } = createScriptedSender(script);
+
+    const result = await signVaultPsbt(send, {
+      psbtHex: vector.psbt_hex,
+      depositorXOnlyHex: TEST_DEPOSITOR_KEY_HEX,
+      onProgress: () => {
+        throw new Error("caller's progress handler is broken");
+      },
+    });
+
+    expect(sent()).toBe(script.length);
+    expect(result.yields).toHaveLength(1);
+    expect(Psbt.fromHex(result.signedPsbtHex).data.inputs[0].tapScriptSig).toHaveLength(1);
+  });
+
+  it("rejects with the aborted error and sends nothing when the signal is already aborted", async () => {
+    const { send, sent } = createScriptedSender([]);
+    const controller = new AbortController();
+    controller.abort();
+
+    const outcome = await signVaultPsbt(send, {
+      psbtHex: vector.psbt_hex,
+      depositorXOnlyHex: TEST_DEPOSITOR_KEY_HEX,
+      signal: controller.signal,
+    }).then(
+      () => undefined,
+      (error: unknown) => error,
+    );
+
+    expect(isLedgerSignPsbtAbortedError(outcome)).toBe(true);
+    expect(sent()).toBe(0);
+  });
+
+  it("propagates a mid-loop abort instead of returning a half-merged PSBT", async () => {
+    const controller = new AbortController();
+    const script: ScriptedExchange[] = [
+      {
+        expectApduHex: SIGN_PSBT_HEADER_HEX + vector.sign_psbt_cdata_hex,
+        respondSw: 0xe000,
+        respondDataHex: traceFile.traces[0].request_hex,
+        onRespond: () => controller.abort(),
+      },
+    ];
+    const { send, sent } = createScriptedSender(script);
+
+    const outcome = await signVaultPsbt(send, {
+      psbtHex: vector.psbt_hex,
+      depositorXOnlyHex: TEST_DEPOSITOR_KEY_HEX,
+      signal: controller.signal,
+    }).then(
+      () => undefined,
+      (error: unknown) => error,
+    );
+
+    expect(isLedgerSignPsbtAbortedError(outcome)).toBe(true);
+    expect(sent()).toBe(1);
+  });
+});

--- a/packages/babylon-ledger-vault-signer/src/__tests__/signPsbtLoop.test.ts
+++ b/packages/babylon-ledger-vault-signer/src/__tests__/signPsbtLoop.test.ts
@@ -1,0 +1,554 @@
+/**
+ * SIGN_PSBT loop vs scripted device transcripts (spec §7.2, T1-T14).
+ *
+ * The fake RawApduSender is an ordered script of
+ * { expectApduHex, respondSw, respondDataHex }; any out-of-order, unexpected,
+ * or extra APDU fails the test, so "no further sends after a throw" is proven
+ * by the sender itself. Happy paths replay the committed Python-oracle
+ * command traces through the real loop; the synthetic YIELD placeholders in
+ * those traces are replaced with payloads valid against the prepared table
+ * (the placeholders carry sha256-derived key/leaf bytes no table accepts).
+ */
+
+import { Psbt } from "bitcoinjs-lib";
+import { Buffer } from "buffer";
+import { readFileSync } from "fs";
+import { join } from "path";
+import { describe, expect, it } from "vitest";
+
+import {
+  LedgerDeviceError,
+  LedgerSignPsbtAbortedError,
+  LedgerSignPsbtProtocolError,
+  LedgerUserRefusedError,
+  LedgerYieldMismatchError,
+  isLedgerDeviceLockedError,
+  isLedgerSignPsbtAbortedError,
+  isLedgerSignPsbtIncompleteError,
+  type LedgerYieldMismatchKind,
+} from "../errors";
+import { createYieldCollector, type ExpectedSignatureTable } from "../expectedSignatures";
+import type { Apdu, RawApduSender } from "../rawApdu";
+import { runSignPsbtLoop, type SignPsbtProgress } from "../signPsbtLoop";
+import { prepareSignPsbt, type PreparedSignPsbt } from "../signPsbtPrepare";
+import { ClientCommandInterpreter } from "../vendor/ledger-bitcoin/clientCommands";
+import { createVarint } from "../vendor/ledger-bitcoin/varint";
+
+const VECTORS_DIR = join(__dirname, "..", "vendor", "ledger-bitcoin", "__tests__", "vectors", "signpsbt");
+const TRACES_DIR = join(__dirname, "..", "vendor", "ledger-bitcoin", "__tests__", "vectors", "command-traces");
+
+interface Trace {
+  command_name: string;
+  request_hex: string;
+  response_hex: string;
+}
+interface TraceFile {
+  vector_id: string;
+  elements_hex?: string[];
+  traces: Trace[];
+}
+
+function loadJson<T>(path: string): T {
+  return JSON.parse(readFileSync(path, "utf8")) as T;
+}
+
+// Valid x-only point (the generated fixtures' depositor key).
+const TEST_DEPOSITOR_KEY_HEX = "e49662aea97a89551401ce54de10474b24b4ab71383b69cf164ea59b3a209e0d";
+const TEST_SIG_HEX = "cd".repeat(64);
+const CONTINUE_HEADER_HEX = "f8010000";
+const SIGN_PSBT_HEADER_HEX = "e1040001";
+
+interface ScriptedExchange {
+  readonly expectApduHex: string;
+  readonly respondSw: number;
+  readonly respondDataHex: string;
+  /** Side effect fired when this exchange answers (e.g. abort mid-loop). */
+  readonly onRespond?: () => void;
+}
+
+function apduHex(apdu: Apdu): string {
+  return (
+    [apdu.cla, apdu.ins, apdu.p1, apdu.p2].map((byte) => byte.toString(16).padStart(2, "0")).join("") +
+    Buffer.from(apdu.data).toString("hex")
+  );
+}
+
+function createScriptedSender(script: readonly ScriptedExchange[]): { send: RawApduSender; sent: () => number } {
+  let calls = 0;
+  const send: RawApduSender = async (apdu) => {
+    const expected = script[calls];
+    if (!expected) throw new Error(`unexpected extra APDU #${calls}: ${apduHex(apdu)}`);
+    expect(apduHex(apdu), `APDU #${calls}`).toBe(expected.expectApduHex);
+    calls += 1;
+    expected.onRespond?.();
+    return { sw: expected.respondSw, data: Uint8Array.from(Buffer.from(expected.respondDataHex, "hex")) };
+  };
+  return { send, sent: () => calls };
+}
+
+function initialApduHexOf(prepared: PreparedSignPsbt): string {
+  return SIGN_PSBT_HEADER_HEX + Buffer.from(prepared.cdata).toString("hex");
+}
+
+/** `0x10 ‖ varint(i) ‖ 0x40 ‖ signer(32) ‖ leaf(32) ‖ sig(64)` — wire-spec §5 tapscript YIELD. */
+function tapscriptYieldRequestHex(inputIndex: number, signerHex: string, leafHex: string, sigHex: string): string {
+  return "10" + createVarint(inputIndex).toString("hex") + "40" + signerHex + leafHex + sigHex;
+}
+
+/** `0x10 ‖ varint(i) ‖ 0x20 ‖ outputKey(32) ‖ sig(64)` — wire-spec §5 keypath YIELD. */
+function keypathYieldRequestHex(inputIndex: number, outputKeyHex: string, sigHex: string): string {
+  return "10" + createVarint(inputIndex).toString("hex") + "20" + outputKeyHex + sigHex;
+}
+
+function tableLeafHex(table: ExpectedSignatureTable, inputIndex: number): string {
+  const expectation = table.byInput.get(inputIndex);
+  if (expectation?.kind !== "tapscript") throw new Error(`input ${inputIndex} is not tapscript in the table`);
+  const [leafHex] = [...expectation.expectedLeafHashHexes];
+  return leafHex;
+}
+
+/** Chain traces into exchanges: each request rides 0xE000, each response rides the next CONTINUE. */
+function scriptFromTraces(initialApduHex: string, traces: readonly Trace[]): ScriptedExchange[] {
+  const exchanges: ScriptedExchange[] = [];
+  let expectApduHex = initialApduHex;
+  for (const trace of traces) {
+    exchanges.push({ expectApduHex, respondSw: 0xe000, respondDataHex: trace.request_hex });
+    expectApduHex = CONTINUE_HEADER_HEX + trace.response_hex;
+  }
+  exchanges.push({ expectApduHex, respondSw: 0x9000, respondDataHex: "" });
+  return exchanges;
+}
+
+function prepareFromVector(vectorId: string): PreparedSignPsbt {
+  const vector = loadJson<{ psbt_hex: string; input_maps: [string, string][][] }>(
+    join(VECTORS_DIR, `${vectorId}.json`),
+  );
+  const internalKey = vector.input_maps[0].find(([key]) => key === "17");
+  const depositorXOnlyHex = vectorId.includes("pre_pegin") && internalKey ? internalKey[1] : TEST_DEPOSITOR_KEY_HEX;
+  return prepareSignPsbt({ psbtHex: vector.psbt_hex, depositorXOnlyHex });
+}
+
+/**
+ * Replace the synthetic YIELD trace with table-valid YIELD request(s) — one
+ * per table entry, covering the pre_pegin one-yield-per-input expansion.
+ */
+function tracesWithValidYields(prepared: PreparedSignPsbt, traces: readonly Trace[]): Trace[] {
+  const validYields: Trace[] = [...prepared.table.byInput.entries()].map(([inputIndex, expectation]) => ({
+    command_name: "YIELD",
+    request_hex:
+      expectation.kind === "tapscript"
+        ? tapscriptYieldRequestHex(
+            inputIndex,
+            expectation.expectedSignerXOnlyHex,
+            tableLeafHex(prepared.table, inputIndex),
+            TEST_SIG_HEX,
+          )
+        : keypathYieldRequestHex(inputIndex, expectation.expectedOutputKeyHex, TEST_SIG_HEX),
+    response_hex: "",
+  }));
+  return traces.flatMap((trace) => (trace.command_name === "YIELD" ? validYields : [trace]));
+}
+
+describe("happy-path trace replay through the loop (T1, T11, T12)", () => {
+  // 175 committed oracle traces across the four flows; claimer_payout__2
+  // carries the GET_MORE_ELEMENTS continuation round (chunking through the loop).
+  const REPLAY_CASES: { file: string; expectedYieldCount: number; expectedKind: "tapscript" | "taproot-keypath" }[] = [
+    { file: "generated__deposit-flow__pegin__0.json", expectedYieldCount: 1, expectedKind: "tapscript" },
+    { file: "deposit-flow__claimer_payout__2.json", expectedYieldCount: 1, expectedKind: "tapscript" },
+    { file: "generated__deposit-flow__depositor_graph__1.json", expectedYieldCount: 1, expectedKind: "tapscript" },
+    { file: "deposit-flow__pre_pegin__0.json", expectedYieldCount: 2, expectedKind: "taproot-keypath" },
+  ];
+
+  it.each(REPLAY_CASES)("$file replays to completion", async ({ file, expectedYieldCount, expectedKind }) => {
+    const traceFile = loadJson<TraceFile>(join(TRACES_DIR, file));
+    const prepared = prepareFromVector(traceFile.vector_id);
+    const traces = tracesWithValidYields(prepared, traceFile.traces);
+    const script = scriptFromTraces(initialApduHexOf(prepared), traces);
+    const { send, sent } = createScriptedSender(script);
+    const progress: SignPsbtProgress[] = [];
+
+    const yields = await runSignPsbtLoop(send, prepared, { onProgress: (p) => progress.push(p) });
+
+    expect(sent()).toBe(script.length);
+    expect(yields.length).toBe(expectedYieldCount);
+    for (const yielded of yields) {
+      expect(yielded.kind).toBe(expectedKind);
+      expect(Buffer.from(yielded.signature).toString("hex")).toBe(TEST_SIG_HEX);
+    }
+    expect(progress.length).toBe(expectedYieldCount);
+    expect(progress[progress.length - 1]).toEqual({
+      inputIndex: yields[yields.length - 1].inputIndex,
+      yieldedCount: expectedYieldCount,
+      expectedYieldCount,
+    });
+  });
+
+  it("replays the synthetic deep tree through the loop (proof depth 8 + GET_MORE_ELEMENTS)", async () => {
+    const traceFile = loadJson<TraceFile>(join(TRACES_DIR, "synthetic__deep_tree.json"));
+    const elements = (traceFile.elements_hex ?? []).map((hex) => Buffer.from(hex, "hex"));
+    expect(elements.length).toBeGreaterThan(0);
+
+    // Hand-built prepared state: the loop only needs interpreter + collector.
+    const fakeLeafHex = "ef".repeat(32);
+    const table: ExpectedSignatureTable = {
+      byInput: new Map([
+        [
+          0,
+          {
+            kind: "tapscript",
+            expectedLeafHashHexes: new Set([fakeLeafHex]),
+            expectedSignerXOnlyHex: TEST_DEPOSITOR_KEY_HEX,
+          },
+        ],
+      ]),
+      expectedYieldCount: 1,
+    };
+    const collector = createYieldCollector(table);
+    const interpreter = new ClientCommandInterpreter(undefined, (payload) => collector.assertAndRecord(payload));
+    interpreter.addKnownList(elements);
+    const prepared: PreparedSignPsbt = {
+      cdata: Uint8Array.from(Buffer.alloc(4, 0x11)),
+      interpreter,
+      collector,
+      table,
+      originalPsbtHex: "",
+    };
+
+    const traces = [
+      ...traceFile.traces,
+      {
+        command_name: "YIELD",
+        request_hex: tapscriptYieldRequestHex(0, TEST_DEPOSITOR_KEY_HEX, fakeLeafHex, TEST_SIG_HEX),
+        response_hex: "",
+      },
+    ];
+    const script = scriptFromTraces(initialApduHexOf(prepared), traces);
+    const { send, sent } = createScriptedSender(script);
+
+    const yields = await runSignPsbtLoop(send, prepared, {});
+
+    expect(sent()).toBe(script.length);
+    expect(yields.length).toBe(1);
+  });
+});
+
+describe("resend-once on 0x6A80 (T2-T5)", () => {
+  function peginSetup() {
+    const traceFile = loadJson<TraceFile>(join(TRACES_DIR, "generated__deposit-flow__pegin__0.json"));
+    const prepared = prepareFromVector(traceFile.vector_id);
+    return { prepared, traces: tracesWithValidYields(prepared, traceFile.traces) };
+  }
+
+  it("T2: flag on — the initial APDU is resent byte-identical once, then the loop completes", async () => {
+    const { prepared, traces } = peginSetup();
+    const initial = initialApduHexOf(prepared);
+    const script: ScriptedExchange[] = [
+      { expectApduHex: initial, respondSw: 0x6a80, respondDataHex: "" },
+      ...scriptFromTraces(initial, traces),
+    ];
+    const { send, sent } = createScriptedSender(script);
+
+    const yields = await runSignPsbtLoop(send, prepared, { resendOnceOnIncorrectData: true });
+
+    expect(yields.length).toBe(1);
+    expect(sent()).toBe(script.length);
+  });
+
+  it("T3b: abort racing the first exchange suppresses the recovery resend", async () => {
+    const { prepared } = peginSetup();
+    const controller = new AbortController();
+    // The sender aborts DURING the first exchange; the 0x6A80 recovery branch
+    // must observe it and never issue the second APDU.
+    const script: ScriptedExchange[] = [
+      { expectApduHex: initialApduHexOf(prepared), respondSw: 0x6a80, respondDataHex: "" },
+    ];
+    const { send: rawSend, sent } = createScriptedSender(script);
+    const send: typeof rawSend = async (apdu) => {
+      const response = await rawSend(apdu);
+      controller.abort();
+      return response;
+    };
+
+    await expect(
+      runSignPsbtLoop(send, prepared, {
+        resendOnceOnIncorrectData: true,
+        signal: controller.signal,
+      }),
+    ).rejects.toMatchObject({ name: LedgerSignPsbtAbortedError.name });
+    expect(sent()).toBe(1);
+  });
+
+  it("T3: flag off — 0x6A80 on the initial APDU is terminal after exactly one send", async () => {
+    const { prepared } = peginSetup();
+    const script: ScriptedExchange[] = [
+      { expectApduHex: initialApduHexOf(prepared), respondSw: 0x6a80, respondDataHex: "" },
+    ];
+    const { send, sent } = createScriptedSender(script);
+
+    await expect(runSignPsbtLoop(send, prepared, {})).rejects.toMatchObject({
+      name: LedgerDeviceError.name,
+      statusWord: 0x6a80,
+    });
+    expect(sent()).toBe(1);
+  });
+
+  it("T4: a second 0x6A80 after the resend is terminal — never a second resend", async () => {
+    const { prepared } = peginSetup();
+    const initial = initialApduHexOf(prepared);
+    const script: ScriptedExchange[] = [
+      { expectApduHex: initial, respondSw: 0x6a80, respondDataHex: "" },
+      { expectApduHex: initial, respondSw: 0x6a80, respondDataHex: "" },
+    ];
+    const { send, sent } = createScriptedSender(script);
+
+    await expect(runSignPsbtLoop(send, prepared, { resendOnceOnIncorrectData: true })).rejects.toMatchObject({
+      statusWord: 0x6a80,
+    });
+    expect(sent()).toBe(2);
+  });
+
+  it("T5: 0xB007 on the resent APDU is terminal (signing-phase abandonment invalidated the intent)", async () => {
+    const { prepared } = peginSetup();
+    const initial = initialApduHexOf(prepared);
+    const script: ScriptedExchange[] = [
+      { expectApduHex: initial, respondSw: 0x6a80, respondDataHex: "" },
+      { expectApduHex: initial, respondSw: 0xb007, respondDataHex: "" },
+    ];
+    const { send, sent } = createScriptedSender(script);
+
+    await expect(runSignPsbtLoop(send, prepared, { resendOnceOnIncorrectData: true })).rejects.toMatchObject({
+      statusWord: 0xb007,
+    });
+    expect(sent()).toBe(2);
+  });
+});
+
+describe("terminal status words mid-loop (T6)", () => {
+  function firstRoundScript(prepared: PreparedSignPsbt, firstTrace: Trace, terminalSw: number): ScriptedExchange[] {
+    return [
+      { expectApduHex: initialApduHexOf(prepared), respondSw: 0xe000, respondDataHex: firstTrace.request_hex },
+      { expectApduHex: CONTINUE_HEADER_HEX + firstTrace.response_hex, respondSw: terminalSw, respondDataHex: "" },
+    ];
+  }
+
+  it("0x6985 on a CONTINUE surfaces as a user refusal", async () => {
+    const traceFile = loadJson<TraceFile>(join(TRACES_DIR, "generated__deposit-flow__pegin__0.json"));
+    const prepared = prepareFromVector(traceFile.vector_id);
+    const script = firstRoundScript(prepared, traceFile.traces[0], 0x6985);
+    const { send, sent } = createScriptedSender(script);
+
+    await expect(runSignPsbtLoop(send, prepared, {})).rejects.toMatchObject({
+      name: LedgerUserRefusedError.name,
+      statusWord: 0x6985,
+    });
+    expect(sent()).toBe(2);
+  });
+
+  it("0x5515 on a CONTINUE surfaces as a locked device", async () => {
+    const traceFile = loadJson<TraceFile>(join(TRACES_DIR, "generated__deposit-flow__pegin__0.json"));
+    const prepared = prepareFromVector(traceFile.vector_id);
+    const script = firstRoundScript(prepared, traceFile.traces[0], 0x5515);
+    const { send } = createScriptedSender(script);
+
+    const outcome = await runSignPsbtLoop(send, prepared, {}).then(
+      () => undefined,
+      (error: unknown) => error,
+    );
+    expect(isLedgerDeviceLockedError(outcome)).toBe(true);
+  });
+});
+
+describe("abort signal (T7 + entry check)", () => {
+  it("aborted before the initial send: zero device I/O", async () => {
+    const prepared = prepareFromVector("generated__deposit-flow__pegin__0");
+    const { send, sent } = createScriptedSender([]);
+    const controller = new AbortController();
+    controller.abort();
+
+    const outcome = await runSignPsbtLoop(send, prepared, { signal: controller.signal }).then(
+      () => undefined,
+      (error: unknown) => error,
+    );
+    expect(isLedgerSignPsbtAbortedError(outcome)).toBe(true);
+    expect(sent()).toBe(0);
+  });
+
+  it("aborted between rounds: the pending CONTINUE is never sent", async () => {
+    const traceFile = loadJson<TraceFile>(join(TRACES_DIR, "generated__deposit-flow__pegin__0.json"));
+    const prepared = prepareFromVector(traceFile.vector_id);
+    const controller = new AbortController();
+    const script: ScriptedExchange[] = [
+      {
+        expectApduHex: initialApduHexOf(prepared),
+        respondSw: 0xe000,
+        respondDataHex: traceFile.traces[0].request_hex,
+        onRespond: () => controller.abort(),
+      },
+    ];
+    const { send, sent } = createScriptedSender(script);
+
+    await expect(runSignPsbtLoop(send, prepared, { signal: controller.signal })).rejects.toBeInstanceOf(
+      LedgerSignPsbtAbortedError,
+    );
+    expect(sent()).toBe(1);
+  });
+});
+
+describe("YIELD assertions abort the ceremony (T8, T9)", () => {
+  function flipFirstHexByte(hex: string): string {
+    const flipped = ((parseInt(hex.slice(0, 2), 16) ^ 0x01) & 0xff).toString(16).padStart(2, "0");
+    return flipped + hex.slice(2);
+  }
+
+  interface MutationCase {
+    label: string;
+    kind: LedgerYieldMismatchKind;
+    requestHex: (prepared: PreparedSignPsbt) => string;
+  }
+
+  const MUTATIONS: MutationCase[] = [
+    {
+      label: "flipped leaf-hash byte",
+      kind: "unknown-leaf-hash",
+      requestHex: (p) =>
+        tapscriptYieldRequestHex(0, TEST_DEPOSITOR_KEY_HEX, flipFirstHexByte(tableLeafHex(p.table, 0)), TEST_SIG_HEX),
+    },
+    {
+      label: "flipped signer-key byte",
+      kind: "wrong-signer-key",
+      requestHex: (p) =>
+        tapscriptYieldRequestHex(0, flipFirstHexByte(TEST_DEPOSITOR_KEY_HEX), tableLeafHex(p.table, 0), TEST_SIG_HEX),
+    },
+    {
+      label: "input index outside the table",
+      kind: "unexpected-input",
+      requestHex: (p) => tapscriptYieldRequestHex(7, TEST_DEPOSITOR_KEY_HEX, tableLeafHex(p.table, 0), TEST_SIG_HEX),
+    },
+    {
+      label: "keypath augm on a tapscript input",
+      kind: "wrong-spend-type",
+      requestHex: () => keypathYieldRequestHex(0, TEST_DEPOSITOR_KEY_HEX, TEST_SIG_HEX),
+    },
+    {
+      label: "65-byte signature (non-zero sighash byte appended)",
+      kind: "non-default-sighash",
+      requestHex: (p) =>
+        tapscriptYieldRequestHex(0, TEST_DEPOSITOR_KEY_HEX, tableLeafHex(p.table, 0), TEST_SIG_HEX + "01"),
+    },
+    {
+      label: "33-byte augm (ECDSA compressed key)",
+      kind: "unexpected-encoding",
+      requestHex: () => "10" + "00" + "21" + "02" + TEST_DEPOSITOR_KEY_HEX + TEST_SIG_HEX,
+    },
+  ];
+
+  it.each(MUTATIONS)("$label -> $kind, no further sends", async ({ kind, requestHex }) => {
+    const prepared = prepareFromVector("generated__deposit-flow__pegin__0");
+    const script: ScriptedExchange[] = [
+      { expectApduHex: initialApduHexOf(prepared), respondSw: 0xe000, respondDataHex: requestHex(prepared) },
+    ];
+    const { send, sent } = createScriptedSender(script);
+
+    await expect(runSignPsbtLoop(send, prepared, {})).rejects.toMatchObject({
+      name: LedgerYieldMismatchError.name,
+      kind,
+    });
+    expect(sent()).toBe(1);
+  });
+
+  it("a duplicate YIELD for the same (input, leaf) aborts on the second delivery", async () => {
+    const prepared = prepareFromVector("generated__deposit-flow__pegin__0");
+    const validYieldHex = tapscriptYieldRequestHex(
+      0,
+      TEST_DEPOSITOR_KEY_HEX,
+      tableLeafHex(prepared.table, 0),
+      TEST_SIG_HEX,
+    );
+    const script: ScriptedExchange[] = [
+      { expectApduHex: initialApduHexOf(prepared), respondSw: 0xe000, respondDataHex: validYieldHex },
+      { expectApduHex: CONTINUE_HEADER_HEX, respondSw: 0xe000, respondDataHex: validYieldHex },
+    ];
+    const { send, sent } = createScriptedSender(script);
+
+    await expect(runSignPsbtLoop(send, prepared, {})).rejects.toMatchObject({
+      name: LedgerYieldMismatchError.name,
+      kind: "duplicate-yield",
+    });
+    expect(sent()).toBe(2);
+  });
+
+  it("T9: a YIELD for Payout input 1 (witnessUtxo-only) is unexpected-input", async () => {
+    const prepared = prepareFromVector("deposit-flow__claimer_payout__2");
+    const requestHex = tapscriptYieldRequestHex(
+      1,
+      TEST_DEPOSITOR_KEY_HEX,
+      tableLeafHex(prepared.table, 0),
+      TEST_SIG_HEX,
+    );
+    const script: ScriptedExchange[] = [
+      { expectApduHex: initialApduHexOf(prepared), respondSw: 0xe000, respondDataHex: requestHex },
+    ];
+    const { send, sent } = createScriptedSender(script);
+
+    await expect(runSignPsbtLoop(send, prepared, {})).rejects.toMatchObject({
+      name: LedgerYieldMismatchError.name,
+      kind: "unexpected-input",
+      inputIndex: 1,
+    });
+    expect(sent()).toBe(1);
+  });
+});
+
+describe("completion check (T10)", () => {
+  it("0x9000 with a missing YIELD lists the missing (input, leaf)", async () => {
+    const prepared = prepareFromVector("generated__deposit-flow__pegin__0");
+    const script: ScriptedExchange[] = [
+      { expectApduHex: initialApduHexOf(prepared), respondSw: 0x9000, respondDataHex: "" },
+    ];
+    const { send } = createScriptedSender(script);
+
+    const outcome = await runSignPsbtLoop(send, prepared, {}).then(
+      () => undefined,
+      (error: unknown) => error,
+    );
+    expect(isLedgerSignPsbtIncompleteError(outcome)).toBe(true);
+    if (!isLedgerSignPsbtIncompleteError(outcome)) throw new Error("expected an incomplete error");
+    expect(outcome.missing).toEqual([`0:${tableLeafHex(prepared.table, 0)}`]);
+  });
+});
+
+describe("protocol failures stop the loop (T13, T14)", () => {
+  it.each([
+    ["unknown client-command code", "99"],
+    ["GET_PREIMAGE for an unknown hash", "4000" + "ee".repeat(32)],
+    ["YIELD truncated inside the varint", "10" + "fd01"],
+    ["YIELD truncated inside the augm block", "10" + "00" + "40" + "aa".repeat(8)],
+  ])("%s -> LedgerSignPsbtProtocolError, no further sends", async (_label, requestHex) => {
+    const prepared = prepareFromVector("generated__deposit-flow__pegin__0");
+    const script: ScriptedExchange[] = [
+      { expectApduHex: initialApduHexOf(prepared), respondSw: 0xe000, respondDataHex: requestHex },
+    ];
+    const { send, sent } = createScriptedSender(script);
+
+    await expect(runSignPsbtLoop(send, prepared, {})).rejects.toBeInstanceOf(LedgerSignPsbtProtocolError);
+    expect(sent()).toBe(1);
+  });
+});
+
+describe("empty table never reaches the wire (G6)", () => {
+  it("prepare throws before the loop can send anything", () => {
+    const { sent } = createScriptedSender([]);
+    // 1-in/1-out v0 PSBT with a witnessUtxo-only input — nothing signable.
+    const psbt = new Psbt();
+    psbt.addInput({ hash: Buffer.alloc(32, 0x01), index: 0 });
+    psbt.updateInput(0, {
+      witnessUtxo: { script: Buffer.concat([Buffer.from([0x51, 0x20]), Buffer.alloc(32, 0x40)]), value: 5000 },
+    });
+    psbt.addOutput({ script: Buffer.concat([Buffer.from([0x51, 0x20]), Buffer.alloc(32, 0x2b)]), value: 1000 });
+
+    expect(() => prepareSignPsbt({ psbtHex: psbt.toHex(), depositorXOnlyHex: TEST_DEPOSITOR_KEY_HEX })).toThrow(
+      /no depositor-signable input/,
+    );
+    expect(sent()).toBe(0);
+  });
+});

--- a/packages/babylon-ledger-vault-signer/src/__tests__/signPsbtLoop.test.ts
+++ b/packages/babylon-ledger-vault-signer/src/__tests__/signPsbtLoop.test.ts
@@ -25,11 +25,13 @@ import {
   isLedgerDeviceLockedError,
   isLedgerSignPsbtAbortedError,
   isLedgerSignPsbtIncompleteError,
+  isLedgerSignPsbtProtocolError,
+  type CollectedYieldRef,
   type LedgerYieldMismatchKind,
 } from "../errors";
 import { createYieldCollector, type ExpectedSignatureTable } from "../expectedSignatures";
 import type { Apdu, RawApduSender } from "../rawApdu";
-import { runSignPsbtLoop, type SignPsbtProgress } from "../signPsbtLoop";
+import { runSignPsbtLoop, type RunSignPsbtLoopOptions, type SignPsbtProgress } from "../signPsbtLoop";
 import { prepareSignPsbt, type PreparedSignPsbt } from "../signPsbtPrepare";
 import { ClientCommandInterpreter } from "../vendor/ledger-bitcoin/clientCommands";
 import { createVarint } from "../vendor/ledger-bitcoin/varint";
@@ -57,6 +59,8 @@ const TEST_DEPOSITOR_KEY_HEX = "e49662aea97a89551401ce54de10474b24b4ab71383b69cf
 const TEST_SIG_HEX = "cd".repeat(64);
 const CONTINUE_HEADER_HEX = "f8010000";
 const SIGN_PSBT_HEADER_HEX = "e1040001";
+/** The loop requires a signal; cases that never abort share this one. */
+const NEVER_ABORTED = new AbortController().signal;
 
 interface ScriptedExchange {
   readonly expectApduHex: string;
@@ -167,7 +171,10 @@ describe("happy-path trace replay through the loop (T1, T11, T12)", () => {
     const { send, sent } = createScriptedSender(script);
     const progress: SignPsbtProgress[] = [];
 
-    const yields = await runSignPsbtLoop(send, prepared, { onProgress: (p) => progress.push(p) });
+    const yields = await runSignPsbtLoop(send, prepared, {
+      onProgress: (p) => progress.push(p),
+      signal: NEVER_ABORTED,
+    });
 
     expect(sent()).toBe(script.length);
     expect(yields.length).toBe(expectedYieldCount);
@@ -225,7 +232,7 @@ describe("happy-path trace replay through the loop (T1, T11, T12)", () => {
     const script = scriptFromTraces(initialApduHexOf(prepared), traces);
     const { send, sent } = createScriptedSender(script);
 
-    const yields = await runSignPsbtLoop(send, prepared, {});
+    const yields = await runSignPsbtLoop(send, prepared, { signal: NEVER_ABORTED });
 
     expect(sent()).toBe(script.length);
     expect(yields.length).toBe(1);
@@ -248,7 +255,7 @@ describe("resend-once on 0x6A80 (T2-T5)", () => {
     ];
     const { send, sent } = createScriptedSender(script);
 
-    const yields = await runSignPsbtLoop(send, prepared, { resendOnceOnIncorrectData: true });
+    const yields = await runSignPsbtLoop(send, prepared, { resendOnceOnIncorrectData: true, signal: NEVER_ABORTED });
 
     expect(yields.length).toBe(1);
     expect(sent()).toBe(script.length);
@@ -285,7 +292,7 @@ describe("resend-once on 0x6A80 (T2-T5)", () => {
     ];
     const { send, sent } = createScriptedSender(script);
 
-    await expect(runSignPsbtLoop(send, prepared, {})).rejects.toMatchObject({
+    await expect(runSignPsbtLoop(send, prepared, { signal: NEVER_ABORTED })).rejects.toMatchObject({
       name: LedgerDeviceError.name,
       statusWord: 0x6a80,
     });
@@ -301,7 +308,9 @@ describe("resend-once on 0x6A80 (T2-T5)", () => {
     ];
     const { send, sent } = createScriptedSender(script);
 
-    await expect(runSignPsbtLoop(send, prepared, { resendOnceOnIncorrectData: true })).rejects.toMatchObject({
+    await expect(
+      runSignPsbtLoop(send, prepared, { resendOnceOnIncorrectData: true, signal: NEVER_ABORTED }),
+    ).rejects.toMatchObject({
       statusWord: 0x6a80,
     });
     expect(sent()).toBe(2);
@@ -316,7 +325,9 @@ describe("resend-once on 0x6A80 (T2-T5)", () => {
     ];
     const { send, sent } = createScriptedSender(script);
 
-    await expect(runSignPsbtLoop(send, prepared, { resendOnceOnIncorrectData: true })).rejects.toMatchObject({
+    await expect(
+      runSignPsbtLoop(send, prepared, { resendOnceOnIncorrectData: true, signal: NEVER_ABORTED }),
+    ).rejects.toMatchObject({
       statusWord: 0xb007,
     });
     expect(sent()).toBe(2);
@@ -337,7 +348,7 @@ describe("terminal status words mid-loop (T6)", () => {
     const script = firstRoundScript(prepared, traceFile.traces[0], 0x6985);
     const { send, sent } = createScriptedSender(script);
 
-    await expect(runSignPsbtLoop(send, prepared, {})).rejects.toMatchObject({
+    await expect(runSignPsbtLoop(send, prepared, { signal: NEVER_ABORTED })).rejects.toMatchObject({
       name: LedgerUserRefusedError.name,
       statusWord: 0x6985,
     });
@@ -350,11 +361,44 @@ describe("terminal status words mid-loop (T6)", () => {
     const script = firstRoundScript(prepared, traceFile.traces[0], 0x5515);
     const { send } = createScriptedSender(script);
 
-    const outcome = await runSignPsbtLoop(send, prepared, {}).then(
+    const outcome = await runSignPsbtLoop(send, prepared, { signal: NEVER_ABORTED }).then(
       () => undefined,
       (error: unknown) => error,
     );
     expect(isLedgerDeviceLockedError(outcome)).toBe(true);
+  });
+
+  it("names the connect-time app on 0x6E00 when the caller supplied one", async () => {
+    // 0x6E00 is what the dashboard answers once the app has exited on host
+    // silence — the diagnosis needs the app the session actually connected to.
+    const prepared = prepareFromVector("generated__deposit-flow__pegin__0");
+    const script: ScriptedExchange[] = [
+      { expectApduHex: initialApduHexOf(prepared), respondSw: 0x6e00, respondDataHex: "" },
+    ];
+    const { send } = createScriptedSender(script);
+
+    await expect(
+      runSignPsbtLoop(send, prepared, {
+        signal: NEVER_ABORTED,
+        appIdentity: { appName: "Babylon Vault", appVersion: "0.1.0" },
+      }),
+    ).rejects.toThrow(/app at connect time: "Babylon Vault" v0\.1\.0/);
+  });
+
+  it("omits the app hint on 0x6E00 when the caller supplied no app identity", async () => {
+    const prepared = prepareFromVector("generated__deposit-flow__pegin__0");
+    const script: ScriptedExchange[] = [
+      { expectApduHex: initialApduHexOf(prepared), respondSw: 0x6e00, respondDataHex: "" },
+    ];
+    const { send } = createScriptedSender(script);
+
+    const outcome = await runSignPsbtLoop(send, prepared, { signal: NEVER_ABORTED }).then(
+      () => undefined,
+      (error: unknown) => error,
+    );
+
+    expect(outcome).toBeInstanceOf(LedgerDeviceError);
+    expect((outcome as LedgerDeviceError).message).not.toMatch(/app at connect time/);
   });
 });
 
@@ -391,6 +435,67 @@ describe("abort signal (T7 + entry check)", () => {
       LedgerSignPsbtAbortedError,
     );
     expect(sent()).toBe(1);
+  });
+
+  it("stops a device that answers 0xE000 forever — the signal is the only bound", async () => {
+    // No round cap by design (see the module header): without the abort this
+    // sender keeps the loop going indefinitely, which is why the signal is
+    // required. GET_MERKLE_LEAF_INDEX is the one command with no response
+    // queue, so replaying it every round is safe.
+    const traceFile = loadJson<TraceFile>(join(TRACES_DIR, "generated__deposit-flow__pegin__0.json"));
+    const prepared = prepareFromVector(traceFile.vector_id);
+    const replayable = traceFile.traces.find((trace) => trace.command_name === "GET_MERKLE_LEAF_INDEX");
+    if (!replayable) throw new Error("the pegin trace has no GET_MERKLE_LEAF_INDEX round");
+    const requestData = Uint8Array.from(Buffer.from(replayable.request_hex, "hex"));
+    const controller = new AbortController();
+    const ROUNDS_BEFORE_ABORT = 5;
+    let rounds = 0;
+    const send: RawApduSender = async () => {
+      rounds += 1;
+      if (rounds === ROUNDS_BEFORE_ABORT) controller.abort();
+      return { sw: 0xe000, data: requestData };
+    };
+
+    await expect(runSignPsbtLoop(send, prepared, { signal: controller.signal })).rejects.toBeInstanceOf(
+      LedgerSignPsbtAbortedError,
+    );
+    expect(rounds).toBe(ROUNDS_BEFORE_ABORT);
+  });
+
+  it("requires a signal in the options bag — omitting it must not typecheck", () => {
+    // @ts-expect-error `signal` is required; if this ever compiles, the loop is unbounded again.
+    const withoutSignal: RunSignPsbtLoopOptions = { resendOnceOnIncorrectData: true };
+
+    expect(withoutSignal.resendOnceOnIncorrectData).toBe(true);
+  });
+
+  it("reports how many yields had already arrived when the host aborted", async () => {
+    const prepared = prepareFromVector("generated__deposit-flow__pegin__0");
+    const controller = new AbortController();
+    const validYieldHex = tapscriptYieldRequestHex(
+      0,
+      TEST_DEPOSITOR_KEY_HEX,
+      tableLeafHex(prepared.table, 0),
+      TEST_SIG_HEX,
+    );
+    const script: ScriptedExchange[] = [
+      {
+        expectApduHex: initialApduHexOf(prepared),
+        respondSw: 0xe000,
+        respondDataHex: validYieldHex,
+        onRespond: () => controller.abort(),
+      },
+    ];
+    const { send } = createScriptedSender(script);
+
+    const outcome = await runSignPsbtLoop(send, prepared, { signal: controller.signal }).then(
+      () => undefined,
+      (error: unknown) => error,
+    );
+
+    expect(isLedgerSignPsbtAbortedError(outcome)).toBe(true);
+    if (!isLedgerSignPsbtAbortedError(outcome)) throw new Error("expected an aborted error");
+    expect(outcome.yieldedCount).toBe(1);
   });
 });
 
@@ -449,7 +554,7 @@ describe("YIELD assertions abort the ceremony (T8, T9)", () => {
     ];
     const { send, sent } = createScriptedSender(script);
 
-    await expect(runSignPsbtLoop(send, prepared, {})).rejects.toMatchObject({
+    await expect(runSignPsbtLoop(send, prepared, { signal: NEVER_ABORTED })).rejects.toMatchObject({
       name: LedgerYieldMismatchError.name,
       kind,
     });
@@ -470,7 +575,7 @@ describe("YIELD assertions abort the ceremony (T8, T9)", () => {
     ];
     const { send, sent } = createScriptedSender(script);
 
-    await expect(runSignPsbtLoop(send, prepared, {})).rejects.toMatchObject({
+    await expect(runSignPsbtLoop(send, prepared, { signal: NEVER_ABORTED })).rejects.toMatchObject({
       name: LedgerYieldMismatchError.name,
       kind: "duplicate-yield",
     });
@@ -490,7 +595,7 @@ describe("YIELD assertions abort the ceremony (T8, T9)", () => {
     ];
     const { send, sent } = createScriptedSender(script);
 
-    await expect(runSignPsbtLoop(send, prepared, {})).rejects.toMatchObject({
+    await expect(runSignPsbtLoop(send, prepared, { signal: NEVER_ABORTED })).rejects.toMatchObject({
       name: LedgerYieldMismatchError.name,
       kind: "unexpected-input",
       inputIndex: 1,
@@ -507,7 +612,7 @@ describe("completion check (T10)", () => {
     ];
     const { send } = createScriptedSender(script);
 
-    const outcome = await runSignPsbtLoop(send, prepared, {}).then(
+    const outcome = await runSignPsbtLoop(send, prepared, { signal: NEVER_ABORTED }).then(
       () => undefined,
       (error: unknown) => error,
     );
@@ -530,8 +635,107 @@ describe("protocol failures stop the loop (T13, T14)", () => {
     ];
     const { send, sent } = createScriptedSender(script);
 
-    await expect(runSignPsbtLoop(send, prepared, {})).rejects.toBeInstanceOf(LedgerSignPsbtProtocolError);
+    await expect(runSignPsbtLoop(send, prepared, { signal: NEVER_ABORTED })).rejects.toBeInstanceOf(
+      LedgerSignPsbtProtocolError,
+    );
     expect(sent()).toBe(1);
+  });
+
+  it("carries the accepted yields by identity only — never their signature bytes", async () => {
+    const prepared = prepareFromVector("generated__deposit-flow__pegin__0");
+    const leafHex = tableLeafHex(prepared.table, 0);
+    const validYieldHex = tapscriptYieldRequestHex(0, TEST_DEPOSITOR_KEY_HEX, leafHex, TEST_SIG_HEX);
+    const script: ScriptedExchange[] = [
+      { expectApduHex: initialApduHexOf(prepared), respondSw: 0xe000, respondDataHex: validYieldHex },
+      // Truncated inside the varint: the YIELD parser raises the protocol error
+      // and cannot itself see the yield accepted on the round before.
+      { expectApduHex: CONTINUE_HEADER_HEX, respondSw: 0xe000, respondDataHex: "10" + "fd01" },
+    ];
+    const { send, sent } = createScriptedSender(script);
+
+    const outcome = await runSignPsbtLoop(send, prepared, { signal: NEVER_ABORTED }).then(
+      () => undefined,
+      (error: unknown) => error,
+    );
+
+    expect(isLedgerSignPsbtProtocolError(outcome)).toBe(true);
+    if (!isLedgerSignPsbtProtocolError(outcome)) throw new Error("expected a protocol error");
+    expect(outcome.collectedYields).toEqual([{ inputIndex: 0, leafHashHex: leafHex }]);
+    expect(outcome.collectedYields[0]).not.toHaveProperty("signature");
+    expect(sent()).toBe(2);
+  });
+
+  it("re-raises a typed parser failure at its own detail, not wrapped as a client-command failure", async () => {
+    const prepared = prepareFromVector("generated__deposit-flow__pegin__0");
+    const script: ScriptedExchange[] = [
+      // Truncated inside the varint — the collector raises a typed protocol error.
+      { expectApduHex: initialApduHexOf(prepared), respondSw: 0xe000, respondDataHex: "10" + "fd01" },
+    ];
+    const { send } = createScriptedSender(script);
+
+    const outcome = await runSignPsbtLoop(send, prepared, { signal: NEVER_ABORTED }).then(
+      () => undefined,
+      (error: unknown) => error,
+    );
+
+    expect(isLedgerSignPsbtProtocolError(outcome)).toBe(true);
+    if (!isLedgerSignPsbtProtocolError(outcome)) throw new Error("expected a protocol error");
+    expect(outcome.detail).toMatch(/^unparseable YIELD payload:/);
+    expect(outcome.message).not.toContain("client command failed");
+  });
+
+  it("carries the accepted yields when a NON-typed interpreter failure hits after a valid YIELD", async () => {
+    const prepared = prepareFromVector("generated__deposit-flow__pegin__0");
+    const leafHex = tableLeafHex(prepared.table, 0);
+    const validYieldHex = tapscriptYieldRequestHex(0, TEST_DEPOSITOR_KEY_HEX, leafHex, TEST_SIG_HEX);
+    const script: ScriptedExchange[] = [
+      { expectApduHex: initialApduHexOf(prepared), respondSw: 0xe000, respondDataHex: validYieldHex },
+      // Unknown command code 0x99: the interpreter throws a plain Error
+      // (`vendor/ledger-bitcoin/clientCommands.ts:373-375`) — generic-wrap branch.
+      { expectApduHex: CONTINUE_HEADER_HEX, respondSw: 0xe000, respondDataHex: "99" },
+    ];
+    const { send, sent } = createScriptedSender(script);
+
+    const outcome = await runSignPsbtLoop(send, prepared, { signal: NEVER_ABORTED }).then(
+      () => undefined,
+      (error: unknown) => error,
+    );
+
+    expect(isLedgerSignPsbtProtocolError(outcome)).toBe(true);
+    if (!isLedgerSignPsbtProtocolError(outcome)) throw new Error("expected a protocol error");
+    expect(outcome.detail).toMatch(/^client command failed:/);
+    expect(outcome.collectedYields).toEqual([{ inputIndex: 0, leafHashHex: leafHex }]);
+    expect(sent()).toBe(2);
+  });
+
+  it("refuses a signature at the type level — the compiler keeps bytes off the error", () => {
+    const withSignature = {
+      inputIndex: 0,
+      leafHashHex: "ab".repeat(32),
+      signature: Uint8Array.from(Buffer.from(TEST_SIG_HEX, "hex")),
+    };
+    // @ts-expect-error `signature?: never` on CollectedYieldRef; if this ever
+    // compiles, a full CollectedYield can ride the thrown error again.
+    const ref: CollectedYieldRef = withSignature;
+
+    expect(ref.inputIndex).toBe(0);
+  });
+
+  it("carries no yields when the failure hits before any YIELD arrived", async () => {
+    const prepared = prepareFromVector("generated__deposit-flow__pegin__0");
+    const script: ScriptedExchange[] = [
+      { expectApduHex: initialApduHexOf(prepared), respondSw: 0xe000, respondDataHex: "99" },
+    ];
+    const { send } = createScriptedSender(script);
+
+    const outcome = await runSignPsbtLoop(send, prepared, { signal: NEVER_ABORTED }).then(
+      () => undefined,
+      (error: unknown) => error,
+    );
+
+    expect(isLedgerSignPsbtProtocolError(outcome)).toBe(true);
+    if (!isLedgerSignPsbtProtocolError(outcome)) throw new Error("expected a protocol error");
+    expect(outcome.collectedYields).toEqual([]);
   });
 });
 

--- a/packages/babylon-ledger-vault-signer/src/__tests__/signPsbtLoop.test.ts
+++ b/packages/babylon-ledger-vault-signer/src/__tests__/signPsbtLoop.test.ts
@@ -111,6 +111,12 @@ function tableLeafHex(table: ExpectedSignatureTable, inputIndex: number): string
   return leafHex;
 }
 
+function tableOutputKeyHex(table: ExpectedSignatureTable, inputIndex: number): string {
+  const expectation = table.byInput.get(inputIndex);
+  if (expectation?.kind !== "taproot-keypath") throw new Error(`input ${inputIndex} is not keypath in the table`);
+  return expectation.expectedOutputKeyHex;
+}
+
 /** Chain traces into exchanges: each request rides 0xE000, each response rides the next CONTINUE. */
 function scriptFromTraces(initialApduHex: string, traces: readonly Trace[]): ScriptedExchange[] {
   const exchanges: ScriptedExchange[] = [];
@@ -561,6 +567,57 @@ describe("YIELD assertions abort the ceremony (T8, T9)", () => {
     expect(sent()).toBe(1);
   });
 
+  // Keypath collector twins: pre_pegin is the flow whose table entries are
+  // taproot-keypath, so these rows exercise the throws only a keypath table
+  // entry can reach.
+  const KEYPATH_MUTATIONS: MutationCase[] = [
+    {
+      label: "tapscript augm on a keypath input",
+      kind: "wrong-spend-type",
+      requestHex: () => tapscriptYieldRequestHex(0, TEST_DEPOSITOR_KEY_HEX, "bb".repeat(32), TEST_SIG_HEX),
+    },
+    {
+      label: "flipped output-key byte",
+      kind: "wrong-signer-key",
+      requestHex: (p) => keypathYieldRequestHex(0, flipFirstHexByte(tableOutputKeyHex(p.table, 0)), TEST_SIG_HEX),
+    },
+    {
+      label: "65-byte keypath signature (non-zero sighash byte appended)",
+      kind: "non-default-sighash",
+      requestHex: (p) => keypathYieldRequestHex(0, tableOutputKeyHex(p.table, 0), TEST_SIG_HEX + "01"),
+    },
+  ];
+
+  it.each(KEYPATH_MUTATIONS)("$label -> $kind, no further sends", async ({ kind, requestHex }) => {
+    const prepared = prepareFromVector("deposit-flow__pre_pegin__0");
+    const script: ScriptedExchange[] = [
+      { expectApduHex: initialApduHexOf(prepared), respondSw: 0xe000, respondDataHex: requestHex(prepared) },
+    ];
+    const { send, sent } = createScriptedSender(script);
+
+    await expect(runSignPsbtLoop(send, prepared, { signal: NEVER_ABORTED })).rejects.toMatchObject({
+      name: LedgerYieldMismatchError.name,
+      kind,
+    });
+    expect(sent()).toBe(1);
+  });
+
+  it("a duplicate keypath YIELD for the same (input, output key) aborts on the second delivery", async () => {
+    const prepared = prepareFromVector("deposit-flow__pre_pegin__0");
+    const validYieldHex = keypathYieldRequestHex(0, tableOutputKeyHex(prepared.table, 0), TEST_SIG_HEX);
+    const script: ScriptedExchange[] = [
+      { expectApduHex: initialApduHexOf(prepared), respondSw: 0xe000, respondDataHex: validYieldHex },
+      { expectApduHex: CONTINUE_HEADER_HEX, respondSw: 0xe000, respondDataHex: validYieldHex },
+    ];
+    const { send, sent } = createScriptedSender(script);
+
+    await expect(runSignPsbtLoop(send, prepared, { signal: NEVER_ABORTED })).rejects.toMatchObject({
+      name: LedgerYieldMismatchError.name,
+      kind: "duplicate-yield",
+    });
+    expect(sent()).toBe(2);
+  });
+
   it("a duplicate YIELD for the same (input, leaf) aborts on the second delivery", async () => {
     const prepared = prepareFromVector("generated__deposit-flow__pegin__0");
     const validYieldHex = tapscriptYieldRequestHex(
@@ -623,20 +680,80 @@ describe("completion check (T10)", () => {
 });
 
 describe("protocol failures stop the loop (T13, T14)", () => {
+  // Each row carries its own message pattern: the requests fail at different
+  // production sites, and a shared `toBeInstanceOf` matcher stays green if any
+  // of them collapses into another.
   it.each([
-    ["unknown client-command code", "99"],
-    ["GET_PREIMAGE for an unknown hash", "4000" + "ee".repeat(32)],
-    ["YIELD truncated inside the varint", "10" + "fd01"],
-    ["YIELD truncated inside the augm block", "10" + "00" + "40" + "aa".repeat(8)],
-  ])("%s -> LedgerSignPsbtProtocolError, no further sends", async (_label, requestHex) => {
+    ["unknown client-command code", "99", /Unexpected command code/],
+    ["GET_PREIMAGE for an unknown hash", "4000" + "ee".repeat(32), /Requested unknown preimage for/],
+    ["YIELD truncated inside the varint", "10" + "fd01", /^unparseable YIELD payload:/],
+    ["YIELD ends after the varint", "10" + "00", /YIELD payload truncated before the augmented-pubkey length/],
+    [
+      "YIELD truncated inside the augm block",
+      "10" + "00" + "40" + "aa".repeat(8),
+      /YIELD payload truncated inside the augmented pubkey/,
+    ],
+  ])("%s -> LedgerSignPsbtProtocolError, no further sends", async (_label, requestHex, messagePattern) => {
     const prepared = prepareFromVector("generated__deposit-flow__pegin__0");
     const script: ScriptedExchange[] = [
       { expectApduHex: initialApduHexOf(prepared), respondSw: 0xe000, respondDataHex: requestHex },
     ];
     const { send, sent } = createScriptedSender(script);
 
-    await expect(runSignPsbtLoop(send, prepared, { signal: NEVER_ABORTED })).rejects.toBeInstanceOf(
-      LedgerSignPsbtProtocolError,
+    const outcome = await runSignPsbtLoop(send, prepared, { signal: NEVER_ABORTED }).then(
+      () => undefined,
+      (error: unknown) => error,
+    );
+
+    expect(outcome).toBeInstanceOf(LedgerSignPsbtProtocolError);
+    expect((outcome as LedgerSignPsbtProtocolError).detail).toMatch(messagePattern);
+    expect(sent()).toBe(1);
+  });
+
+  it("YIELD with a short-but-nonempty signature -> LedgerSignPsbtProtocolError, no further sends", async () => {
+    // Pins the short arm of the shared signature-length check: under 64 bytes
+    // is a malformed payload, not a `non-default-sighash` mismatch.
+    const prepared = prepareFromVector("generated__deposit-flow__pegin__0");
+    const shortSigYieldHex = tapscriptYieldRequestHex(
+      0,
+      TEST_DEPOSITOR_KEY_HEX,
+      tableLeafHex(prepared.table, 0),
+      "cd".repeat(8),
+    );
+    const script: ScriptedExchange[] = [
+      { expectApduHex: initialApduHexOf(prepared), respondSw: 0xe000, respondDataHex: shortSigYieldHex },
+    ];
+    const { send, sent } = createScriptedSender(script);
+
+    const outcome = await runSignPsbtLoop(send, prepared, { signal: NEVER_ABORTED }).then(
+      () => undefined,
+      (error: unknown) => error,
+    );
+
+    expect(outcome).toBeInstanceOf(LedgerSignPsbtProtocolError);
+    expect((outcome as LedgerSignPsbtProtocolError).detail).toMatch(/YIELD payload truncated inside the signature/);
+    expect(sent()).toBe(1);
+  });
+
+  it("YIELD truncated inside the keypath augm block -> LedgerSignPsbtProtocolError, no further sends", async () => {
+    // The keypath twin of the augm-truncation row above: that length check
+    // sits after the branch's spend-type gate, so only a fixture whose input 0
+    // is keypath in the table can reach it.
+    const prepared = prepareFromVector("deposit-flow__pre_pegin__0");
+    const truncatedKeypathYieldHex = "10" + "00" + "20" + "aa".repeat(8);
+    const script: ScriptedExchange[] = [
+      { expectApduHex: initialApduHexOf(prepared), respondSw: 0xe000, respondDataHex: truncatedKeypathYieldHex },
+    ];
+    const { send, sent } = createScriptedSender(script);
+
+    const outcome = await runSignPsbtLoop(send, prepared, { signal: NEVER_ABORTED }).then(
+      () => undefined,
+      (error: unknown) => error,
+    );
+
+    expect(outcome).toBeInstanceOf(LedgerSignPsbtProtocolError);
+    expect((outcome as LedgerSignPsbtProtocolError).detail).toMatch(
+      /YIELD payload truncated inside the augmented pubkey/,
     );
     expect(sent()).toBe(1);
   });

--- a/packages/babylon-ledger-vault-signer/src/__tests__/signPsbtMerge.test.ts
+++ b/packages/babylon-ledger-vault-signer/src/__tests__/signPsbtMerge.test.ts
@@ -110,7 +110,7 @@ describe("mergeYields (G5)", () => {
     const psbtHex = loadPsbtHex("generated__deposit-flow__pegin__0");
     const yields = yieldsFor(psbtHex, TEST_DEPOSITOR_KEY_HEX);
 
-    expect(() => mergeYields(psbtHex, [...yields, ...yields])).toThrow();
+    expect(() => mergeYields(psbtHex, [...yields, ...yields])).toThrow("Can not add duplicate data to array");
   });
 
   it("throws when merging a tapKeySig into an already-signed input instead of overwriting", () => {
@@ -120,6 +120,6 @@ describe("mergeYields (G5)", () => {
 
     const mergedHex = mergeYields(psbtHex, yields);
 
-    expect(() => mergeYields(mergedHex, yields)).toThrow();
+    expect(() => mergeYields(mergedHex, yields)).toThrow("Can not add duplicate data to input");
   });
 });

--- a/packages/babylon-ledger-vault-signer/src/__tests__/signPsbtMerge.test.ts
+++ b/packages/babylon-ledger-vault-signer/src/__tests__/signPsbtMerge.test.ts
@@ -1,0 +1,125 @@
+/**
+ * G5 gate: mergeYields writes signature fields ONLY into the original v0 PSBT
+ * — the unsigned tx stays byte-identical, tapScriptSig/tapKeySig carry exactly
+ * the collected yields, and nothing is finalized (the caller finalizes; a
+ * finalized return would be rejected outright by the SDK's PegIn path). The
+ * bip174 duplicate throws are asserted as the documented integrity backstop.
+ */
+
+import { Psbt } from "bitcoinjs-lib";
+import { Buffer } from "buffer";
+import { readFileSync } from "fs";
+import { join } from "path";
+import { describe, expect, it } from "vitest";
+
+import type { CollectedYield } from "../expectedSignatures";
+import { mergeYields } from "../signPsbtMerge";
+import { prepareSignPsbt } from "../signPsbtPrepare";
+
+const VECTORS_DIR = join(__dirname, "..", "vendor", "ledger-bitcoin", "__tests__", "vectors", "signpsbt");
+
+// Valid x-only point (the generated fixtures' depositor key).
+const TEST_DEPOSITOR_KEY_HEX = "e49662aea97a89551401ce54de10474b24b4ab71383b69cf164ea59b3a209e0d";
+const TEST_SIG = Uint8Array.from(Buffer.alloc(64, 0xcd));
+
+function loadPsbtHex(name: string): string {
+  return (JSON.parse(readFileSync(join(VECTORS_DIR, `${name}.json`), "utf8")) as { psbt_hex: string }).psbt_hex;
+}
+
+function loadInternalKeyHex(name: string): string {
+  const vector = JSON.parse(readFileSync(join(VECTORS_DIR, `${name}.json`), "utf8")) as {
+    input_maps: [string, string][][];
+  };
+  const entry = vector.input_maps[0].find(([key]) => key === "17");
+  if (!entry) throw new Error("fixture has no TAP_INTERNAL_KEY on input 0");
+  return entry[1];
+}
+
+function unsignedTxHex(psbtHex: string): string {
+  return Psbt.fromHex(psbtHex).data.globalMap.unsignedTx.toBuffer().toString("hex");
+}
+
+/** Table-derived yields with a fixed test signature — what a completed loop returns. */
+function yieldsFor(psbtHex: string, depositorXOnlyHex: string): readonly CollectedYield[] {
+  const { table } = prepareSignPsbt({ psbtHex, depositorXOnlyHex });
+  return [...table.byInput.entries()].map(([inputIndex, expectation]) =>
+    expectation.kind === "tapscript"
+      ? {
+          kind: "tapscript",
+          inputIndex,
+          signerXOnlyHex: expectation.expectedSignerXOnlyHex,
+          leafHashHex: [...expectation.expectedLeafHashHexes][0],
+          signature: TEST_SIG,
+        }
+      : { kind: "taproot-keypath", inputIndex, outputKeyHex: expectation.expectedOutputKeyHex, signature: TEST_SIG },
+  );
+}
+
+describe("mergeYields (G5)", () => {
+  it("merges a tapscript yield: tapScriptSig only, unsigned tx untouched, nothing finalized", () => {
+    const psbtHex = loadPsbtHex("generated__deposit-flow__pegin__0");
+    const yields = yieldsFor(psbtHex, TEST_DEPOSITOR_KEY_HEX);
+
+    const mergedHex = mergeYields(psbtHex, yields);
+
+    expect(unsignedTxHex(mergedHex)).toBe(unsignedTxHex(psbtHex));
+    const merged = Psbt.fromHex(mergedHex);
+    const input = merged.data.inputs[0];
+    expect(input.tapScriptSig).toHaveLength(1);
+    expect(input.tapScriptSig?.[0].pubkey.toString("hex")).toBe(TEST_DEPOSITOR_KEY_HEX);
+    const yielded = yields[0];
+    if (yielded.kind !== "tapscript") throw new Error("pegin yield must be tapscript");
+    expect(input.tapScriptSig?.[0].leafHash.toString("hex")).toBe(yielded.leafHashHex);
+    expect(input.tapScriptSig?.[0].signature.toString("hex")).toBe(Buffer.from(TEST_SIG).toString("hex"));
+    for (const mergedInput of merged.data.inputs) {
+      expect(mergedInput.tapKeySig).toBeUndefined();
+      expect(mergedInput.finalScriptWitness).toBeUndefined();
+      expect(mergedInput.finalScriptSig).toBeUndefined();
+    }
+  });
+
+  it("merges Payout-shaped yields: input 0 signed, input 1 untouched", () => {
+    const psbtHex = loadPsbtHex("deposit-flow__claimer_payout__2");
+    const mergedHex = mergeYields(psbtHex, yieldsFor(psbtHex, TEST_DEPOSITOR_KEY_HEX));
+
+    expect(unsignedTxHex(mergedHex)).toBe(unsignedTxHex(psbtHex));
+    const merged = Psbt.fromHex(mergedHex);
+    expect(merged.data.inputs[0].tapScriptSig).toHaveLength(1);
+    expect(merged.data.inputs[1].tapScriptSig).toBeUndefined();
+    expect(merged.data.inputs[1].tapKeySig).toBeUndefined();
+  });
+
+  it("merges keypath yields: tapKeySig on every wallet input, nothing finalized", () => {
+    const psbtHex = loadPsbtHex("deposit-flow__pre_pegin__0");
+    const depositorXOnlyHex = loadInternalKeyHex("deposit-flow__pre_pegin__0");
+    const yields = yieldsFor(psbtHex, depositorXOnlyHex);
+    expect(yields).toHaveLength(2);
+
+    const mergedHex = mergeYields(psbtHex, yields);
+
+    expect(unsignedTxHex(mergedHex)).toBe(unsignedTxHex(psbtHex));
+    const merged = Psbt.fromHex(mergedHex);
+    for (const input of merged.data.inputs) {
+      expect(input.tapKeySig?.toString("hex")).toBe(Buffer.from(TEST_SIG).toString("hex"));
+      expect(input.tapScriptSig).toBeUndefined();
+      expect(input.finalScriptWitness).toBeUndefined();
+    }
+  });
+
+  it("throws on a duplicate (pubkey, leafHash) tapScriptSig instead of overwriting", () => {
+    const psbtHex = loadPsbtHex("generated__deposit-flow__pegin__0");
+    const yields = yieldsFor(psbtHex, TEST_DEPOSITOR_KEY_HEX);
+
+    expect(() => mergeYields(psbtHex, [...yields, ...yields])).toThrow();
+  });
+
+  it("throws when merging a tapKeySig into an already-signed input instead of overwriting", () => {
+    const psbtHex = loadPsbtHex("deposit-flow__pre_pegin__0");
+    const depositorXOnlyHex = loadInternalKeyHex("deposit-flow__pre_pegin__0");
+    const yields = yieldsFor(psbtHex, depositorXOnlyHex);
+
+    const mergedHex = mergeYields(psbtHex, yields);
+
+    expect(() => mergeYields(mergedHex, yields)).toThrow();
+  });
+});

--- a/packages/babylon-ledger-vault-signer/src/__tests__/signPsbtPrepare.test.ts
+++ b/packages/babylon-ledger-vault-signer/src/__tests__/signPsbtPrepare.test.ts
@@ -7,14 +7,14 @@
  * - §2.2 rejections: every prepare-time throw is typed and pre-I/O.
  */
 
-import { crypto as bcrypto } from "bitcoinjs-lib";
+import { crypto as bcrypto, Psbt } from "bitcoinjs-lib";
 import { Buffer } from "buffer";
 import { readFileSync } from "fs";
 import { join } from "path";
 import { describe, expect, it } from "vitest";
 
 import { isLedgerSignPsbtProtocolError } from "../errors";
-import { buildSignPsbtApdu, buildSignPsbtCdata, prepareSignPsbt } from "../signPsbtPrepare";
+import { buildSignPsbtApdu, prepareSignPsbt } from "../signPsbtPrepare";
 import { MerkelizedPsbt } from "../vendor/ledger-bitcoin/merkelizedPsbt";
 import { hashLeaf, Merkle } from "../vendor/ledger-bitcoin/merkle";
 import { PsbtV2 } from "../vendor/ledger-bitcoin/psbtv2";
@@ -69,6 +69,16 @@ function depositorKeyFor(name: string, vector: SignPsbtVector): string {
   return entry[1];
 }
 
+function expectPrepareRejects(psbtHex: string, depositorXOnlyHex: string, messagePattern: RegExp): void {
+  try {
+    prepareSignPsbt({ psbtHex, depositorXOnlyHex });
+    throw new Error("prepareSignPsbt did not throw");
+  } catch (error) {
+    expect(isLedgerSignPsbtProtocolError(error)).toBe(true);
+    expect((error as Error).message).toMatch(messagePattern);
+  }
+}
+
 describe("SIGN_PSBT cdata + APDU golden (G1, 22 fixtures)", () => {
   it.each(ALL_VECTOR_NAMES.map((name) => [name]))("%s", (name) => {
     const vector = loadVector(name);
@@ -80,41 +90,6 @@ describe("SIGN_PSBT cdata + APDU golden (G1, 22 fixtures)", () => {
     const apdu = buildSignPsbtApdu(prepared.cdata);
     expect({ cla: apdu.cla, ins: apdu.ins, p1: apdu.p1, p2: apdu.p2 }).toEqual(vector.apdu);
     expect(Buffer.from(apdu.data).toString("hex")).toBe(vector.sign_psbt_cdata_hex);
-  });
-});
-
-describe("header builder wallet fields (#2221/#2222 seam)", () => {
-  function merkelize(psbtHex: string): MerkelizedPsbt {
-    const psbt = new PsbtV2();
-    psbt.deserialize(Buffer.from(psbtHex, "hex"));
-    return new MerkelizedPsbt(psbt);
-  }
-
-  it("places a caller-provided walletId/walletHmac in the 64-byte tail", () => {
-    const vector = loadVector("generated__deposit-flow__pegin__0");
-    const merkelized = merkelize(vector.psbt_hex);
-    const walletId = Buffer.alloc(32, 0xaa);
-    const walletHmac = Buffer.alloc(32, 0xbb);
-    const cdata = Buffer.from(buildSignPsbtCdata(merkelized, { walletId, walletHmac }));
-
-    // Same head as the zero-tail golden, custom tail.
-    const golden = Buffer.from(vector.sign_psbt_cdata_hex, "hex");
-    expect(cdata.subarray(0, cdata.length - 64).toString("hex")).toBe(
-      golden.subarray(0, golden.length - 64).toString("hex"),
-    );
-    expect(cdata.subarray(cdata.length - 64).toString("hex")).toBe("aa".repeat(32) + "bb".repeat(32));
-  });
-
-  it("rejects wallet fields that are not exactly 32 bytes", () => {
-    const vector = loadVector("generated__deposit-flow__pegin__0");
-    const merkelized = merkelize(vector.psbt_hex);
-    try {
-      buildSignPsbtCdata(merkelized, { walletId: Buffer.alloc(31, 0xaa) });
-      throw new Error("buildSignPsbtCdata did not throw");
-    } catch (error) {
-      expect(isLedgerSignPsbtProtocolError(error)).toBe(true);
-      expect((error as Error).message).toMatch(/32 bytes/);
-    }
   });
 });
 
@@ -210,16 +185,6 @@ describe("interpreter completeness after seeding (G4, 22 fixtures)", () => {
 describe("prepare-time rejections (§2.2 — all typed, all pre-I/O)", () => {
   const VALID_PSBT_HEX = loadVector("generated__deposit-flow__pegin__0").psbt_hex;
 
-  function expectPrepareRejects(psbtHex: string, depositorXOnlyHex: string, messagePattern: RegExp): void {
-    try {
-      prepareSignPsbt({ psbtHex, depositorXOnlyHex });
-      throw new Error("prepareSignPsbt did not throw");
-    } catch (error) {
-      expect(isLedgerSignPsbtProtocolError(error)).toBe(true);
-      expect((error as Error).message).toMatch(messagePattern);
-    }
-  }
-
   it.each([
     ["uppercase hex", TEST_DEPOSITOR_KEY_HEX.toUpperCase()],
     ["63 chars", TEST_DEPOSITOR_KEY_HEX.slice(0, 63)],
@@ -262,5 +227,102 @@ describe("prepare-time rejections (§2.2 — all typed, all pre-I/O)", () => {
     // rejected inside PsbtV2.deserialize and surfaces as a typed error.
     const versionOnePsbtHex = "70736274ff" + "01fb" + "0401000000" + "00";
     expectPrepareRejects(versionOnePsbtHex, TEST_DEPOSITOR_KEY_HEX, /PSBT rejected at parse/);
+  });
+
+  it("rejects a PSBT keypair whose key length is a non-minimal CompactSize", () => {
+    // The parser differential, end to end: bip174 advances by the CANONICAL
+    // width, so this keypair leaves it 2 bytes early — landing exactly on the
+    // final separator, which is why bitcoinjs still accepts the bytes and the
+    // merge-target gate passes. Only the strict decode rejects it.
+    const nonMinimalKeypair =
+      "fd0300" + // key length 3, written as a 3-byte CompactSize instead of 1
+      "5003aa" + // key: unknown output keytype 0x50 ‖ key data 0x03 0xaa
+      "01" + // value length 1
+      "ff"; // value
+    const craftedHex = VALID_PSBT_HEX.slice(0, -2) + nonMinimalKeypair + "00";
+
+    expectPrepareRejects(craftedHex, TEST_DEPOSITOR_KEY_HEX, /PSBT rejected at parse: Non-minimal varint/);
+  });
+});
+
+describe("already-signed inputs are rejected before any device I/O", () => {
+  // Without this gate the collision only surfaces in bip174 at merge — after
+  // the ceremony ran and the depositor approved. A retry is the live trigger.
+  const TAPSCRIPT_VECTOR = "generated__deposit-flow__pegin__0";
+  const KEYPATH_VECTOR = "generated__deposit-flow__pre_pegin__0";
+
+  /** The leaf hashes prepare will request for input 0 of the tapscript fixture. */
+  function expectedLeafHashHexesOfInput0(psbtHex: string): ReadonlySet<string> {
+    const expectation = prepareSignPsbt({ psbtHex, depositorXOnlyHex: TEST_DEPOSITOR_KEY_HEX }).table.byInput.get(0);
+    if (expectation?.kind !== "tapscript") throw new Error("fixture input 0 is not a tapscript input");
+    return expectation.expectedLeafHashHexes;
+  }
+
+  it("rejects an input already carrying our tapScriptSig for a leaf this round signs", () => {
+    const psbtHex = loadVector(TAPSCRIPT_VECTOR).psbt_hex;
+    const [signedLeafHashHex] = [...expectedLeafHashHexesOfInput0(psbtHex)];
+    const psbt = Psbt.fromHex(psbtHex);
+    psbt.updateInput(0, {
+      tapScriptSig: [
+        {
+          pubkey: Buffer.from(TEST_DEPOSITOR_KEY_HEX, "hex"),
+          leafHash: Buffer.from(signedLeafHashHex, "hex"),
+          signature: Buffer.alloc(64, 0x11),
+        },
+      ],
+    });
+
+    expectPrepareRejects(psbt.toHex(), TEST_DEPOSITOR_KEY_HEX, /input 0 already carries a tapScriptSig/);
+  });
+
+  it("accepts an input carrying another signer's tapScriptSig on the same leaf", () => {
+    // bip174's dupe key is (pubkey ‖ leafHash), so a co-signer's entry on our
+    // leaf never collides — the gate must not over-reject it.
+    const psbtHex = loadVector(TAPSCRIPT_VECTOR).psbt_hex;
+    const [signedLeafHashHex] = [...expectedLeafHashHexesOfInput0(psbtHex)];
+    const psbt = Psbt.fromHex(psbtHex);
+    psbt.updateInput(0, {
+      tapScriptSig: [
+        {
+          pubkey: Buffer.from("25d1dff95105f5253c4022f628a996ad3a0d95fbf21d468a1b33f8c160d8f517", "hex"),
+          leafHash: Buffer.from(signedLeafHashHex, "hex"),
+          signature: Buffer.alloc(64, 0x11),
+        },
+      ],
+    });
+
+    const prepared = prepareSignPsbt({ psbtHex: psbt.toHex(), depositorXOnlyHex: TEST_DEPOSITOR_KEY_HEX });
+    expect(prepared.table.expectedYieldCount).toBe(1);
+  });
+
+  it("accepts an input carrying our own tapScriptSig on a leaf this round does not sign", () => {
+    // The other half of the (key, leaf) conjunction: our signature on a leaf
+    // outside this round's set is no bip174 collision, so rejecting it would
+    // block the multi-leaf retry the gate exists to let through.
+    const psbtHex = loadVector(TAPSCRIPT_VECTOR).psbt_hex;
+    const foreignLeafHashHex = "ff".repeat(32);
+    expect(expectedLeafHashHexesOfInput0(psbtHex).has(foreignLeafHashHex)).toBe(false);
+
+    const psbt = Psbt.fromHex(psbtHex);
+    psbt.updateInput(0, {
+      tapScriptSig: [
+        {
+          pubkey: Buffer.from(TEST_DEPOSITOR_KEY_HEX, "hex"),
+          leafHash: Buffer.from(foreignLeafHashHex, "hex"),
+          signature: Buffer.alloc(64, 0x11),
+        },
+      ],
+    });
+
+    const prepared = prepareSignPsbt({ psbtHex: psbt.toHex(), depositorXOnlyHex: TEST_DEPOSITOR_KEY_HEX });
+    expect(prepared.table.expectedYieldCount).toBe(1);
+  });
+
+  it("rejects an input already carrying a tapKeySig when this round signs its keypath", () => {
+    const vector = loadVector(KEYPATH_VECTOR);
+    const psbt = Psbt.fromHex(vector.psbt_hex);
+    psbt.updateInput(0, { tapKeySig: Buffer.alloc(64, 0x22) });
+
+    expectPrepareRejects(psbt.toHex(), depositorKeyFor(KEYPATH_VECTOR, vector), /input 0 already carries a tapKeySig/);
   });
 });

--- a/packages/babylon-ledger-vault-signer/src/__tests__/signPsbtPrepare.test.ts
+++ b/packages/babylon-ledger-vault-signer/src/__tests__/signPsbtPrepare.test.ts
@@ -235,9 +235,9 @@ describe("prepare-time rejections (§2.2 — all typed, all pre-I/O)", () => {
 
   it("rejects a tapscript input with no witnessUtxo before any device work", () => {
     // Strip input 0's WITNESS_UTXO (keytype 0x01) by raw-byte surgery — a model
-    // round-trip through PsbtV2.serialize would trip the merge-target parse
-    // gate first (its v0 re-emission is not bitcoinjs-canonical). The stripped
-    // bytes stay bitcoinjs-parseable, so the tapscript preflight is what fires.
+    // round-trip would trip the merge-target parse gate first, since deserialize
+    // normalizes and serialize then emits v2 bytes bitcoinjs won't parse. The
+    // stripped bytes stay v0, so the tapscript preflight is what fires.
     const raw = Buffer.from(VALID_PSBT_HEX, "hex");
     // key = len(01) ‖ keytype(01), value = varint(len) ‖ witnessUtxo bytes.
     const keyIndex = raw.indexOf(Buffer.from([0x01, 0x01]), 5);

--- a/packages/babylon-ledger-vault-signer/src/__tests__/signPsbtPrepare.test.ts
+++ b/packages/babylon-ledger-vault-signer/src/__tests__/signPsbtPrepare.test.ts
@@ -1,0 +1,266 @@
+/**
+ * Prepare-pipeline gates:
+ * - G1: cdata + full APDU byte-identity against the Python oracle for all 22
+ *   SIGN_PSBT fixtures, through the production builder and `prepareSignPsbt`.
+ * - G4: interpreter completeness — every key, value, and map commitment the
+ *   device can ask for is answerable after seeding (the 0x00-prefix leaf trap).
+ * - §2.2 rejections: every prepare-time throw is typed and pre-I/O.
+ */
+
+import { crypto as bcrypto } from "bitcoinjs-lib";
+import { Buffer } from "buffer";
+import { readFileSync } from "fs";
+import { join } from "path";
+import { describe, expect, it } from "vitest";
+
+import { isLedgerSignPsbtProtocolError } from "../errors";
+import { buildSignPsbtApdu, buildSignPsbtCdata, prepareSignPsbt } from "../signPsbtPrepare";
+import { MerkelizedPsbt } from "../vendor/ledger-bitcoin/merkelizedPsbt";
+import { hashLeaf, Merkle } from "../vendor/ledger-bitcoin/merkle";
+import { PsbtV2 } from "../vendor/ledger-bitcoin/psbtv2";
+import { createVarint, parseVarint, sanitizeBigintToNumber } from "../vendor/ledger-bitcoin/varint";
+
+const VECTORS_DIR = join(__dirname, "..", "vendor", "ledger-bitcoin", "__tests__", "vectors", "signpsbt");
+
+interface SignPsbtVector {
+  psbt_hex: string;
+  input_maps: [string, string][][];
+  sign_psbt_cdata_hex: string;
+  apdu: { cla: number; ins: number; p1: number; p2: number };
+}
+
+function loadVector(name: string): SignPsbtVector {
+  return JSON.parse(readFileSync(join(VECTORS_DIR, `${name}.json`), "utf8")) as SignPsbtVector;
+}
+
+const ALL_VECTOR_NAMES = [
+  "deposit-flow__claimer_payout__0",
+  "deposit-flow__claimer_payout__1",
+  "deposit-flow__claimer_payout__2",
+  "deposit-flow__claimer_payout__3",
+  "deposit-flow__claimer_payout__4",
+  "deposit-flow__depositor_graph__0",
+  "deposit-flow__depositor_graph__1",
+  "deposit-flow__depositor_graph__2",
+  "deposit-flow__depositor_graph__3",
+  "deposit-flow__depositor_graph__4",
+  "deposit-flow__depositor_graph__5",
+  "deposit-flow__depositor_graph__6",
+  "deposit-flow__depositor_graph__7",
+  "deposit-flow__depositor_graph__8",
+  "deposit-flow__pegin__0",
+  "deposit-flow__pre_pegin__0",
+  "generated__deposit-flow__claimer_payout__0",
+  "generated__deposit-flow__depositor_graph__0",
+  "generated__deposit-flow__depositor_graph__1",
+  "generated__deposit-flow__depositor_graph__2",
+  "generated__deposit-flow__pegin__0",
+  "generated__deposit-flow__pre_pegin__0",
+];
+
+// Valid x-only point (the generated fixtures' depositor key) — free parameter
+// for tapscript fixtures; pre_pegin fixtures pin their own key instead.
+const TEST_DEPOSITOR_KEY_HEX = "e49662aea97a89551401ce54de10474b24b4ab71383b69cf164ea59b3a209e0d";
+
+function depositorKeyFor(name: string, vector: SignPsbtVector): string {
+  if (!name.includes("pre_pegin")) return TEST_DEPOSITOR_KEY_HEX;
+  const entry = vector.input_maps[0].find(([key]) => key === "17");
+  if (!entry) throw new Error("pre_pegin fixture has no TAP_INTERNAL_KEY on input 0");
+  return entry[1];
+}
+
+describe("SIGN_PSBT cdata + APDU golden (G1, 22 fixtures)", () => {
+  it.each(ALL_VECTOR_NAMES.map((name) => [name]))("%s", (name) => {
+    const vector = loadVector(name);
+    const prepared = prepareSignPsbt({ psbtHex: vector.psbt_hex, depositorXOnlyHex: depositorKeyFor(name, vector) });
+
+    expect(Buffer.from(prepared.cdata).toString("hex")).toBe(vector.sign_psbt_cdata_hex);
+    expect(prepared.originalPsbtHex).toBe(vector.psbt_hex);
+
+    const apdu = buildSignPsbtApdu(prepared.cdata);
+    expect({ cla: apdu.cla, ins: apdu.ins, p1: apdu.p1, p2: apdu.p2 }).toEqual(vector.apdu);
+    expect(Buffer.from(apdu.data).toString("hex")).toBe(vector.sign_psbt_cdata_hex);
+  });
+});
+
+describe("header builder wallet fields (#2221/#2222 seam)", () => {
+  function merkelize(psbtHex: string): MerkelizedPsbt {
+    const psbt = new PsbtV2();
+    psbt.deserialize(Buffer.from(psbtHex, "hex"));
+    return new MerkelizedPsbt(psbt);
+  }
+
+  it("places a caller-provided walletId/walletHmac in the 64-byte tail", () => {
+    const vector = loadVector("generated__deposit-flow__pegin__0");
+    const merkelized = merkelize(vector.psbt_hex);
+    const walletId = Buffer.alloc(32, 0xaa);
+    const walletHmac = Buffer.alloc(32, 0xbb);
+    const cdata = Buffer.from(buildSignPsbtCdata(merkelized, { walletId, walletHmac }));
+
+    // Same head as the zero-tail golden, custom tail.
+    const golden = Buffer.from(vector.sign_psbt_cdata_hex, "hex");
+    expect(cdata.subarray(0, cdata.length - 64).toString("hex")).toBe(
+      golden.subarray(0, golden.length - 64).toString("hex"),
+    );
+    expect(cdata.subarray(cdata.length - 64).toString("hex")).toBe("aa".repeat(32) + "bb".repeat(32));
+  });
+
+  it("rejects wallet fields that are not exactly 32 bytes", () => {
+    const vector = loadVector("generated__deposit-flow__pegin__0");
+    const merkelized = merkelize(vector.psbt_hex);
+    try {
+      buildSignPsbtCdata(merkelized, { walletId: Buffer.alloc(31, 0xaa) });
+      throw new Error("buildSignPsbtCdata did not throw");
+    } catch (error) {
+      expect(isLedgerSignPsbtProtocolError(error)).toBe(true);
+      expect((error as Error).message).toMatch(/32 bytes/);
+    }
+  });
+});
+
+describe("interpreter completeness after seeding (G4, 22 fixtures)", () => {
+  const GET_PREIMAGE = 0x40;
+  const GET_MERKLE_LEAF_PROOF = 0x41;
+  const GET_MORE_ELEMENTS = 0xa0;
+  const SHA256_LEN = 32;
+
+  /** Fetch a full preimage through GET_PREIMAGE + GET_MORE_ELEMENTS rounds. */
+  function fetchPreimage(interpreter: { execute(request: Buffer): Buffer }, element: Buffer): Buffer {
+    const leafPreimage = Buffer.concat([Buffer.from([0x00]), element]);
+    const request = Buffer.concat([Buffer.from([GET_PREIMAGE, 0x00]), bcrypto.sha256(leafPreimage)]);
+    const response = interpreter.execute(request);
+    const [totalBig, varintSize] = parseVarint(response, 0);
+    const total = sanitizeBigintToNumber(totalBig);
+    const firstChunkLen = response[varintSize];
+    let collected = Buffer.from(response.subarray(varintSize + 1));
+    expect(collected.length).toBe(firstChunkLen);
+    while (collected.length < total) {
+      const more = interpreter.execute(Buffer.from([GET_MORE_ELEMENTS]));
+      expect(more[1]).toBe(1); // preimage spill queues 1-byte elements
+      collected = Buffer.concat([collected, more.subarray(2)]);
+    }
+    return collected;
+  }
+
+  /** Fetch a leaf proof, draining any spilled proof hashes. */
+  function fetchLeafProof(
+    interpreter: { execute(request: Buffer): Buffer },
+    root: Buffer,
+    treeSize: number,
+    leafIndex: number,
+  ): Buffer {
+    const request = Buffer.concat([
+      Buffer.from([GET_MERKLE_LEAF_PROOF]),
+      root,
+      createVarint(treeSize),
+      createVarint(leafIndex),
+    ]);
+    const response = interpreter.execute(request);
+    const proofLen = response[SHA256_LEN];
+    let delivered = response[SHA256_LEN + 1];
+    while (delivered < proofLen) {
+      const more = interpreter.execute(Buffer.from([GET_MORE_ELEMENTS]));
+      expect(more[1]).toBe(SHA256_LEN);
+      delivered += more[0];
+    }
+    return Buffer.from(response.subarray(0, SHA256_LEN)); // the leaf hash
+  }
+
+  it.each(ALL_VECTOR_NAMES.map((name) => [name]))("%s: every committed element and tree is answerable", (name) => {
+    const vector = loadVector(name);
+    const prepared = prepareSignPsbt({ psbtHex: vector.psbt_hex, depositorXOnlyHex: depositorKeyFor(name, vector) });
+    const { interpreter } = prepared;
+
+    // Independent reconstruction of what the device may ask for.
+    const psbt = new PsbtV2();
+    psbt.deserialize(Buffer.from(vector.psbt_hex, "hex"));
+    const merkelized = new MerkelizedPsbt(psbt);
+    const maps = [merkelized.globalMerkleMap, ...merkelized.inputMerkleMaps, ...merkelized.outputMerkleMaps];
+
+    for (const map of maps) {
+      for (const element of [...map.keys, ...map.values]) {
+        // Preimage of a Merkle leaf includes its 0x00 prefix — the trap G4 pins.
+        expect(fetchPreimage(interpreter, element).toString("hex")).toBe(
+          Buffer.concat([Buffer.from([0x00]), element]).toString("hex"),
+        );
+      }
+      for (const tree of [map.keysTree, map.valuesTree]) {
+        for (let leafIndex = 0; leafIndex < tree.size(); leafIndex++) {
+          expect(fetchLeafProof(interpreter, tree.getRoot(), tree.size(), leafIndex).toString("hex")).toBe(
+            tree.getLeafHash(leafIndex).toString("hex"),
+          );
+        }
+      }
+    }
+
+    for (const commitments of [merkelized.inputMapCommitments, merkelized.outputMapCommitments]) {
+      const tree = new Merkle(commitments.map((commitment) => hashLeaf(commitment)));
+      for (const [leafIndex, commitment] of commitments.entries()) {
+        expect(fetchPreimage(interpreter, commitment).toString("hex")).toBe(
+          Buffer.concat([Buffer.from([0x00]), commitment]).toString("hex"),
+        );
+        expect(fetchLeafProof(interpreter, tree.getRoot(), tree.size(), leafIndex).toString("hex")).toBe(
+          tree.getLeafHash(leafIndex).toString("hex"),
+        );
+      }
+    }
+  });
+});
+
+describe("prepare-time rejections (§2.2 — all typed, all pre-I/O)", () => {
+  const VALID_PSBT_HEX = loadVector("generated__deposit-flow__pegin__0").psbt_hex;
+
+  function expectPrepareRejects(psbtHex: string, depositorXOnlyHex: string, messagePattern: RegExp): void {
+    try {
+      prepareSignPsbt({ psbtHex, depositorXOnlyHex });
+      throw new Error("prepareSignPsbt did not throw");
+    } catch (error) {
+      expect(isLedgerSignPsbtProtocolError(error)).toBe(true);
+      expect((error as Error).message).toMatch(messagePattern);
+    }
+  }
+
+  it.each([
+    ["uppercase hex", TEST_DEPOSITOR_KEY_HEX.toUpperCase()],
+    ["63 chars", TEST_DEPOSITOR_KEY_HEX.slice(0, 63)],
+    ["non-hex", "zz".repeat(32)],
+  ])("rejects a depositor key that is not 64 lowercase hex chars (%s)", (_label, badKey) => {
+    expectPrepareRejects(VALID_PSBT_HEX, badKey, /64 lowercase hex/);
+  });
+
+  it("rejects a psbtHex that is not even-length hex", () => {
+    expectPrepareRejects(VALID_PSBT_HEX + "z", TEST_DEPOSITOR_KEY_HEX, /not even-length hex/);
+    expectPrepareRejects(VALID_PSBT_HEX.slice(0, -1), TEST_DEPOSITOR_KEY_HEX, /not even-length hex/);
+  });
+
+  it("rejects a tapscript input with no witnessUtxo before any device work", () => {
+    // Strip input 0's WITNESS_UTXO (keytype 0x01) by raw-byte surgery — a model
+    // round-trip through PsbtV2.serialize would trip the merge-target parse
+    // gate first (its v0 re-emission is not bitcoinjs-canonical). The stripped
+    // bytes stay bitcoinjs-parseable, so the tapscript preflight is what fires.
+    const raw = Buffer.from(VALID_PSBT_HEX, "hex");
+    // key = len(01) ‖ keytype(01), value = varint(len) ‖ witnessUtxo bytes.
+    const keyIndex = raw.indexOf(Buffer.from([0x01, 0x01]), 5);
+    expect(keyIndex).toBeGreaterThan(0);
+    const valueLen = raw[keyIndex + 2];
+    const stripped = Buffer.concat([raw.subarray(0, keyIndex), raw.subarray(keyIndex + 2 + 1 + valueLen)]);
+    expectPrepareRejects(
+      stripped.toString("hex"),
+      depositorKeyFor("generated__deposit-flow__pegin__0", loadVector("generated__deposit-flow__pegin__0")),
+      /tapscript but has no witnessUtxo/,
+    );
+  });
+
+  it("wraps an off-curve depositor key as a typed preflight rejection", () => {
+    // 64 valid hex chars, but not a point on secp256k1 — bitcoinjs p2tr throws
+    // a raw TypeError; the prepare contract must retype it.
+    expectPrepareRejects(VALID_PSBT_HEX, "ff".repeat(32), /PSBT rejected at preflight/);
+  });
+
+  it("wraps the vendored parse throw for an unsupported PSBT version", () => {
+    // magic ‖ global map { VERSION(0xfb) → 1 } ‖ end-of-map — version 1 is
+    // rejected inside PsbtV2.deserialize and surfaces as a typed error.
+    const versionOnePsbtHex = "70736274ff" + "01fb" + "0401000000" + "00";
+    expectPrepareRejects(versionOnePsbtHex, TEST_DEPOSITOR_KEY_HEX, /PSBT rejected at parse/);
+  });
+});

--- a/packages/babylon-ledger-vault-signer/src/__tests__/signPsbtPrepare.test.ts
+++ b/packages/babylon-ledger-vault-signer/src/__tests__/signPsbtPrepare.test.ts
@@ -223,10 +223,22 @@ describe("prepare-time rejections (§2.2 — all typed, all pre-I/O)", () => {
   });
 
   it("wraps the vendored parse throw for an unsupported PSBT version", () => {
-    // magic ‖ global map { VERSION(0xfb) → 1 } ‖ end-of-map — version 1 is
-    // rejected inside PsbtV2.deserialize and surfaces as a typed error.
-    const versionOnePsbtHex = "70736274ff" + "01fb" + "0401000000" + "00";
-    expectPrepareRejects(versionOnePsbtHex, TEST_DEPOSITOR_KEY_HEX, /PSBT rejected at parse/);
+    // A bitcoinjs-ACCEPTABLE v0 PSBT with a global VERSION keypair (01fb
+    // 0401000000) spliced in after the magic. The merge-target gate runs first,
+    // so a bare magic+VERSION stub never reaches PsbtV2 — it dies earlier on
+    // "Only one UNSIGNED_TX allowed" and would pass even with the version guard
+    // deleted. The matcher's colon-space is what excludes the "(merge target)"
+    // wrapper, so only the vendored rejection satisfies it.
+    const versionOnePsbtHex =
+      "70736274ff01fb040100000001005e02000000010101010101010101010101010101010101010101010101010101010101010101" +
+      "0000000000ffffffff01840300000000000022512003030303030303030303030303030303030303030303030303030303030303" +
+      "03000000000001012be8030000000000002251200202020202020202020202020202020202020202020202020202020202020202" +
+      "0000";
+    expectPrepareRejects(
+      versionOnePsbtHex,
+      TEST_DEPOSITOR_KEY_HEX,
+      /PSBT rejected at parse: Only PSBTs of version 0 or 2 are supported/,
+    );
   });
 
   it("rejects a PSBT keypair whose key length is a non-minimal CompactSize", () => {
@@ -273,6 +285,34 @@ describe("already-signed inputs are rejected before any device I/O", () => {
     });
 
     expectPrepareRejects(psbt.toHex(), TEST_DEPOSITOR_KEY_HEX, /input 0 already carries a tapScriptSig/);
+  });
+
+  it("rejects an input that is already finalized", () => {
+    // Nothing downstream catches this at all: bip174 has no finalized guard,
+    // the merge writes the partial sig next to the final witness, and the
+    // SDK's finalize fallback then ships the stale witness — after the device
+    // signed and the user approved.
+    const psbt = Psbt.fromHex(loadVector(TAPSCRIPT_VECTOR).psbt_hex);
+    psbt.data.inputs[0].finalScriptWitness = Buffer.from("0101ff", "hex");
+
+    expectPrepareRejects(psbt.toHex(), TEST_DEPOSITOR_KEY_HEX, /input 0 is already finalized/);
+  });
+
+  it("rejects an input that is already finalized via finalScriptSig", () => {
+    const psbt = Psbt.fromHex(loadVector(TAPSCRIPT_VECTOR).psbt_hex);
+    psbt.data.inputs[0].finalScriptSig = Buffer.from("00", "hex");
+
+    expectPrepareRejects(psbt.toHex(), TEST_DEPOSITOR_KEY_HEX, /input 0 is already finalized/);
+  });
+
+  it("accepts a finalized input this round does not sign", () => {
+    // Payout input 1 is witnessUtxo-only, so it never enters the table — a
+    // co-signed, already-finalized input must not trip the gate.
+    const psbt = Psbt.fromHex(loadVector("deposit-flow__claimer_payout__2").psbt_hex);
+    psbt.data.inputs[1].finalScriptWitness = Buffer.from("0101ff", "hex");
+
+    const prepared = prepareSignPsbt({ psbtHex: psbt.toHex(), depositorXOnlyHex: TEST_DEPOSITOR_KEY_HEX });
+    expect(prepared.table.byInput.has(1)).toBe(false);
   });
 
   it("accepts an input carrying another signer's tapScriptSig on the same leaf", () => {

--- a/packages/babylon-ledger-vault-signer/src/__tests__/signPsbtPrepare.test.ts
+++ b/packages/babylon-ledger-vault-signer/src/__tests__/signPsbtPrepare.test.ts
@@ -305,6 +305,32 @@ describe("already-signed inputs are rejected before any device I/O", () => {
     expectPrepareRejects(psbt.toHex(), TEST_DEPOSITOR_KEY_HEX, /input 0 is already finalized/);
   });
 
+  it("rejects a tapscript input requesting a non-default sighash type", () => {
+    // The device would sign it and append the sighash byte — the 65-byte yield
+    // then fails only AFTER the user approved. Gate is pre-I/O.
+    const psbt = Psbt.fromHex(loadVector(TAPSCRIPT_VECTOR).psbt_hex);
+    psbt.data.inputs[0].sighashType = 1;
+
+    expectPrepareRejects(psbt.toHex(), TEST_DEPOSITOR_KEY_HEX, /input 0 requests sighash type 1/);
+  });
+
+  it("rejects a keypath input requesting a non-default sighash type", () => {
+    const vector = loadVector(KEYPATH_VECTOR);
+    const psbt = Psbt.fromHex(vector.psbt_hex);
+    psbt.data.inputs[0].sighashType = 1;
+
+    expectPrepareRejects(psbt.toHex(), depositorKeyFor(KEYPATH_VECTOR, vector), /input 0 requests sighash type 1/);
+  });
+
+  it("accepts an input with an explicit SIGHASH_DEFAULT entry", () => {
+    // BIP-371 permits an explicit 0x00 entry; it means the same as absence.
+    const psbt = Psbt.fromHex(loadVector(TAPSCRIPT_VECTOR).psbt_hex);
+    psbt.data.inputs[0].sighashType = 0;
+
+    const prepared = prepareSignPsbt({ psbtHex: psbt.toHex(), depositorXOnlyHex: TEST_DEPOSITOR_KEY_HEX });
+    expect(prepared.table.byInput.get(0)?.kind).toBe("tapscript");
+  });
+
   it("accepts a finalized input this round does not sign", () => {
     // Payout input 1 is witnessUtxo-only, so it never enters the table — a
     // co-signed, already-finalized input must not trip the gate.

--- a/packages/babylon-ledger-vault-signer/src/__tests__/tapLeafHash.test.ts
+++ b/packages/babylon-ledger-vault-signer/src/__tests__/tapLeafHash.test.ts
@@ -1,0 +1,34 @@
+/**
+ * G3 gate: the standalone tapLeafHash must be byte-equal to bitcoinjs's
+ * bip341.tapleafHash (deep import, test-only) across the CompactSize encoding
+ * boundary, and reproduce the BIP-341 wallet test vector — two independent
+ * oracles for the hash the expected-signature table pins YIELDs against.
+ */
+
+import { tapleafHash as bip341TapleafHash } from "bitcoinjs-lib/src/payments/bip341";
+import { Buffer } from "buffer";
+import { describe, expect, it } from "vitest";
+
+import { tapLeafHash } from "../tapLeafHash";
+
+const TAPSCRIPT_LEAF_VERSION = 0xc0;
+
+describe("tapLeafHash", () => {
+  // 252/253 straddles the 1-byte→3-byte CompactSize boundary — WOTS leaf
+  // scripts exceed 252 bytes, so the multi-byte form is load-bearing.
+  it.each([[1], [252], [253], [300]])("matches bip341.tapleafHash for a %i-byte script", (length) => {
+    const script = Buffer.alloc(length, 0x51);
+    expect(tapLeafHash(TAPSCRIPT_LEAF_VERSION, script).toString("hex")).toBe(
+      bip341TapleafHash({ output: script, version: TAPSCRIPT_LEAF_VERSION }).toString("hex"),
+    );
+  });
+
+  it("reproduces the BIP-341 wallet test vector leaf hash", () => {
+    // https://github.com/bitcoin/bips/blob/master/bip-0341/wallet-test-vectors.json
+    // — first scriptPubKey vector with a script tree (single leaf, version 192).
+    const script = Buffer.from("20d85a959b0290bf19bb89ed43c916be835475d013da4b362117393e25a48229b8ac", "hex");
+    expect(tapLeafHash(TAPSCRIPT_LEAF_VERSION, script).toString("hex")).toBe(
+      "5b75adecf53548f3ec6ad7d78383bf84cc57b55a3127c72b9a2481752dd88b21",
+    );
+  });
+});

--- a/packages/babylon-ledger-vault-signer/src/__tests__/varint.test.ts
+++ b/packages/babylon-ledger-vault-signer/src/__tests__/varint.test.ts
@@ -1,0 +1,67 @@
+/**
+ * `parseVarint` minimality gate — a LOCAL DIVERGENCE from upstream
+ * `ledger-bitcoin`, which parse-accepts overlong CompactSize encodings.
+ *
+ * WHY it is enforced: an overlong length desynchronizes this parser from
+ * `bitcoinjs-lib`'s bip174, which advances by the CANONICAL width
+ * (`bip174@2.1.1 src/lib/parser/fromBuffer.js:10-11`) while `parseVarint`
+ * returns the TRUE wire width — so the same bytes yield two different keypair
+ * sets. Full rationale: `../vendor/ledger-bitcoin/README.md`, `varint.ts` bullet.
+ *
+ * Canonical round-trips across all four widths are covered by
+ * `../vendor/ledger-bitcoin/__tests__/varint.golden.test.ts` against the Python
+ * oracle's vectors; this file covers the rejection behaviour and the
+ * accept/reject boundary that pins it.
+ */
+
+import { Buffer } from "buffer";
+import { describe, expect, it } from "vitest";
+
+import { createVarint, parseVarint } from "../vendor/ledger-bitcoin/varint";
+
+describe("parseVarint minimality", () => {
+  it("rejects a 3-byte varint encoding a value below 0xfd", () => {
+    // 252 — one below the smallest value the 0xfd form may carry; fits in 1 byte.
+    const overlong = Buffer.from("fdfc00", "hex");
+    expect(() => parseVarint(overlong, 0)).toThrow(RangeError);
+    expect(() => parseVarint(overlong, 0)).toThrow(/Non-minimal varint/);
+  });
+
+  it("rejects a 5-byte varint encoding a value of 0xffff or below", () => {
+    // 65535 — the largest value the 3-byte form carries, so the 5-byte form is overlong.
+    const overlong = Buffer.from("feffff0000", "hex");
+    expect(() => parseVarint(overlong, 0)).toThrow(RangeError);
+    expect(() => parseVarint(overlong, 0)).toThrow(/Non-minimal varint/);
+  });
+
+  it("rejects a 9-byte varint encoding a value of 0xffffffff or below", () => {
+    // 4294967295 — the largest value the 5-byte form carries.
+    const overlong = Buffer.from("ffffffffff00000000", "hex");
+    expect(() => parseVarint(overlong, 0)).toThrow(RangeError);
+    expect(() => parseVarint(overlong, 0)).toThrow(/Non-minimal varint/);
+  });
+
+  it("rejects the overlong value length of the bip174 parser-differential keypair", () => {
+    // Regression guard for the reported differential: keypair `01fc fd0800 deadbeefcafe0000`
+    // — its 8-byte value is prefixed by `fd0800` (8 in the 3-byte form). bip174 advances one
+    // byte past that prefix and takes `0800deadbeefcafe`; PsbtV2 advances three and takes
+    // `deadbeefcafe0000`. Parsed at the value-length offset, where the two parsers diverge.
+    const keypair = Buffer.from("01fc" + "fd0800" + "deadbeefcafe0000", "hex");
+    expect(() => parseVarint(keypair, 2)).toThrow(/Non-minimal varint/);
+  });
+
+  it("accepts 253, the minimal value of the 3-byte width", () => {
+    expect(createVarint(253n).toString("hex")).toBe("fdfd00");
+    expect(parseVarint(Buffer.from("fdfd00", "hex"), 0)).toEqual([253n, 3]);
+  });
+
+  it("accepts 65536, the minimal value of the 5-byte width", () => {
+    expect(createVarint(65536n).toString("hex")).toBe("fe00000100");
+    expect(parseVarint(Buffer.from("fe00000100", "hex"), 0)).toEqual([65536n, 5]);
+  });
+
+  it("accepts 4294967296, the minimal value of the 9-byte width", () => {
+    expect(createVarint(4294967296n).toString("hex")).toBe("ff0000000001000000");
+    expect(parseVarint(Buffer.from("ff0000000001000000", "hex"), 0)).toEqual([4294967296n, 9]);
+  });
+});

--- a/packages/babylon-ledger-vault-signer/src/dmkApduSender.ts
+++ b/packages/babylon-ledger-vault-signer/src/dmkApduSender.ts
@@ -3,7 +3,7 @@
  * one wire encoding: the non-throwing {@link RawApduSender} for the SIGN_PSBT
  * interrupt/continue loop (#2219, where 0xE000 is data), and the throwing
  * {@link ApduSender} the DERIVE/APPROVE ceremony rides, re-based on the raw
- * sender via `classifyStatusWord`. Debugging:
+ * sender via the shared `createThrowingApduSender`. Debugging:
  * `globalThis.__LEDGER_VAULT_APDU_TRACE__ = true` logs header + status word
  * per exchange — never payload bytes (pubkeys, context preimage).
  *
@@ -11,7 +11,7 @@
  */
 
 import type { DmkSessionHandle } from "./dmkSession";
-import { classifyStatusWord, hex2, hex4, type Apdu, type RawApduSender } from "./rawApdu";
+import { createThrowingApduSender, hex2, hex4, type Apdu, type RawApduSender } from "./rawApdu";
 import type { ApduSender } from "./vaultCommands";
 
 const STATUS_WORD_BYTES = 2;
@@ -92,19 +92,12 @@ export function createDmkRawApduSender(handle: DmkSessionHandle): RawApduSender 
 
 /**
  * Build the ceremony's throwing sender: the raw sender plus the shared
- * status-word classification (typed error on anything but 0x9000).
+ * status-word classification (typed error on anything but 0x9000), carrying
+ * the connect-time app identity so 0x6E00 names the app that answered.
  */
 export function createDmkApduSender(handle: DmkSessionHandle): ApduSender {
-  const sendRaw = createDmkRawApduSender(handle);
-  return async (apdu) => {
-    const { sw, data } = await sendRaw(apdu);
-    const error = classifyStatusWord(sw, {
-      ins: apdu.ins,
-      p1: apdu.p1,
-      appName: handle.appName,
-      appVersion: handle.appVersion,
-    });
-    if (error) throw error;
-    return data;
-  };
+  return createThrowingApduSender(createDmkRawApduSender(handle), {
+    appName: handle.appName,
+    appVersion: handle.appVersion,
+  });
 }

--- a/packages/babylon-ledger-vault-signer/src/errors.ts
+++ b/packages/babylon-ledger-vault-signer/src/errors.ts
@@ -113,6 +113,36 @@ export class LedgerSignPsbtIncompleteError extends Error {
 }
 
 /**
+ * Non-secret identity of one accepted YIELD: which input it signed, and for a
+ * tapscript spend which taptree leaf — a public value the input's control
+ * block already commits to. It deliberately carries NO signature material:
+ * an Error is the object most likely to be `console.error`'d or shipped to
+ * telemetry, and both that and `JSON.stringify` serialize own enumerable
+ * properties, so anything attached here is effectively logged (CLAUDE.md
+ * critical path #7 — never log signatures or payload bytes).
+ */
+export interface CollectedYieldRef {
+  readonly inputIndex: number;
+  /** Lowercase-hex tapleaf hash; absent on keypath spends. */
+  readonly leafHashHex?: string;
+  /** Type-level guard: makes a full `CollectedYield` fail to assign here. */
+  readonly signature?: never;
+}
+
+/**
+ * Strip accepted yields down to their identity. The parameter is structural so
+ * this module imports nothing, and every returned object is fresh — no
+ * signature bytes ride along by reference.
+ */
+export function toCollectedYieldRefs(
+  yields: readonly { readonly inputIndex: number; readonly leafHashHex?: string }[],
+): readonly CollectedYieldRef[] {
+  return yields.map(({ inputIndex, leafHashHex }) =>
+    leafHashHex === undefined ? { inputIndex } : { inputIndex, leafHashHex },
+  );
+}
+
+/**
  * A host-side SIGN_PSBT protocol failure: a prepare-time rejection, an
  * unparseable YIELD payload, or an interpreter request outside the committed
  * PSBT material. With our commitments seeded up front, these mean host bug or
@@ -120,11 +150,20 @@ export class LedgerSignPsbtIncompleteError extends Error {
  */
 export class LedgerSignPsbtProtocolError extends Error {
   readonly detail: string;
+  /**
+   * Which yields the device had already delivered when the failure hit, by
+   * identity only (see {@link CollectedYieldRef}); empty for prepare-time
+   * rejections, which run before any device I/O. Diagnostics only — nothing in
+   * this package reads them, and whether a failed ceremony burns the device
+   * signatures is unresolved, so there is no retry or resume path here.
+   */
+  readonly collectedYields: readonly CollectedYieldRef[];
 
-  constructor(detail: string) {
+  constructor(detail: string, collectedYields: readonly CollectedYieldRef[] = []) {
     super(`SIGN_PSBT protocol failure: ${detail}`);
     this.name = LEDGER_SIGN_PSBT_PROTOCOL_ERROR_NAME;
     this.detail = detail;
+    this.collectedYields = collectedYields;
   }
 }
 
@@ -146,9 +185,13 @@ export class LedgerSignPsbtProtocolError extends Error {
  *   a transport failure — full re-ceremony required.
  */
 export class LedgerSignPsbtAbortedError extends Error {
-  constructor() {
+  /** Yields the device had already delivered when the host stopped sending. */
+  readonly yieldedCount: number;
+
+  constructor(yieldedCount: number) {
     super("SIGN_PSBT was abandoned host-side before completion");
     this.name = LEDGER_SIGN_PSBT_ABORTED_ERROR_NAME;
+    this.yieldedCount = yieldedCount;
   }
 }
 

--- a/packages/babylon-ledger-vault-signer/src/errors.ts
+++ b/packages/babylon-ledger-vault-signer/src/errors.ts
@@ -11,6 +11,10 @@
 export const LEDGER_USER_REFUSED_ERROR_NAME = "LedgerUserRefusedError";
 export const LEDGER_DEVICE_LOCKED_ERROR_NAME = "LedgerDeviceLockedError";
 export const LEDGER_DEVICE_ERROR_NAME = "LedgerDeviceError";
+export const LEDGER_YIELD_MISMATCH_ERROR_NAME = "LedgerYieldMismatchError";
+export const LEDGER_SIGN_PSBT_INCOMPLETE_ERROR_NAME = "LedgerSignPsbtIncompleteError";
+export const LEDGER_SIGN_PSBT_PROTOCOL_ERROR_NAME = "LedgerSignPsbtProtocolError";
+export const LEDGER_SIGN_PSBT_ABORTED_ERROR_NAME = "LedgerSignPsbtAbortedError";
 
 function hex4(value: number): string {
   return value.toString(16).padStart(4, "0");
@@ -58,6 +62,96 @@ export class LedgerDeviceError extends Error {
   }
 }
 
+export type LedgerYieldMismatchKind =
+  | "unexpected-input"
+  | "wrong-spend-type"
+  | "wrong-signer-key"
+  | "unknown-leaf-hash"
+  | "non-default-sighash"
+  | "duplicate-yield"
+  | "unexpected-encoding";
+
+/**
+ * A SIGN_PSBT YIELD failed the expected-signature table assertion — a
+ * misrouted signature caught before it is ever recorded or merged. The loop
+ * stops sending CONTINUEs and never retries a YIELD (per-type signature caps
+ * and the payout claimer mask make a replayed SIGN_PSBT after partial YIELDs
+ * non-idempotent — fw `sign_custom_inputs.c:180-181,348-352`).
+ */
+export class LedgerYieldMismatchError extends Error {
+  readonly kind: LedgerYieldMismatchKind;
+  readonly inputIndex?: number;
+
+  constructor(kind: LedgerYieldMismatchKind, inputIndex?: number) {
+    super(
+      `The device yielded a signature that fails the expected-signature table ` +
+        `(${kind}${inputIndex === undefined ? "" : ` on input ${inputIndex}`})`,
+    );
+    this.name = LEDGER_YIELD_MISMATCH_ERROR_NAME;
+    this.kind = kind;
+    this.inputIndex = inputIndex;
+  }
+}
+
+/**
+ * SIGN_PSBT ended 0x9000 but the collected yields are not set-equal to the
+ * expected table — e.g. the device silently skipped an input. Failing here
+ * loudly prevents a half-signed PSBT from reaching the merge.
+ */
+export class LedgerSignPsbtIncompleteError extends Error {
+  /** Missing (input, leaf) units: `"i:leafHex"` for tapscript, `"i"` for keypath. */
+  readonly missing: readonly string[];
+
+  constructor(missing: readonly string[]) {
+    super(
+      `The device completed SIGN_PSBT without yielding every expected signature ` +
+        `(missing ${missing.length}: ${missing.join(", ")})`,
+    );
+    this.name = LEDGER_SIGN_PSBT_INCOMPLETE_ERROR_NAME;
+    this.missing = missing;
+  }
+}
+
+/**
+ * A host-side SIGN_PSBT protocol failure: a prepare-time rejection, an
+ * unparseable YIELD payload, or an interpreter request outside the committed
+ * PSBT material. With our commitments seeded up front, these mean host bug or
+ * corrupted exchange — never a user action.
+ */
+export class LedgerSignPsbtProtocolError extends Error {
+  readonly detail: string;
+
+  constructor(detail: string) {
+    super(`SIGN_PSBT protocol failure: ${detail}`);
+    this.name = LEDGER_SIGN_PSBT_PROTOCOL_ERROR_NAME;
+    this.detail = detail;
+  }
+}
+
+/**
+ * The host abandoned the SIGN_PSBT loop (abort signal) — the loop stops
+ * sending, nothing else. What the device does next (verified at base app rev
+ * `e400d8d8` + fw `6fcad4fd`):
+ *
+ * - Within ~5 s (50 ticks, `base:io_ext.h:28`) the device sits blocked
+ *   awaiting CONTINUE; the next non-CONTINUE APDU is eaten with 0x6A80 and the
+ *   interrupted handler unwinds (`base:dispatcher.c:107-111`) — a direct retry
+ *   uses `resendOnceOnIncorrectData`.
+ * - A validation-phase abandonment leaves the intent intact; a Payout/NoPayout
+ *   SIGNING-phase abandonment invalidates it (`fw:sign_custom_inputs.c:207-344`)
+ *   — post-abort "intent-loaded" is a HINT only, and the retry path must also
+ *   absorb 0xB007.
+ * - After >5 s of host silence the app exits to the dashboard
+ *   (`base:io_ext.c:103-111` → SDK `app_exit()`); the host then sees 0x6E00 or
+ *   a transport failure — full re-ceremony required.
+ */
+export class LedgerSignPsbtAbortedError extends Error {
+  constructor() {
+    super("SIGN_PSBT was abandoned host-side before completion");
+    this.name = LEDGER_SIGN_PSBT_ABORTED_ERROR_NAME;
+  }
+}
+
 export function isLedgerUserRefusedError(error: unknown): error is LedgerUserRefusedError {
   return error instanceof Error && error.name === LEDGER_USER_REFUSED_ERROR_NAME;
 }
@@ -68,4 +162,20 @@ export function isLedgerDeviceError(error: unknown): error is LedgerDeviceError 
 
 export function isLedgerDeviceLockedError(error: unknown): error is LedgerDeviceLockedError {
   return error instanceof Error && error.name === LEDGER_DEVICE_LOCKED_ERROR_NAME;
+}
+
+export function isLedgerYieldMismatchError(error: unknown): error is LedgerYieldMismatchError {
+  return error instanceof Error && error.name === LEDGER_YIELD_MISMATCH_ERROR_NAME;
+}
+
+export function isLedgerSignPsbtIncompleteError(error: unknown): error is LedgerSignPsbtIncompleteError {
+  return error instanceof Error && error.name === LEDGER_SIGN_PSBT_INCOMPLETE_ERROR_NAME;
+}
+
+export function isLedgerSignPsbtProtocolError(error: unknown): error is LedgerSignPsbtProtocolError {
+  return error instanceof Error && error.name === LEDGER_SIGN_PSBT_PROTOCOL_ERROR_NAME;
+}
+
+export function isLedgerSignPsbtAbortedError(error: unknown): error is LedgerSignPsbtAbortedError {
+  return error instanceof Error && error.name === LEDGER_SIGN_PSBT_ABORTED_ERROR_NAME;
 }

--- a/packages/babylon-ledger-vault-signer/src/errors.ts
+++ b/packages/babylon-ledger-vault-signer/src/errors.ts
@@ -170,7 +170,8 @@ export class LedgerSignPsbtProtocolError extends Error {
 /**
  * The host abandoned the SIGN_PSBT loop (abort signal) — the loop stops
  * sending, nothing else. What the device does next (verified at base app rev
- * `e400d8d8` + fw `6fcad4fd`):
+ * `e400d8d8` + fw `90cf41f`; the `6fcad4fd`→`90cf41f` delta is payout-validation
+ * only and touches neither path below):
  *
  * - Within ~5 s (50 ticks, `base:io_ext.h:28`) the device sits blocked
  *   awaiting CONTINUE; the next non-CONTINUE APDU is eaten with 0x6A80 and the

--- a/packages/babylon-ledger-vault-signer/src/expectedSignatures.ts
+++ b/packages/babylon-ledger-vault-signer/src/expectedSignatures.ts
@@ -1,0 +1,389 @@
+/**
+ * SIGN_PSBT expected-signature table + per-YIELD collector (#2219).
+ *
+ * The device signs from an approved intent, not from what we display; the
+ * table pins every YIELD's (input, spend-type, signer key, tapleaf hash)
+ * against values computed from the exact map model committed to the device,
+ * BEFORE the signature is recorded. A mismatch aborts the ceremony — a
+ * misrouted signature must never reach the merge. Unit of expectation is
+ * (input, leaf), not input; completion is set equality in both directions.
+ *
+ * YIELD wire shape (base app `sign_input.c:47-87`, protocol v1 / P2=1):
+ * `varint(input_index) ‖ augm_len(1) ‖ pubkey_augm(augm_len) ‖ signature` —
+ * tapscript: augm = untweaked x-only key(32) ‖ tapleaf_hash(32), keypath:
+ * augm = tweaked output key(32); Schnorr sig is exactly 64 bytes at
+ * SIGHASH_DEFAULT (a 65th byte means a non-zero sighash byte,
+ * `sign_input.c:202-206` — reject, never strip).
+ *
+ * @module ledger-vault-signer/expectedSignatures
+ */
+
+import * as ecc from "@bitcoin-js/tiny-secp256k1-asmjs";
+import { crypto as bcrypto, initEccLib, payments } from "bitcoinjs-lib";
+import { Buffer } from "buffer";
+
+import { LedgerSignPsbtIncompleteError, LedgerSignPsbtProtocolError, LedgerYieldMismatchError } from "./errors";
+import { tapLeafHash } from "./tapLeafHash";
+import { psbtIn } from "./vendor/ledger-bitcoin/psbtv2";
+import { parseVarint, sanitizeBigintToNumber } from "./vendor/ledger-bitcoin/varint";
+
+/** BIP-341 tapscript leaf version — the only one our builders emit. */
+const TAPSCRIPT_LEAF_VERSION = 0xc0;
+const X_ONLY_KEY_BYTES = 32;
+/** Tapscript augm = x-only key(32) ‖ tapleaf hash(32) — base `sign_input.c:66`. */
+const AUGM_TAPSCRIPT_BYTES = 64;
+/** Keypath augm = tweaked x-only output key(32) — base `sign_input.c:208-215`. */
+const AUGM_KEYPATH_BYTES = 32;
+/** BIP-340 Schnorr signature at SIGHASH_DEFAULT — no trailing sighash byte. */
+const SCHNORR_SIG_BYTES = 64;
+/** P2TR scriptPubKey: OP_1 ‖ push-32 ‖ program(32) (BIP-341). */
+const P2TR_SCRIPT_BYTES = 34;
+const P2TR_SCRIPT_PREFIX = Buffer.from([0x51, 0x20]);
+/** P2WPKH scriptPubKey: OP_0 ‖ push-20 ‖ hash160(pubkey) (BIP-141). */
+const P2WPKH_SCRIPT_PREFIX = Buffer.from([0x00, 0x14]);
+const COMPRESSED_KEY_EVEN_PREFIX = 0x02;
+const COMPRESSED_KEY_ODD_PREFIX = 0x03;
+
+export type InputSigExpectation =
+  | {
+      readonly kind: "tapscript";
+      /** TapLeaf hashes (lowercase hex) of this input's TAP_LEAF_SCRIPT entries. */
+      readonly expectedLeafHashHexes: ReadonlySet<string>;
+      /** UNTWEAKED depositor x-only key — `sign_input.c:211` with `tweak_data=NULL` on every vault path. */
+      readonly expectedSignerXOnlyHex: string;
+    }
+  | {
+      readonly kind: "taproot-keypath";
+      /** BIP-86 tweaked output key == witness program of the input's P2TR scriptPubKey. */
+      readonly expectedOutputKeyHex: string;
+    };
+
+export interface ExpectedSignatureTable {
+  /** inputIndex → expectation. Inputs absent here must never appear in a YIELD. */
+  readonly byInput: ReadonlyMap<number, InputSigExpectation>;
+  /** Σ over inputs: tapscript → |expectedLeafHashHexes|; keypath → 1. */
+  readonly expectedYieldCount: number;
+}
+
+export type CollectedYield =
+  | {
+      readonly kind: "tapscript";
+      readonly inputIndex: number;
+      readonly signerXOnlyHex: string;
+      readonly leafHashHex: string;
+      /** Exactly 64 bytes (SIGHASH_DEFAULT on all vault paths). */
+      readonly signature: Uint8Array;
+    }
+  | {
+      readonly kind: "taproot-keypath";
+      readonly inputIndex: number;
+      readonly outputKeyHex: string;
+      readonly signature: Uint8Array;
+    };
+
+/**
+ * The per-input read surface of the vendored `PsbtV2` the table builder
+ * consumes — structural, so no vendored symbol reaches the emitted
+ * declarations (vendor d.ts is excluded from dist; see `vite.config.ts`).
+ */
+export interface ExpectedSignaturePsbt {
+  getGlobalInputCount(): number;
+  getInputEntriesOfType(
+    inputIndex: number,
+    keyType: number,
+  ): readonly { readonly keyData: Buffer; readonly value: Buffer }[];
+  getInputWitnessUtxo(inputIndex: number): { readonly amount: number; readonly scriptPubKey: Buffer } | undefined;
+}
+
+export interface BuildExpectedSignatureTableParams {
+  /**
+   * The exact map model committed to the device — pass the MerkelizedPsbt
+   * instance, not a re-parse, so there is no parse/serialize gap.
+   */
+  readonly psbt: ExpectedSignaturePsbt;
+  /** Connected depositor x-only key (64 lowercase hex) — pins the table. */
+  readonly depositorXOnlyHex: string;
+}
+
+// bitcoinjs `initEccLib` re-verifies only when handed a DIFFERENT instance —
+// init once so a second tiny-secp256k1 copy in the bundle can't thrash the cache.
+let eccInitialized = false;
+
+/** BIP-86/BIP-341 keypath-only P2TR scriptPubKey of an x-only internal key. */
+function bip86OutputScript(xOnlyKeyHex: string): Buffer {
+  if (!eccInitialized) {
+    initEccLib(ecc);
+    eccInitialized = true;
+  }
+  const output = payments.p2tr({ internalPubkey: Buffer.from(xOnlyKeyHex, "hex") }).output;
+  if (!output) {
+    throw new LedgerSignPsbtProtocolError("p2tr produced no output script for the depositor key");
+  }
+  return output;
+}
+
+/** BIP-141 P2WPKH scriptPubKey for one compressed-key parity of an x-only key. */
+function p2wpkhOutputScript(xOnlyKeyHex: string, parityPrefix: number): Buffer {
+  const compressed = Buffer.concat([Buffer.from([parityPrefix]), Buffer.from(xOnlyKeyHex, "hex")]);
+  return Buffer.concat([P2WPKH_SCRIPT_PREFIX, bcrypto.hash160(compressed)]);
+}
+
+/**
+ * Classify every input of the committed map model (build rules per the B1-c
+ * spec §3.1; BIP-371 key types verified against base app `psbt.h:37-42`).
+ * Throws `LedgerSignPsbtProtocolError` on any rule violation — all before any
+ * device I/O.
+ */
+export function buildExpectedSignatureTable(params: BuildExpectedSignatureTableParams): ExpectedSignatureTable {
+  const { psbt, depositorXOnlyHex } = params;
+  const byInput = new Map<number, InputSigExpectation>();
+  const inputCount = psbt.getGlobalInputCount();
+
+  // Precompute the depositor-owned scriptPubKeys once for the ownership scan.
+  const depositorP2trScript = bip86OutputScript(depositorXOnlyHex);
+  const depositorP2wpkhScripts = [
+    p2wpkhOutputScript(depositorXOnlyHex, COMPRESSED_KEY_EVEN_PREFIX),
+    p2wpkhOutputScript(depositorXOnlyHex, COMPRESSED_KEY_ODD_PREFIX),
+  ];
+
+  for (let inputIndex = 0; inputIndex < inputCount; inputIndex++) {
+    const leafEntries = psbt.getInputEntriesOfType(inputIndex, psbtIn.TAP_LEAF_SCRIPT);
+    if (leafEntries.length > 0) {
+      // Exactly one leaf per input for now — >1 is an ambiguous leaf set,
+      // mirroring fw `sign_psbt_validate.c:2981,3004` and the ts-sdk rule.
+      if (leafEntries.length > 1) {
+        throw new LedgerSignPsbtProtocolError(
+          `input ${inputIndex} carries an ambiguous leaf set (${leafEntries.length} TAP_LEAF_SCRIPT entries)`,
+        );
+      }
+      const value = leafEntries[0].value;
+      if (value.length < 1) {
+        throw new LedgerSignPsbtProtocolError(`input ${inputIndex} TAP_LEAF_SCRIPT value is empty`);
+      }
+      // BIP-371: value = script ‖ leaf_version (1 trailing byte).
+      const leafVersion = value[value.length - 1];
+      if (leafVersion !== TAPSCRIPT_LEAF_VERSION) {
+        throw new LedgerSignPsbtProtocolError(
+          `input ${inputIndex} leaf version 0x${leafVersion.toString(16)} is not tapscript (0xc0)`,
+        );
+      }
+      // Firmware requires witnessUtxo on every segwit input; catch its absence
+      // in the zero-I/O preflight instead of burning an approved intent on-device.
+      if (!psbt.getInputWitnessUtxo(inputIndex)) {
+        throw new LedgerSignPsbtProtocolError(`input ${inputIndex} is tapscript but has no witnessUtxo`);
+      }
+      const script = value.subarray(0, value.length - 1);
+      const leafHashHex = tapLeafHash(TAPSCRIPT_LEAF_VERSION, script).toString("hex");
+      byInput.set(inputIndex, {
+        kind: "tapscript",
+        expectedLeafHashHexes: new Set([leafHashHex]),
+        expectedSignerXOnlyHex: depositorXOnlyHex,
+      });
+      continue;
+    }
+
+    const internalKeyEntries = psbt.getInputEntriesOfType(inputIndex, psbtIn.TAP_INTERNAL_KEY);
+    if (internalKeyEntries.length > 0) {
+      const entry = internalKeyEntries[0];
+      if (internalKeyEntries.length > 1 || entry.keyData.length !== 0 || entry.value.length !== X_ONLY_KEY_BYTES) {
+        throw new LedgerSignPsbtProtocolError(`input ${inputIndex} carries a malformed TAP_INTERNAL_KEY entry`);
+      }
+      // A foreign internal key is not ours to expect.
+      if (entry.value.toString("hex") !== depositorXOnlyHex) {
+        throw new LedgerSignPsbtProtocolError(`input ${inputIndex} internal key is not the connected depositor key`);
+      }
+      const witnessUtxo = psbt.getInputWitnessUtxo(inputIndex);
+      if (!witnessUtxo) {
+        throw new LedgerSignPsbtProtocolError(`input ${inputIndex} is keypath but has no witnessUtxo`);
+      }
+      const script = witnessUtxo.scriptPubKey;
+      if (script.length !== P2TR_SCRIPT_BYTES || !script.subarray(0, 2).equals(P2TR_SCRIPT_PREFIX)) {
+        throw new LedgerSignPsbtProtocolError(`input ${inputIndex} witnessUtxo script is not P2TR`);
+      }
+      // Pins "witness program" == "BIP-86 tweak of OUR key" independently.
+      if (!script.equals(depositorP2trScript)) {
+        throw new LedgerSignPsbtProtocolError(
+          `input ${inputIndex} witnessUtxo is not the BIP-86 P2TR of the depositor key`,
+        );
+      }
+      byInput.set(inputIndex, {
+        kind: "taproot-keypath",
+        expectedOutputKeyHex: script.subarray(2).toString("hex"),
+      });
+      continue;
+    }
+
+    // Not signed by the device (Payout input 1, NoPayout inputs 1-2 today).
+    // Ownership scan: a depositor-owned UTXO here means our builder dropped
+    // the device-required metadata — fail before burning a ceremony.
+    const witnessUtxo = psbt.getInputWitnessUtxo(inputIndex);
+    if (
+      witnessUtxo &&
+      (witnessUtxo.scriptPubKey.equals(depositorP2trScript) ||
+        depositorP2wpkhScripts.some((s) => witnessUtxo.scriptPubKey.equals(s)))
+    ) {
+      throw new LedgerSignPsbtProtocolError(
+        `input ${inputIndex} spends a depositor-owned UTXO but carries no signing metadata`,
+      );
+    }
+  }
+
+  if (byInput.size === 0) {
+    // A signPsbt call with nothing to sign is a host bug — thrown before ANY APDU.
+    throw new LedgerSignPsbtProtocolError("PSBT contains no depositor-signable input");
+  }
+
+  let expectedYieldCount = 0;
+  for (const expectation of byInput.values()) {
+    expectedYieldCount += expectation.kind === "tapscript" ? expectation.expectedLeafHashHexes.size : 1;
+  }
+  return { byInput, expectedYieldCount };
+}
+
+export interface YieldCollector {
+  /**
+   * Interpreter `onYield`: parse + assert + record. Throws
+   * `LedgerYieldMismatchError` (semantic) / `LedgerSignPsbtProtocolError`
+   * (unparseable). A throw propagates out of `interpreter.execute()` BEFORE
+   * the payload is recorded (`clientCommands.ts` onYield seam).
+   */
+  assertAndRecord(payload: Buffer): void;
+  readonly yields: readonly CollectedYield[];
+  /** Drives onProgress in the loop. */
+  readonly lastYield: CollectedYield | undefined;
+  /**
+   * After sw 0x9000, before merge: set equality in BOTH directions.
+   * Throws `LedgerSignPsbtIncompleteError`.
+   */
+  assertComplete(): void;
+}
+
+function seenKeyOf(yielded: CollectedYield): string {
+  return yielded.kind === "tapscript" ? `${yielded.inputIndex}:${yielded.leafHashHex}` : `${yielded.inputIndex}`;
+}
+
+export function createYieldCollector(table: ExpectedSignatureTable): YieldCollector {
+  const yields: CollectedYield[] = [];
+  const seen = new Set<string>();
+
+  const assertAndRecord = (payload: Buffer): void => {
+    // Payload = request minus the 0x10 code byte, exactly base `sign_input.c:47-87`.
+    let inputIndex: number;
+    let offset: number;
+    try {
+      const [value, size] = parseVarint(payload, 0);
+      inputIndex = sanitizeBigintToNumber(value);
+      offset = size;
+    } catch (error) {
+      throw new LedgerSignPsbtProtocolError(
+        `unparseable YIELD payload: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+    const augmLen = payload[offset];
+    if (augmLen === undefined) {
+      throw new LedgerSignPsbtProtocolError("YIELD payload truncated before the augmented-pubkey length");
+    }
+    const expectation = table.byInput.get(inputIndex);
+    if (expectation === undefined) {
+      throw new LedgerYieldMismatchError("unexpected-input", inputIndex);
+    }
+
+    if (augmLen === AUGM_TAPSCRIPT_BYTES) {
+      if (expectation.kind !== "tapscript") {
+        throw new LedgerYieldMismatchError("wrong-spend-type", inputIndex);
+      }
+      const augmEnd = offset + 1 + AUGM_TAPSCRIPT_BYTES;
+      if (payload.length < augmEnd) {
+        throw new LedgerSignPsbtProtocolError("YIELD payload truncated inside the augmented pubkey");
+      }
+      const signerXOnlyHex = payload.subarray(offset + 1, offset + 1 + X_ONLY_KEY_BYTES).toString("hex");
+      const leafHashHex = payload.subarray(offset + 1 + X_ONLY_KEY_BYTES, augmEnd).toString("hex");
+      const signature = payload.subarray(augmEnd);
+      if (signerXOnlyHex !== expectation.expectedSignerXOnlyHex) {
+        throw new LedgerYieldMismatchError("wrong-signer-key", inputIndex);
+      }
+      if (!expectation.expectedLeafHashHexes.has(leafHashHex)) {
+        throw new LedgerYieldMismatchError("unknown-leaf-hash", inputIndex);
+      }
+      if (signature.length !== SCHNORR_SIG_BYTES) {
+        throw new LedgerYieldMismatchError("non-default-sighash", inputIndex);
+      }
+      const recorded: CollectedYield = {
+        kind: "tapscript",
+        inputIndex,
+        signerXOnlyHex,
+        leafHashHex,
+        signature: Uint8Array.from(signature),
+      };
+      if (seen.has(seenKeyOf(recorded))) {
+        throw new LedgerYieldMismatchError("duplicate-yield", inputIndex);
+      }
+      seen.add(seenKeyOf(recorded));
+      yields.push(recorded);
+      return;
+    }
+
+    if (augmLen === AUGM_KEYPATH_BYTES) {
+      if (expectation.kind !== "taproot-keypath") {
+        throw new LedgerYieldMismatchError("wrong-spend-type", inputIndex);
+      }
+      const augmEnd = offset + 1 + AUGM_KEYPATH_BYTES;
+      if (payload.length < augmEnd) {
+        throw new LedgerSignPsbtProtocolError("YIELD payload truncated inside the augmented pubkey");
+      }
+      const outputKeyHex = payload.subarray(offset + 1, augmEnd).toString("hex");
+      const signature = payload.subarray(augmEnd);
+      if (outputKeyHex !== expectation.expectedOutputKeyHex) {
+        throw new LedgerYieldMismatchError("wrong-signer-key", inputIndex);
+      }
+      if (signature.length !== SCHNORR_SIG_BYTES) {
+        throw new LedgerYieldMismatchError("non-default-sighash", inputIndex);
+      }
+      const recorded: CollectedYield = {
+        kind: "taproot-keypath",
+        inputIndex,
+        outputKeyHex,
+        signature: Uint8Array.from(signature),
+      };
+      if (seen.has(seenKeyOf(recorded))) {
+        throw new LedgerYieldMismatchError("duplicate-yield", inputIndex);
+      }
+      seen.add(seenKeyOf(recorded));
+      yields.push(recorded);
+      return;
+    }
+
+    // 33 = ECDSA compressed — never legitimate on our P2TR-only inputs.
+    throw new LedgerYieldMismatchError("unexpected-encoding", inputIndex);
+  };
+
+  const assertComplete = (): void => {
+    const expectedKeys = new Set<string>();
+    for (const [inputIndex, expectation] of table.byInput) {
+      if (expectation.kind === "tapscript") {
+        for (const leafHashHex of expectation.expectedLeafHashHexes) {
+          expectedKeys.add(`${inputIndex}:${leafHashHex}`);
+        }
+      } else {
+        expectedKeys.add(`${inputIndex}`);
+      }
+    }
+    const missing = [...expectedKeys].filter((key) => !seen.has(key));
+    // The per-YIELD check already forbids extras; assert both directions anyway.
+    const hasExtras = [...seen].some((key) => !expectedKeys.has(key));
+    if (missing.length > 0 || hasExtras || seen.size !== table.expectedYieldCount) {
+      throw new LedgerSignPsbtIncompleteError(missing);
+    }
+  };
+
+  return {
+    assertAndRecord,
+    get yields(): readonly CollectedYield[] {
+      return yields;
+    },
+    get lastYield(): CollectedYield | undefined {
+      return yields[yields.length - 1];
+    },
+    assertComplete,
+  };
+}

--- a/packages/babylon-ledger-vault-signer/src/expectedSignatures.ts
+++ b/packages/babylon-ledger-vault-signer/src/expectedSignatures.ts
@@ -7,13 +7,20 @@
  * BEFORE the signature is recorded. A mismatch aborts the ceremony — a
  * misrouted signature must never reach the merge. Unit of expectation is
  * (input, leaf), not input; completion is set equality in both directions.
+ * Building the table also asserts each tapscript input's control block really
+ * commits to its leaf, so a leaf the spent output never paid to is never armed.
  *
- * YIELD wire shape (base app `sign_input.c:47-87`, protocol v1 / P2=1):
+ * Firmware citations in this file are pinned, because the same path on another
+ * branch shows the opposite behaviour: `base:` = LedgerHQ/app-bitcoin @
+ * `e400d8d8` (`src/handler/sign_psbt/`, `src/common/`), `fw:` =
+ * LedgerHQ/app-babylon-vault `fix/feedback` @ `90cf41f` (`src/`).
+ *
+ * YIELD wire shape (`base:sign_input.c:47-87`, protocol v1 / P2=1):
  * `varint(input_index) ‖ augm_len(1) ‖ pubkey_augm(augm_len) ‖ signature` —
  * tapscript: augm = untweaked x-only key(32) ‖ tapleaf_hash(32), keypath:
  * augm = tweaked output key(32); Schnorr sig is exactly 64 bytes at
  * SIGHASH_DEFAULT (a 65th byte means a non-zero sighash byte,
- * `sign_input.c:202-206` — reject, never strip).
+ * `base:sign_input.c:197-201` — reject, never strip).
  *
  * @module ledger-vault-signer/expectedSignatures
  */
@@ -30,9 +37,24 @@ import { parseVarint, sanitizeBigintToNumber } from "./vendor/ledger-bitcoin/var
 /** BIP-341 tapscript leaf version — the only one our builders emit. */
 const TAPSCRIPT_LEAF_VERSION = 0xc0;
 const X_ONLY_KEY_BYTES = 32;
-/** Tapscript augm = x-only key(32) ‖ tapleaf hash(32) — base `sign_input.c:66`. */
+/** BIP-371 TAP_LEAF_SCRIPT value = script ‖ leaf_version(1): ≥1 script byte + the version byte. */
+const MIN_TAP_LEAF_SCRIPT_VALUE_BYTES = 2;
+/** BIP-341 control block head: `leaf_version|parity`(1) ‖ internal x-only key(32). */
+const CONTROL_BLOCK_HEAD_BYTES = 33;
+/** BIP-341 merkle path element (one sibling hash per taptree level). */
+const TAPROOT_MERKLE_NODE_BYTES = 32;
+/** BIP-341: bit 0 of control-block byte 0 is the taproot output key's y-parity. */
+const CONTROL_BLOCK_PARITY_MASK = 0x01;
+/** BIP-341 tagged-hash tags for the taptree fold and the output-key tweak. */
+const TAPBRANCH_TAG = "TapBranch";
+const TAPTWEAK_TAG = "TapTweak";
+/**
+ * Tapscript augm = x-only key(32) ‖ tapleaf hash(32). Line 66 fixes only the
+ * +32 delta; `:206-207` is what pins the taproot `pubkey_len` at 32 (the ECDSA
+ * call site at `:117` yields 33) — `base:sign_input.c:66,206-207`.
+ */
 const AUGM_TAPSCRIPT_BYTES = 64;
-/** Keypath augm = tweaked x-only output key(32) — base `sign_input.c:208-215`. */
+/** Keypath augm = tweaked x-only output key(32) — `base:sign_input.c:66,206-207,419-429`. */
 const AUGM_KEYPATH_BYTES = 32;
 /** BIP-340 Schnorr signature at SIGHASH_DEFAULT — no trailing sighash byte. */
 const SCHNORR_SIG_BYTES = 64;
@@ -49,7 +71,8 @@ export type InputSigExpectation =
       readonly kind: "tapscript";
       /** TapLeaf hashes (lowercase hex) of this input's TAP_LEAF_SCRIPT entries. */
       readonly expectedLeafHashHexes: ReadonlySet<string>;
-      /** UNTWEAKED depositor x-only key — `sign_input.c:211` with `tweak_data=NULL` on every vault path. */
+      /** UNTWEAKED depositor x-only key — the tapscript branch leaves `tweak_data` NULL
+       * (`base:sign_input.c:430-433`), so no tweak is applied (`base:sign_input.c:159-161`). */
       readonly expectedSignerXOnlyHex: string;
     }
   | {
@@ -105,16 +128,12 @@ export interface BuildExpectedSignatureTableParams {
   readonly depositorXOnlyHex: string;
 }
 
-// bitcoinjs `initEccLib` re-verifies only when handed a DIFFERENT instance —
-// init once so a second tiny-secp256k1 copy in the bundle can't thrash the cache.
-let eccInitialized = false;
-
 /** BIP-86/BIP-341 keypath-only P2TR scriptPubKey of an x-only internal key. */
 function bip86OutputScript(xOnlyKeyHex: string): Buffer {
-  if (!eccInitialized) {
-    initEccLib(ecc);
-    eccInitialized = true;
-  }
+  // Not memoized: bitcoinjs re-verifies only when handed a DIFFERENT instance
+  // (`bitcoinjs-lib@6.1.7 src/ecc_lib.js:13-23`), so a "done" flag would
+  // silently skip that check once another instance reached the same copy.
+  initEccLib(ecc);
   const output = payments.p2tr({ internalPubkey: Buffer.from(xOnlyKeyHex, "hex") }).output;
   if (!output) {
     throw new LedgerSignPsbtProtocolError("p2tr produced no output script for the depositor key");
@@ -128,9 +147,76 @@ function p2wpkhOutputScript(xOnlyKeyHex: string, parityPrefix: number): Buffer {
   return Buffer.concat([P2WPKH_SCRIPT_PREFIX, bcrypto.hash160(compressed)]);
 }
 
+/** BIP-341 P2TR scriptPubKey shape: `OP_1 ‖ push-32 ‖ output key(32)`. */
+function isP2trScript(script: Buffer): boolean {
+  return (
+    script.length === P2TR_SCRIPT_BYTES && script.subarray(0, P2TR_SCRIPT_PREFIX.length).equals(P2TR_SCRIPT_PREFIX)
+  );
+}
+
+/**
+ * Assert the input's control block actually commits to the leaf we hashed:
+ * fold the control block's merkle path onto the leaf hash and tweak its
+ * internal key with the resulting root (BIP-341), then require the recomputed
+ * taproot output key AND its y-parity to equal the ones the witnessUtxo pays
+ * to. Without this the host would accept a signature over a leaf the spent
+ * output never committed to. The firmware requires the same binding on the
+ * flows it reconstructs (wire spec §8, Refund row →
+ * `fw:sign_psbt_validate.c:513-562`, `_refund_verify_taproot_commitment`).
+ */
+function assertControlBlockCommitsToLeaf(
+  inputIndex: number,
+  controlBlock: Buffer,
+  leafHash: Buffer,
+  scriptPubKey: Buffer,
+): void {
+  if (!isP2trScript(scriptPubKey)) {
+    throw new LedgerSignPsbtProtocolError(`input ${inputIndex} is tapscript but its witnessUtxo script is not P2TR`);
+  }
+  const pathBytes = controlBlock.length - CONTROL_BLOCK_HEAD_BYTES;
+  if (pathBytes < 0 || pathBytes % TAPROOT_MERKLE_NODE_BYTES !== 0) {
+    throw new LedgerSignPsbtProtocolError(
+      `input ${inputIndex} control block length ${controlBlock.length} is not ` +
+        `${CONTROL_BLOCK_HEAD_BYTES} plus a multiple of ${TAPROOT_MERKLE_NODE_BYTES}`,
+    );
+  }
+  const internalKey = controlBlock.subarray(1, CONTROL_BLOCK_HEAD_BYTES);
+  if (!ecc.isXOnlyPoint(internalKey)) {
+    throw new LedgerSignPsbtProtocolError(`input ${inputIndex} control block internal key is not an x-only point`);
+  }
+  let node = leafHash;
+  for (let offset = CONTROL_BLOCK_HEAD_BYTES; offset < controlBlock.length; offset += TAPROOT_MERKLE_NODE_BYTES) {
+    const sibling = controlBlock.subarray(offset, offset + TAPROOT_MERKLE_NODE_BYTES);
+    // BIP-341 orders each branch pair lexicographically before hashing.
+    const pair = Buffer.compare(node, sibling) < 0 ? [node, sibling] : [sibling, node];
+    node = bcrypto.taggedHash(TAPBRANCH_TAG, Buffer.concat(pair));
+  }
+  const tweak = bcrypto.taggedHash(TAPTWEAK_TAG, Buffer.concat([internalKey, node]));
+  const tweaked = ecc.xOnlyPointAddTweak(internalKey, tweak);
+  if (!tweaked) {
+    // null = tweaked point at infinity; unreachable for a real key, but the
+    // commitment is unverifiable when it happens, so it is never a pass.
+    throw new LedgerSignPsbtProtocolError(`input ${inputIndex} control block internal key has no taproot output key`);
+  }
+  const outputKey = scriptPubKey.subarray(P2TR_SCRIPT_PREFIX.length);
+  // Separate arms: this one binds the leaf to the spent output, the parity bit
+  // below is a 1-bit consistency check — one message would hide which failed.
+  if (!outputKey.equals(Buffer.from(tweaked.xOnlyPubkey))) {
+    throw new LedgerSignPsbtProtocolError(
+      `input ${inputIndex} control block does not commit to its TAP_LEAF_SCRIPT ` +
+        `(recomputed taproot output key differs from the witnessUtxo witness program)`,
+    );
+  }
+  if (tweaked.parity !== (controlBlock[0] & CONTROL_BLOCK_PARITY_MASK)) {
+    throw new LedgerSignPsbtProtocolError(
+      `input ${inputIndex} control block parity bit disagrees with the recomputed taproot output key`,
+    );
+  }
+}
+
 /**
  * Classify every input of the committed map model (build rules per the B1-c
- * spec §3.1; BIP-371 key types verified against base app `psbt.h:37-42`).
+ * spec §3.1; BIP-371 key types verified against `base:psbt.h:37-42`).
  * Throws `LedgerSignPsbtProtocolError` on any rule violation — all before any
  * device I/O.
  */
@@ -147,18 +233,23 @@ export function buildExpectedSignatureTable(params: BuildExpectedSignatureTableP
   ];
 
   for (let inputIndex = 0; inputIndex < inputCount; inputIndex++) {
+    // A leaf input also carries TAP_INTERNAL_KEY (NUMS) by spec — wire spec §8,
+    // PegIn row — so the leaf branch wins and never looks at the internal key.
     const leafEntries = psbt.getInputEntriesOfType(inputIndex, psbtIn.TAP_LEAF_SCRIPT);
     if (leafEntries.length > 0) {
       // Exactly one leaf per input for now — >1 is an ambiguous leaf set,
-      // mirroring fw `sign_psbt_validate.c:2981,3004` and the ts-sdk rule.
+      // mirroring `fw:sign_psbt_validate.c:2981,3004` and the ts-sdk rule.
       if (leafEntries.length > 1) {
         throw new LedgerSignPsbtProtocolError(
           `input ${inputIndex} carries an ambiguous leaf set (${leafEntries.length} TAP_LEAF_SCRIPT entries)`,
         );
       }
       const value = leafEntries[0].value;
-      if (value.length < 1) {
-        throw new LedgerSignPsbtProtocolError(`input ${inputIndex} TAP_LEAF_SCRIPT value is empty`);
+      if (value.length < MIN_TAP_LEAF_SCRIPT_VALUE_BYTES) {
+        throw new LedgerSignPsbtProtocolError(
+          `input ${inputIndex} TAP_LEAF_SCRIPT value length ${value.length} is below the ` +
+            `${MIN_TAP_LEAF_SCRIPT_VALUE_BYTES}-byte minimum (script byte plus the leaf-version byte)`,
+        );
       }
       // BIP-371: value = script ‖ leaf_version (1 trailing byte).
       const leafVersion = value[value.length - 1];
@@ -169,14 +260,17 @@ export function buildExpectedSignatureTable(params: BuildExpectedSignatureTableP
       }
       // Firmware requires witnessUtxo on every segwit input; catch its absence
       // in the zero-I/O preflight instead of burning an approved intent on-device.
-      if (!psbt.getInputWitnessUtxo(inputIndex)) {
+      const leafWitnessUtxo = psbt.getInputWitnessUtxo(inputIndex);
+      if (!leafWitnessUtxo) {
         throw new LedgerSignPsbtProtocolError(`input ${inputIndex} is tapscript but has no witnessUtxo`);
       }
       const script = value.subarray(0, value.length - 1);
-      const leafHashHex = tapLeafHash(TAPSCRIPT_LEAF_VERSION, script).toString("hex");
+      const leafHash = tapLeafHash(TAPSCRIPT_LEAF_VERSION, script);
+      // BIP-371 keyData of a TAP_LEAF_SCRIPT entry IS the control block.
+      assertControlBlockCommitsToLeaf(inputIndex, leafEntries[0].keyData, leafHash, leafWitnessUtxo.scriptPubKey);
       byInput.set(inputIndex, {
         kind: "tapscript",
-        expectedLeafHashHexes: new Set([leafHashHex]),
+        expectedLeafHashHexes: new Set([leafHash.toString("hex")]),
         expectedSignerXOnlyHex: depositorXOnlyHex,
       });
       continue;
@@ -197,7 +291,7 @@ export function buildExpectedSignatureTable(params: BuildExpectedSignatureTableP
         throw new LedgerSignPsbtProtocolError(`input ${inputIndex} is keypath but has no witnessUtxo`);
       }
       const script = witnessUtxo.scriptPubKey;
-      if (script.length !== P2TR_SCRIPT_BYTES || !script.subarray(0, 2).equals(P2TR_SCRIPT_PREFIX)) {
+      if (!isP2trScript(script)) {
         throw new LedgerSignPsbtProtocolError(`input ${inputIndex} witnessUtxo script is not P2TR`);
       }
       // Pins "witness program" == "BIP-86 tweak of OUR key" independently.
@@ -208,14 +302,17 @@ export function buildExpectedSignatureTable(params: BuildExpectedSignatureTableP
       }
       byInput.set(inputIndex, {
         kind: "taproot-keypath",
-        expectedOutputKeyHex: script.subarray(2).toString("hex"),
+        expectedOutputKeyHex: script.subarray(P2TR_SCRIPT_PREFIX.length).toString("hex"),
       });
       continue;
     }
 
     // Not signed by the device (Payout input 1, NoPayout inputs 1-2 today).
     // Ownership scan: a depositor-owned UTXO here means our builder dropped
-    // the device-required metadata — fail before burning a ceremony.
+    // the device-required metadata — fail before burning a ceremony. Deliberately
+    // limited to these inputs: a Pre-PegIn keypath input legitimately IS the
+    // depositor's BIP-86 P2TR, and leaf semantics (including where the depositor
+    // key sits) are the device's job — the host's is the commitment asserted above.
     const witnessUtxo = psbt.getInputWitnessUtxo(inputIndex);
     if (
       witnessUtxo &&
@@ -262,12 +359,28 @@ function seenKeyOf(yielded: CollectedYield): string {
   return yielded.kind === "tapscript" ? `${yielded.inputIndex}:${yielded.leafHashHex}` : `${yielded.inputIndex}`;
 }
 
+/**
+ * A short tail is a malformed payload, not a claim about which key signed; only
+ * a longer one is the device appending a non-zero sighash byte
+ * (`base:sign_input.c:197-201` — reject, never strip).
+ */
+function assertSignatureLength(length: number, inputIndex: number): void {
+  if (length < SCHNORR_SIG_BYTES) {
+    throw new LedgerSignPsbtProtocolError(
+      `YIELD payload truncated inside the signature (${length} of ${SCHNORR_SIG_BYTES} bytes on input ${inputIndex})`,
+    );
+  }
+  if (length !== SCHNORR_SIG_BYTES) {
+    throw new LedgerYieldMismatchError("non-default-sighash", inputIndex);
+  }
+}
+
 export function createYieldCollector(table: ExpectedSignatureTable): YieldCollector {
   const yields: CollectedYield[] = [];
   const seen = new Set<string>();
 
   const assertAndRecord = (payload: Buffer): void => {
-    // Payload = request minus the 0x10 code byte, exactly base `sign_input.c:47-87`.
+    // Payload = request minus the 0x10 code byte, exactly `base:sign_input.c:47-87`.
     let inputIndex: number;
     let offset: number;
     try {
@@ -305,9 +418,7 @@ export function createYieldCollector(table: ExpectedSignatureTable): YieldCollec
       if (!expectation.expectedLeafHashHexes.has(leafHashHex)) {
         throw new LedgerYieldMismatchError("unknown-leaf-hash", inputIndex);
       }
-      if (signature.length !== SCHNORR_SIG_BYTES) {
-        throw new LedgerYieldMismatchError("non-default-sighash", inputIndex);
-      }
+      assertSignatureLength(signature.length, inputIndex);
       const recorded: CollectedYield = {
         kind: "tapscript",
         inputIndex,
@@ -336,9 +447,7 @@ export function createYieldCollector(table: ExpectedSignatureTable): YieldCollec
       if (outputKeyHex !== expectation.expectedOutputKeyHex) {
         throw new LedgerYieldMismatchError("wrong-signer-key", inputIndex);
       }
-      if (signature.length !== SCHNORR_SIG_BYTES) {
-        throw new LedgerYieldMismatchError("non-default-sighash", inputIndex);
-      }
+      assertSignatureLength(signature.length, inputIndex);
       const recorded: CollectedYield = {
         kind: "taproot-keypath",
         inputIndex,

--- a/packages/babylon-ledger-vault-signer/src/expectedSignatures.ts
+++ b/packages/babylon-ledger-vault-signer/src/expectedSignatures.ts
@@ -313,6 +313,8 @@ export function buildExpectedSignatureTable(params: BuildExpectedSignatureTableP
     // limited to these inputs: a Pre-PegIn keypath input legitimately IS the
     // depositor's BIP-86 P2TR, and leaf semantics (including where the depositor
     // key sits) are the device's job — the host's is the commitment asserted above.
+    // Recognises only P2TR/P2WPKH shapes of the connected key; P2SH-P2WPKH and
+    // P2PKH depositor UTXOs are deliberately out of scope (tripwire, not a guarantee).
     const witnessUtxo = psbt.getInputWitnessUtxo(inputIndex);
     if (
       witnessUtxo &&

--- a/packages/babylon-ledger-vault-signer/src/index.ts
+++ b/packages/babylon-ledger-vault-signer/src/index.ts
@@ -1,10 +1,11 @@
 /**
  * Host-side client for the Ledger Babylon Vault app: DMK session lifecycle,
  * raw APDU framing over the {@link ApduSender} seam, the silent key read,
- * the device envelope gate, and the DERIVE_CONTEXT_HASH / APPROVE_VAULT_INTENT
- * ceremony. Wallet-connector's LedgerVaultProvider is the consuming adapter;
- * this package holds everything device-protocol-shaped and nothing
- * wallet-taxonomy-shaped.
+ * the device envelope gate, the DERIVE_CONTEXT_HASH / APPROVE_VAULT_INTENT
+ * ceremony, and the SIGN_PSBT interrupt/continue signing loop
+ * ({@link signVaultPsbt}). Wallet-connector's LedgerVaultProvider is the
+ * consuming adapter; this package holds everything device-protocol-shaped and
+ * nothing wallet-taxonomy-shaped.
  *
  * @module ledger-vault-signer
  */
@@ -16,13 +17,26 @@ export { assertDepositTermsDeviceCompatible } from "./envelope";
 export {
   LEDGER_DEVICE_ERROR_NAME,
   LEDGER_DEVICE_LOCKED_ERROR_NAME,
+  LEDGER_SIGN_PSBT_ABORTED_ERROR_NAME,
+  LEDGER_SIGN_PSBT_INCOMPLETE_ERROR_NAME,
+  LEDGER_SIGN_PSBT_PROTOCOL_ERROR_NAME,
   LEDGER_USER_REFUSED_ERROR_NAME,
+  LEDGER_YIELD_MISMATCH_ERROR_NAME,
   LedgerDeviceError,
   LedgerDeviceLockedError,
+  LedgerSignPsbtAbortedError,
+  LedgerSignPsbtIncompleteError,
+  LedgerSignPsbtProtocolError,
   LedgerUserRefusedError,
+  LedgerYieldMismatchError,
   isLedgerDeviceError,
   isLedgerDeviceLockedError,
+  isLedgerSignPsbtAbortedError,
+  isLedgerSignPsbtIncompleteError,
+  isLedgerSignPsbtProtocolError,
   isLedgerUserRefusedError,
+  isLedgerYieldMismatchError,
+  type LedgerYieldMismatchKind,
 } from "./errors";
 export {
   encodeIntentGroup,
@@ -31,6 +45,14 @@ export {
   type IntentScalars,
   type IntentVaultGroup,
 } from "./intentTlv";
+export { type Apdu, type RawApduResponse, type RawApduSender } from "./rawApdu";
+export {
+  signVaultPsbt,
+  type CollectedYield,
+  type SignPsbtProgress,
+  type SignVaultPsbtParams,
+  type SignVaultPsbtResult,
+} from "./signPsbt";
 export {
   DEPOSIT_TERMS_REJECTED_ERROR_NAME,
   DepositTermsRejectedError,

--- a/packages/babylon-ledger-vault-signer/src/index.ts
+++ b/packages/babylon-ledger-vault-signer/src/index.ts
@@ -36,6 +36,7 @@ export {
   isLedgerSignPsbtProtocolError,
   isLedgerUserRefusedError,
   isLedgerYieldMismatchError,
+  type CollectedYieldRef,
   type LedgerYieldMismatchKind,
 } from "./errors";
 export {
@@ -45,7 +46,7 @@ export {
   type IntentScalars,
   type IntentVaultGroup,
 } from "./intentTlv";
-export { type Apdu, type RawApduResponse, type RawApduSender } from "./rawApdu";
+export { type Apdu, type AppIdentity, type RawApduResponse, type RawApduSender } from "./rawApdu";
 export {
   signVaultPsbt,
   type CollectedYield,

--- a/packages/babylon-ledger-vault-signer/src/rawApdu.ts
+++ b/packages/babylon-ledger-vault-signer/src/rawApdu.ts
@@ -12,6 +12,9 @@
  * terminal words are classified by the caller via {@link classifyStatusWord},
  * so raw-seam consumers and the throwing sender raise identical typed errors.
  *
+ * `base:` = LedgerHQ/app-bitcoin branch `baseapp` @ `e400d8d8`
+ * (`src/boilerplate/dispatcher.c`); the same path on `develop` differs.
+ *
  * @module ledger-vault-signer/rawApdu
  */
 
@@ -85,13 +88,21 @@ export function hex4(value: number): string {
   return value.toString(16).padStart(4, "0");
 }
 
-/** Request context woven into the error message (and the 0x6E00 app hint). */
-export interface StatusWordContext {
-  readonly ins: number;
-  readonly p1: number;
-  /** App name/version at connect time ("BOLOS" = dashboard). Diagnostic only. */
+/**
+ * App name/version captured at connect time ("BOLOS" = dashboard). Diagnostics
+ * only: it is woven into the 0x6E00 message and never gates control flow.
+ * Optional because the raw seam is an opaque function — a caller driving a bare
+ * transport (the Speculos e2e client) has nothing to report.
+ */
+export interface AppIdentity {
   readonly appName?: string;
   readonly appVersion?: string;
+}
+
+/** Request context woven into the error message (and the 0x6E00 app hint). */
+export interface StatusWordContext extends AppIdentity {
+  readonly ins: number;
+  readonly p1: number;
 }
 
 /**
@@ -128,4 +139,24 @@ export function classifyStatusWord(
     `${known ?? "The device rejected the request"} ` +
       `(ins 0x${hex2(context.ins)} p1 0x${hex2(context.p1)}, sw 0x${hex4(sw)})${appHint}`,
   );
+}
+
+/**
+ * Re-base a {@link RawApduSender} as the ceremony's throwing sender: data on
+ * 0x9000, the shared typed error otherwise. The single place that pairing is
+ * written — `createDmkApduSender` and the Speculos e2e client's sender both
+ * re-base on it, so a decline reads identically over either transport. The
+ * 0x6E00 app hint appears only when the caller supplies an identity (the
+ * Speculos client has none). Structural return type is `ApduSender`.
+ */
+export function createThrowingApduSender(
+  sendRaw: RawApduSender,
+  appIdentity?: AppIdentity,
+): (apdu: Apdu) => Promise<Uint8Array> {
+  return async (apdu) => {
+    const { sw, data } = await sendRaw(apdu);
+    const error = classifyStatusWord(sw, { ...appIdentity, ins: apdu.ins, p1: apdu.p1 });
+    if (error) throw error;
+    return data;
+  };
 }

--- a/packages/babylon-ledger-vault-signer/src/signPsbt.ts
+++ b/packages/babylon-ledger-vault-signer/src/signPsbt.ts
@@ -1,0 +1,92 @@
+/**
+ * Public SIGN_PSBT entry point (#2219): prepare → loop → merge.
+ *
+ * CRITICAL PATH (CLAUDE.md §7). `prepareSignPsbt` builds the expected-signature
+ * table and rejects before any device I/O; `runSignPsbtLoop` asserts every
+ * YIELD against the table and set-equal completion; `mergeYields` writes
+ * signature fields into the ORIGINAL v0 PSBT and never finalizes — the caller
+ * finalizes. No payload bytes are ever logged anywhere in the core (module
+ * contract inherited from `dmkApduSender.ts`).
+ *
+ * @module ledger-vault-signer/signPsbt
+ */
+
+import { LedgerSignPsbtProtocolError } from "./errors";
+import type { CollectedYield } from "./expectedSignatures";
+import type { RawApduSender } from "./rawApdu";
+import { runSignPsbtLoop, type SignPsbtProgress } from "./signPsbtLoop";
+import { mergeYields } from "./signPsbtMerge";
+import { prepareSignPsbt } from "./signPsbtPrepare";
+
+export type { CollectedYield } from "./expectedSignatures";
+export type { SignPsbtProgress } from "./signPsbtLoop";
+
+export interface SignVaultPsbtParams {
+  /** v0 PSBT hex from the SDK builders. */
+  readonly psbtHex: string;
+  /** Cached GET_EXTENDED_PUBKEY read (64 lowercase hex) — pins the table. */
+  readonly depositorXOnlyHex: string;
+  /**
+   * Fires after each accepted YIELD. Invocation is isolated: a throw inside
+   * the callback is swallowed — progress is display-only, and a caller bug
+   * must not abort a non-idempotent ceremony mid-loop.
+   */
+  readonly onProgress?: (progress: SignPsbtProgress) => void;
+  /**
+   * Host liveness control, checked before the initial send and before every
+   * CONTINUE. The loop has no round cap and no internal timeout (the abort
+   * signal is by design the only way to bound it) — production callers MUST
+   * always pass a signal; omit it only in tests with a scripted transport.
+   * The check runs between exchanges: an in-flight transport call that hangs
+   * is not itself cancelled, so a bounded transport remains the caller's job.
+   */
+  readonly signal?: AbortSignal;
+  /**
+   * Provider's `loopAbandoned` flag: resend the initial SIGN_PSBT APDU once
+   * if it answers 0x6A80 (the dispatcher eats exactly one non-CONTINUE APDU
+   * after a host-abandoned interruption). Never set on a first attempt.
+   */
+  readonly resendOnceOnIncorrectData?: boolean;
+}
+
+export interface SignVaultPsbtResult {
+  /**
+   * The original v0 PSBT plus signature fields (`tapScriptSig`/`tapKeySig`),
+   * unsigned tx byte-identical, NEVER finalized — the caller finalizes.
+   */
+  readonly signedPsbtHex: string;
+  /** The raw collected yields — the #2221 PoP seam (detached witness packaging). */
+  readonly yields: readonly CollectedYield[];
+}
+
+/**
+ * Sign a vault PSBT on the device: build the expected-signature table (zero
+ * device I/O on any rejection), drive the interrupt/continue loop with
+ * per-YIELD assertions, check set-equal completion, then merge the yields
+ * into the original PSBT. Throws the typed SIGN_PSBT errors from `errors.ts`.
+ *
+ * Production callers MUST pass `params.signal`: the loop is unbounded by
+ * design (no round cap, no internal timeout), so the abort signal is the only
+ * way to stop a device that never answers 0x9000. The signal is observed
+ * between exchanges — a transport call that itself hangs is not cancelled.
+ */
+export async function signVaultPsbt(send: RawApduSender, params: SignVaultPsbtParams): Promise<SignVaultPsbtResult> {
+  const prepared = prepareSignPsbt({ psbtHex: params.psbtHex, depositorXOnlyHex: params.depositorXOnlyHex });
+  // Completion (collector.assertComplete) runs inside the loop's completing state.
+  const yields = await runSignPsbtLoop(send, prepared, {
+    onProgress: params.onProgress,
+    signal: params.signal,
+    resendOnceOnIncorrectData: params.resendOnceOnIncorrectData,
+  });
+  let signedPsbtHex: string;
+  try {
+    signedPsbtHex = mergeYields(prepared.originalPsbtHex, yields);
+  } catch (error) {
+    // Post-ceremony merge failures stay inside the typed contract.
+    throw new LedgerSignPsbtProtocolError(
+      `merge failed after signing: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+  // Finding-3 hardening: detach from the collector's live backing array.
+  return { signedPsbtHex, yields: [...yields] };
+}

--- a/packages/babylon-ledger-vault-signer/src/signPsbt.ts
+++ b/packages/babylon-ledger-vault-signer/src/signPsbt.ts
@@ -11,9 +11,9 @@
  * @module ledger-vault-signer/signPsbt
  */
 
-import { LedgerSignPsbtProtocolError } from "./errors";
+import { LedgerSignPsbtProtocolError, toCollectedYieldRefs } from "./errors";
 import type { CollectedYield } from "./expectedSignatures";
-import type { RawApduSender } from "./rawApdu";
+import type { AppIdentity, RawApduSender } from "./rawApdu";
 import { runSignPsbtLoop, type SignPsbtProgress } from "./signPsbtLoop";
 import { mergeYields } from "./signPsbtMerge";
 import { prepareSignPsbt } from "./signPsbtPrepare";
@@ -34,13 +34,17 @@ export interface SignVaultPsbtParams {
   readonly onProgress?: (progress: SignPsbtProgress) => void;
   /**
    * Host liveness control, checked before the initial send and before every
-   * CONTINUE. The loop has no round cap and no internal timeout (the abort
-   * signal is by design the only way to bound it) — production callers MUST
-   * always pass a signal; omit it only in tests with a scripted transport.
-   * The check runs between exchanges: an in-flight transport call that hangs
-   * is not itself cancelled, so a bounded transport remains the caller's job.
+   * CONTINUE. Required: the loop has no round cap and no internal timeout, so
+   * the signal is by design the only way to bound it. The check runs between
+   * exchanges — an in-flight transport call that hangs is not itself
+   * cancelled, so a bounded transport remains the caller's job.
    */
-  readonly signal?: AbortSignal;
+  readonly signal: AbortSignal;
+  /**
+   * Connect-time app name/version, woven into terminal status-word
+   * diagnostics. Never gates control flow.
+   */
+  readonly appIdentity?: AppIdentity;
   /**
    * Provider's `loopAbandoned` flag: resend the initial SIGN_PSBT APDU once
    * if it answers 0x6A80 (the dispatcher eats exactly one non-CONTINUE APDU
@@ -65,10 +69,10 @@ export interface SignVaultPsbtResult {
  * per-YIELD assertions, check set-equal completion, then merge the yields
  * into the original PSBT. Throws the typed SIGN_PSBT errors from `errors.ts`.
  *
- * Production callers MUST pass `params.signal`: the loop is unbounded by
- * design (no round cap, no internal timeout), so the abort signal is the only
- * way to stop a device that never answers 0x9000. The signal is observed
- * between exchanges — a transport call that itself hangs is not cancelled.
+ * `params.signal` is required: the loop is unbounded by design (no round cap,
+ * no internal timeout), so the abort signal is the only way to stop a device
+ * that never answers 0x9000. It is observed between exchanges — a transport
+ * call that itself hangs is not cancelled.
  */
 export async function signVaultPsbt(send: RawApduSender, params: SignVaultPsbtParams): Promise<SignVaultPsbtResult> {
   const prepared = prepareSignPsbt({ psbtHex: params.psbtHex, depositorXOnlyHex: params.depositorXOnlyHex });
@@ -76,15 +80,18 @@ export async function signVaultPsbt(send: RawApduSender, params: SignVaultPsbtPa
   const yields = await runSignPsbtLoop(send, prepared, {
     onProgress: params.onProgress,
     signal: params.signal,
+    appIdentity: params.appIdentity,
     resendOnceOnIncorrectData: params.resendOnceOnIncorrectData,
   });
   let signedPsbtHex: string;
   try {
     signedPsbtHex = mergeYields(prepared.originalPsbtHex, yields);
   } catch (error) {
-    // Post-ceremony merge failures stay inside the typed contract.
+    // Post-ceremony merge failures stay inside the typed contract. The error
+    // names WHICH yields arrived, never their bytes (CLAUDE.md §7).
     throw new LedgerSignPsbtProtocolError(
       `merge failed after signing: ${error instanceof Error ? error.message : String(error)}`,
+      toCollectedYieldRefs(yields),
     );
   }
   // Finding-3 hardening: detach from the collector's live backing array.

--- a/packages/babylon-ledger-vault-signer/src/signPsbtLoop.ts
+++ b/packages/babylon-ledger-vault-signer/src/signPsbtLoop.ts
@@ -1,0 +1,143 @@
+/**
+ * SIGN_PSBT interrupt/continue state machine over the raw APDU seam (#2219).
+ *
+ * States per attempt: submitting → serving* → completing → done; exits
+ * failed/abandoned. Only 0xE000 continues the loop; every other status word is
+ * terminal and classifies through the shared `classifyStatusWord`. No round
+ * cap — the upstream client loops unbounded and the abort signal is the host's
+ * liveness control. No await sits inside a round other than the transport call
+ * (50-tick ≈ 5 s device deadline, `base:io_ext.h:28`).
+ *
+ * @module ledger-vault-signer/signPsbtLoop
+ */
+
+import { Buffer } from "buffer";
+
+import {
+  LedgerSignPsbtAbortedError,
+  LedgerSignPsbtProtocolError,
+  isLedgerSignPsbtProtocolError,
+  isLedgerYieldMismatchError,
+} from "./errors";
+import type { CollectedYield } from "./expectedSignatures";
+import { classifyStatusWord, type Apdu, type RawApduSender } from "./rawApdu";
+import { buildSignPsbtApdu, type PreparedSignPsbt } from "./signPsbtPrepare";
+
+/** Framework CLA / CONTINUE INS (`base:constants.h:15,20`). */
+const CLA_FRAMEWORK = 0xf8;
+const INS_CONTINUE = 0x01;
+const P1_CONTINUE = 0x00;
+const P2_CONTINUE = 0x00;
+
+const SW_OK = 0x9000;
+/** A client-command request follows in the response data (`base:sw.h:90`). */
+const SW_INTERRUPTED_EXECUTION = 0xe000;
+const SW_INCORRECT_DATA = 0x6a80;
+
+export interface SignPsbtProgress {
+  readonly inputIndex: number;
+  /** After this yield. */
+  readonly yieldedCount: number;
+  readonly expectedYieldCount: number;
+}
+
+export interface RunSignPsbtLoopOptions {
+  /**
+   * Invocation is isolated: a throw inside the callback is swallowed —
+   * progress is display-only, and a caller bug must not abort a
+   * non-idempotent ceremony mid-loop.
+   */
+  readonly onProgress?: (progress: SignPsbtProgress) => void;
+  /** Checked before the initial send and before every CONTINUE. */
+  readonly signal?: AbortSignal;
+  /**
+   * Provider's `loopAbandoned` flag: resend the initial SIGN_PSBT APDU once if
+   * it answers 0x6A80 — the dispatcher eats exactly one non-CONTINUE APDU
+   * after a host-abandoned interruption (`base:dispatcher.c:107-111`). A
+   * genuine validation 0x6A80 is indistinguishable on the wire, hence the
+   * explicit gate. Never applies to CONTINUEs; never more than one resend.
+   */
+  readonly resendOnceOnIncorrectData?: boolean;
+}
+
+/**
+ * Drive the device from the initial SIGN_PSBT APDU to 0x9000, serving client
+ * commands from the prepared interpreter; YIELD assertions fire inside
+ * `interpreter.execute` via the onYield seam. Returns the collector's yields
+ * after the completion check passes.
+ */
+export async function runSignPsbtLoop(
+  send: RawApduSender,
+  prepared: PreparedSignPsbt,
+  opts: RunSignPsbtLoopOptions,
+): Promise<readonly CollectedYield[]> {
+  const { collector, interpreter, table } = prepared;
+  if (opts.signal?.aborted) {
+    // Abandoned before any I/O.
+    throw new LedgerSignPsbtAbortedError();
+  }
+
+  const signPsbtApdu = buildSignPsbtApdu(prepared.cdata);
+  let lastSentApdu: Apdu = signPsbtApdu;
+  let response = await send(signPsbtApdu);
+  if (response.sw === SW_INCORRECT_DATA && opts.resendOnceOnIncorrectData === true) {
+    if (opts.signal?.aborted) {
+      // Abort raced the first exchange — do not issue the recovery resend.
+      throw new LedgerSignPsbtAbortedError();
+    }
+    // Resend the SAME APDU once; this branch is structurally unreachable a
+    // second time — any later 0x6A80 (including on the resend) is terminal.
+    response = await send(signPsbtApdu);
+  }
+
+  let reportedYields = 0;
+  while (response.sw === SW_INTERRUPTED_EXECUTION) {
+    let continueData: Buffer;
+    try {
+      continueData = interpreter.execute(Buffer.from(response.data));
+    } catch (error) {
+      // A mismatch or an unparseable YIELD is already typed; anything else
+      // means the device asked for something outside the committed PSBT.
+      if (isLedgerYieldMismatchError(error) || isLedgerSignPsbtProtocolError(error)) {
+        throw error;
+      }
+      throw new LedgerSignPsbtProtocolError(
+        `client command failed: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+    if (collector.yields.length > reportedYields) {
+      reportedYields = collector.yields.length;
+      const lastYield = collector.lastYield;
+      if (lastYield !== undefined && opts.onProgress !== undefined) {
+        try {
+          opts.onProgress({
+            inputIndex: lastYield.inputIndex,
+            yieldedCount: reportedYields,
+            expectedYieldCount: table.expectedYieldCount,
+          });
+        } catch {
+          // Deliberately swallowed and unrecorded (no logging on this path):
+          // a display-callback bug must not halt the ceremony.
+        }
+      }
+    }
+    if (opts.signal?.aborted) {
+      // Stop sending — the CONTINUE for this round is never sent.
+      throw new LedgerSignPsbtAbortedError();
+    }
+    lastSentApdu = { cla: CLA_FRAMEWORK, ins: INS_CONTINUE, p1: P1_CONTINUE, p2: P2_CONTINUE, data: continueData };
+    response = await send(lastSentApdu);
+  }
+
+  if (response.sw !== SW_OK) {
+    const terminal = classifyStatusWord(response.sw, { ins: lastSentApdu.ins, p1: lastSentApdu.p1 });
+    // classifyStatusWord is undefined only for 0x9000, excluded above.
+    if (terminal === undefined) {
+      throw new LedgerSignPsbtProtocolError(`status word 0x${response.sw.toString(16)} escaped classification`);
+    }
+    throw terminal;
+  }
+
+  collector.assertComplete();
+  return collector.yields;
+}

--- a/packages/babylon-ledger-vault-signer/src/signPsbtLoop.ts
+++ b/packages/babylon-ledger-vault-signer/src/signPsbtLoop.ts
@@ -5,8 +5,14 @@
  * failed/abandoned. Only 0xE000 continues the loop; every other status word is
  * terminal and classifies through the shared `classifyStatusWord`. No round
  * cap — the upstream client loops unbounded and the abort signal is the host's
- * liveness control. No await sits inside a round other than the transport call
- * (50-tick ≈ 5 s device deadline, `base:io_ext.h:28`).
+ * liveness control, which is why the signal is a REQUIRED option rather than an
+ * opt-in. No await sits inside a round other than the transport call (50-tick
+ * ≈ 5 s device deadline, `base:io_ext.h:28`).
+ *
+ * `base:` = LedgerHQ/app-bitcoin branch `baseapp` @ `e400d8d8`:
+ * `io_ext.h`, `sw.h` and `dispatcher.c` live under `src/boilerplate/`,
+ * `constants.h` under `src/`. The pin is load-bearing — the same paths on
+ * `develop` describe different behaviour.
  *
  * @module ledger-vault-signer/signPsbtLoop
  */
@@ -18,9 +24,10 @@ import {
   LedgerSignPsbtProtocolError,
   isLedgerSignPsbtProtocolError,
   isLedgerYieldMismatchError,
+  toCollectedYieldRefs,
 } from "./errors";
 import type { CollectedYield } from "./expectedSignatures";
-import { classifyStatusWord, type Apdu, type RawApduSender } from "./rawApdu";
+import { classifyStatusWord, type Apdu, type AppIdentity, type RawApduSender } from "./rawApdu";
 import { buildSignPsbtApdu, type PreparedSignPsbt } from "./signPsbtPrepare";
 
 /** Framework CLA / CONTINUE INS (`base:constants.h:15,20`). */
@@ -48,8 +55,19 @@ export interface RunSignPsbtLoopOptions {
    * non-idempotent ceremony mid-loop.
    */
   readonly onProgress?: (progress: SignPsbtProgress) => void;
-  /** Checked before the initial send and before every CONTINUE. */
-  readonly signal?: AbortSignal;
+  /**
+   * Required, checked before the initial send and before every CONTINUE. The
+   * loop has no round cap and no internal timeout, so this is the only thing
+   * that bounds it — a device that keeps answering 0xE000 would otherwise spin
+   * forever. Observed between exchanges: an in-flight transport call that hangs
+   * is not itself cancelled, so a bounded transport remains the caller's job.
+   */
+  readonly signal: AbortSignal;
+  /**
+   * Connect-time app name/version, woven into terminal status-word
+   * diagnostics. Never gates control flow.
+   */
+  readonly appIdentity?: AppIdentity;
   /**
    * Provider's `loopAbandoned` flag: resend the initial SIGN_PSBT APDU once if
    * it answers 0x6A80 — the dispatcher eats exactly one non-CONTINUE APDU
@@ -72,18 +90,18 @@ export async function runSignPsbtLoop(
   opts: RunSignPsbtLoopOptions,
 ): Promise<readonly CollectedYield[]> {
   const { collector, interpreter, table } = prepared;
-  if (opts.signal?.aborted) {
+  if (opts.signal.aborted) {
     // Abandoned before any I/O.
-    throw new LedgerSignPsbtAbortedError();
+    throw new LedgerSignPsbtAbortedError(collector.yields.length);
   }
 
   const signPsbtApdu = buildSignPsbtApdu(prepared.cdata);
   let lastSentApdu: Apdu = signPsbtApdu;
   let response = await send(signPsbtApdu);
   if (response.sw === SW_INCORRECT_DATA && opts.resendOnceOnIncorrectData === true) {
-    if (opts.signal?.aborted) {
+    if (opts.signal.aborted) {
       // Abort raced the first exchange — do not issue the recovery resend.
-      throw new LedgerSignPsbtAbortedError();
+      throw new LedgerSignPsbtAbortedError(collector.yields.length);
     }
     // Resend the SAME APDU once; this branch is structurally unreachable a
     // second time — any later 0x6A80 (including on the resend) is terminal.
@@ -96,13 +114,19 @@ export async function runSignPsbtLoop(
     try {
       continueData = interpreter.execute(Buffer.from(response.data));
     } catch (error) {
-      // A mismatch or an unparseable YIELD is already typed; anything else
-      // means the device asked for something outside the committed PSBT.
-      if (isLedgerYieldMismatchError(error) || isLedgerSignPsbtProtocolError(error)) {
+      if (isLedgerYieldMismatchError(error)) {
         throw error;
       }
+      // An unparseable YIELD is already typed but is raised inside the parser,
+      // which cannot see the yields accepted so far — re-raise carrying them.
+      // Re-raising the DETAIL (not the message) keeps the wrap single.
+      if (isLedgerSignPsbtProtocolError(error)) {
+        throw new LedgerSignPsbtProtocolError(error.detail, toCollectedYieldRefs(collector.yields));
+      }
+      // Anything else means the device asked for something outside the committed PSBT.
       throw new LedgerSignPsbtProtocolError(
         `client command failed: ${error instanceof Error ? error.message : String(error)}`,
+        toCollectedYieldRefs(collector.yields),
       );
     }
     if (collector.yields.length > reportedYields) {
@@ -121,19 +145,26 @@ export async function runSignPsbtLoop(
         }
       }
     }
-    if (opts.signal?.aborted) {
+    if (opts.signal.aborted) {
       // Stop sending — the CONTINUE for this round is never sent.
-      throw new LedgerSignPsbtAbortedError();
+      throw new LedgerSignPsbtAbortedError(collector.yields.length);
     }
     lastSentApdu = { cla: CLA_FRAMEWORK, ins: INS_CONTINUE, p1: P1_CONTINUE, p2: P2_CONTINUE, data: continueData };
     response = await send(lastSentApdu);
   }
 
   if (response.sw !== SW_OK) {
-    const terminal = classifyStatusWord(response.sw, { ins: lastSentApdu.ins, p1: lastSentApdu.p1 });
+    const terminal = classifyStatusWord(response.sw, {
+      ...opts.appIdentity,
+      ins: lastSentApdu.ins,
+      p1: lastSentApdu.p1,
+    });
     // classifyStatusWord is undefined only for 0x9000, excluded above.
     if (terminal === undefined) {
-      throw new LedgerSignPsbtProtocolError(`status word 0x${response.sw.toString(16)} escaped classification`);
+      throw new LedgerSignPsbtProtocolError(
+        `status word 0x${response.sw.toString(16)} escaped classification`,
+        toCollectedYieldRefs(collector.yields),
+      );
     }
     throw terminal;
   }

--- a/packages/babylon-ledger-vault-signer/src/signPsbtMerge.ts
+++ b/packages/babylon-ledger-vault-signer/src/signPsbtMerge.ts
@@ -1,0 +1,46 @@
+/**
+ * Fold collected SIGN_PSBT yields into the ORIGINAL v0 PSBT (#2219).
+ *
+ * CRITICAL PATH (CLAUDE.md §7): signature fields only — the unsigned tx is
+ * never rewritten, and this package NEVER finalizes. The SDK's far-side checks
+ * (`assertPsbtUnsignedTxMatches`, signature extraction,
+ * `assertScriptPathSchnorrSignature`) run unchanged on the returned hex, and
+ * `peginInput.ts` rejects finalized PSBTs outright. bip174's converters give a
+ * free integrity backstop: a duplicate (pubkey, leafHash) tapScriptSig or a
+ * pre-existing tapKeySig throws instead of being silently overwritten
+ * (verified in `bip174@2.1.1` `converter/input/tapScriptSig.js:52-63`,
+ * `tapKeySig.js:32-35`).
+ *
+ * @module ledger-vault-signer/signPsbtMerge
+ */
+
+import { Psbt } from "bitcoinjs-lib";
+import { Buffer } from "buffer";
+
+import type { CollectedYield } from "./expectedSignatures";
+
+/**
+ * Write each yield into the PSBT it was collected for: tapscript →
+ * `tapScriptSig[{ pubkey, leafHash, signature }]`, keypath → `tapKeySig`.
+ * Kind-driven — no per-flow switch. Completion is asserted by the collector
+ * BEFORE this is called; the caller finalizes, never this function.
+ */
+export function mergeYields(originalPsbtHex: string, yields: readonly CollectedYield[]): string {
+  const psbt = Psbt.fromHex(originalPsbtHex);
+  for (const yielded of yields) {
+    if (yielded.kind === "tapscript") {
+      psbt.updateInput(yielded.inputIndex, {
+        tapScriptSig: [
+          {
+            pubkey: Buffer.from(yielded.signerXOnlyHex, "hex"),
+            leafHash: Buffer.from(yielded.leafHashHex, "hex"),
+            signature: Buffer.from(yielded.signature),
+          },
+        ],
+      });
+    } else {
+      psbt.updateInput(yielded.inputIndex, { tapKeySig: Buffer.from(yielded.signature) });
+    }
+  }
+  return psbt.toHex();
+}

--- a/packages/babylon-ledger-vault-signer/src/signPsbtPrepare.ts
+++ b/packages/babylon-ledger-vault-signer/src/signPsbtPrepare.ts
@@ -7,6 +7,10 @@
  * a round may wait on anything but the transport. Any throw here means zero
  * device I/O.
  *
+ * Every `base:` citation resolves at `LedgerHQ/app-bitcoin` branch `baseapp`
+ * @ `e400d8d8`, the `bitcoin_app_base` rev `app-babylon-vault` pins — earlier
+ * revs of that branch differ (`has_no_wallet_policy` is absent at `132d911`).
+ *
  * @module ledger-vault-signer/signPsbtPrepare
  */
 
@@ -39,27 +43,33 @@ const P2_PROTOCOL_V1 = 0x01;
 
 /** `wallet_id` and `wallet_hmac` are each 32 bytes (`base:init_global_state.c:63-114`). */
 const WALLET_FIELD_BYTES = 32;
+/**
+ * No-policy mode: an all-zero `wallet_id` routes into the vault validators
+ * (`has_no_wallet_policy`, `base:init_global_state.c:192-198`), which treat
+ * every input/output as external — nothing is marked internal because both
+ * preprocess passes return early on that flag (`base:preprocess_inputs.c:66-68`,
+ * `base:preprocess_outputs.c:54-56`). A non-zero id would make the device fetch a
+ * serialized policy this module never seeds — a mid-loop "unknown preimage".
+ */
+const NO_WALLET_POLICY_ID = new Uint8Array(WALLET_FIELD_BYTES);
+/**
+ * Derived apps have no registered policies, so all-zero is the only sendable
+ * hmac: a non-zero one is refused with SW_NOT_SUPPORTED
+ * (`base:init_global_state.c:184-187`), REGISTER_WALLET is a stub
+ * (`base:register_wallet.c:27-33`), and the app declares no SLIP-21 policy
+ * path (`base:Makefile:58-81`).
+ */
+const NO_WALLET_POLICY_HMAC = new Uint8Array(WALLET_FIELD_BYTES);
 
 const DEPOSITOR_X_ONLY_HEX_RE = /^[0-9a-f]{64}$/;
 const PSBT_HEX_RE = /^(?:[0-9a-fA-F]{2})+$/;
-
-/**
- * #2221/#2222 seam. Both fields default to 32 zero bytes: all-zero `wallet_id`
- * routes into the vault validators (`has_no_wallet_policy`,
- * `base:init_global_state.c:192-198`), and a non-zero `wallet_hmac` is
- * `SW_NOT_SUPPORTED` — B1 hard-zeroes both.
- */
-export interface SignPsbtHeaderOptions {
-  readonly walletId?: Uint8Array;
-  readonly walletHmac?: Uint8Array;
-}
 
 /**
  * The commitment surface of the vendored `MerkelizedPsbt` the header builder
  * consumes — structural, so no vendored symbol reaches the emitted
  * declarations (vendor d.ts is excluded from dist; see `vite.config.ts`).
  */
-export interface SignPsbtCommitments {
+interface SignPsbtCommitments {
   readonly inputMapCommitments: readonly Buffer[];
   readonly outputMapCommitments: readonly Buffer[];
   getGlobalKeysValuesRoot(): Buffer;
@@ -83,14 +93,7 @@ export interface SignPsbtInterpreter {
  * outputsRoot(32) ‖ walletId(32) ‖ walletHmac(32)`.
  * Built from parts — never assert a fixed length (varints grow past 252).
  */
-export function buildSignPsbtCdata(merkelized: SignPsbtCommitments, options?: SignPsbtHeaderOptions): Uint8Array {
-  const walletId = options?.walletId ?? new Uint8Array(WALLET_FIELD_BYTES);
-  const walletHmac = options?.walletHmac ?? new Uint8Array(WALLET_FIELD_BYTES);
-  if (walletId.length !== WALLET_FIELD_BYTES || walletHmac.length !== WALLET_FIELD_BYTES) {
-    throw new LedgerSignPsbtProtocolError(
-      `walletId and walletHmac must be ${WALLET_FIELD_BYTES} bytes (got ${walletId.length}/${walletHmac.length})`,
-    );
-  }
+function buildSignPsbtCdata(merkelized: SignPsbtCommitments): Uint8Array {
   // Outer trees hash each per-map COMMITMENT as a 0x00-prefixed leaf
   // (`js:appClient.ts:317-325`; consumed at `base:get_merkleized_map.c:20-39`).
   const inputsRoot = new Merkle(merkelized.inputMapCommitments.map((commitment) => hashLeaf(commitment))).getRoot();
@@ -102,8 +105,8 @@ export function buildSignPsbtCdata(merkelized: SignPsbtCommitments, options?: Si
       inputsRoot,
       createVarint(merkelized.getGlobalOutputCount()),
       outputsRoot,
-      Buffer.from(walletId),
-      Buffer.from(walletHmac),
+      Buffer.from(NO_WALLET_POLICY_ID),
+      Buffer.from(NO_WALLET_POLICY_HMAC),
     ]),
   );
 }
@@ -111,6 +114,38 @@ export function buildSignPsbtCdata(merkelized: SignPsbtCommitments, options?: Si
 /** The initial SIGN_PSBT APDU: `E1 04 00 01 ‖ cdata` (`js:appClient.ts:85-92`). */
 export function buildSignPsbtApdu(cdata: Uint8Array): Apdu {
   return { cla: CLA_APP, ins: INS_SIGN_PSBT, p1: P1_SIGN_PSBT, p2: P2_PROTOCOL_V1, data: cdata };
+}
+
+/**
+ * Reject an input already carrying a signature this round would collide with.
+ * bip174 refuses a duplicate (pubkey, leafHash) tapScriptSig and any second
+ * tapKeySig (`bip174@2.1.1` `converter/input/tapScriptSig.js:52-63`,
+ * `tapKeySig.js:32-35`) — but only at merge, long after the user approved on
+ * device. Retrying with an already-signed PSBT is the realistic trigger.
+ */
+function assertNoConflictingSignatures(mergeTarget: BitcoinjsPsbt, table: ExpectedSignatureTable): void {
+  for (const [inputIndex, expectation] of table.byInput) {
+    const input = mergeTarget.data.inputs[inputIndex];
+    if (expectation.kind === "tapscript") {
+      // Same (key, leaf) notion the table and bip174's dupe set both key on.
+      const conflicts = input.tapScriptSig?.some(
+        (existing) =>
+          existing.pubkey.toString("hex") === expectation.expectedSignerXOnlyHex &&
+          expectation.expectedLeafHashHexes.has(existing.leafHash.toString("hex")),
+      );
+      if (conflicts) {
+        throw new LedgerSignPsbtProtocolError(
+          `input ${inputIndex} already carries a tapScriptSig for a (key, leaf) we sign — pass an unsigned PSBT`,
+        );
+      }
+      continue;
+    }
+    if (input.tapKeySig) {
+      throw new LedgerSignPsbtProtocolError(
+        `input ${inputIndex} already carries a tapKeySig and this round signs its keypath — pass an unsigned PSBT`,
+      );
+    }
+  }
 }
 
 export interface PrepareSignPsbtParams {
@@ -134,8 +169,9 @@ export interface PreparedSignPsbt {
 
 /**
  * Deserialize → normalize v0→v2 → merkelize → expected-signature table →
- * seeded interpreter → cdata. Pure and synchronous; throws typed
- * `LedgerSignPsbtProtocolError` on every rejection, all before any device I/O.
+ * already-signed gate → seeded interpreter → cdata. Pure and synchronous;
+ * throws typed `LedgerSignPsbtProtocolError` on every rejection, all before any
+ * device I/O.
  */
 export function prepareSignPsbt(params: PrepareSignPsbtParams): PreparedSignPsbt {
   const { psbtHex, depositorXOnlyHex } = params;
@@ -150,8 +186,9 @@ export function prepareSignPsbt(params: PrepareSignPsbtParams): PreparedSignPsbt
   // The merge stage folds signatures back via bitcoinjs Psbt — assert
   // parseability BEFORE any device I/O so a PsbtV2-acceptable-but-
   // bitcoinjs-rejected PSBT cannot burn an approved intent and then fail.
+  let mergeTarget: BitcoinjsPsbt;
   try {
-    BitcoinjsPsbt.fromHex(psbtHex);
+    mergeTarget = BitcoinjsPsbt.fromHex(psbtHex);
   } catch (error) {
     throw new LedgerSignPsbtProtocolError(
       `PSBT rejected at parse (merge target): ${error instanceof Error ? error.message : String(error)}`,
@@ -183,6 +220,7 @@ export function prepareSignPsbt(params: PrepareSignPsbtParams): PreparedSignPsbt
       `PSBT rejected at preflight: ${error instanceof Error ? error.message : String(error)}`,
     );
   }
+  assertNoConflictingSignatures(mergeTarget, table);
   const collector = createYieldCollector(table);
 
   // ONE yield mechanism: the onYield seam — the loop never parses YIELDs.

--- a/packages/babylon-ledger-vault-signer/src/signPsbtPrepare.ts
+++ b/packages/babylon-ledger-vault-signer/src/signPsbtPrepare.ts
@@ -116,6 +116,26 @@ export function buildSignPsbtApdu(cdata: Uint8Array): Apdu {
   return { cla: CLA_APP, ins: INS_SIGN_PSBT, p1: P1_SIGN_PSBT, p2: P2_PROTOCOL_V1, data: cdata };
 }
 
+/** BIP-341 SIGHASH_DEFAULT (0x00) — the only type any vault flow signs (wire spec §5). */
+const SIGHASH_DEFAULT = 0;
+
+/**
+ * An explicit non-default PSBT_IN_SIGHASH_TYPE on an input this round signs
+ * would make the device sign it and append the sighash byte
+ * (`base:sign_input.c:197-201`) — the 65-byte yield then dies at the
+ * collector's length check AFTER the user approved. Reject before any I/O.
+ */
+function assertDefaultSighashTypes(mergeTarget: BitcoinjsPsbt, table: ExpectedSignatureTable): void {
+  for (const [inputIndex] of table.byInput) {
+    const sighashType = mergeTarget.data.inputs[inputIndex].sighashType;
+    if (sighashType !== undefined && sighashType !== SIGHASH_DEFAULT) {
+      throw new LedgerSignPsbtProtocolError(
+        `input ${inputIndex} requests sighash type ${sighashType}, but vault flows sign SIGHASH_DEFAULT only`,
+      );
+    }
+  }
+}
+
 /**
  * Reject an input already carrying a signature this round would collide with.
  * bip174 refuses a duplicate (pubkey, leafHash) tapScriptSig and any second
@@ -232,6 +252,7 @@ export function prepareSignPsbt(params: PrepareSignPsbtParams): PreparedSignPsbt
     );
   }
   assertNoConflictingSignatures(mergeTarget, table);
+  assertDefaultSighashTypes(mergeTarget, table);
   const collector = createYieldCollector(table);
 
   // ONE yield mechanism: the onYield seam — the loop never parses YIELDs.

--- a/packages/babylon-ledger-vault-signer/src/signPsbtPrepare.ts
+++ b/packages/babylon-ledger-vault-signer/src/signPsbtPrepare.ts
@@ -1,0 +1,209 @@
+/**
+ * SIGN_PSBT synchronous data-prep pipeline (#2219 B1-c).
+ *
+ * Everything is computed before the first APDU: after prepare, each loop round
+ * is Map/Set lookups plus vendored interpreter arithmetic only — the device
+ * arms a 50-tick (~5 s) continue deadline (`base:io_ext.h:28`), so nothing in
+ * a round may wait on anything but the transport. Any throw here means zero
+ * device I/O.
+ *
+ * @module ledger-vault-signer/signPsbtPrepare
+ */
+
+import { Psbt as BitcoinjsPsbt } from "bitcoinjs-lib";
+import { Buffer } from "buffer";
+
+import { LedgerSignPsbtProtocolError } from "./errors";
+import {
+  buildExpectedSignatureTable,
+  createYieldCollector,
+  type ExpectedSignatureTable,
+  type YieldCollector,
+} from "./expectedSignatures";
+import type { Apdu } from "./rawApdu";
+import { CLA_APP } from "./vaultCommands";
+import { ClientCommandInterpreter } from "./vendor/ledger-bitcoin/clientCommands";
+import { MerkelizedPsbt } from "./vendor/ledger-bitcoin/merkelizedPsbt";
+import { hashLeaf, Merkle } from "./vendor/ledger-bitcoin/merkle";
+import { PsbtV2 } from "./vendor/ledger-bitcoin/psbtv2";
+import { createVarint } from "./vendor/ledger-bitcoin/varint";
+
+/** Base app SIGN_PSBT instruction (`base:commands.h`). */
+const INS_SIGN_PSBT = 0x04;
+const P1_SIGN_PSBT = 0x00;
+/**
+ * Protocol v1 (`base:constants.h:25`) — the YIELD augmented-pubkey block the
+ * collector asserts on exists only under v1 (`base:sign_input.c:68-76`).
+ */
+const P2_PROTOCOL_V1 = 0x01;
+
+/** `wallet_id` and `wallet_hmac` are each 32 bytes (`base:init_global_state.c:63-114`). */
+const WALLET_FIELD_BYTES = 32;
+
+const DEPOSITOR_X_ONLY_HEX_RE = /^[0-9a-f]{64}$/;
+const PSBT_HEX_RE = /^(?:[0-9a-fA-F]{2})+$/;
+
+/**
+ * #2221/#2222 seam. Both fields default to 32 zero bytes: all-zero `wallet_id`
+ * routes into the vault validators (`has_no_wallet_policy`,
+ * `base:init_global_state.c:192-198`), and a non-zero `wallet_hmac` is
+ * `SW_NOT_SUPPORTED` — B1 hard-zeroes both.
+ */
+export interface SignPsbtHeaderOptions {
+  readonly walletId?: Uint8Array;
+  readonly walletHmac?: Uint8Array;
+}
+
+/**
+ * The commitment surface of the vendored `MerkelizedPsbt` the header builder
+ * consumes — structural, so no vendored symbol reaches the emitted
+ * declarations (vendor d.ts is excluded from dist; see `vite.config.ts`).
+ */
+export interface SignPsbtCommitments {
+  readonly inputMapCommitments: readonly Buffer[];
+  readonly outputMapCommitments: readonly Buffer[];
+  getGlobalKeysValuesRoot(): Buffer;
+  getGlobalInputCount(): number;
+  getGlobalOutputCount(): number;
+}
+
+/**
+ * The one interpreter surface the loop drives (vendored
+ * `ClientCommandInterpreter`, typed structurally for the same reason as
+ * {@link SignPsbtCommitments}).
+ */
+export interface SignPsbtInterpreter {
+  execute(request: Buffer): Buffer;
+}
+
+/**
+ * SIGN_PSBT client data, parsed by the device in this exact order
+ * (`base:init_global_state.c:63-114`):
+ * `globalCommitment ‖ varint(nIn) ‖ inputsRoot(32) ‖ varint(nOut) ‖
+ * outputsRoot(32) ‖ walletId(32) ‖ walletHmac(32)`.
+ * Built from parts — never assert a fixed length (varints grow past 252).
+ */
+export function buildSignPsbtCdata(merkelized: SignPsbtCommitments, options?: SignPsbtHeaderOptions): Uint8Array {
+  const walletId = options?.walletId ?? new Uint8Array(WALLET_FIELD_BYTES);
+  const walletHmac = options?.walletHmac ?? new Uint8Array(WALLET_FIELD_BYTES);
+  if (walletId.length !== WALLET_FIELD_BYTES || walletHmac.length !== WALLET_FIELD_BYTES) {
+    throw new LedgerSignPsbtProtocolError(
+      `walletId and walletHmac must be ${WALLET_FIELD_BYTES} bytes (got ${walletId.length}/${walletHmac.length})`,
+    );
+  }
+  // Outer trees hash each per-map COMMITMENT as a 0x00-prefixed leaf
+  // (`js:appClient.ts:317-325`; consumed at `base:get_merkleized_map.c:20-39`).
+  const inputsRoot = new Merkle(merkelized.inputMapCommitments.map((commitment) => hashLeaf(commitment))).getRoot();
+  const outputsRoot = new Merkle(merkelized.outputMapCommitments.map((commitment) => hashLeaf(commitment))).getRoot();
+  return Uint8Array.from(
+    Buffer.concat([
+      merkelized.getGlobalKeysValuesRoot(),
+      createVarint(merkelized.getGlobalInputCount()),
+      inputsRoot,
+      createVarint(merkelized.getGlobalOutputCount()),
+      outputsRoot,
+      Buffer.from(walletId),
+      Buffer.from(walletHmac),
+    ]),
+  );
+}
+
+/** The initial SIGN_PSBT APDU: `E1 04 00 01 ‖ cdata` (`js:appClient.ts:85-92`). */
+export function buildSignPsbtApdu(cdata: Uint8Array): Apdu {
+  return { cla: CLA_APP, ins: INS_SIGN_PSBT, p1: P1_SIGN_PSBT, p2: P2_PROTOCOL_V1, data: cdata };
+}
+
+export interface PrepareSignPsbtParams {
+  /** v0 PSBT hex from the SDK builders. */
+  readonly psbtHex: string;
+  /** Cached GET_EXTENDED_PUBKEY read (64 lowercase hex) — pins the table. */
+  readonly depositorXOnlyHex: string;
+}
+
+export interface PreparedSignPsbt {
+  readonly cdata: Uint8Array;
+  /** Seeded; onYield wired to the collector. Discard on abort — never reuse. */
+  readonly interpreter: SignPsbtInterpreter;
+  /** Owns table + seen set + per-YIELD/completion assertions. */
+  readonly collector: YieldCollector;
+  /** The collector's table, exposed for tests and progress totals. */
+  readonly table: ExpectedSignatureTable;
+  /** Merge target — the v0 bytes, untouched. */
+  readonly originalPsbtHex: string;
+}
+
+/**
+ * Deserialize → normalize v0→v2 → merkelize → expected-signature table →
+ * seeded interpreter → cdata. Pure and synchronous; throws typed
+ * `LedgerSignPsbtProtocolError` on every rejection, all before any device I/O.
+ */
+export function prepareSignPsbt(params: PrepareSignPsbtParams): PreparedSignPsbt {
+  const { psbtHex, depositorXOnlyHex } = params;
+  if (!DEPOSITOR_X_ONLY_HEX_RE.test(depositorXOnlyHex)) {
+    throw new LedgerSignPsbtProtocolError("depositorXOnlyHex must be 64 lowercase hex characters");
+  }
+  // Buffer.from(hex) silently truncates at the first invalid character.
+  if (!PSBT_HEX_RE.test(psbtHex)) {
+    throw new LedgerSignPsbtProtocolError("psbtHex is not even-length hex");
+  }
+
+  // The merge stage folds signatures back via bitcoinjs Psbt — assert
+  // parseability BEFORE any device I/O so a PsbtV2-acceptable-but-
+  // bitcoinjs-rejected PSBT cannot burn an approved intent and then fail.
+  try {
+    BitcoinjsPsbt.fromHex(psbtHex);
+  } catch (error) {
+    throw new LedgerSignPsbtProtocolError(
+      `PSBT rejected at parse (merge target): ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  const psbt = new PsbtV2();
+  try {
+    // Parses the v0 unsigned tx for counts, then normalizeToV2 synthesizes the
+    // v2 fields and deletes UNSIGNED_TX; unknown keys (all taproot fields)
+    // pass through byte-identical (`psbtv2.ts` deserialize/normalizeToV2).
+    psbt.deserialize(Buffer.from(psbtHex, "hex"));
+  } catch (error) {
+    throw new LedgerSignPsbtProtocolError(
+      `PSBT rejected at parse: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+  let merkelized: MerkelizedPsbt;
+  let table: ExpectedSignatureTable;
+  try {
+    merkelized = new MerkelizedPsbt(psbt);
+    // Table from the SAME instance that was committed — no re-parse gap.
+    table = buildExpectedSignatureTable({ psbt: merkelized, depositorXOnlyHex });
+  } catch (error) {
+    // Totalize the typed contract: already-typed rejections pass through;
+    // anything else (vendored reader throws, bitcoinjs point math) is wrapped.
+    if (error instanceof LedgerSignPsbtProtocolError) throw error;
+    throw new LedgerSignPsbtProtocolError(
+      `PSBT rejected at preflight: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+  const collector = createYieldCollector(table);
+
+  // ONE yield mechanism: the onYield seam — the loop never parses YIELDs.
+  const interpreter = new ClientCommandInterpreter(undefined, (payload) => collector.assertAndRecord(payload));
+  // Reference composition: the stock client's signPsbt seeding. NO policy
+  // registration — B1 is no-policy mode only (wallet_id = 32×00).
+  interpreter.addKnownMapping(merkelized.globalMerkleMap);
+  for (const inputMap of merkelized.inputMerkleMaps) {
+    interpreter.addKnownMapping(inputMap);
+  }
+  for (const outputMap of merkelized.outputMerkleMaps) {
+    interpreter.addKnownMapping(outputMap);
+  }
+  interpreter.addKnownList(merkelized.inputMapCommitments);
+  interpreter.addKnownList(merkelized.outputMapCommitments);
+
+  return {
+    cdata: buildSignPsbtCdata(merkelized),
+    interpreter,
+    collector,
+    table,
+    originalPsbtHex: psbtHex,
+  };
+}

--- a/packages/babylon-ledger-vault-signer/src/signPsbtPrepare.ts
+++ b/packages/babylon-ledger-vault-signer/src/signPsbtPrepare.ts
@@ -126,6 +126,17 @@ export function buildSignPsbtApdu(cdata: Uint8Array): Apdu {
 function assertNoConflictingSignatures(mergeTarget: BitcoinjsPsbt, table: ExpectedSignatureTable): void {
   for (const [inputIndex, expectation] of table.byInput) {
     const input = mergeTarget.data.inputs[inputIndex];
+    // A finalized input is silently signable: bip174 has no finalized guard, so
+    // the merge writes the partial sig ALONGSIDE the final witness instead of
+    // throwing — and nothing downstream notices: extraction reads the merged
+    // tapScriptSig fine (`peginInput.ts:233-240`) and `finalizePeginInputPsbt`'s
+    // allFinalized fallback (`peginInput.ts:272-292`) then ships the STALE
+    // witness. Reject here, where a throw still costs zero device I/O.
+    if (input.finalScriptWitness || input.finalScriptSig) {
+      throw new LedgerSignPsbtProtocolError(
+        `input ${inputIndex} is already finalized and this round signs it — pass an unsigned PSBT`,
+      );
+    }
     if (expectation.kind === "tapscript") {
       // Same (key, leaf) notion the table and bip174's dupe set both key on.
       const conflicts = input.tapScriptSig?.some(

--- a/packages/babylon-ledger-vault-signer/src/tapLeafHash.ts
+++ b/packages/babylon-ledger-vault-signer/src/tapLeafHash.ts
@@ -1,0 +1,53 @@
+/**
+ * BIP-341 TapLeaf hash for the SIGN_PSBT expected-signature table (#2219).
+ *
+ * Standalone ~25-line copy of the ts-sdk reference
+ * (`verifyScriptPathSchnorrSignature.ts` `encodeCompactSize` +
+ * `computeTapLeafHash`) — this package must not depend on ts-sdk. The leaf
+ * version is an explicit parameter with no default, avoiding bip341's
+ * `leaf.version || LEAF_VERSION_TAPSCRIPT` falsy-zero footgun and the
+ * deep-import fragility. Gated against `bip341.tapleafHash` and the BIP-341
+ * wallet test vector in `__tests__/tapLeafHash.test.ts`.
+ *
+ * @module ledger-vault-signer/tapLeafHash
+ */
+
+import { crypto as bcrypto } from "bitcoinjs-lib";
+import { Buffer } from "buffer";
+
+// Bitcoin CompactSize (varint) prefix markers — values fixed by the protocol.
+// https://developer.bitcoin.org/reference/transactions.html#compactsize-unsigned-integers
+const COMPACT_SIZE_UINT16_PREFIX = 0xfd; // value in [0xfd, 0xffff] → 0xfd + uint16 LE
+const COMPACT_SIZE_UINT32_PREFIX = 0xfe; // value in [0x10000, 0xffffffff] → 0xfe + uint32 LE
+const COMPACT_SIZE_UINT16_MAX = 0xffff;
+const COMPACT_SIZE_UINT32_MAX = 0xffffffff;
+
+/**
+ * Encode a length as a Bitcoin CompactSize. WOTS leaf scripts exceed 252
+ * bytes, so the multi-byte forms are required, not just the 1-byte fast path.
+ */
+function encodeCompactSize(n: number): Buffer {
+  if (n < COMPACT_SIZE_UINT16_PREFIX) {
+    return Buffer.from([n]);
+  }
+  if (n <= COMPACT_SIZE_UINT16_MAX) {
+    const value = Buffer.alloc(2); // uint16, little-endian
+    value.writeUInt16LE(n);
+    return Buffer.concat([Buffer.from([COMPACT_SIZE_UINT16_PREFIX]), value]);
+  }
+  if (n <= COMPACT_SIZE_UINT32_MAX) {
+    const value = Buffer.alloc(4); // uint32, little-endian
+    value.writeUInt32LE(n);
+    return Buffer.concat([Buffer.from([COMPACT_SIZE_UINT32_PREFIX]), value]);
+  }
+  throw new Error(`Script too large to encode as CompactSize: ${n} bytes`);
+}
+
+/** BIP-341 tag for the TapLeaf hash. */
+const TAPLEAF_TAG = "TapLeaf";
+
+/** BIP-341: `tagged_hash("TapLeaf", leaf_version(1) ‖ compact_size(len(script)) ‖ script)`. */
+export function tapLeafHash(leafVersion: number, script: Uint8Array): Buffer {
+  const preimage = Buffer.concat([Buffer.from([leafVersion]), encodeCompactSize(script.length), Buffer.from(script)]);
+  return bcrypto.taggedHash(TAPLEAF_TAG, preimage);
+}

--- a/packages/babylon-ledger-vault-signer/src/vendor/ledger-bitcoin/README.md
+++ b/packages/babylon-ledger-vault-signer/src/vendor/ledger-bitcoin/README.md
@@ -96,13 +96,14 @@ until #2221/#2222 use it. `bitcoinjs-lib` and `buffer` remain vite externals.
   `0a9e9e14`. Provenance headers plus the golden-vector gates below are what
   makes that surface auditable — not its absence from the bundle.
 
-## Known upstream behaviour (kept): v0 round-trip is not bitcoinjs-canonical
+## Known upstream behaviour (kept): a deserialized v0 PSBT serializes as v2
 
-`PsbtV2.serialize()` on a deserialized-but-NOT-normalized v0 model re-emits
-bytes that `bitcoinjs-lib` rejects ("Only one UNSIGNED_TX allowed"). No
-production path serializes an un-normalized model (prepare always normalizes),
-and `prepareSignPsbt`'s merge-target parse gate rejects such input pre-I/O.
-Kept upstream-faithful.
+`deserialize()` always normalizes, so `serialize()` re-emits v2 bytes — v2
+globals, no `PSBT_GLOBAL_UNSIGNED_TX` — which `bitcoinjs-lib` 6.1.7 rejects
+("Only one UNSIGNED_TX allowed"). Production signs from the normalized v2
+model and `prepareSignPsbt`'s merge-target parse gate rejects incompatible
+input pre-I/O, so this only bites a test that round-trips a v0 fixture through
+the model. Kept upstream-faithful.
 
 ## Golden-vector gate
 

--- a/packages/babylon-ledger-vault-signer/src/vendor/ledger-bitcoin/README.md
+++ b/packages/babylon-ledger-vault-signer/src/vendor/ledger-bitcoin/README.md
@@ -18,12 +18,6 @@ v6-compatible source and gate it with golden vectors.
 - Each file's header records its upstream path, version, upstream sha256, and the
   exact modifications made (§4(b)).
 - **Known upstream behaviour (kept):**
-  - `parseVarint` accepts non-canonical (overlong) encodings — e.g. `fd0100`
-    decodes to `1` — with no minimality check, matching upstream and the Python
-    oracle. Resolved with `psbtv2`: it parses length varints through
-    `sanitizeBigintToNumber(readVarInt())` and re-serializes every map through
-    `createVarint` (`serializeMap`), so overlong lengths in a hostile PSBT are
-    re-emitted canonically — parse-accept, emit-canonical.
   - `policy.ts` `serialize()` writes the descriptor-template length in UTF-16
     code units but hashes its UTF-8 bytes; the Python oracle (`wallet.py:70`)
     counts UTF-8 for both, and encodes name/keys as UTF-8 where the JS uses
@@ -43,6 +37,52 @@ v6-compatible source and gate it with golden vectors.
 Everything else — protocol logic, byte layout, function surface — is verbatim,
 with the exceptions recorded per file header; the substantive ones:
 
+- `varint.ts`: **behaviour change** — `parseVarint` rejects non-minimal
+  (overlong) CompactSize encodings with a `RangeError`; upstream and the Python
+  oracle accept them (`fd0100` decodes to `1`). It joins the `psbtv2.ts` parse
+  gates (repeated keypair, trailing bytes — see that file's header) in
+  rejecting bytes upstream accepts. WHY: overlong lengths create a _parser
+  differential_ against `bitcoinjs-lib`'s bip174. bip174 advances its cursor by
+  the CANONICAL width
+  (`bip174@2.1.1 src/lib/parser/fromBuffer.js:10-11` —
+  `offset += varuint.encodingLength(keyLen)`) while `parseVarint` returns the
+  TRUE wire width, so the same bytes deserialize into two different keypair
+  sets. Take the crafted 13-byte keypair `01 fc fd0800 deadbeefcafe0000`: both
+  parsers read a 1-byte key of type `0xfc` and a value of length 8 — what
+  differs is where that value starts and where the map ends. bip174 advances
+  one byte past `fd0800` (`encodingLength(8) === 1`), takes `0800deadbeefcafe`
+  as the value, then reads the `00` at offset 11 as the map terminator;
+  `PsbtV2` advances the true 3, takes `deadbeefcafe0000`, consumes all 13 bytes
+  and is still inside the map. From there the two models sit at different
+  offsets, so every later keypair and map boundary can differ.
+  `prepareSignPsbt`'s merge target is a bitcoinjs `Psbt`, so a ceremony driven
+  by the `PsbtV2` model would run to completion and then merge into a target
+  parsed into a different keypair set, failing at `finalizeInput`. Fail-closed
+  for funds today (device commitment, on-device display and the
+  expected-signature table all derive from the SAME `PsbtV2`) and not
+  production-reachable — no production caller feeds attacker bytes — but it
+  makes "bip174 already validated these bytes" a bypassable mitigation, so the
+  differential is closed at the parser instead. Canonical encodings are
+  unaffected: `createVarint` only ever emits minimal forms, so every
+  serialize→parse path and every oracle-generated vector is untouched, and the
+  `psbtv2` parse-accept/emit-canonical round-trip now rejects rather than
+  normalizes. The device-fed parse sites are unaffected too — the firmware
+  writes both varints we parse through the SDK's `varint_write`, which sizes
+  via `varint_size` and so always picks the minimal width
+  (`LedgerHQ/ledger-secure-sdk` `lib_standard_app/varint.c` — `varint_size`
+  `:25-40`, `varint_write` `:79-104`; blob `fb199f91`, byte-identical on
+  `master@6862436` and on `API_LEVEL_25`/`26`/`27`). Both call sites live in the
+  base app pinned as `app-babylon-vault@develop`'s `bitcoin_app_base` submodule
+  (`LedgerHQ/app-bitcoin@baseapp`, commit `e400d8d8`): the
+  GET_MERKLE_LEAF_PROOF `tree_size`/`leaf_index` at
+  `src/handler/lib/get_merkle_leaf_hash.c:33-37` (parsed at
+  `clientCommands.ts:177-178`) and the YIELD input index at
+  `src/handler/sign_psbt/sign_input.c:62` (parsed by `parseVarint(payload, 0)`
+  in `expectedSignatures.ts`'s `createYieldCollector`). A device that emitted
+  an overlong form would now fail closed. Same rule Bitcoin Core enforces in
+  `ReadCompactSize`
+  (`bitcoin/bitcoin src/serialize.h:333-358`, blob `a1395c47` —
+  `"non-canonical ReadCompactSize()"`). Re-apply on any upstream re-diff.
 - `psbtv2.ts`: `fromBitcoinJS` is dropped — it throws on taproot inputs,
   exactly our case; the map-level `normalizeToV2` is the path we use.
 - `psbtv2.ts`: the `serializeMap` key comparator is unified from
@@ -66,6 +106,20 @@ with the exceptions recorded per file header; the substantive ones:
   `protected` with no generic public getter; the SIGN_PSBT expected-signature
   table reads per-input taproot entries through this accessor so the table is
   built from the exact map model the device Merkle-verifies.
+- `buffertools.ts`: **behaviour change** — `unsafeTo64bitLE` rejects any input
+  that is not a non-negative safe integer; upstream only capped values above
+  `MAX_SAFE_INTEGER`, so negatives two's-complement wrapped and `NaN` encoded
+  as zero — silent corruption for an amount field.
+- `merkelizedPsbt.ts`: **behaviour change** — symmetric map-count guards in the
+  constructor: the input/output map counts must equal the declared
+  `PSBT_GLOBAL_INPUT_COUNT` / `PSBT_GLOBAL_OUTPUT_COUNT` in BOTH directions.
+  Upstream `TypeError`s on missing maps and silently ignores surplus ones, and
+  `psbt.copy` already copied those surplus maps, so `serialize()` would emit
+  maps the commitment never covers. Valid PSBTs are unchanged.
+- `merkle.ts`: **behaviour change** — `getLeafHash` / `getProof` throw a typed
+  `Error("Index out of bounds")` on an invalid index instead of upstream's raw
+  `TypeError` (`getLeafHash` was unguarded; `getProof` guarded only
+  `index >= length`, not negatives); valid indices unchanged.
 
 Vendored so far: `varint.ts`, `merkle.ts`, `merkleMap.ts`, `buffertools.ts`,
 `psbtv2.ts`, `merkelizedPsbt.ts`, `clientCommands.ts`, `policy.ts` — the
@@ -77,9 +131,10 @@ From #2219 B1-d, `src/index.ts` → `signPsbt.ts` reaches this directory, so the
 vendored JavaScript is bundled into the published `dist/`. Verified against
 `dist/index.js.map`'s `sources` after a build: `varint`, `buffertools`,
 `psbtv2`, `merkle`, `merkleMap`, `merkelizedPsbt`, `clientCommands` are inlined
-(1,643 of the 1,735 vendored lines); `policy.ts` is reachable only through a
-type position (`addKnownWalletPolicy`'s parameter) and stays tree-shaken out
-until #2221/#2222 use it. `bitcoinjs-lib` and `buffer` remain vite externals.
+(1,690 of the 1,789 vendored lines — everything except `policy.ts`'s 99);
+`policy.ts` is reachable only through a type position
+(`addKnownWalletPolicy`'s parameter) and stays tree-shaken out until
+#2221/#2222 use it. `bitcoinjs-lib` and `buffer` remain vite externals.
 
 - **Attribution** lives in `THIRD-PARTY-NOTICES.md`, shipped via package.json
   `files`. `esbuild.legalComments: "none"` strips the per-file Apache-2.0
@@ -92,7 +147,7 @@ until #2221/#2222 use it. `bitcoinjs-lib` and `buffer` remain vite externals.
   declarations before write. **Review check on every public-API change: never
   re-export a vendored type** (`PsbtV2`, `PartialSignature`,
   `ClientCommandInterpreter`, …) — return a first-party shape instead.
-- The audit surface is therefore ~1.7 kLOC of Apache-2.0 source pinned at
+- The audit surface is therefore ~1.8 kLOC of Apache-2.0 source pinned at
   `0a9e9e14`. Provenance headers plus the golden-vector gates below are what
   makes that surface auditable — not its absence from the bundle.
 

--- a/packages/babylon-ledger-vault-signer/src/vendor/ledger-bitcoin/README.md
+++ b/packages/babylon-ledger-vault-signer/src/vendor/ledger-bitcoin/README.md
@@ -34,6 +34,13 @@ v6-compatible source and gate it with golden vectors.
 - Strict-null / strict-index fixes for this repo's strict `tsconfig`.
 - Prettier/quote formatting to the package style.
 
+The repo's general code-style guidance (naming magic numbers, extracting
+constants) yields to upstream fidelity inside this directory: a cosmetic rename
+turns a line that currently diffs clean into a hand-merge obligation on the next
+re-diff, for no behavioural gain. Name a literal here only when its
+justification lives off-file — the protocol caps in `clientCommands.ts` are
+named so each can carry a firmware citation, which a bare number could not.
+
 Everything else — protocol logic, byte layout, function surface — is verbatim,
 with the exceptions recorded per file header; the substantive ones:
 

--- a/packages/babylon-ledger-vault-signer/src/vendor/ledger-bitcoin/README.md
+++ b/packages/babylon-ledger-vault-signer/src/vendor/ledger-bitcoin/README.md
@@ -58,22 +58,51 @@ with the exceptions recorded per file header; the substantive ones:
   flows yield once per input). Discard the interpreter on abort; a retry must
   seed a fresh one. The validator receives a copy, and the payload push itself
   stays raw (`subarray(1)`, no shape assumption).
+- `psbtv2.ts`: local addition — two `psbtIn` enum members the upstream enum
+  lacks (`TAP_LEAF_SCRIPT = 0x15`, `TAP_INTERNAL_KEY = 0x17` — BIP-371, byte
+  values verified against base app `psbt.h:37-42`) plus a public
+  `getInputEntriesOfType(inputIndex, keyType)` reader returning Buffer copies
+  of every `{ keyData, value }` entry of one key type. `PsbtV2`'s maps are
+  `protected` with no generic public getter; the SIGN_PSBT expected-signature
+  table reads per-input taproot entries through this accessor so the table is
+  built from the exact map model the device Merkle-verifies.
 
 Vendored so far: `varint.ts`, `merkle.ts`, `merkleMap.ts`, `buffertools.ts`,
 `psbtv2.ts`, `merkelizedPsbt.ts`, `clientCommands.ts`, `policy.ts` — the
-full #2219 vendoring closure. These modules are referenced only by their
-golden-vector and unit tests, not by any production entrypoint (nothing
-reachable from `src/index.ts` imports them), so the bundler tree-shakes them
-out of the JS bundle and the vendor dir is excluded from declaration emission
-(see `vite.config.ts`) — the published `dist/` ships none of the vendored code
-(no JS, no `.d.ts`), and the `bitcoinjs-lib` / `buffer` deps they pull in stay
-out of the bundle, until the SIGN_PSBT task (#2219 B1-d) wires them in.
+full #2219 vendoring closure.
 
-### Planned local additions (not yet applied)
+## Audit boundary — the vendored JS ships
 
-- `psbtv2.ts` local addition `getInputEntriesOfType` (generic reader for the
-  expected-signature table) lands with its consumer, not before — zero dead
-  code.
+From #2219 B1-d, `src/index.ts` → `signPsbt.ts` reaches this directory, so the
+vendored JavaScript is bundled into the published `dist/`. Verified against
+`dist/index.js.map`'s `sources` after a build: `varint`, `buffertools`,
+`psbtv2`, `merkle`, `merkleMap`, `merkelizedPsbt`, `clientCommands` are inlined
+(1,643 of the 1,735 vendored lines); `policy.ts` is reachable only through a
+type position (`addKnownWalletPolicy`'s parameter) and stays tree-shaken out
+until #2221/#2222 use it. `bitcoinjs-lib` and `buffer` remain vite externals.
+
+- **Attribution** lives in `THIRD-PARTY-NOTICES.md`, shipped via package.json
+  `files`. `esbuild.legalComments: "none"` strips the per-file Apache-2.0
+  §4(b) provenance headers from the bundle — that trade-off is recorded in
+  `vite.config.ts`.
+- **No vendored declaration ships.** The first-party modules type every
+  vendored surface structurally (`ExpectedSignaturePsbt`,
+  `SignPsbtCommitments`, `SignPsbtInterpreter`), so no `dist/*.d.ts` references
+  `src/vendor`, and `vite.config.ts`'s `beforeWriteFile` drops vendor
+  declarations before write. **Review check on every public-API change: never
+  re-export a vendored type** (`PsbtV2`, `PartialSignature`,
+  `ClientCommandInterpreter`, …) — return a first-party shape instead.
+- The audit surface is therefore ~1.7 kLOC of Apache-2.0 source pinned at
+  `0a9e9e14`. Provenance headers plus the golden-vector gates below are what
+  makes that surface auditable — not its absence from the bundle.
+
+## Known upstream behaviour (kept): v0 round-trip is not bitcoinjs-canonical
+
+`PsbtV2.serialize()` on a deserialized-but-NOT-normalized v0 model re-emits
+bytes that `bitcoinjs-lib` rejects ("Only one UNSIGNED_TX allowed"). No
+production path serializes an un-normalized model (prepare always normalizes),
+and `prepareSignPsbt`'s merge-target parse gate rejects such input pre-I/O.
+Kept upstream-faithful.
 
 ## Golden-vector gate
 

--- a/packages/babylon-ledger-vault-signer/src/vendor/ledger-bitcoin/__tests__/psbtv2.golden.test.ts
+++ b/packages/babylon-ledger-vault-signer/src/vendor/ledger-bitcoin/__tests__/psbtv2.golden.test.ts
@@ -13,9 +13,9 @@
  * `sorted_key_order`.
  *
  * Raw `serialize()` bytes are compared to the oracle only via the `splitMaps`
- * round-trip (which parse-accepts overlong varints); canonical varint emission
- * is separately closed by the shared `createVarint` encoder + `varint.json`
- * goldens + the two ported upstream round-trips that DO pin raw bytes.
+ * round-trip; canonical varint emission is separately closed by the shared
+ * `createVarint` encoder + `varint.json` goldens + the two ported upstream
+ * round-trips that DO pin raw bytes.
  */
 
 import { Buffer } from "buffer";

--- a/packages/babylon-ledger-vault-signer/src/vendor/ledger-bitcoin/psbtv2.ts
+++ b/packages/babylon-ledger-vault-signer/src/vendor/ledger-bitcoin/psbtv2.ts
@@ -26,7 +26,12 @@
  *                  silently last-wins); `deserialize` rejects trailing bytes
  *                  after the last output map (upstream silently dropped them);
  *                  defensive strict-null guards (behaviour-preserving);
- *                  `==` → `===`; `slice` → `subarray`; formatting.
+ *                  `==` → `===`; `slice` → `subarray`; formatting;
+ *                  LOCAL ADDITION: two `psbtIn` members the upstream enum
+ *                  lacks (`TAP_LEAF_SCRIPT = 0x15`, `TAP_INTERNAL_KEY = 0x17`
+ *                  — BIP-371, byte values verified against base app
+ *                  psbt.h:37-42) and a public `getInputEntriesOfType` reader,
+ *                  both for the vault SIGN_PSBT expected-signature table.
  */
 
 import { Transaction } from "bitcoinjs-lib";
@@ -59,7 +64,10 @@ export enum psbtIn {
   OUTPUT_INDEX = 0x0f,
   SEQUENCE = 0x10,
   TAP_KEY_SIG = 0x13,
+  // Local additions — BIP-371; byte values verified against base app psbt.h:37-42.
+  TAP_LEAF_SCRIPT = 0x15, // keydata = control block; value = script ‖ leaf_version(1B trailing)
   TAP_BIP32_DERIVATION = 0x16,
+  TAP_INTERNAL_KEY = 0x17, // keydata = ∅; value = 32B x-only internal key
 }
 export enum psbtOut {
   REDEEM_SCRIPT = 0x00,
@@ -256,6 +264,23 @@ export class PsbtV2 {
   }
   getInputKeyDatas(inputIndex: number, keyType: KeyType): readonly Buffer[] {
     return this.getKeyDatas(this.inputMaps[inputIndex], keyType);
+  }
+  /** LOCAL ADDITION (vault expected-signature table): all entries of one key type. */
+  getInputEntriesOfType(
+    inputIndex: number,
+    keyType: KeyType,
+  ): readonly { readonly keyData: Buffer; readonly value: Buffer }[] {
+    const map = this.inputMaps[inputIndex];
+    if (!map) {
+      throw new Error("No such map");
+    }
+    const entries: { readonly keyData: Buffer; readonly value: Buffer }[] = [];
+    map.forEach((value, key) => {
+      if (this.isKeyType(key, [keyType])) {
+        entries.push({ keyData: Buffer.from(key.substring(2), "hex"), value: Buffer.from(value) });
+      }
+    });
+    return entries;
   }
 
   setOutputRedeemScript(outputIndex: number, redeemScript: Buffer) {

--- a/packages/babylon-ledger-vault-signer/src/vendor/ledger-bitcoin/varint.ts
+++ b/packages/babylon-ledger-vault-signer/src/vendor/ledger-bitcoin/varint.ts
@@ -11,6 +11,10 @@
  *                  global — this package ships to the browser); defensive
  *                  strict-null guards (`const first = data[offset]` + explicit
  *                  `=== undefined` checks; behaviour-preserving); formatting.
+ *                  BEHAVIOUR CHANGE — `parseVarint` rejects non-minimal
+ *                  (overlong) CompactSize encodings, which upstream accepts;
+ *                  closes a parser differential against `bitcoinjs-lib`'s
+ *                  bip174. See ./README.md, `varint.ts` bullet.
  */
 
 import { Buffer } from "buffer";
@@ -71,6 +75,13 @@ function getVarintSize(value: number | bigint): 1 | 3 | 5 | 9 {
   else return 9;
 }
 
+// Smallest value each multi-byte CompactSize width may legally encode — the
+// `getVarintSize` width boundaries read backwards. Below its width's minimum a
+// value fits a shorter form, so the encoding is non-minimal.
+const MIN_VALUE_FOR_3_BYTE_VARINT = BigInt(0xfd);
+const MIN_VALUE_FOR_5_BYTE_VARINT = BigInt(0xffff) + BigInt(1);
+const MIN_VALUE_FOR_9_BYTE_VARINT = BigInt(0xffffffff) + BigInt(1);
+
 /**
  * Parses a Bitcoin-style variable length integer from a buffer, starting at the given `offset`. Returns a pair
  * containing the parsed `BigInt`, and its length in bytes from the buffer.
@@ -82,6 +93,7 @@ function getVarintSize(value: number | bigint): 1 | 3 | 5 | 9 {
  *
  * @throws `RangeError` if offset is negative.
  * @throws `Error` if the buffer's end is reached withut parsing being completed.
+ * @throws `RangeError` if the encoding is non-minimal (LOCAL DIVERGENCE — upstream accepts them).
  */
 export function parseVarint(data: Buffer, offset: number): readonly [bigint, number] {
   if (offset < 0) {
@@ -96,11 +108,34 @@ export function parseVarint(data: Buffer, offset: number): readonly [bigint, num
     return [BigInt(first), 1];
   } else {
     let size: number;
-    if (first === 0xfd) size = 2;
-    else if (first === 0xfe) size = 4;
-    else size = 8;
+    let minimum: bigint;
+    if (first === 0xfd) {
+      size = 2;
+      minimum = MIN_VALUE_FOR_3_BYTE_VARINT;
+    } else if (first === 0xfe) {
+      size = 4;
+      minimum = MIN_VALUE_FOR_5_BYTE_VARINT;
+    } else {
+      size = 8;
+      minimum = MIN_VALUE_FOR_9_BYTE_VARINT;
+    }
 
-    return [smallEndianToBigint(data, offset + 1, size), size + 1];
+    const value = smallEndianToBigint(data, offset + 1, size);
+
+    // LOCAL DIVERGENCE from upstream (behaviour change). An overlong length
+    // desynchronizes this parser from bip174, which advances by the CANONICAL
+    // width (bip174@2.1.1 src/lib/parser/fromBuffer.js:10-11 —
+    // `offset += varuint.encodingLength(keyLen)`) while we return the true wire
+    // width. Same rule as Bitcoin Core's ReadCompactSize (bitcoin/bitcoin
+    // src/serialize.h:333-358, blob a1395c47 — "non-canonical ReadCompactSize()").
+    if (value < minimum) {
+      throw RangeError(
+        `Non-minimal varint at offset ${offset}: a ${size + 1}-byte CompactSize must encode a ` +
+          `value of at least ${minimum}; re-encode it in its canonical (shorter) form`,
+      );
+    }
+
+    return [value, size + 1];
   }
 }
 

--- a/packages/babylon-ledger-vault-signer/vite.config.ts
+++ b/packages/babylon-ledger-vault-signer/vite.config.ts
@@ -2,6 +2,15 @@ import path from "node:path";
 import { defineConfig } from "vite";
 import dts from "vite-plugin-dts";
 
+const DIST_DIR = path.resolve(__dirname, "dist");
+
+// beforeWriteFile receives an ABSOLUTE destination path (vite-plugin-dts@4.5.4,
+// dist/index.mjs: `resolve(outDir, relative(entryRoot, filePath))`), so the test is
+// anchored to dist and matched per path segment. A bare substring match dropped every
+// declaration — including dist/index.d.ts — when the checkout itself lived under a
+// directory named "vendor", and the build still exited 0.
+const isVendorDeclaration = (filePath: string) => path.relative(DIST_DIR, filePath).split(/[\\/]/).includes("vendor");
+
 export default defineConfig({
   plugins: [
     dts({
@@ -14,7 +23,7 @@ export default defineConfig({
       exclude: ["src/**/__tests__/**"],
       // No vendored .d.ts ships: the first-party modules type the vendored
       // surfaces structurally, so no emitted declaration references src/vendor.
-      beforeWriteFile: (filePath) => (/[\\/]vendor[\\/]/.test(filePath) ? false : undefined),
+      beforeWriteFile: (filePath) => (isVendorDeclaration(filePath) ? false : undefined),
     }),
   ],
   build: {

--- a/packages/babylon-ledger-vault-signer/vite.config.ts
+++ b/packages/babylon-ledger-vault-signer/vite.config.ts
@@ -8,10 +8,13 @@ export default defineConfig({
       tsconfigPath: "./tsconfig.lib.json",
       insertTypesEntry: true,
       include: ["src"],
-      // Vendored SIGN_PSBT primitives are unreferenced by index.ts (test-only
-      // until #2219) — keep their declarations out of the published dist too,
-      // so nothing vendored ships until the code is actually wired in.
-      exclude: ["src/**/__tests__/**", "src/vendor/**"],
+      // Vendored files stay IN the declaration program (index.ts reaches them
+      // through signPsbt.ts; excluding them makes tsc report TS6307 on every
+      // vendor import), but their declarations are dropped before write.
+      exclude: ["src/**/__tests__/**"],
+      // No vendored .d.ts ships: the first-party modules type the vendored
+      // surfaces structurally, so no emitted declaration references src/vendor.
+      beforeWriteFile: (filePath) => (/[\\/]vendor[\\/]/.test(filePath) ? false : undefined),
     }),
   ],
   build: {
@@ -25,6 +28,7 @@ export default defineConfig({
     },
     rollupOptions: {
       external: [
+        "@bitcoin-js/tiny-secp256k1-asmjs",
         "@ledgerhq/device-management-kit",
         "@ledgerhq/device-transport-kit-web-hid",
         "@scure/bip32",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -293,6 +293,9 @@ importers:
 
   packages/babylon-ledger-vault-signer:
     dependencies:
+      '@bitcoin-js/tiny-secp256k1-asmjs':
+        specifier: 2.2.3
+        version: 2.2.3
       '@ledgerhq/device-management-kit':
         specifier: 1.7.1
         version: 1.7.1(bufferutil@4.0.9)(rxjs@7.8.2)(utf-8-validate@5.0.10)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -750,6 +750,9 @@ importers:
       bitcoinjs-lib:
         specifier: 6.1.7
         version: 6.1.7
+      buffer:
+        specifier: 6.0.3
+        version: 6.0.3
       core-js:
         specifier: 3.41.0
         version: 3.41.0

--- a/services/simple-staking/package.json
+++ b/services/simple-staking/package.json
@@ -40,6 +40,7 @@
     "@tanstack/react-query": "^5.74.4",
     "awilix": "12.0.5",
     "bitcoinjs-lib": "6.1.7",
+    "buffer": "6.0.3",
     "core-js": "3.41.0",
     "cosmjs-types": "^0.10.1",
     "date-fns": "3.6.0",

--- a/services/simple-staking/vite.config.ts
+++ b/services/simple-staking/vite.config.ts
@@ -59,7 +59,11 @@ export default defineConfig({
     tsconfigPaths({
       projects: [resolve(__dirname, "./tsconfig.lib.json")],
     }),
-    nodePolyfills({ include: ["buffer", "crypto"] }),
+    // "buffer" is deliberately not included (vault does the same): including it
+    // aliases every bare `buffer` import to a bare shim specifier, which cannot
+    // resolve from a workspace dependency's dist under pnpm. App code keeps the
+    // injected global Buffer; deps that import "buffer" resolve their own copy.
+    nodePolyfills({ include: ["crypto"] }),
     EnvironmentPlugin("all", { prefix: "NEXT_PUBLIC_" }),
     sentryVitePlugin({
       disable: !enableSentryPlugin,


### PR DESCRIPTION
The offline signing engine — merkleized-PSBT prepare, the 0xE000 interrupt loop, per-YIELD assertions with set-equal completeness, and bip174 merge — behind a public signVaultPsbt.

Gated by 22 firmware-fixture goldens and a byte-replay of 175 real-flow traces (+6 synthetic deep-tree) against Ledger's Python oracle. A Speculos E2E runs against real v0.9.5 firmware — derive → approve intent → SIGN_PSBT through our production encoders, with the yielded Schnorr signature verified against an independently computed BIP-341 sighash — but only when SPECULOS_URL is set; default runs skip it.
