### PR TITLE
feat(vault): wait 8 ETH confirmations before prepegin

### DIFF
--- a/packages/babylon-ts-sdk/docs/api/managers.md
+++ b/packages/babylon-ts-sdk/docs/api/managers.md
@@ -264,6 +264,14 @@ This method:
 5. Finalizes and extracts the transaction
 6. Broadcasts via mempool API
 
+IMPORTANT — this method does NOT gate on Ethereum finality. Committing
+BTC to the HTLC while the peg-in registration is still reorg-exposed can
+strand the deposit: the vault record disappears from the chain while the
+BTC stays locked until the HTLC refund timelock. Callers must await
+`waitForPeginRegistrationDepth` for the registered vault(s) before calling
+this. The gate is not applied here because the params carry no vault ID —
+adding one would be a breaking signature change.
+
 ###### Parameters
 
 ###### params

--- a/packages/babylon-ts-sdk/docs/api/services.md
+++ b/packages/babylon-ts-sdk/docs/api/services.md
@@ -3033,28 +3033,6 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginRegistra
 
 ***
 
-### isPeginRegistrationFinal()
-
-```ts
-function isPeginRegistrationFinal(params): boolean;
-```
-
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginRegistrationDepth.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginRegistrationDepth.ts)
-
-Whether a registration has reached the required confirmation depth.
-
-#### Parameters
-
-##### params
-
-[`RegistrationDepthParams`](#registrationdepthparams) & `object`
-
-#### Returns
-
-`boolean`
-
-***
-
 ### waitForPeginRegistrationDepth()
 
 ```ts

--- a/packages/babylon-ts-sdk/docs/api/services.md
+++ b/packages/babylon-ts-sdk/docs/api/services.md
@@ -7,6 +7,84 @@ Callers own the wallet; services own the orchestration.
 
 ## Classes
 
+### PeginRegistrationMissingError
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginRegistrationDepth.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginRegistrationDepth.ts)
+
+The vault is not registered on-chain at all. Thrown only on the FIRST poll,
+where it means the caller's premise was wrong rather than that a reorg took
+the registration away — retrying will not help.
+
+#### Extends
+
+- `Error`
+
+#### Constructors
+
+##### Constructor
+
+```ts
+new PeginRegistrationMissingError(message): PeginRegistrationMissingError;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginRegistrationDepth.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginRegistrationDepth.ts)
+
+###### Parameters
+
+###### message
+
+`string`
+
+###### Returns
+
+[`PeginRegistrationMissingError`](#peginregistrationmissingerror)
+
+###### Overrides
+
+```ts
+Error.constructor
+```
+
+***
+
+### PeginRegistrationNotFinalError
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginRegistrationDepth.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginRegistrationDepth.ts)
+
+The registration did not reach the required depth within the budget.
+
+#### Extends
+
+- `Error`
+
+#### Constructors
+
+##### Constructor
+
+```ts
+new PeginRegistrationNotFinalError(message): PeginRegistrationNotFinalError;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginRegistrationDepth.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginRegistrationDepth.ts)
+
+###### Parameters
+
+###### message
+
+`string`
+
+###### Returns
+
+[`PeginRegistrationNotFinalError`](#peginregistrationnotfinalerror)
+
+###### Overrides
+
+```ts
+Error.constructor
+```
+
+***
+
 ### ParticipantKeyDriftError
 
 Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegisteredParticipantKeys.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/verifyRegisteredParticipantKeys.ts)
@@ -551,6 +629,180 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/interfaces.ts
 ###### Returns
 
 `Promise`\<[`RequestDepositorClaimerArtifactsResponse`](clients.md#requestdepositorclaimerartifactsresponse)\>
+
+***
+
+### RegistrationDepthParams
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginRegistrationDepth.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginRegistrationDepth.ts)
+
+#### Properties
+
+##### currentBlock
+
+```ts
+currentBlock: bigint;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginRegistrationDepth.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginRegistrationDepth.ts)
+
+Current chain tip block number.
+
+##### createdAtBlock
+
+```ts
+createdAtBlock: bigint;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginRegistrationDepth.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginRegistrationDepth.ts)
+
+Block number the registration was mined at (`VaultBasicInfo.createdAt`).
+
+***
+
+### RegistrationDepthProgress
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginRegistrationDepth.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginRegistrationDepth.ts)
+
+#### Properties
+
+##### confirmations
+
+```ts
+confirmations: number;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginRegistrationDepth.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginRegistrationDepth.ts)
+
+Shallowest depth across every vault being waited on.
+
+##### required
+
+```ts
+required: number;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginRegistrationDepth.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginRegistrationDepth.ts)
+
+***
+
+### WaitForPeginRegistrationDepthParams
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginRegistrationDepth.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginRegistrationDepth.ts)
+
+#### Properties
+
+##### vaultRegistryReader
+
+```ts
+vaultRegistryReader: VaultRegistryReader;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginRegistrationDepth.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginRegistrationDepth.ts)
+
+##### getBlockNumber()
+
+```ts
+getBlockNumber: () => Promise<bigint>;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginRegistrationDepth.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginRegistrationDepth.ts)
+
+Chain-tip reader. A thunk rather than a `PublicClient` so this module has
+no viem-client dependency and stays testable with two plain fakes — the
+same shape `verifyRegisteredVaultVersions` uses for its reader.
+
+###### Returns
+
+`Promise`\<`bigint`\>
+
+##### vaultIds
+
+```ts
+vaultIds: readonly `0x${string}`[];
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginRegistrationDepth.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginRegistrationDepth.ts)
+
+Vaults registered by the same transaction; the shallowest one gates.
+
+##### required?
+
+```ts
+optional required: number;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginRegistrationDepth.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginRegistrationDepth.ts)
+
+##### pollIntervalMs?
+
+```ts
+optional pollIntervalMs: number;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginRegistrationDepth.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginRegistrationDepth.ts)
+
+##### timeoutMs?
+
+```ts
+optional timeoutMs: number;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginRegistrationDepth.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginRegistrationDepth.ts)
+
+##### signal?
+
+```ts
+optional signal: AbortSignal;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginRegistrationDepth.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginRegistrationDepth.ts)
+
+##### onProgress()?
+
+```ts
+optional onProgress: (progress) => void;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginRegistrationDepth.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginRegistrationDepth.ts)
+
+###### Parameters
+
+###### progress
+
+[`RegistrationDepthProgress`](#registrationdepthprogress)
+
+###### Returns
+
+`void`
+
+***
+
+### PeginRegistrationDepthResult
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginRegistrationDepth.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginRegistrationDepth.ts)
+
+#### Properties
+
+##### confirmations
+
+```ts
+confirmations: number;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginRegistrationDepth.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginRegistrationDepth.ts)
+
+##### basicInfo
+
+```ts
+basicInfo: VaultBasicInfo;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginRegistrationDepth.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginRegistrationDepth.ts)
+
+The final observation for the shallowest vault. Callers that gated on
+`status` before the wait should re-assert it against this — the wait can
+span minutes, and a vault can leave PENDING in that time.
 
 ***
 
@@ -2741,6 +2993,102 @@ whatever the injected `writeContract` throws
 
 ***
 
+### isPeginRegistrationMissingError()
+
+```ts
+function isPeginRegistrationMissingError(err): err is PeginRegistrationMissingError;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginRegistrationDepth.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginRegistrationDepth.ts)
+
+#### Parameters
+
+##### err
+
+`unknown`
+
+#### Returns
+
+`err is PeginRegistrationMissingError`
+
+***
+
+### isPeginRegistrationNotFinalError()
+
+```ts
+function isPeginRegistrationNotFinalError(err): err is PeginRegistrationNotFinalError;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginRegistrationDepth.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginRegistrationDepth.ts)
+
+#### Parameters
+
+##### err
+
+`unknown`
+
+#### Returns
+
+`err is PeginRegistrationNotFinalError`
+
+***
+
+### isPeginRegistrationFinal()
+
+```ts
+function isPeginRegistrationFinal(params): boolean;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginRegistrationDepth.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginRegistrationDepth.ts)
+
+Whether a registration has reached the required confirmation depth.
+
+#### Parameters
+
+##### params
+
+[`RegistrationDepthParams`](#registrationdepthparams) & `object`
+
+#### Returns
+
+`boolean`
+
+***
+
+### waitForPeginRegistrationDepth()
+
+```ts
+function waitForPeginRegistrationDepth(params): Promise<PeginRegistrationDepthResult>;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginRegistrationDepth.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginRegistrationDepth.ts)
+
+Poll until every vault's registration is at least `required` blocks deep.
+
+#### Parameters
+
+##### params
+
+[`WaitForPeginRegistrationDepthParams`](#waitforpeginregistrationdepthparams)
+
+#### Returns
+
+`Promise`\<[`PeginRegistrationDepthResult`](#peginregistrationdepthresult)\>
+
+#### Throws
+
+if no vault is registered on the first poll.
+
+#### Throws
+
+on timeout.
+
+#### Throws
+
+if aborted, or if the tip read fails on the first poll.
+
+***
+
 ### getPeginProtocolState()
 
 ```ts
@@ -3853,6 +4201,26 @@ PAYOUT_BLOCKED: "PayoutBlocked";
 Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/pegout/state.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/pegout/state.ts)
 
 ## Variables
+
+### PEGIN\_ETH\_CONFIRMATIONS
+
+```ts
+const PEGIN_ETH_CONFIRMATIONS: 8 = 8;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginRegistrationDepth.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginRegistrationDepth.ts)
+
+Ethereum block confirmations required before the Pre-PegIn BTC transaction
+may be broadcast.
+
+8 exceeds the deepest reorg ever observed on Ethereum (7, pre-merge, caused
+by a client bug), and costs ~1.6 min at 12s slots. Deliberately not the
+`safe` block tag: a full epoch (~12.8 min) was rejected as too slow for the
+benefit. This is a liveness guard against an orphaned registration, not a
+theft mitigation — every Pre-PegIn HTLC spend path requires the depositor's
+own BTC key regardless.
+
+***
 
 ### REFUND\_VSIZE
 

--- a/packages/babylon-ts-sdk/docs/api/services.md
+++ b/packages/babylon-ts-sdk/docs/api/services.md
@@ -11,9 +11,9 @@ Callers own the wallet; services own the orchestration.
 
 Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginRegistrationDepth.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginRegistrationDepth.ts)
 
-The vault is not registered on-chain at all. Thrown only on the FIRST poll,
-where it means the caller's premise was wrong rather than that a reorg took
-the registration away — retrying will not help.
+The vault is not registered on-chain, and stayed that way past the grace
+window — long enough that a lagging backend has been ruled out. Retrying
+will not help.
 
 #### Extends
 
@@ -3043,6 +3043,11 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginRegistra
 
 Poll until every vault's registration is at least `required` blocks deep.
 
+A read that comes back empty is treated as "not visible yet", not as
+"absent": both callers reach this having already proven the registration
+exists, so an empty read means a lagging RPC backend or a reorg, and both
+resolve on their own.
+
 #### Parameters
 
 ##### params
@@ -3055,7 +3060,7 @@ Poll until every vault's registration is at least `required` blocks deep.
 
 #### Throws
 
-if no vault is registered on the first poll.
+if no vault has ever been observed and the grace window is spent.
 
 #### Throws
 
@@ -3063,7 +3068,7 @@ on timeout.
 
 #### Throws
 
-if aborted, or if the tip read fails on the first poll.
+if aborted.
 
 ***
 

--- a/packages/babylon-ts-sdk/docs/api/utils.md
+++ b/packages/babylon-ts-sdk/docs/api/utils.md
@@ -230,6 +230,16 @@ optional confirmations: number;
 
 Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/eth/waitForTransactionReceiptSmartAware.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/eth/waitForTransactionReceiptSmartAware.ts)
 
+Forwarded to viem verbatim.
+
+MUST NOT be used as a finality/reorg gate. viem fetches the receipt once
+and then only compares block numbers against that cached copy — it never
+re-checks that the receipt's block is still canonical, so it resolves
+happily for a transaction that has been reorged out. Setting this buys a
+delay, not a guarantee. For peg-in registration finality use
+`waitForPeginRegistrationDepth`, which re-reads live contract state on
+every poll.
+
 ##### timeout?
 
 ```ts

--- a/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts
@@ -1067,6 +1067,14 @@ export class PeginManager {
    * 5. Finalizes and extracts the transaction
    * 6. Broadcasts via mempool API
    *
+   * IMPORTANT — this method does NOT gate on Ethereum finality. Committing
+   * BTC to the HTLC while the peg-in registration is still reorg-exposed can
+   * strand the deposit: the vault record disappears from the chain while the
+   * BTC stays locked until the HTLC refund timelock. Callers must await
+   * `waitForPeginRegistrationDepth` for the registered vault(s) before calling
+   * this. The gate is not applied here because the params carry no vault ID —
+   * adding one would be a breaking signature change.
+   *
    * @param params - Transaction hex and depositor public key
    * @returns The broadcasted Bitcoin transaction ID
    * @throws Error if signing or broadcasting fails

--- a/packages/babylon-ts-sdk/src/tbv/core/services/deposit/__tests__/peginRegistrationDepth.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/deposit/__tests__/peginRegistrationDepth.test.ts
@@ -18,7 +18,6 @@ import {
   PeginRegistrationMissingError,
   PeginRegistrationNotFinalError,
   computeRegistrationConfirmations,
-  isPeginRegistrationFinal,
   waitForPeginRegistrationDepth,
 } from "../peginRegistrationDepth";
 
@@ -73,20 +72,6 @@ describe("computeRegistrationConfirmations", () => {
         createdAtBlock: 101n,
       }),
     ).toBe(0);
-  });
-});
-
-describe("isPeginRegistrationFinal", () => {
-  it("is final at exactly 8 confirmations", () => {
-    expect(
-      isPeginRegistrationFinal({ currentBlock: 107n, createdAtBlock: 100n }),
-    ).toBe(true);
-  });
-
-  it("is not final at 7 confirmations", () => {
-    expect(
-      isPeginRegistrationFinal({ currentBlock: 106n, createdAtBlock: 100n }),
-    ).toBe(false);
   });
 });
 

--- a/packages/babylon-ts-sdk/src/tbv/core/services/deposit/__tests__/peginRegistrationDepth.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/deposit/__tests__/peginRegistrationDepth.test.ts
@@ -28,6 +28,8 @@ const VAULT_ID_B =
 
 const DEPOSITOR = "0x1111111111111111111111111111111111111111" as const;
 const POLL_MS = 6_000;
+/** Mirrors the module-private REGISTRATION_ABSENT_GRACE_POLLS. */
+const ABSENT_GRACE_POLLS = 10;
 
 function basicInfo(createdAt: bigint): VaultBasicInfo {
   return {
@@ -162,34 +164,88 @@ describe("waitForPeginRegistrationDepth", () => {
     });
   });
 
-  it("throws PeginRegistrationMissingError when the vault is absent on the first poll", async () => {
+  it("keeps polling when the first read comes back empty, then proceeds once it appears", async () => {
+    // The inline deposit flow calls this milliseconds after a 1-confirmation
+    // receipt. A load-balanced pool member one block behind answers with a
+    // valid zero struct, which no transport retry can absorb — treating that
+    // as terminal would tell a user with a paid registration to start over.
+    getBlockNumber.mockResolvedValue(107n);
+    getVaultBasicInfo
+      .mockResolvedValueOnce(absentInfo())
+      .mockResolvedValueOnce(absentInfo())
+      .mockResolvedValue(basicInfo(100n));
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const pending = waitForPeginRegistrationDepth({
+      vaultRegistryReader: reader,
+      getBlockNumber,
+      vaultIds: [VAULT_ID_A],
+    });
+
+    await vi.advanceTimersByTimeAsync(POLL_MS * 2);
+    await expect(pending).resolves.toMatchObject({ confirmations: 8 });
+  });
+
+  it("does not arm the terminal branch when the first poll fails transiently", async () => {
+    // A read failure on poll 1 must not leave the never-seen state pinned to
+    // "first poll" — the count of absent observations is what gates the
+    // terminal branch, and a thrown read is not an observation.
+    getBlockNumber
+      .mockRejectedValueOnce(new Error("RPC timeout"))
+      .mockResolvedValue(107n);
+    getVaultBasicInfo
+      .mockResolvedValueOnce(absentInfo())
+      .mockResolvedValue(basicInfo(100n));
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const pending = waitForPeginRegistrationDepth({
+      vaultRegistryReader: reader,
+      getBlockNumber,
+      vaultIds: [VAULT_ID_A],
+    });
+
+    await vi.advanceTimersByTimeAsync(POLL_MS * 3);
+    await expect(pending).resolves.toMatchObject({ confirmations: 8 });
+  });
+
+  it("throws PeginRegistrationMissingError once the grace window is spent", async () => {
     getBlockNumber.mockResolvedValue(107n);
     getVaultBasicInfo.mockResolvedValue(absentInfo());
+    vi.spyOn(console, "warn").mockImplementation(() => {});
 
-    await expect(
-      waitForPeginRegistrationDepth({
-        vaultRegistryReader: reader,
-        getBlockNumber,
-        vaultIds: [VAULT_ID_A],
-      }),
-    ).rejects.toBeInstanceOf(PeginRegistrationMissingError);
+    const pending = waitForPeginRegistrationDepth({
+      vaultRegistryReader: reader,
+      getBlockNumber,
+      vaultIds: [VAULT_ID_A],
+    });
+    const assertion = expect(pending).rejects.toBeInstanceOf(
+      PeginRegistrationMissingError,
+    );
 
-    expect(getVaultBasicInfo).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(POLL_MS * (ABSENT_GRACE_POLLS + 1));
+    await assertion;
   });
 
   it("treats createdAt of 0 as absent rather than as an infinitely deep registration", async () => {
     getBlockNumber.mockResolvedValue(107n);
     // A populated depositor with a zero createdAt would compute as 108
-    // confirmations and pass the gate if it were not rejected here.
+    // confirmations and pass the gate if it were not rejected here. It gets
+    // the same grace as a zero struct — a half-populated record from a
+    // lagging backend is the same class of event.
     getVaultBasicInfo.mockResolvedValue({ ...basicInfo(0n) });
+    vi.spyOn(console, "warn").mockImplementation(() => {});
 
-    await expect(
-      waitForPeginRegistrationDepth({
-        vaultRegistryReader: reader,
-        getBlockNumber,
-        vaultIds: [VAULT_ID_A],
-      }),
-    ).rejects.toBeInstanceOf(PeginRegistrationMissingError);
+    const pending = waitForPeginRegistrationDepth({
+      vaultRegistryReader: reader,
+      getBlockNumber,
+      vaultIds: [VAULT_ID_A],
+    });
+    const assertion = expect(pending).rejects.toBeInstanceOf(
+      PeginRegistrationMissingError,
+    );
+
+    await vi.advanceTimersByTimeAsync(POLL_MS * (ABSENT_GRACE_POLLS + 1));
+    await assertion;
   });
 
   it("survives a reorg that removes and then re-includes the registration", async () => {

--- a/packages/babylon-ts-sdk/src/tbv/core/services/deposit/__tests__/peginRegistrationDepth.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/deposit/__tests__/peginRegistrationDepth.test.ts
@@ -1,0 +1,333 @@
+import { type Hex, zeroAddress } from "viem";
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+  type Mock,
+} from "vitest";
+
+import type {
+  VaultBasicInfo,
+  VaultRegistryReader,
+} from "../../../clients/eth/types";
+import {
+  PEGIN_ETH_CONFIRMATIONS,
+  PeginRegistrationMissingError,
+  PeginRegistrationNotFinalError,
+  computeRegistrationConfirmations,
+  isPeginRegistrationFinal,
+  waitForPeginRegistrationDepth,
+} from "../peginRegistrationDepth";
+
+const VAULT_ID_A =
+  "0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" as Hex;
+const VAULT_ID_B =
+  "0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb" as Hex;
+
+const DEPOSITOR = "0x1111111111111111111111111111111111111111" as const;
+const POLL_MS = 6_000;
+
+function basicInfo(createdAt: bigint): VaultBasicInfo {
+  return {
+    depositor: DEPOSITOR,
+    depositorBtcPubKey: "0xabcd" as Hex,
+    amount: 100_000n,
+    vaultProvider: "0x2222222222222222222222222222222222222222",
+    status: 0,
+    applicationEntryPoint: "0x3333333333333333333333333333333333333333",
+    createdAt,
+  };
+}
+
+/** An unregistered / orphaned record: the contract returns a zero struct. */
+function absentInfo(): VaultBasicInfo {
+  return { ...basicInfo(0n), depositor: zeroAddress, createdAt: 0n };
+}
+
+describe("computeRegistrationConfirmations", () => {
+  it("counts the mining block itself as the first confirmation", () => {
+    expect(
+      computeRegistrationConfirmations({
+        currentBlock: 100n,
+        createdAtBlock: 100n,
+      }),
+    ).toBe(1);
+  });
+
+  it("reports 8 confirmations seven blocks after the registration block", () => {
+    expect(
+      computeRegistrationConfirmations({
+        currentBlock: 107n,
+        createdAtBlock: 100n,
+      }),
+    ).toBe(8);
+  });
+
+  it("clamps to 0 when a reorg puts the registration block above the observed tip", () => {
+    expect(
+      computeRegistrationConfirmations({
+        currentBlock: 100n,
+        createdAtBlock: 101n,
+      }),
+    ).toBe(0);
+  });
+});
+
+describe("isPeginRegistrationFinal", () => {
+  it("is final at exactly 8 confirmations", () => {
+    expect(
+      isPeginRegistrationFinal({ currentBlock: 107n, createdAtBlock: 100n }),
+    ).toBe(true);
+  });
+
+  it("is not final at 7 confirmations", () => {
+    expect(
+      isPeginRegistrationFinal({ currentBlock: 106n, createdAtBlock: 100n }),
+    ).toBe(false);
+  });
+});
+
+describe("PEGIN_ETH_CONFIRMATIONS", () => {
+  // Pinned so changing the protocol's reorg tolerance is a deliberate edit
+  // with a failing test attached, not a silent tuning tweak.
+  it("is 8", () => {
+    expect(PEGIN_ETH_CONFIRMATIONS).toBe(8);
+  });
+});
+
+describe("waitForPeginRegistrationDepth", () => {
+  let getVaultBasicInfo: Mock<(vaultId: Hex) => Promise<VaultBasicInfo>>;
+  let getBlockNumber: Mock<() => Promise<bigint>>;
+  let reader: VaultRegistryReader;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    getVaultBasicInfo = vi.fn<(vaultId: Hex) => Promise<VaultBasicInfo>>();
+    getBlockNumber = vi.fn<() => Promise<bigint>>();
+    reader = { getVaultBasicInfo } as unknown as VaultRegistryReader;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("resolves without polling when the registration is already 8 blocks deep", async () => {
+    getBlockNumber.mockResolvedValue(107n);
+    getVaultBasicInfo.mockResolvedValue(basicInfo(100n));
+
+    const result = await waitForPeginRegistrationDepth({
+      vaultRegistryReader: reader,
+      getBlockNumber,
+      vaultIds: [VAULT_ID_A],
+    });
+
+    expect(result.confirmations).toBe(8);
+    expect(getBlockNumber).toHaveBeenCalledTimes(1);
+    expect(getVaultBasicInfo).toHaveBeenCalledTimes(1);
+  });
+
+  it("reads the chain tip before the vault record so the depth is never over-counted", async () => {
+    const callOrder: string[] = [];
+    getBlockNumber.mockImplementation(async () => {
+      callOrder.push("tip");
+      return 107n;
+    });
+    getVaultBasicInfo.mockImplementation(async () => {
+      callOrder.push("vault");
+      return basicInfo(100n);
+    });
+
+    await waitForPeginRegistrationDepth({
+      vaultRegistryReader: reader,
+      getBlockNumber,
+      vaultIds: [VAULT_ID_A],
+    });
+
+    expect(callOrder).toEqual(["tip", "vault"]);
+  });
+
+  it("keeps polling until the required depth and reports each observed depth", async () => {
+    getBlockNumber
+      .mockResolvedValueOnce(104n)
+      .mockResolvedValueOnce(105n)
+      .mockResolvedValueOnce(107n);
+    getVaultBasicInfo.mockResolvedValue(basicInfo(100n));
+    const onProgress = vi.fn();
+
+    const pending = waitForPeginRegistrationDepth({
+      vaultRegistryReader: reader,
+      getBlockNumber,
+      vaultIds: [VAULT_ID_A],
+      onProgress,
+    });
+
+    await vi.advanceTimersByTimeAsync(POLL_MS * 2);
+    await expect(pending).resolves.toMatchObject({ confirmations: 8 });
+
+    expect(onProgress.mock.calls.map(([p]) => p.confirmations)).toEqual([
+      5, 6, 8,
+    ]);
+    expect(onProgress).toHaveBeenLastCalledWith({
+      confirmations: 8,
+      required: 8,
+    });
+  });
+
+  it("throws PeginRegistrationMissingError when the vault is absent on the first poll", async () => {
+    getBlockNumber.mockResolvedValue(107n);
+    getVaultBasicInfo.mockResolvedValue(absentInfo());
+
+    await expect(
+      waitForPeginRegistrationDepth({
+        vaultRegistryReader: reader,
+        getBlockNumber,
+        vaultIds: [VAULT_ID_A],
+      }),
+    ).rejects.toBeInstanceOf(PeginRegistrationMissingError);
+
+    expect(getVaultBasicInfo).toHaveBeenCalledTimes(1);
+  });
+
+  it("treats createdAt of 0 as absent rather than as an infinitely deep registration", async () => {
+    getBlockNumber.mockResolvedValue(107n);
+    // A populated depositor with a zero createdAt would compute as 108
+    // confirmations and pass the gate if it were not rejected here.
+    getVaultBasicInfo.mockResolvedValue({ ...basicInfo(0n) });
+
+    await expect(
+      waitForPeginRegistrationDepth({
+        vaultRegistryReader: reader,
+        getBlockNumber,
+        vaultIds: [VAULT_ID_A],
+      }),
+    ).rejects.toBeInstanceOf(PeginRegistrationMissingError);
+  });
+
+  it("survives a reorg that removes and then re-includes the registration", async () => {
+    getBlockNumber
+      .mockResolvedValueOnce(104n) // seen at 5 confirmations
+      .mockResolvedValueOnce(105n) // reorged out
+      .mockResolvedValueOnce(106n) // still out
+      .mockResolvedValueOnce(107n) // re-included at a later block
+      .mockResolvedValueOnce(114n); // now deep enough again
+    getVaultBasicInfo
+      .mockResolvedValueOnce(basicInfo(100n))
+      .mockResolvedValueOnce(absentInfo())
+      .mockResolvedValueOnce(absentInfo())
+      .mockResolvedValueOnce(basicInfo(107n))
+      .mockResolvedValueOnce(basicInfo(107n));
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const onProgress = vi.fn();
+
+    const pending = waitForPeginRegistrationDepth({
+      vaultRegistryReader: reader,
+      getBlockNumber,
+      vaultIds: [VAULT_ID_A],
+      onProgress,
+    });
+
+    await vi.advanceTimersByTimeAsync(POLL_MS * 4);
+    await expect(pending).resolves.toMatchObject({ confirmations: 8 });
+
+    // The counter rewinds to 0 across the reorg and climbs again from the
+    // new inclusion block, rather than the wait aborting.
+    expect(onProgress.mock.calls.map(([p]) => p.confirmations)).toEqual([
+      5, 0, 0, 1, 8,
+    ]);
+  });
+
+  it("retries a transient read failure instead of failing the deposit", async () => {
+    getBlockNumber
+      .mockRejectedValueOnce(new Error("RPC timeout"))
+      .mockResolvedValueOnce(107n);
+    getVaultBasicInfo.mockResolvedValue(basicInfo(100n));
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const pending = waitForPeginRegistrationDepth({
+      vaultRegistryReader: reader,
+      getBlockNumber,
+      vaultIds: [VAULT_ID_A],
+    });
+
+    await vi.advanceTimersByTimeAsync(POLL_MS);
+    await expect(pending).resolves.toMatchObject({ confirmations: 8 });
+  });
+
+  it("throws PeginRegistrationNotFinalError when the depth is not reached in the budget", async () => {
+    getBlockNumber.mockResolvedValue(100n);
+    getVaultBasicInfo.mockResolvedValue(basicInfo(100n));
+
+    const pending = waitForPeginRegistrationDepth({
+      vaultRegistryReader: reader,
+      getBlockNumber,
+      vaultIds: [VAULT_ID_A],
+      timeoutMs: POLL_MS * 3,
+    });
+    const assertion = expect(pending).rejects.toBeInstanceOf(
+      PeginRegistrationNotFinalError,
+    );
+
+    await vi.advanceTimersByTimeAsync(POLL_MS * 4);
+    await assertion;
+  });
+
+  it("stops polling promptly when aborted", async () => {
+    const controller = new AbortController();
+    getBlockNumber.mockResolvedValue(100n);
+    getVaultBasicInfo.mockResolvedValue(basicInfo(100n));
+
+    const pending = waitForPeginRegistrationDepth({
+      vaultRegistryReader: reader,
+      getBlockNumber,
+      vaultIds: [VAULT_ID_A],
+      signal: controller.signal,
+    });
+    const assertion = expect(pending).rejects.toThrow(/Aborted/);
+
+    await vi.advanceTimersByTimeAsync(POLL_MS);
+    const callsAtAbort = getBlockNumber.mock.calls.length;
+    controller.abort();
+    await assertion;
+
+    await vi.advanceTimersByTimeAsync(POLL_MS * 3);
+    expect(getBlockNumber).toHaveBeenCalledTimes(callsAtAbort);
+  });
+
+  it("gates on the shallowest vault when a batch registered several", async () => {
+    getBlockNumber.mockResolvedValueOnce(107n).mockResolvedValueOnce(110n);
+    // Vault B is three blocks younger, so the batch is not final at tip 107
+    // even though vault A alone would be.
+    getVaultBasicInfo
+      .mockResolvedValueOnce(basicInfo(100n))
+      .mockResolvedValueOnce(basicInfo(103n))
+      .mockResolvedValueOnce(basicInfo(100n))
+      .mockResolvedValueOnce(basicInfo(103n));
+    const onProgress = vi.fn();
+
+    const pending = waitForPeginRegistrationDepth({
+      vaultRegistryReader: reader,
+      getBlockNumber,
+      vaultIds: [VAULT_ID_A, VAULT_ID_B],
+      onProgress,
+    });
+
+    await vi.advanceTimersByTimeAsync(POLL_MS);
+    await expect(pending).resolves.toMatchObject({ confirmations: 8 });
+
+    expect(onProgress.mock.calls.map(([p]) => p.confirmations)).toEqual([5, 8]);
+  });
+
+  it("rejects an empty vault list rather than vacuously reporting finality", async () => {
+    await expect(
+      waitForPeginRegistrationDepth({
+        vaultRegistryReader: reader,
+        getBlockNumber,
+        vaultIds: [],
+      }),
+    ).rejects.toThrow(/at least one vault ID/);
+  });
+});

--- a/packages/babylon-ts-sdk/src/tbv/core/services/deposit/index.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/deposit/index.ts
@@ -8,7 +8,6 @@ export {
   PEGIN_ETH_CONFIRMATIONS,
   PeginRegistrationMissingError,
   PeginRegistrationNotFinalError,
-  isPeginRegistrationFinal,
   isPeginRegistrationMissingError,
   isPeginRegistrationNotFinalError,
   waitForPeginRegistrationDepth,

--- a/packages/babylon-ts-sdk/src/tbv/core/services/deposit/index.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/deposit/index.ts
@@ -5,6 +5,19 @@ export type {
   WotsKeySubmitter,
 } from "./interfaces";
 export {
+  PEGIN_ETH_CONFIRMATIONS,
+  PeginRegistrationMissingError,
+  PeginRegistrationNotFinalError,
+  isPeginRegistrationFinal,
+  isPeginRegistrationMissingError,
+  isPeginRegistrationNotFinalError,
+  waitForPeginRegistrationDepth,
+  type PeginRegistrationDepthResult,
+  type RegistrationDepthParams,
+  type RegistrationDepthProgress,
+  type WaitForPeginRegistrationDepthParams,
+} from "./peginRegistrationDepth";
+export {
   ContractStatus,
   PeginAction,
   canPerformAction,

--- a/packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginRegistrationDepth.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginRegistrationDepth.ts
@@ -119,14 +119,6 @@ export function computeRegistrationConfirmations(
   return depth < 0n ? 0 : Number(depth);
 }
 
-/** Whether a registration has reached the required confirmation depth. */
-export function isPeginRegistrationFinal(
-  params: RegistrationDepthParams & { required?: number },
-): boolean {
-  const { required = PEGIN_ETH_CONFIRMATIONS, ...depth } = params;
-  return computeRegistrationConfirmations(depth) >= required;
-}
-
 export interface RegistrationDepthProgress {
   /** Shallowest depth across every vault being waited on. */
   confirmations: number;

--- a/packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginRegistrationDepth.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginRegistrationDepth.ts
@@ -56,9 +56,20 @@ const REGISTRATION_DEPTH_POLL_INTERVAL_MS = 6_000;
 const REGISTRATION_DEPTH_TIMEOUT_MS = 10 * 60_000;
 
 /**
- * The vault is not registered on-chain at all. Thrown only on the FIRST poll,
- * where it means the caller's premise was wrong rather than that a reorg took
- * the registration away — retrying will not help.
+ * Consecutive absent reads tolerated before concluding the registration is
+ * genuinely not on-chain. At the 6s cadence this is ~60s — five Ethereum
+ * blocks — which is what absorbs a load-balanced pool member still serving
+ * pre-block state moments after the receipt. Such a node answers HTTP 200
+ * with a validly encoded zero struct, so no transport-level retry can see it;
+ * only re-reading later can. Expressed in polls rather than milliseconds so
+ * the tolerance scales with the cadence.
+ */
+const REGISTRATION_ABSENT_GRACE_POLLS = 10;
+
+/**
+ * The vault is not registered on-chain, and stayed that way past the grace
+ * window — long enough that a lagging backend has been ruled out. Retrying
+ * will not help.
  */
 export class PeginRegistrationMissingError extends Error {
   constructor(message: string) {
@@ -155,9 +166,14 @@ export interface PeginRegistrationDepthResult {
 /**
  * Poll until every vault's registration is at least `required` blocks deep.
  *
- * @throws {PeginRegistrationMissingError} if no vault is registered on the first poll.
+ * A read that comes back empty is treated as "not visible yet", not as
+ * "absent": both callers reach this having already proven the registration
+ * exists, so an empty read means a lagging RPC backend or a reorg, and both
+ * resolve on their own.
+ *
+ * @throws {PeginRegistrationMissingError} if no vault has ever been observed and the grace window is spent.
  * @throws {PeginRegistrationNotFinalError} on timeout.
- * @throws if aborted, or if the tip read fails on the first poll.
+ * @throws if aborted.
  */
 export async function waitForPeginRegistrationDepth(
   params: WaitForPeginRegistrationDepthParams,
@@ -180,10 +196,12 @@ export async function waitForPeginRegistrationDepth(
   }
 
   const startTime = Date.now();
-  let isFirstPoll = true;
-  // Once any poll has seen the registration, a later disappearance is a reorg
-  // rather than a bad premise — the two cases get different treatment below.
+  // Once any poll has seen the registration, a later disappearance is a reorg,
+  // and re-inclusion is the expected outcome — that case polls to the full
+  // budget. Before the first sighting, absence is far more likely to be a
+  // lagging backend than a missing registration, so it gets a grace window.
   let hasObservedRegistration = false;
+  let absentPolls = 0;
   let lastError: unknown;
 
   while (true) {
@@ -194,10 +212,14 @@ export async function waitForPeginRegistrationDepth(
     }
 
     if (Date.now() - startTime >= timeoutMs) {
+      // Deliberately avoids the word "broadcast". Callers classify this by
+      // type, but any surface that stringifies it would otherwise land in the
+      // message-matching "broadcast failed" bucket and tell the user the exact
+      // opposite of what happened.
       throw new PeginRegistrationNotFinalError(
         `Peg-in registration did not reach ${required} Ethereum confirmations within ${timeoutMs}ms. ` +
           `The registration transaction was submitted but is not yet final, so the Pre-PegIn ` +
-          `Bitcoin transaction has NOT been broadcast and no funds are at risk. ` +
+          `Bitcoin transaction was never sent and no funds are at risk. ` +
           `Resume this deposit from the dashboard once the network settles.` +
           (lastError instanceof Error ? ` Last read error: ${lastError.message}` : ""),
       );
@@ -209,6 +231,12 @@ export async function waitForPeginRegistrationDepth(
       // the state the vault read observes, so the computed depth is an
       // under-estimate. Reversing the order could over-count by a block and
       // release the broadcast at 7 confirmations.
+      //
+      // That ordering only guarantees the under-count when both land on the
+      // same backend. Against a load-balanced pool the tip can come from an
+      // ahead node and the vault from a behind one — the same root cause as
+      // the empty-read handling below, and why this is a best-effort skew
+      // guard rather than a proof.
       const currentBlock = await getBlockNumber();
       const infos = await Promise.all(
         vaultIds.map((vaultId) => vaultRegistryReader.getVaultBasicInfo(vaultId)),
@@ -223,24 +251,38 @@ export async function waitForPeginRegistrationDepth(
       );
 
       if (missingIndex !== -1) {
-        if (isFirstPoll && !hasObservedRegistration) {
+        absentPolls += 1;
+
+        // Never seen it, and the grace window is spent: a lagging backend has
+        // been ruled out, so the registration really is not there. Only ever
+        // reachable for a caller that supplied a vault ID which was never
+        // registered — both in-repo callers arrive here having already proven
+        // the vault visible (a receipt inline, a throwing `getVaultFromChain`
+        // on resume).
+        if (
+          !hasObservedRegistration &&
+          absentPolls > REGISTRATION_ABSENT_GRACE_POLLS
+        ) {
           throw new PeginRegistrationMissingError(
-            `Vault ${vaultIds[missingIndex]} is not registered on-chain — ` +
-              `cannot wait for confirmation depth on a registration that does not exist.`,
+            `Vault ${vaultIds[missingIndex]} is still not visible on-chain after ` +
+              `${absentPolls} reads — the registration does not exist.`,
           );
         }
-        // Seen before, gone now: this is precisely the reorg this gate exists
-        // for. Re-inclusion within a block or two is the expected outcome, so
-        // report a rewind to the caller and keep polling to the budget rather
-        // than aborting a deposit that is about to be fine.
+
+        // Otherwise keep polling. Before the first sighting this is almost
+        // always an RPC backend that has not caught up to the registration
+        // block; after one, it is the reorg this gate exists for, where
+        // re-inclusion within a block or two is the expected outcome. Both
+        // resolve themselves, and both would be made worse by aborting a
+        // deposit that is about to be fine.
         console.warn(
-          `Peg-in registration for vault ${vaultIds[missingIndex]} disappeared from chain state ` +
-            `at block ${currentBlock} — possible Ethereum reorg. Continuing to poll for re-inclusion.`,
+          `Peg-in registration for vault ${vaultIds[missingIndex]} is not visible in chain state ` +
+            `at block ${currentBlock} — a lagging RPC backend or an Ethereum reorg. Still polling.`,
         );
         onProgress?.({ confirmations: 0, required });
       } else {
-        isFirstPoll = false;
         hasObservedRegistration = true;
+        absentPolls = 0;
         lastError = undefined;
 
         // The shallowest vault gates the batch: they share one registration

--- a/packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginRegistrationDepth.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/deposit/peginRegistrationDepth.ts
@@ -1,0 +1,308 @@
+/**
+ * Ethereum confirmation-depth gate for a peg-in registration.
+ *
+ * Between `submitPeginRequestBatch` landing on Ethereum and the Pre-PegIn
+ * BTC transaction being broadcast there is a reorg window. If the block
+ * carrying the registration is orphaned *after* the BTC broadcast, the vault
+ * record is gone from the chain while the depositor's BTC is already locked
+ * in the HTLC — the deposit is stuck, recoverable only via the HTLC refund
+ * leaf after `T_refund` (~3 days). This module closes that window by proving
+ * the registration is buried before any BTC is committed.
+ *
+ * Depth is measured from `BTCVaultBasicInfo.createdAt`, which is the Ethereum
+ * **block number** the registration was mined at (see
+ * {@link isActivationDeadlinePassedOnChain}, which mirrors the contract's own
+ * `block.number > createdAt + pegInActivationTimeout` check). Reading it needs
+ * no transaction hash, so the same primitive serves the inline deposit flow
+ * and the cross-device resume flow, and every poll re-reads live contract
+ * state — an orphaned registration reads back as `depositor === zeroAddress`.
+ *
+ * Deliberately NOT built on viem's `waitForTransactionReceipt({confirmations})`.
+ * That helper fetches the receipt once and thereafter only does block-number
+ * arithmetic against the cached copy; it never re-checks that the receipt's
+ * block is still canonical, so it resolves happily for a transaction that has
+ * been reorged out. It buys a delay, not a finality guarantee.
+ *
+ * @module services/deposit
+ */
+
+import { type Hex, zeroAddress } from "viem";
+
+import type { VaultBasicInfo, VaultRegistryReader } from "../../clients/eth/types";
+
+/**
+ * Ethereum block confirmations required before the Pre-PegIn BTC transaction
+ * may be broadcast.
+ *
+ * 8 exceeds the deepest reorg ever observed on Ethereum (7, pre-merge, caused
+ * by a client bug), and costs ~1.6 min at 12s slots. Deliberately not the
+ * `safe` block tag: a full epoch (~12.8 min) was rejected as too slow for the
+ * benefit. This is a liveness guard against an orphaned registration, not a
+ * theft mitigation — every Pre-PegIn HTLC spend path requires the depositor's
+ * own BTC key regardless.
+ */
+export const PEGIN_ETH_CONFIRMATIONS = 8;
+
+/** Poll cadence — half an Ethereum slot, so a new block is never missed by long. */
+const REGISTRATION_DEPTH_POLL_INTERVAL_MS = 6_000;
+
+/**
+ * Overall budget for reaching depth. Nominally ~96s (8 × 12s); the rest
+ * absorbs missed slots and RPC lag. Generous on purpose: timing out discards
+ * a valid registration that only needed a few more seconds, and the failure is
+ * recoverable through the resume flow, so over-waiting is cheaper than
+ * under-waiting.
+ */
+const REGISTRATION_DEPTH_TIMEOUT_MS = 10 * 60_000;
+
+/**
+ * The vault is not registered on-chain at all. Thrown only on the FIRST poll,
+ * where it means the caller's premise was wrong rather than that a reorg took
+ * the registration away — retrying will not help.
+ */
+export class PeginRegistrationMissingError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "PeginRegistrationMissingError";
+  }
+}
+
+/** The registration did not reach the required depth within the budget. */
+export class PeginRegistrationNotFinalError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "PeginRegistrationNotFinalError";
+  }
+}
+
+// `instanceof` alone fails across module boundaries (duplicate SDK copies,
+// test mocks). Fall back to the name field, as the other deposit-service
+// errors in this directory do.
+export function isPeginRegistrationMissingError(
+  err: unknown,
+): err is PeginRegistrationMissingError {
+  return (
+    err instanceof PeginRegistrationMissingError ||
+    (err instanceof Error && err.name === "PeginRegistrationMissingError")
+  );
+}
+
+export function isPeginRegistrationNotFinalError(
+  err: unknown,
+): err is PeginRegistrationNotFinalError {
+  return (
+    err instanceof PeginRegistrationNotFinalError ||
+    (err instanceof Error && err.name === "PeginRegistrationNotFinalError")
+  );
+}
+
+export interface RegistrationDepthParams {
+  /** Current chain tip block number. */
+  currentBlock: bigint;
+  /** Block number the registration was mined at (`VaultBasicInfo.createdAt`). */
+  createdAtBlock: bigint;
+}
+
+/**
+ * Confirmations accrued by a registration: the mining block counts as the
+ * first confirmation, so `tip === createdAt` is 1.
+ *
+ * Clamped at 0. A reorg between the tip read and the vault read can surface a
+ * `createdAt` above the tip already in hand; a negative depth must never
+ * propagate into a comparison.
+ */
+export function computeRegistrationConfirmations(
+  params: RegistrationDepthParams,
+): number {
+  const { currentBlock, createdAtBlock } = params;
+  const depth = currentBlock - createdAtBlock + 1n;
+  return depth < 0n ? 0 : Number(depth);
+}
+
+/** Whether a registration has reached the required confirmation depth. */
+export function isPeginRegistrationFinal(
+  params: RegistrationDepthParams & { required?: number },
+): boolean {
+  const { required = PEGIN_ETH_CONFIRMATIONS, ...depth } = params;
+  return computeRegistrationConfirmations(depth) >= required;
+}
+
+export interface RegistrationDepthProgress {
+  /** Shallowest depth across every vault being waited on. */
+  confirmations: number;
+  required: number;
+}
+
+export interface WaitForPeginRegistrationDepthParams {
+  vaultRegistryReader: VaultRegistryReader;
+  /**
+   * Chain-tip reader. A thunk rather than a `PublicClient` so this module has
+   * no viem-client dependency and stays testable with two plain fakes — the
+   * same shape `verifyRegisteredVaultVersions` uses for its reader.
+   */
+  getBlockNumber: () => Promise<bigint>;
+  /** Vaults registered by the same transaction; the shallowest one gates. */
+  vaultIds: readonly Hex[];
+  required?: number;
+  pollIntervalMs?: number;
+  timeoutMs?: number;
+  signal?: AbortSignal;
+  onProgress?: (progress: RegistrationDepthProgress) => void;
+}
+
+export interface PeginRegistrationDepthResult {
+  confirmations: number;
+  /**
+   * The final observation for the shallowest vault. Callers that gated on
+   * `status` before the wait should re-assert it against this — the wait can
+   * span minutes, and a vault can leave PENDING in that time.
+   */
+  basicInfo: VaultBasicInfo;
+}
+
+/**
+ * Poll until every vault's registration is at least `required` blocks deep.
+ *
+ * @throws {PeginRegistrationMissingError} if no vault is registered on the first poll.
+ * @throws {PeginRegistrationNotFinalError} on timeout.
+ * @throws if aborted, or if the tip read fails on the first poll.
+ */
+export async function waitForPeginRegistrationDepth(
+  params: WaitForPeginRegistrationDepthParams,
+): Promise<PeginRegistrationDepthResult> {
+  const {
+    vaultRegistryReader,
+    getBlockNumber,
+    vaultIds,
+    required = PEGIN_ETH_CONFIRMATIONS,
+    pollIntervalMs = REGISTRATION_DEPTH_POLL_INTERVAL_MS,
+    timeoutMs = REGISTRATION_DEPTH_TIMEOUT_MS,
+    signal,
+    onProgress,
+  } = params;
+
+  if (vaultIds.length === 0) {
+    throw new Error(
+      "waitForPeginRegistrationDepth requires at least one vault ID",
+    );
+  }
+
+  const startTime = Date.now();
+  let isFirstPoll = true;
+  // Once any poll has seen the registration, a later disappearance is a reorg
+  // rather than a bad premise — the two cases get different treatment below.
+  let hasObservedRegistration = false;
+  let lastError: unknown;
+
+  while (true) {
+    if (signal?.aborted) {
+      throw new Error(
+        `Aborted while waiting for peg-in registration depth (${vaultIds.length} vault(s))`,
+      );
+    }
+
+    if (Date.now() - startTime >= timeoutMs) {
+      throw new PeginRegistrationNotFinalError(
+        `Peg-in registration did not reach ${required} Ethereum confirmations within ${timeoutMs}ms. ` +
+          `The registration transaction was submitted but is not yet final, so the Pre-PegIn ` +
+          `Bitcoin transaction has NOT been broadcast and no funds are at risk. ` +
+          `Resume this deposit from the dashboard once the network settles.` +
+          (lastError instanceof Error ? ` Last read error: ${lastError.message}` : ""),
+      );
+    }
+
+    try {
+      // Tip FIRST, vault state SECOND. Both read `latest`, but they are two
+      // round-trips: reading the tip first means it can only be at or behind
+      // the state the vault read observes, so the computed depth is an
+      // under-estimate. Reversing the order could over-count by a block and
+      // release the broadcast at 7 confirmations.
+      const currentBlock = await getBlockNumber();
+      const infos = await Promise.all(
+        vaultIds.map((vaultId) => vaultRegistryReader.getVaultBasicInfo(vaultId)),
+      );
+
+      // A zero record is what an orphaned (or never-included) registration
+      // reads back as. `createdAt === 0n` is checked alongside the zero
+      // depositor because a partially-decoded record must never be treated as
+      // block 0 — that would compute as infinitely deep and pass the gate.
+      const missingIndex = infos.findIndex(
+        (info) => info.depositor === zeroAddress || info.createdAt === 0n,
+      );
+
+      if (missingIndex !== -1) {
+        if (isFirstPoll && !hasObservedRegistration) {
+          throw new PeginRegistrationMissingError(
+            `Vault ${vaultIds[missingIndex]} is not registered on-chain — ` +
+              `cannot wait for confirmation depth on a registration that does not exist.`,
+          );
+        }
+        // Seen before, gone now: this is precisely the reorg this gate exists
+        // for. Re-inclusion within a block or two is the expected outcome, so
+        // report a rewind to the caller and keep polling to the budget rather
+        // than aborting a deposit that is about to be fine.
+        console.warn(
+          `Peg-in registration for vault ${vaultIds[missingIndex]} disappeared from chain state ` +
+            `at block ${currentBlock} — possible Ethereum reorg. Continuing to poll for re-inclusion.`,
+        );
+        onProgress?.({ confirmations: 0, required });
+      } else {
+        isFirstPoll = false;
+        hasObservedRegistration = true;
+        lastError = undefined;
+
+        // The shallowest vault gates the batch: they share one registration
+        // transaction, so in practice the depths are equal, but taking the
+        // minimum is the fail-safe reading if they ever diverge.
+        let shallowest = infos[0];
+        let shallowestDepth = computeRegistrationConfirmations({
+          currentBlock,
+          createdAtBlock: infos[0].createdAt,
+        });
+        for (const info of infos.slice(1)) {
+          const depth = computeRegistrationConfirmations({
+            currentBlock,
+            createdAtBlock: info.createdAt,
+          });
+          if (depth < shallowestDepth) {
+            shallowestDepth = depth;
+            shallowest = info;
+          }
+        }
+
+        onProgress?.({ confirmations: shallowestDepth, required });
+
+        if (shallowestDepth >= required) {
+          return { confirmations: shallowestDepth, basicInfo: shallowest };
+        }
+      }
+    } catch (error) {
+      if (isPeginRegistrationMissingError(error)) {
+        throw error;
+      }
+      // Transient RPC failure. Retry on the next tick; the outer timeout owns
+      // the overall budget, so one blip must not consume it.
+      console.warn(
+        `Registration-depth read failed (retrying in ${pollIntervalMs}ms): ` +
+          (error instanceof Error ? error.message : String(error)),
+      );
+      lastError = error;
+    }
+
+    await new Promise<void>((resolve, reject) => {
+      const onAbort = () => {
+        clearTimeout(timeoutId);
+        reject(
+          new Error(
+            `Aborted while waiting for peg-in registration depth (${vaultIds.length} vault(s))`,
+          ),
+        );
+      };
+      const timeoutId = setTimeout(() => {
+        signal?.removeEventListener("abort", onAbort);
+        resolve();
+      }, pollIntervalMs);
+      signal?.addEventListener("abort", onAbort, { once: true });
+    });
+  }
+}

--- a/packages/babylon-ts-sdk/src/tbv/core/utils/eth/waitForTransactionReceiptSmartAware.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/utils/eth/waitForTransactionReceiptSmartAware.ts
@@ -41,6 +41,17 @@ export interface WaitForTransactionReceiptSmartAwareParams {
   publicClient: PublicClient;
   walletAddress: Address;
   hash: Hash;
+  /**
+   * Forwarded to viem verbatim.
+   *
+   * MUST NOT be used as a finality/reorg gate. viem fetches the receipt once
+   * and then only compares block numbers against that cached copy — it never
+   * re-checks that the receipt's block is still canonical, so it resolves
+   * happily for a transaction that has been reorged out. Setting this buys a
+   * delay, not a guarantee. For peg-in registration finality use
+   * `waitForPeginRegistrationDepth`, which re-reads live contract state on
+   * every poll.
+   */
   confirmations?: number;
   /**
    * Forwarded to viem on the EOA (externally owned account) path.

--- a/services/vault/e2e/real/timing.ts
+++ b/services/vault/e2e/real/timing.ts
@@ -59,9 +59,11 @@ export const SPLIT_ALLOCATION_TIMEOUT_MS = 30_000;
 
 // ── pegin: step machine ──────────────────────────────────────────────────────
 /**
- * Overall budget for the 15-step signing machine. It spans multiple on-chain gates — Pre-PegIn
- * inclusion (~10 min/block), the WOTS-key gate (~20 min), and the payout gate (~3 min) — so a real
- * peg-in runs 30 min–2 hr. Budgeted generously; the action imposes NO short per-step timeout.
+ * Overall budget for the 15-step signing machine. It spans multiple on-chain gates — the Ethereum
+ * finality gate between steps 4 and 5 (8 confirmations, ~1.6 min, during which step 4 legitimately
+ * dwells with no UI transition), Pre-PegIn inclusion (~10 min/block), the WOTS-key gate (~20 min),
+ * and the payout gate (~3 min) — so a real peg-in runs 30 min–2 hr. Budgeted generously; the action
+ * imposes NO short per-step timeout, which is what lets those dwells pass without a special case.
  */
 export const PEGIN_STEP_MACHINE_BUDGET_MS = 2.5 * 60 * 60 * 1_000;
 /** How often to poll the progress UI (advance the step log, handle the Activate/Skip dapp gates). */

--- a/services/vault/src/clients/eth-contract/btc-vault-registry/__tests__/query.test.ts
+++ b/services/vault/src/clients/eth-contract/btc-vault-registry/__tests__/query.test.ts
@@ -138,6 +138,21 @@ describe("getVaultFromChain", () => {
     expect(result.prePeginTxHash).toBe(("0x" + "2".repeat(64)) as Hex);
   });
 
+  // `createdAt` is the ETH block the registration mined at; the Pre-PegIn
+  // broadcast finality gate measures confirmation depth from it. Dropping it
+  // in the basic+protocol merge would leave the gate comparing against
+  // `undefined`.
+  it("surfaces basic.createdAt as the registration block number", async () => {
+    mockGetVaultData.mockResolvedValue({
+      basic: { ...basicInfo(60_000_000n), createdAt: 21_000_000n },
+      protocol: protocolInfo(),
+    });
+
+    const result = await getVaultFromChain(VAULT_A);
+
+    expect(result.createdAt).toBe(21_000_000n);
+  });
+
   it("surfaces the stamped vaultCoreVersion for resume flows", async () => {
     mockGetVaultData.mockResolvedValue({
       basic: basicInfo(60_000_000n),

--- a/services/vault/src/clients/eth-contract/btc-vault-registry/query.ts
+++ b/services/vault/src/clients/eth-contract/btc-vault-registry/query.ts
@@ -52,6 +52,13 @@ export interface OnChainVaultData {
    * would mislabel a chain read.
    */
   status: number;
+  /**
+   * Ethereum **block number** the registration was mined at (not a timestamp
+   * — the contract compares it against `block.number`). Feeds the activation
+   * deadline check and the Pre-PegIn broadcast finality gate, which measures
+   * confirmation depth as `tip - createdAt + 1`.
+   */
+  createdAt: bigint;
 }
 
 /**
@@ -90,6 +97,7 @@ export async function getVaultFromChain(
     prePeginTxHash: protocol.prePeginTxHash,
     vaultProviderCommissionBps: Number(protocol.vaultProviderCommissionBps),
     status: basic.status,
+    createdAt: basic.createdAt,
   };
 }
 

--- a/services/vault/src/components/simple/DepositProgressView/DepositProgressView.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/DepositProgressView.tsx
@@ -27,6 +27,7 @@ import { useBTCWallet } from "@/context/wallet";
 import { COPY } from "@/copy";
 import { DepositFlowStep } from "@/hooks/deposit/depositFlowSteps/types";
 import { useBtcWalletUnlock } from "@/hooks/useBtcWalletUnlock";
+import type { RegistrationDepthProgress } from "@/services/vault/ethConfirmationGate";
 import type { PayoutSigningProgress } from "@/services/vault/vaultPayoutSignatureService";
 import type { PeginSigningProgress } from "@/services/vault/vaultTransactionService";
 import type { DepositErrorContent } from "@/utils/errors";
@@ -34,6 +35,7 @@ import type { DepositErrorContent } from "@/utils/errors";
 import { BtcConfirmationDetailContainer } from "./BtcConfirmationDetailContainer";
 import { CompletedStepsPill } from "./CompletedStepsPill";
 import { DepositCardShell } from "./DepositCardShell";
+import { EthConfirmationDetail } from "./EthConfirmationDetail";
 import { GroupedProgress } from "./GroupedProgress";
 import { PeginFeeWarning } from "./PeginFeeWarning";
 import { ProgressBar } from "./ProgressBar";
@@ -126,6 +128,14 @@ export interface DepositProgressViewProps {
    */
   btcConfirmationDetail?: BtcConfirmationDetailData | null;
   /**
+   * Live Ethereum confirmation depth, rendered under the active SUBMIT_PEGIN
+   * step while the finality gate holds the flow between the ETH registration
+   * receipt and the Pre-PegIn broadcast. `null`/omitted outside that window —
+   * without it, step 4 would sit on a bare spinner for ~1.6 min with no
+   * explanation.
+   */
+  ethConfirmationDetail?: RegistrationDepthProgress | null;
+  /**
    * Hint rendered under the active SUBMIT_WOTS_KEYS step. Resume passes it
    * because its cold path fires a wallet approval the step copy doesn't
    * mention — and some extensions queue that approval without a popup.
@@ -149,6 +159,7 @@ export interface DepositProgressViewProps {
 function resolveActiveStepDetail(params: {
   currentStep: DepositFlowStep;
   btcConfirmationDetail: BtcConfirmationDetailData | null | undefined;
+  ethConfirmationDetail?: RegistrationDepthProgress | null;
   wotsApprovalHint?: string | null;
   /** Stack the panel's rows — used for the narrow split-deposit columns. */
   stacked?: boolean;
@@ -162,12 +173,24 @@ function resolveActiveStepDetail(params: {
   const {
     currentStep,
     btcConfirmationDetail,
+    ethConfirmationDetail,
     wotsApprovalHint,
     stacked,
     isActiveVault,
   } = params;
   if (currentStep === DepositFlowStep.SIGN_PEGIN_BTC) {
     return <PeginFeeWarning />;
+  }
+  // Only while the gate is actually holding. Step 4 also covers the wallet
+  // popup and the receipt wait, which have nothing to count yet.
+  if (currentStep === DepositFlowStep.SUBMIT_PEGIN && ethConfirmationDetail) {
+    return (
+      <EthConfirmationDetail
+        confirmations={ethConfirmationDetail.confirmations}
+        required={ethConfirmationDetail.required}
+        stacked={stacked}
+      />
+    );
   }
   if (
     currentStep === DepositFlowStep.SUBMIT_WOTS_KEYS &&
@@ -220,6 +243,7 @@ export function DepositProgressView(props: DepositProgressViewProps) {
     terminalMessage,
     onRetry,
     btcConfirmationDetail,
+    ethConfirmationDetail,
     wotsApprovalHint,
     offchainParamsVersion,
     started = true,
@@ -322,13 +346,19 @@ export function DepositProgressView(props: DepositProgressViewProps) {
   const showCompletedGroupsPill = completedGroups >= 1;
 
   const steps = useMemo(
-    () => buildStepItems(payoutSigningProgress, peginSigningProgress),
-    [payoutSigningProgress, peginSigningProgress],
+    () =>
+      buildStepItems(
+        payoutSigningProgress,
+        peginSigningProgress,
+        ethConfirmationDetail,
+      ),
+    [payoutSigningProgress, peginSigningProgress, ethConfirmationDetail],
   );
 
   const activeStepDetail = resolveActiveStepDetail({
     currentStep,
     btcConfirmationDetail,
+    ethConfirmationDetail,
     wotsApprovalHint,
   });
 
@@ -344,11 +374,12 @@ export function DepositProgressView(props: DepositProgressViewProps) {
       resolveActiveStepDetail({
         currentStep: step,
         btcConfirmationDetail,
+        ethConfirmationDetail,
         wotsApprovalHint,
         stacked: opts.stacked,
         isActiveVault: opts.isActiveVault,
       }),
-    [btcConfirmationDetail, wotsApprovalHint],
+    [btcConfirmationDetail, ethConfirmationDetail, wotsApprovalHint],
   );
 
   return (

--- a/services/vault/src/components/simple/DepositProgressView/EthConfirmationDetail.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/EthConfirmationDetail.tsx
@@ -1,0 +1,78 @@
+import { Loader, Text } from "@babylonlabs-io/core-ui";
+
+import { COPY } from "@/copy";
+
+import { computeRemainingEthEstimateSeconds } from "./ethConfirmationProgress";
+
+interface EthConfirmationDetailProps {
+  /** Confirmations accrued by the ETH registration. */
+  confirmations: number;
+  /** Required depth before the Pre-PegIn may broadcast. */
+  required: number;
+  /**
+   * Stack each row's label above its value instead of side-by-side. Used in the
+   * narrow split-deposit columns, where the inline layout collapses.
+   */
+  stacked?: boolean;
+}
+
+/**
+ * Live counter for the Ethereum finality gate.
+ *
+ * Deliberately carries no transaction hash row: the resume path reaches this
+ * panel from a chain read with no ETH tx hash in hand (the local record may be
+ * from another device), and a row that renders on one path but not the other
+ * reads as a bug. The counter is the information that matters.
+ */
+export function EthConfirmationDetail({
+  confirmations,
+  required,
+  stacked = false,
+}: EthConfirmationDetailProps) {
+  const copy = COPY.deposit.ethConfirmation;
+  const remainingSeconds = computeRemainingEthEstimateSeconds(
+    confirmations,
+    required,
+  );
+  const rowClass = stacked
+    ? "flex flex-col gap-0.5"
+    : "flex items-center justify-between gap-2";
+
+  return (
+    <div className="mt-3 flex flex-col gap-2 rounded-lg bg-secondary-highlight p-3">
+      <div className={rowClass}>
+        <Text as="span" variant="body2" className="text-accent-secondary">
+          {copy.confirmations}:
+        </Text>
+        <Text as="span" variant="body2" className="text-accent-primary">
+          {copy.confirmationsValue(confirmations, required)}
+        </Text>
+      </div>
+
+      <div className={rowClass}>
+        <Text as="span" variant="body2" className="text-accent-secondary">
+          {remainingSeconds === null
+            ? COPY.deposit.waitDetails.status
+            : copy.estRemaining}
+          :
+        </Text>
+        {remainingSeconds === null ? (
+          <div className="flex items-center gap-2">
+            <Loader size={14} className="text-accent-primary" />
+            <Text as="span" variant="body2" className="text-accent-primary">
+              {copy.finalizing}
+            </Text>
+          </div>
+        ) : (
+          <Text as="span" variant="body2" className="text-accent-primary">
+            {copy.estRemainingValue(remainingSeconds, required - confirmations)}
+          </Text>
+        )}
+      </div>
+
+      <Text as="span" variant="body2" className="text-accent-secondary">
+        {copy.rationale}
+      </Text>
+    </div>
+  );
+}

--- a/services/vault/src/components/simple/DepositProgressView/__tests__/DepositProgressView.test.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/__tests__/DepositProgressView.test.tsx
@@ -1028,4 +1028,48 @@ describe("DepositProgressView", () => {
       ).not.toBeInTheDocument();
     });
   });
+  describe("Ethereum confirmation panel", () => {
+    it("renders the live counter under the ETH registration step while the gate holds", () => {
+      render(
+        <DepositProgressView
+          {...baseProps}
+          currentStep={DepositFlowStep.SUBMIT_PEGIN}
+          ethConfirmationDetail={{ confirmations: 3, required: 8 }}
+        />,
+      );
+
+      expect(
+        screen.getByText(COPY.deposit.ethConfirmation.rationale),
+      ).toBeInTheDocument();
+      expect(screen.getAllByText("3 of 8").length).toBeGreaterThan(0);
+    });
+
+    it("renders nothing extra on the ETH step before the gate starts counting", () => {
+      // Step 4 also covers the wallet popup and the receipt wait.
+      render(
+        <DepositProgressView
+          {...baseProps}
+          currentStep={DepositFlowStep.SUBMIT_PEGIN}
+        />,
+      );
+
+      expect(
+        screen.queryByText(COPY.deposit.ethConfirmation.rationale),
+      ).not.toBeInTheDocument();
+    });
+
+    it("does not render the panel on unrelated steps", () => {
+      render(
+        <DepositProgressView
+          {...baseProps}
+          currentStep={DepositFlowStep.SIGN_POP}
+          ethConfirmationDetail={{ confirmations: 3, required: 8 }}
+        />,
+      );
+
+      expect(
+        screen.queryByText(COPY.deposit.ethConfirmation.rationale),
+      ).not.toBeInTheDocument();
+    });
+  });
 });

--- a/services/vault/src/components/simple/DepositProgressView/__tests__/EthConfirmationDetail.test.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/__tests__/EthConfirmationDetail.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { COPY } from "@/copy";
+
+import { EthConfirmationDetail } from "../EthConfirmationDetail";
+
+describe("EthConfirmationDetail", () => {
+  it("shows the accrued confirmations against the required depth", () => {
+    render(<EthConfirmationDetail confirmations={3} required={8} />);
+    expect(screen.getByText("3 of 8")).toBeInTheDocument();
+  });
+
+  it("shows the estimated seconds and the Ethereum blocks left", () => {
+    render(<EthConfirmationDetail confirmations={3} required={8} />);
+    expect(screen.getByText("~60 sec (5 Ethereum blocks)")).toBeInTheDocument();
+  });
+
+  it("uses the singular block form when one confirmation remains", () => {
+    render(<EthConfirmationDetail confirmations={7} required={8} />);
+    expect(screen.getByText("~12 sec (1 Ethereum block)")).toBeInTheDocument();
+  });
+
+  it("switches to the finalizing state once the depth is reached", () => {
+    render(<EthConfirmationDetail confirmations={8} required={8} />);
+    expect(
+      screen.getByText(COPY.deposit.ethConfirmation.finalizing),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/sec \(/)).not.toBeInTheDocument();
+  });
+
+  it("explains why the flow is paused here", () => {
+    // Without this the step reads as a hang: the user has just signed on
+    // Ethereum and is expecting a Bitcoin prompt next.
+    render(<EthConfirmationDetail confirmations={1} required={8} />);
+    expect(
+      screen.getByText(COPY.deposit.ethConfirmation.rationale),
+    ).toBeInTheDocument();
+  });
+
+  it("renders without a transaction hash, as the resume path supplies none", () => {
+    render(<EthConfirmationDetail confirmations={2} required={8} />);
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+    expect(screen.getByText("2 of 8")).toBeInTheDocument();
+  });
+});

--- a/services/vault/src/components/simple/DepositProgressView/__tests__/ethConfirmationProgress.test.ts
+++ b/services/vault/src/components/simple/DepositProgressView/__tests__/ethConfirmationProgress.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { computeRemainingEthEstimateSeconds } from "../ethConfirmationProgress";
+
+describe("computeRemainingEthEstimateSeconds", () => {
+  it("estimates 12 seconds per outstanding Ethereum block", () => {
+    expect(computeRemainingEthEstimateSeconds(3, 8)).toBe(60);
+  });
+
+  it("estimates the full wait when no confirmations have accrued", () => {
+    expect(computeRemainingEthEstimateSeconds(0, 8)).toBe(96);
+  });
+
+  it("returns null once the required depth is reached", () => {
+    // There is no remaining wait to estimate — the panel switches to its
+    // finalizing state instead of showing "~0 sec".
+    expect(computeRemainingEthEstimateSeconds(8, 8)).toBeNull();
+  });
+
+  it("returns null when the depth is exceeded", () => {
+    expect(computeRemainingEthEstimateSeconds(11, 8)).toBeNull();
+  });
+});

--- a/services/vault/src/components/simple/DepositProgressView/__tests__/steps.test.ts
+++ b/services/vault/src/components/simple/DepositProgressView/__tests__/steps.test.ts
@@ -126,6 +126,51 @@ describe("buildStepItems payout-signing counters", () => {
   });
 });
 
+describe("buildStepItems Ethereum confirmation counter", () => {
+  const ethStep = (items: ReturnType<typeof buildStepItems>) =>
+    items[getVisualStep(DepositFlowStep.SUBMIT_PEGIN) - 1];
+
+  it("puts the confirmation counter on the ETH registration step while the gate holds", () => {
+    const items = buildStepItems(null, null, {
+      confirmations: 3,
+      required: 8,
+    });
+    expect(ethStep(items).description).toBe(
+      COPY.deposit.steps.signingCounter(3, 8),
+    );
+  });
+
+  it("leaves the ETH registration step bare outside the gate's window", () => {
+    // Step 4 also covers the wallet popup and the receipt wait, where there is
+    // nothing to count yet.
+    expect(ethStep(buildStepItems(null)).description).toBeUndefined();
+  });
+
+  it("does not add the counter to any other step", () => {
+    const items = buildStepItems(null, null, {
+      confirmations: 3,
+      required: 8,
+    });
+    const withDescription = items
+      .map((item, index) => ({ index, description: item.description }))
+      .filter((entry) => entry.description !== undefined);
+    expect(withDescription).toEqual([
+      {
+        index: getVisualStep(DepositFlowStep.SUBMIT_PEGIN) - 1,
+        description: COPY.deposit.steps.signingCounter(3, 8),
+      },
+    ]);
+  });
+
+  it("keeps the visual step count unchanged", () => {
+    // The counter is a sub-state of an existing step; adding a 16th step would
+    // renumber every consumer of getVisualStep, including the e2e step machine.
+    expect(
+      buildStepItems(null, null, { confirmations: 3, required: 8 }),
+    ).toHaveLength(TOTAL_VISUAL_STEPS);
+  });
+});
+
 describe("STEP_GROUPS", () => {
   it("covers every visual step from 1..TOTAL_VISUAL_STEPS with no gaps or overlaps", () => {
     expect(STEP_GROUPS[0].startStep).toBe(1);

--- a/services/vault/src/components/simple/DepositProgressView/ethConfirmationProgress.ts
+++ b/services/vault/src/components/simple/DepositProgressView/ethConfirmationProgress.ts
@@ -1,0 +1,27 @@
+/**
+ * Pure helper for the "Ethereum confirmations" detail panel's estimate.
+ *
+ * The deposit holds between the Ethereum registration receipt and the
+ * Pre-PegIn Bitcoin broadcast until the registration is
+ * `PEGIN_ETH_CONFIRMATIONS` blocks deep. Unlike Bitcoin's ~10-minute target,
+ * Ethereum's 12-second slot cadence makes seconds the readable unit here.
+ */
+
+import { ETH_SLOT_SECONDS } from "@/utils/activationDeadline";
+
+/**
+ * Estimated seconds until the registration reaches `required` confirmations.
+ * Returns `null` once the depth is met — there is no remaining wait to
+ * estimate and the flow is about to move on.
+ *
+ * Missed slots only stretch real intervals beyond 12s, so this is a lower
+ * bound. That is the right direction for a progress hint: better to under-
+ * promise than to show a countdown that stalls.
+ */
+export function computeRemainingEthEstimateSeconds(
+  confirmations: number,
+  required: number,
+): number | null {
+  if (confirmations >= required) return null;
+  return (required - confirmations) * ETH_SLOT_SECONDS;
+}

--- a/services/vault/src/components/simple/DepositProgressView/steps.ts
+++ b/services/vault/src/components/simple/DepositProgressView/steps.ts
@@ -2,12 +2,14 @@ import type { StepperItem } from "@babylonlabs-io/core-ui";
 
 import { COPY } from "@/copy";
 import { DepositFlowStep } from "@/hooks/deposit/depositFlowSteps/types";
+import type { RegistrationDepthProgress } from "@/services/vault/ethConfirmationGate";
 import type { PayoutSigningProgress } from "@/services/vault/vaultPayoutSignatureService";
 import type { PeginSigningProgress } from "@/services/vault/vaultTransactionService";
 
 export function buildStepItems(
   progress: PayoutSigningProgress | null,
   peginProgress: PeginSigningProgress | null = null,
+  ethConfirmationProgress: RegistrationDepthProgress | null = null,
 ): StepperItem[] {
   const payoutCounter =
     progress?.phase === "claimers" && progress.total > 0
@@ -29,6 +31,15 @@ export function buildStepItems(
         )
       : undefined;
 
+  // Ethereum finality gate depth. Absent outside the gate's window, so the
+  // step reads normally during the wallet popup and the receipt wait.
+  const ethConfirmationCounter = ethConfirmationProgress
+    ? COPY.deposit.steps.signingCounter(
+        ethConfirmationProgress.confirmations,
+        ethConfirmationProgress.required,
+      )
+    : undefined;
+
   return [
     {
       label: COPY.deposit.steps.generateSecret,
@@ -42,6 +53,7 @@ export function buildStepItems(
     },
     {
       label: COPY.deposit.steps.signAndBroadcastEth,
+      description: ethConfirmationCounter,
     },
     {
       label: COPY.deposit.steps.signAndBroadcastPrePegin,

--- a/services/vault/src/components/simple/DepositSignContent.tsx
+++ b/services/vault/src/components/simple/DepositSignContent.tsx
@@ -59,6 +59,7 @@ export function DepositSignContent({
     peginSigningProgress,
     perVaultSteps,
     btcConfirmationDetail,
+    ethConfirmationDetail,
   } = useDepositFlow({
     vaultAmounts,
     ...flowParams,
@@ -208,6 +209,7 @@ export function DepositSignContent({
         started={started}
         onSign={handleSign}
         btcConfirmationDetail={btcConfirmationDetail}
+        ethConfirmationDetail={ethConfirmationDetail}
       />
     </>
   );

--- a/services/vault/src/components/simple/ResumeDepositContent.tsx
+++ b/services/vault/src/components/simple/ResumeDepositContent.tsx
@@ -194,12 +194,22 @@ export function ResumeBroadcastContent({
   onClose,
   onSuccess,
 }: ResumeBroadcastContentProps) {
-  const { broadcasting, error, handleBroadcast } = useBroadcastState({
-    activity,
-    batchVaultIds,
-    depositorEthAddress,
-    onSuccess,
-  });
+  const { broadcasting, error, ethConfirmationDetail, handleBroadcast } =
+    useBroadcastState({
+      activity,
+      batchVaultIds,
+      depositorEthAddress,
+      onSuccess,
+    });
+
+  // While the Ethereum finality gate holds, the honest step is the ETH
+  // registration — it genuinely is not final yet — not the BTC broadcast the
+  // user has not been asked to sign. Only ever true for a deposit registered
+  // in the last ~1.6 min; every older resume renders the broadcast step
+  // exactly as before.
+  const step = ethConfirmationDetail
+    ? DepositFlowStep.SUBMIT_PEGIN
+    : DepositFlowStep.BROADCAST_PRE_PEGIN;
 
   const btcConnector = useChainConnector("BTC");
   const btcWalletProvider = btcConnector?.connectedWallet?.provider;
@@ -214,7 +224,7 @@ export function ResumeBroadcastContent({
   );
 
   const derived = computeDepositDerivedState(
-    DepositFlowStep.BROADCAST_PRE_PEGIN,
+    step,
     broadcasting,
     false,
     error != null,
@@ -224,15 +234,11 @@ export function ResumeBroadcastContent({
   // step, so the active-vault index is irrelevant — what matters is that the
   // multi-column UI lights up when the deposit is a split.
   const { vaultCount, currentVaultIndex, perVaultSteps } =
-    useSplitVaultProgress(
-      batchVaultIds,
-      activity.id,
-      DepositFlowStep.BROADCAST_PRE_PEGIN,
-    );
+    useSplitVaultProgress(batchVaultIds, activity.id, step);
 
   return (
     <DepositProgressView
-      currentStep={DepositFlowStep.BROADCAST_PRE_PEGIN}
+      currentStep={step}
       offchainParamsVersion={activity.offchainParamsVersion}
       error={error ? mapDepositError(error) : null}
       isComplete={derived.isComplete}
@@ -241,6 +247,7 @@ export function ResumeBroadcastContent({
       canContinueInBackground={derived.canContinueInBackground}
       payoutSigningProgress={null}
       peginSigningProgress={null}
+      ethConfirmationDetail={ethConfirmationDetail}
       vaultCount={vaultCount}
       currentVaultIndex={currentVaultIndex}
       perVaultSteps={perVaultSteps}

--- a/services/vault/src/components/simple/ResumeDepositContent.tsx
+++ b/services/vault/src/components/simple/ResumeDepositContent.tsx
@@ -240,7 +240,7 @@ export function ResumeBroadcastContent({
     <DepositProgressView
       currentStep={step}
       offchainParamsVersion={activity.offchainParamsVersion}
-      error={error ? mapDepositError(error) : null}
+      error={error}
       isComplete={derived.isComplete}
       isProcessing={derived.isProcessing}
       canClose={derived.canClose}

--- a/services/vault/src/components/simple/__tests__/ResumeDepositContent.test.tsx
+++ b/services/vault/src/components/simple/__tests__/ResumeDepositContent.test.tsx
@@ -51,6 +51,8 @@ vi.mock("@babylonlabs-io/ts-sdk/tbv/core", () => ({
   isWotsMismatchError: vi.fn(() => false),
   isRegisteredVaultVersionMismatchError: vi.fn(() => false),
   isParticipantKeyDriftError: vi.fn(() => false),
+  isPeginRegistrationMissingError: vi.fn(() => false),
+  isPeginRegistrationNotFinalError: vi.fn(() => false),
   parseFundingOutpointsFromTx: mockParseFundingOutpointsFromTx,
   stripHexPrefix: vi.fn((hex: string) => hex.replace(/^0x/, "")),
   uint8ArrayToHex: vi.fn(() => "00".repeat(32)),

--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -384,6 +384,21 @@ export const COPY = {
         "Waiting for vault provider to prepare claim and payout transactions...",
       bitcoinTx: "Pre-Pegin Bitcoin transaction",
     },
+    ethConfirmation: {
+      confirmations: "Confirmations",
+      confirmationsValue: (confirmed: number, required: number) =>
+        `${confirmed} of ${required}`,
+      estRemaining: "Est. remaining",
+      estRemainingValue: (seconds: number, blocksLeft: number) =>
+        `~${seconds} sec (${blocksLeft} Ethereum ${
+          blocksLeft === 1 ? "block" : "blocks"
+        })`,
+      finalizing: "Finalizing...",
+      // Explains why the flow pauses here rather than moving straight to the
+      // Bitcoin signature the user is expecting next.
+      rationale:
+        "Waiting for your Ethereum registration to be confirmed before broadcasting to Bitcoin. This protects your deposit if the Ethereum network reorganizes.",
+    },
     waitDetails: {
       status: "Status",
       // Fallback status used at the AWAIT_PAYOUT_TRANSACTIONS step on the
@@ -746,6 +761,18 @@ export const COPY = {
       copyDiagnostics: "Copy error details",
       diagnosticsCopied: "Copied",
       diagnosticsCopyFailed: "Couldn't copy — select and copy manually",
+      // Ethereum finality gate (see services/vault/ethConfirmationGate.ts).
+      // Both fire before the Pre-PegIn broadcast, so no Bitcoin has moved —
+      // say that first, because stopping right after an on-chain registration
+      // reads as alarming and is not.
+      ethRegistrationNotFinal: {
+        title: "Ethereum confirmation timed out",
+        body: "Your Ethereum registration was submitted but hasn't been confirmed deeply enough yet. No Bitcoin has been broadcast and nothing is at risk. Resume this deposit from your dashboard once the network settles.",
+      },
+      ethRegistrationMissing: {
+        title: TRANSACTION_FAILED_TITLE,
+        body: "Your Ethereum registration is no longer visible on-chain, so the deposit was stopped before any Bitcoin was broadcast. Please start a new deposit.",
+      },
       insufficientEthForGas: {
         title: TRANSACTION_FAILED_TITLE,
         body: "Your wallet doesn't have enough ETH to cover the network fee. Add more ETH and retry the transaction.",

--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -743,6 +743,15 @@ export const COPY = {
         "New deposits are temporarily disabled while the protocol is frozen or paused. No Bitcoin was sent — please try again once it resumes.",
       cannotActivateInState: (state: string) =>
         `Cannot activate: BTC Vault is in ${state} state. Activation is only valid when VERIFIED.`,
+      // Deliberately worded without the token "broadcast". These are state
+      // preconditions, not broadcast failures, and `mapDepositError` matches
+      // "broadcast" on the message — which would replace this precise sentence
+      // with "Broadcast failed / please try again", wrong for a terminal state
+      // like EXPIRED where retrying can never succeed.
+      cannotBroadcastInState: (state: string) =>
+        `Cannot continue: BTC Vault is in ${state} state. This step is only valid while the vault is PENDING.`,
+      cannotBroadcastInOnChainState: (state: string) =>
+        `Cannot continue: on-chain BTC Vault is in ${state} state. This step is only valid while the vault is PENDING.`,
       chainSwitchRequired: (network: string) =>
         `Please switch to ${network} in your wallet`,
       ethereumMainnet: "Ethereum Mainnet",

--- a/services/vault/src/hooks/deposit/__tests__/useDepositFlow.test.tsx
+++ b/services/vault/src/hooks/deposit/__tests__/useDepositFlow.test.tsx
@@ -47,6 +47,16 @@ vi.mock("@babylonlabs-io/wallet-connector", () => ({
   useChainConnector: vi.fn(),
 }));
 
+// The Ethereum finality gate polls the chain for ~1.6 min in production. It is
+// a real await in the flow, so every test would hang without a stub; the tests
+// that care about the gate itself override this per-case.
+vi.mock("@/services/vault/ethConfirmationGate", () => ({
+  waitForEthRegistrationDepth: vi.fn(async () => ({
+    confirmations: 8,
+    basicInfo: { status: 0 },
+  })),
+}));
+
 // Local override of the global gate mock so we can drive a frozen/paused scope.
 const depositGateMock = vi.hoisted(() => ({
   value: { protocol: null as string | null, aave: null as string | null },
@@ -693,6 +703,84 @@ describe("useDepositFlow", () => {
           }),
         );
       });
+    });
+
+    it("waits for Ethereum finality before broadcasting the Pre-PegIn", async () => {
+      const { waitForEthRegistrationDepth } = vi.mocked(
+        await import("@/services/vault/ethConfirmationGate"),
+      );
+      const { broadcastPrePeginTransaction } = vi.mocked(
+        await import("@/services/vault/vaultPeginBroadcastService"),
+      );
+
+      const { result } = renderHook(() => useDepositFlow(MOCK_PARAMS));
+
+      await executeDepositFlow(result);
+
+      await waitFor(() => {
+        expect(broadcastPrePeginTransaction).toHaveBeenCalledTimes(1);
+      });
+      expect(waitForEthRegistrationDepth).toHaveBeenCalledWith(
+        expect.objectContaining({
+          vaultIds: ["0xVault0Id", "0xVault1Id"],
+        }),
+      );
+      expect(
+        waitForEthRegistrationDepth.mock.invocationCallOrder[0],
+      ).toBeLessThan(broadcastPrePeginTransaction.mock.invocationCallOrder[0]);
+    });
+
+    it("persists the pending records BEFORE the finality wait so a tab close stays resumable", async () => {
+      const { waitForEthRegistrationDepth } = vi.mocked(
+        await import("@/services/vault/ethConfirmationGate"),
+      );
+      const { addPendingPegin } = vi.mocked(
+        await import("@/storage/peginStorage"),
+      );
+
+      const { result } = renderHook(() => useDepositFlow(MOCK_PARAMS));
+
+      await executeDepositFlow(result);
+
+      await waitFor(() => {
+        expect(addPendingPegin).toHaveBeenCalledTimes(2);
+      });
+      // The records carry the build-version and participant-key stamps, and
+      // the resume path skips both of those checks when the stamp is absent.
+      // Waiting first would open a ~1.6 min window in which closing the tab
+      // silently downgrades the resume path's guard set.
+      expect(addPendingPegin.mock.invocationCallOrder[0]).toBeLessThan(
+        waitForEthRegistrationDepth.mock.invocationCallOrder[0],
+      );
+    });
+
+    it("does not broadcast and keeps the pending records when the finality wait fails", async () => {
+      const { waitForEthRegistrationDepth } = vi.mocked(
+        await import("@/services/vault/ethConfirmationGate"),
+      );
+      const { broadcastPrePeginTransaction } = vi.mocked(
+        await import("@/services/vault/vaultPeginBroadcastService"),
+      );
+      const { addPendingPegin, removePendingPegin } = vi.mocked(
+        await import("@/storage/peginStorage"),
+      );
+      waitForEthRegistrationDepth.mockRejectedValueOnce(
+        new Error("Peg-in registration did not reach 8 Ethereum confirmations"),
+      );
+
+      const { result } = renderHook(() => useDepositFlow(MOCK_PARAMS));
+
+      await executeDepositFlow(result);
+
+      await waitFor(() => {
+        expect(result.current.error).not.toBeNull();
+      });
+      expect(broadcastPrePeginTransaction).not.toHaveBeenCalled();
+      // The registration is on-chain and valid; the deposit is resumable, so
+      // the records must survive.
+      expect(addPendingPegin).toHaveBeenCalledTimes(2);
+      expect(removePendingPegin).not.toHaveBeenCalled();
+      expect(result.current.ethConfirmationDetail).toBeNull();
     });
 
     it("aborts before broadcast when on-chain offchainParamsVersion drifted from the build version", async () => {

--- a/services/vault/src/hooks/deposit/__tests__/useVaultActions.test.ts
+++ b/services/vault/src/hooks/deposit/__tests__/useVaultActions.test.ts
@@ -335,7 +335,9 @@ describe("useVaultActions — handleBroadcast transaction integrity", () => {
       });
     });
 
-    expect(result.current.broadcastError?.body).toContain("Transaction mismatch");
+    expect(result.current.broadcastError?.body).toContain(
+      "Transaction mismatch",
+    );
   });
 
   it("throws when cached local tx matches GraphQL but mismatches on-chain hash", async () => {

--- a/services/vault/src/hooks/deposit/__tests__/useVaultActions.test.ts
+++ b/services/vault/src/hooks/deposit/__tests__/useVaultActions.test.ts
@@ -14,6 +14,10 @@ import { getVaultFromChain } from "@/clients/eth-contract/btc-vault-registry/que
 import { getVaultRegistryReader } from "@/clients/eth-contract/sdk-readers";
 import { ContractStatus } from "@/models/peginStateMachine";
 import { broadcastPrePeginTransaction, fetchVaultById } from "@/services/vault";
+import {
+  isEthRegistrationFinal,
+  waitForEthRegistrationDepth,
+} from "@/services/vault/ethConfirmationGate";
 import { rebuildDepositTerms } from "@/services/vault/rebuildDepositTerms";
 import { resolveFundedTxFeeAndUtxos } from "@/services/vault/resolveFundedTxFee";
 import { activateVaultWithSecret } from "@/services/vault/vaultActivationService";
@@ -93,8 +97,23 @@ vi.mock("@/clients/eth-contract/btc-vault-registry/query", () => ({
     Promise.resolve({
       prePeginTxHash: "0xmatching_pre_pegin_hash",
       hashlock: "0xonchain_hashlock",
+      // ETH block the registration mined at. Feeds the finality gate; the
+      // default pairs with a far-ahead tip so the common case (a deposit
+      // registered long ago) takes the no-wait fast path.
+      createdAt: 1_000n,
     }),
   ),
+}));
+
+// Ethereum finality gate. Default: already final, so the gate is a no-op and
+// the pre-existing broadcast tests are unaffected. The gate's own tests drive
+// these two directly.
+vi.mock("@/services/vault/ethConfirmationGate", () => ({
+  isEthRegistrationFinal: vi.fn(async () => true),
+  waitForEthRegistrationDepth: vi.fn(async () => ({
+    confirmations: 8,
+    basicInfo: { status: OnChainBtcVaultStatus.PENDING },
+  })),
 }));
 
 // Fresh on-chain pause read used by the activation preflight. Holder so tests
@@ -183,6 +202,8 @@ const mockBroadcastPrePeginTransaction = vi.mocked(
 const mockGetVaultFromChain = vi.mocked(getVaultFromChain);
 const mockGetVaultRegistryReader = vi.mocked(getVaultRegistryReader);
 const mockActivateVaultWithSecret = vi.mocked(activateVaultWithSecret);
+const mockIsEthRegistrationFinal = vi.mocked(isEthRegistrationFinal);
+const mockWaitForEthRegistrationDepth = vi.mocked(waitForEthRegistrationDepth);
 
 /**
  * Build a fake reader that returns a combined basic+protocol payload from
@@ -1416,5 +1437,195 @@ describe("useVaultActions — handleBroadcast intent (Ledger) resume branch", ()
     expect(mockBroadcastPrePeginTransaction).toHaveBeenCalledTimes(1);
     // Restore the factory default — implementations survive clearAllMocks.
     vi.mocked(utxosToExpectedRecord).mockImplementation(() => ({}));
+  });
+});
+
+// ============================================================================
+// Ethereum finality gate on the resume broadcast path
+//
+// The resume path can broadcast a Pre-PegIn moments after the ETH registration
+// mined (user closes the modal, clicks Broadcast from the dashboard). Doing so
+// while the registration is still reorg-exposed can leave BTC locked in an
+// HTLC whose vault record no longer exists, so the broadcast waits for depth
+// first — including on a cross-device resume, where there is no local record
+// and no ETH transaction hash to wait on.
+// ============================================================================
+describe("useVaultActions — handleBroadcast Ethereum finality gate", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCalculateBtcTxHash.mockReturnValue("0xmatching_pre_pegin_hash");
+    mockGetVaultFromChain.mockResolvedValue({
+      prePeginTxHash: "0xmatching_pre_pegin_hash",
+      hashlock: "0xonchain_hashlock",
+      status: OnChainBtcVaultStatus.PENDING,
+      createdAt: 1_000n,
+    } as never);
+    mockGetVaultRegistryReader.mockReturnValue({
+      getProtocolInfoBatch: makeMatchingProtocolInfoBatch(),
+    } as unknown as ReturnType<typeof getVaultRegistryReader>);
+    mockVerifyResumeParticipantKeys.mockResolvedValue(undefined);
+    mockFetchVaultById.mockResolvedValue(baseVault as never);
+    mockIsEthRegistrationFinal.mockResolvedValue(true);
+    mockWaitForEthRegistrationDepth.mockResolvedValue({
+      confirmations: 8,
+      basicInfo: { status: OnChainBtcVaultStatus.PENDING },
+    } as never);
+  });
+
+  it("broadcasts without waiting when the registration is already deep enough", async () => {
+    const { result } = renderHook(() => useVaultActions());
+
+    await act(async () => {
+      await result.current.handleBroadcast({
+        ...baseBroadcastParams,
+        pendingPegin: { ...basePendingPegin },
+      });
+    });
+
+    expect(mockIsEthRegistrationFinal).toHaveBeenCalledWith(1_000n);
+    expect(mockWaitForEthRegistrationDepth).not.toHaveBeenCalled();
+    expect(result.current.ethConfirmationDetail).toBeNull();
+    expect(mockBroadcastPrePeginTransaction).toHaveBeenCalledTimes(1);
+  });
+
+  it("waits for depth before broadcasting when the registration is too recent", async () => {
+    mockIsEthRegistrationFinal.mockResolvedValue(false);
+
+    const { result } = renderHook(() => useVaultActions());
+
+    await act(async () => {
+      await result.current.handleBroadcast({
+        ...baseBroadcastParams,
+        pendingPegin: { ...basePendingPegin },
+      });
+    });
+
+    expect(mockWaitForEthRegistrationDepth).toHaveBeenCalledWith(
+      expect.objectContaining({ vaultIds: ["0xvaultId"] }),
+    );
+    expect(mockBroadcastPrePeginTransaction).toHaveBeenCalledTimes(1);
+    expect(
+      mockWaitForEthRegistrationDepth.mock.invocationCallOrder[0],
+    ).toBeLessThan(
+      mockBroadcastPrePeginTransaction.mock.invocationCallOrder[0],
+    );
+  });
+
+  it("does not touch the BTC wallet while waiting for depth", async () => {
+    mockIsEthRegistrationFinal.mockResolvedValue(false);
+    mockWaitForEthRegistrationDepth.mockRejectedValue(
+      new Error("still waiting for Ethereum confirmations"),
+    );
+
+    const { result } = renderHook(() => useVaultActions());
+
+    await act(async () => {
+      await result.current.handleBroadcast({
+        ...baseBroadcastParams,
+        pendingPegin: { ...basePendingPegin },
+      });
+    });
+
+    // The gate sits ahead of the wallet-liveness probe and everything after
+    // it, so a deposit we refuse to broadcast never produces a wallet popup.
+    expect(mockSignPsbt).not.toHaveBeenCalled();
+    expect(mockBroadcastPrePeginTransaction).not.toHaveBeenCalled();
+    expect(result.current.broadcastError).toBe(
+      "still waiting for Ethereum confirmations",
+    );
+  });
+
+  it("publishes live confirmation progress while waiting and clears it after", async () => {
+    mockIsEthRegistrationFinal.mockResolvedValue(false);
+    const observed: Array<{ confirmations: number; required: number }> = [];
+    mockWaitForEthRegistrationDepth.mockImplementation((async (params: {
+      onProgress?: (p: { confirmations: number; required: number }) => void;
+    }) => {
+      for (const confirmations of [5, 6, 7, 8]) {
+        params.onProgress?.({ confirmations, required: 8 });
+        observed.push({ confirmations, required: 8 });
+      }
+      return {
+        confirmations: 8,
+        basicInfo: { status: OnChainBtcVaultStatus.PENDING },
+      };
+    }) as never);
+
+    const { result } = renderHook(() => useVaultActions());
+
+    await act(async () => {
+      await result.current.handleBroadcast({
+        ...baseBroadcastParams,
+        pendingPegin: { ...basePendingPegin },
+      });
+    });
+
+    expect(observed.map((p) => p.confirmations)).toEqual([5, 6, 7, 8]);
+    // Cleared once the gate releases, so the panel does not linger over the
+    // BTC signing step that follows.
+    expect(result.current.ethConfirmationDetail).toBeNull();
+  });
+
+  it("re-checks the on-chain status after the wait and refuses a vault that left PENDING", async () => {
+    mockIsEthRegistrationFinal.mockResolvedValue(false);
+    // The PENDING gate ran before the wait; a wait spanning minutes can outlive
+    // that reading, so the post-wait observation is authoritative.
+    mockWaitForEthRegistrationDepth.mockResolvedValue({
+      confirmations: 8,
+      basicInfo: { status: OnChainBtcVaultStatus.VERIFIED },
+    } as never);
+
+    const { result } = renderHook(() => useVaultActions());
+
+    await act(async () => {
+      await result.current.handleBroadcast({
+        ...baseBroadcastParams,
+        pendingPegin: { ...basePendingPegin },
+      });
+    });
+
+    expect(mockBroadcastPrePeginTransaction).not.toHaveBeenCalled();
+    expect(result.current.broadcastError).toContain("VERIFIED");
+  });
+
+  it("applies the gate on a cross-device resume that has no local record", async () => {
+    mockIsEthRegistrationFinal.mockResolvedValue(false);
+
+    const { result } = renderHook(() => useVaultActions());
+
+    await act(async () => {
+      // No pendingPegin: the depth proof comes from the chain read, not from
+      // localStorage, which is what makes this path gate-able at all.
+      await result.current.handleBroadcast({ ...baseBroadcastParams });
+    });
+
+    expect(mockWaitForEthRegistrationDepth).toHaveBeenCalledWith(
+      expect.objectContaining({ vaultIds: ["0xvaultId"] }),
+    );
+    expect(mockBroadcastPrePeginTransaction).toHaveBeenCalledTimes(1);
+  });
+
+  it("surfaces a depth timeout as an error and keeps the pending entry", async () => {
+    mockIsEthRegistrationFinal.mockResolvedValue(false);
+    mockWaitForEthRegistrationDepth.mockRejectedValue(
+      new Error("Peg-in registration did not reach 8 Ethereum confirmations"),
+    );
+    const removePendingPegin = vi.fn();
+
+    const { result } = renderHook(() => useVaultActions());
+
+    await act(async () => {
+      await result.current.handleBroadcast({
+        ...baseBroadcastParams,
+        pendingPegin: { ...basePendingPegin },
+        removePendingPegin,
+      });
+    });
+
+    expect(mockBroadcastPrePeginTransaction).not.toHaveBeenCalled();
+    // The registration is valid and retryable — dropping the record would
+    // discard the build-version and key stamps the next attempt needs.
+    expect(removePendingPegin).not.toHaveBeenCalled();
+    expect(result.current.ethConfirmationDetail).toBeNull();
   });
 });

--- a/services/vault/src/hooks/deposit/__tests__/useVaultActions.test.ts
+++ b/services/vault/src/hooks/deposit/__tests__/useVaultActions.test.ts
@@ -4,6 +4,7 @@
  * a malicious transaction for signing.
  */
 
+import { PeginRegistrationNotFinalError } from "@babylonlabs-io/ts-sdk/tbv/core";
 import { OnChainBtcVaultStatus } from "@babylonlabs-io/ts-sdk/tbv/core/clients";
 import { useChainConnector } from "@babylonlabs-io/wallet-connector";
 import { act, renderHook } from "@testing-library/react";
@@ -12,6 +13,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { getVaultFromChain } from "@/clients/eth-contract/btc-vault-registry/query";
 import { getVaultRegistryReader } from "@/clients/eth-contract/sdk-readers";
+import { COPY } from "@/copy";
 import { ContractStatus } from "@/models/peginStateMachine";
 import {
   assertUtxosAvailable,
@@ -333,7 +335,7 @@ describe("useVaultActions — handleBroadcast transaction integrity", () => {
       });
     });
 
-    expect(result.current.broadcastError).toContain("Transaction mismatch");
+    expect(result.current.broadcastError?.body).toContain("Transaction mismatch");
   });
 
   it("throws when cached local tx matches GraphQL but mismatches on-chain hash", async () => {
@@ -357,7 +359,7 @@ describe("useVaultActions — handleBroadcast transaction integrity", () => {
       });
     });
 
-    expect(result.current.broadcastError).toContain(
+    expect(result.current.broadcastError?.body).toContain(
       "Transaction integrity check failed",
     );
     expect(mockBroadcastPrePeginTransaction).not.toHaveBeenCalled();
@@ -379,7 +381,7 @@ describe("useVaultActions — handleBroadcast transaction integrity", () => {
       });
     });
 
-    expect(result.current.broadcastError).toContain("EXPIRED");
+    expect(result.current.broadcastError?.body).toContain("EXPIRED");
     expect(mockBroadcastPrePeginTransaction).not.toHaveBeenCalled();
   });
 
@@ -398,7 +400,7 @@ describe("useVaultActions — handleBroadcast transaction integrity", () => {
       });
     });
 
-    expect(result.current.broadcastError).toContain("VERIFIED");
+    expect(result.current.broadcastError?.body).toContain("VERIFIED");
     expect(mockBroadcastPrePeginTransaction).not.toHaveBeenCalled();
   });
 
@@ -424,7 +426,7 @@ describe("useVaultActions — handleBroadcast transaction integrity", () => {
       });
     });
 
-    expect(result.current.broadcastError).toMatch(/on-chain.*EXPIRED/);
+    expect(result.current.broadcastError?.body).toMatch(/on-chain.*EXPIRED/);
     expect(mockBroadcastPrePeginTransaction).not.toHaveBeenCalled();
     expect(mockSignPsbt).not.toHaveBeenCalled();
   });
@@ -452,8 +454,8 @@ describe("useVaultActions — handleBroadcast transaction integrity", () => {
       });
     });
 
-    expect(result.current.broadcastError).toContain("EXPIRED");
-    expect(result.current.broadcastError).not.toContain("LIQUIDATED");
+    expect(result.current.broadcastError?.body).toContain("EXPIRED");
+    expect(result.current.broadcastError?.body).not.toContain("LIQUIDATED");
     expect(mockBroadcastPrePeginTransaction).not.toHaveBeenCalled();
   });
 });
@@ -491,7 +493,7 @@ describe("useVaultActions — handleBroadcast version drift guard", () => {
       await result.current.handleBroadcast(baseBroadcastParams);
     });
 
-    expect(result.current.broadcastError).toMatch(
+    expect(result.current.broadcastError?.body).toMatch(
       /requires a newer version of the app/,
     );
     expect(mockBroadcastPrePeginTransaction).not.toHaveBeenCalled();
@@ -519,7 +521,9 @@ describe("useVaultActions — handleBroadcast version drift guard", () => {
       });
     });
 
-    expect(result.current.broadcastError).toContain("offchainParams expected");
+    expect(result.current.broadcastError).toEqual(
+      COPY.deposit.errors.versionMismatch,
+    );
     expect(mockBroadcastPrePeginTransaction).not.toHaveBeenCalled();
     expect(mockSignPsbt).not.toHaveBeenCalled();
   });
@@ -546,7 +550,9 @@ describe("useVaultActions — handleBroadcast version drift guard", () => {
       });
     });
 
-    expect(result.current.broadcastError).toContain("appVaultKeepers expected");
+    expect(result.current.broadcastError).toEqual(
+      COPY.deposit.errors.versionMismatch,
+    );
     expect(mockBroadcastPrePeginTransaction).not.toHaveBeenCalled();
     expect(mockSignPsbt).not.toHaveBeenCalled();
   });
@@ -572,8 +578,8 @@ describe("useVaultActions — handleBroadcast version drift guard", () => {
       });
     });
 
-    expect(result.current.broadcastError).toContain(
-      "universalChallengers expected",
+    expect(result.current.broadcastError).toEqual(
+      COPY.deposit.errors.versionMismatch,
     );
     expect(mockBroadcastPrePeginTransaction).not.toHaveBeenCalled();
     expect(mockSignPsbt).not.toHaveBeenCalled();
@@ -649,7 +655,7 @@ describe("useVaultActions — handleBroadcast version drift guard", () => {
       });
     });
 
-    expect(result.current.broadcastError).toContain(
+    expect(result.current.broadcastError?.body).toContain(
       "Transaction integrity check failed",
     );
     expect(mockBroadcastPrePeginTransaction).not.toHaveBeenCalled();
@@ -803,7 +809,7 @@ describe("useVaultActions — handleBroadcast version drift guard", () => {
       });
     });
 
-    expect(result.current.broadcastError).toContain("eth_call failed");
+    expect(result.current.broadcastError?.body).toContain("eth_call failed");
     expect(removePendingPegin).not.toHaveBeenCalled();
     expect(mockBroadcastPrePeginTransaction).not.toHaveBeenCalled();
   });
@@ -1346,7 +1352,7 @@ describe("useVaultActions — handleBroadcast intent (Ledger) resume branch", ()
     });
 
     expect(mockBroadcastPrePeginTransaction).not.toHaveBeenCalled();
-    expect(result.current.broadcastError).toContain("disagree on");
+    expect(result.current.broadcastError?.body).toContain("disagree on");
   });
 
   it("skips the rebuild entirely for a software (signPsbt-only) wallet", async () => {
@@ -1556,7 +1562,7 @@ describe("useVaultActions — handleBroadcast Ethereum finality gate", () => {
     // it, so a deposit we refuse to broadcast never produces a wallet popup.
     expect(mockSignPsbt).not.toHaveBeenCalled();
     expect(mockBroadcastPrePeginTransaction).not.toHaveBeenCalled();
-    expect(result.current.broadcastError).toBe(
+    expect(result.current.broadcastError?.body).toBe(
       "still waiting for Ethereum confirmations",
     );
   });
@@ -1693,7 +1699,7 @@ describe("useVaultActions — handleBroadcast Ethereum finality gate", () => {
     });
 
     expect(mockBroadcastPrePeginTransaction).not.toHaveBeenCalled();
-    expect(result.current.broadcastError).toContain("VERIFIED");
+    expect(result.current.broadcastError?.body).toContain("VERIFIED");
   });
 
   it("applies the gate on a cross-device resume that has no local record", async () => {
@@ -1711,7 +1717,39 @@ describe("useVaultActions — handleBroadcast Ethereum finality gate", () => {
     expect(mockBroadcastPrePeginTransaction).toHaveBeenCalledTimes(1);
   });
 
-  it("surfaces a depth timeout as an error and keeps the pending entry", async () => {
+  it("surfaces a depth timeout as the Ethereum-confirmation copy, not a broadcast failure", async () => {
+    // The typed error must survive the catch with its prototype intact. If it
+    // is flattened to a string first, the mapper falls through to message
+    // matching and the user is told their Bitcoin broadcast failed — when no
+    // broadcast was ever attempted.
+    mockWaitForEthRegistrationDepth.mockRejectedValue(
+      new PeginRegistrationNotFinalError(
+        "Peg-in registration did not reach 8 Ethereum confirmations within 600000ms.",
+      ),
+    );
+    const removePendingPeginTyped = vi.fn();
+
+    const { result } = renderHook(() => useVaultActions());
+
+    await act(async () => {
+      await result.current.handleBroadcast({
+        ...baseBroadcastParams,
+        pendingPegin: { ...basePendingPegin },
+        removePendingPegin: removePendingPeginTyped,
+      });
+    });
+
+    expect(result.current.broadcastError).toEqual(
+      COPY.deposit.errors.ethRegistrationNotFinal,
+    );
+    expect(result.current.broadcastError).not.toEqual(
+      COPY.deposit.errors.broadcastFailed,
+    );
+    expect(mockBroadcastPrePeginTransaction).not.toHaveBeenCalled();
+    expect(removePendingPeginTyped).not.toHaveBeenCalled();
+  });
+
+  it("keeps the pending entry when the depth wait fails", async () => {
     mockWaitForEthRegistrationDepth.mockRejectedValue(
       new Error("Peg-in registration did not reach 8 Ethereum confirmations"),
     );

--- a/services/vault/src/hooks/deposit/__tests__/useVaultActions.test.ts
+++ b/services/vault/src/hooks/deposit/__tests__/useVaultActions.test.ts
@@ -14,10 +14,7 @@ import { getVaultFromChain } from "@/clients/eth-contract/btc-vault-registry/que
 import { getVaultRegistryReader } from "@/clients/eth-contract/sdk-readers";
 import { ContractStatus } from "@/models/peginStateMachine";
 import { broadcastPrePeginTransaction, fetchVaultById } from "@/services/vault";
-import {
-  isEthRegistrationFinal,
-  waitForEthRegistrationDepth,
-} from "@/services/vault/ethConfirmationGate";
+import { waitForEthRegistrationDepth } from "@/services/vault/ethConfirmationGate";
 import { rebuildDepositTerms } from "@/services/vault/rebuildDepositTerms";
 import { resolveFundedTxFeeAndUtxos } from "@/services/vault/resolveFundedTxFee";
 import { activateVaultWithSecret } from "@/services/vault/vaultActivationService";
@@ -109,7 +106,6 @@ vi.mock("@/clients/eth-contract/btc-vault-registry/query", () => ({
 // the pre-existing broadcast tests are unaffected. The gate's own tests drive
 // these two directly.
 vi.mock("@/services/vault/ethConfirmationGate", () => ({
-  isEthRegistrationFinal: vi.fn(async () => true),
   waitForEthRegistrationDepth: vi.fn(async () => ({
     confirmations: 8,
     basicInfo: { status: OnChainBtcVaultStatus.PENDING },
@@ -202,7 +198,6 @@ const mockBroadcastPrePeginTransaction = vi.mocked(
 const mockGetVaultFromChain = vi.mocked(getVaultFromChain);
 const mockGetVaultRegistryReader = vi.mocked(getVaultRegistryReader);
 const mockActivateVaultWithSecret = vi.mocked(activateVaultWithSecret);
-const mockIsEthRegistrationFinal = vi.mocked(isEthRegistrationFinal);
 const mockWaitForEthRegistrationDepth = vi.mocked(waitForEthRegistrationDepth);
 
 /**
@@ -1465,14 +1460,13 @@ describe("useVaultActions — handleBroadcast Ethereum finality gate", () => {
     } as unknown as ReturnType<typeof getVaultRegistryReader>);
     mockVerifyResumeParticipantKeys.mockResolvedValue(undefined);
     mockFetchVaultById.mockResolvedValue(baseVault as never);
-    mockIsEthRegistrationFinal.mockResolvedValue(true);
     mockWaitForEthRegistrationDepth.mockResolvedValue({
       confirmations: 8,
       basicInfo: { status: OnChainBtcVaultStatus.PENDING },
     } as never);
   });
 
-  it("broadcasts without waiting when the registration is already deep enough", async () => {
+  it("consults the gate before broadcasting, even for an already-deep registration", async () => {
     const { result } = renderHook(() => useVaultActions());
 
     await act(async () => {
@@ -1482,28 +1476,52 @@ describe("useVaultActions — handleBroadcast Ethereum finality gate", () => {
       });
     });
 
-    expect(mockIsEthRegistrationFinal).toHaveBeenCalledWith(1_000n);
-    expect(mockWaitForEthRegistrationDepth).not.toHaveBeenCalled();
-    expect(result.current.ethConfirmationDetail).toBeNull();
-    expect(mockBroadcastPrePeginTransaction).toHaveBeenCalledTimes(1);
-  });
-
-  it("waits for depth before broadcasting when the registration is too recent", async () => {
-    mockIsEthRegistrationFinal.mockResolvedValue(false);
-
-    const { result } = renderHook(() => useVaultActions());
-
-    await act(async () => {
-      await result.current.handleBroadcast({
-        ...baseBroadcastParams,
-        pendingPegin: { ...basePendingPegin },
-      });
-    });
-
+    // No "already deep enough" shortcut computed from the earlier vault read:
+    // the gate re-reads live registry state and supplies the observation the
+    // post-wait status check uses.
     expect(mockWaitForEthRegistrationDepth).toHaveBeenCalledWith(
       expect.objectContaining({ vaultIds: ["0xvaultId"] }),
     );
     expect(mockBroadcastPrePeginTransaction).toHaveBeenCalledTimes(1);
+    expect(result.current.broadcastError).toBeNull();
+  });
+
+  it("shows no confirmation counter for a registration that is already final", async () => {
+    // The gate reports the (large) depth once on its way out. Rendering that
+    // would flash a nonsensical counter over a deposit that never waited.
+    mockWaitForEthRegistrationDepth.mockImplementation((async (params: {
+      onProgress?: (p: { confirmations: number; required: number }) => void;
+    }) => {
+      params.onProgress?.({ confirmations: 50_000, required: 8 });
+      return {
+        confirmations: 50_000,
+        basicInfo: { status: OnChainBtcVaultStatus.PENDING },
+      };
+    }) as never);
+
+    const { result } = renderHook(() => useVaultActions());
+
+    await act(async () => {
+      await result.current.handleBroadcast({
+        ...baseBroadcastParams,
+        pendingPegin: { ...basePendingPegin },
+      });
+    });
+
+    expect(result.current.ethConfirmationDetail).toBeNull();
+    expect(mockBroadcastPrePeginTransaction).toHaveBeenCalledTimes(1);
+  });
+
+  it("waits for depth before broadcasting", async () => {
+    const { result } = renderHook(() => useVaultActions());
+
+    await act(async () => {
+      await result.current.handleBroadcast({
+        ...baseBroadcastParams,
+        pendingPegin: { ...basePendingPegin },
+      });
+    });
+
     expect(
       mockWaitForEthRegistrationDepth.mock.invocationCallOrder[0],
     ).toBeLessThan(
@@ -1512,7 +1530,6 @@ describe("useVaultActions — handleBroadcast Ethereum finality gate", () => {
   });
 
   it("does not touch the BTC wallet while waiting for depth", async () => {
-    mockIsEthRegistrationFinal.mockResolvedValue(false);
     mockWaitForEthRegistrationDepth.mockRejectedValue(
       new Error("still waiting for Ethereum confirmations"),
     );
@@ -1536,7 +1553,6 @@ describe("useVaultActions — handleBroadcast Ethereum finality gate", () => {
   });
 
   it("publishes live confirmation progress while waiting and clears it after", async () => {
-    mockIsEthRegistrationFinal.mockResolvedValue(false);
     const observed: Array<{ confirmations: number; required: number }> = [];
     mockWaitForEthRegistrationDepth.mockImplementation((async (params: {
       onProgress?: (p: { confirmations: number; required: number }) => void;
@@ -1566,8 +1582,55 @@ describe("useVaultActions — handleBroadcast Ethereum finality gate", () => {
     expect(result.current.ethConfirmationDetail).toBeNull();
   });
 
+  it("passes an abort signal and stops before the wallet when the modal unmounts", async () => {
+    let capturedSignal: AbortSignal | undefined;
+    let releaseWait: (() => void) | undefined;
+    mockWaitForEthRegistrationDepth.mockImplementation((async (params: {
+      signal?: AbortSignal;
+    }) => {
+      capturedSignal = params.signal;
+      await new Promise<void>((resolve) => {
+        releaseWait = resolve;
+      });
+      return {
+        confirmations: 8,
+        basicInfo: { status: OnChainBtcVaultStatus.PENDING },
+      };
+    }) as never);
+
+    const { result, unmount } = renderHook(() => useVaultActions());
+
+    let broadcastPromise: Promise<void> | undefined;
+    await act(async () => {
+      broadcastPromise = result.current.handleBroadcast({
+        ...baseBroadcastParams,
+        pendingPegin: { ...basePendingPegin },
+      });
+      await Promise.resolve();
+    });
+
+    expect(capturedSignal).toBeDefined();
+    expect(capturedSignal!.aborted).toBe(false);
+
+    // Closing the resume modal must cancel the wait, not leave it running to
+    // raise a BTC wallet popup with no UI behind it.
+    await act(async () => {
+      unmount();
+      await new Promise((resolve) => queueMicrotask(() => resolve(null)));
+    });
+
+    expect(capturedSignal!.aborted).toBe(true);
+
+    await act(async () => {
+      releaseWait?.();
+      await broadcastPromise;
+    });
+
+    expect(mockSignPsbt).not.toHaveBeenCalled();
+    expect(mockBroadcastPrePeginTransaction).not.toHaveBeenCalled();
+  });
+
   it("re-checks the on-chain status after the wait and refuses a vault that left PENDING", async () => {
-    mockIsEthRegistrationFinal.mockResolvedValue(false);
     // The PENDING gate ran before the wait; a wait spanning minutes can outlive
     // that reading, so the post-wait observation is authoritative.
     mockWaitForEthRegistrationDepth.mockResolvedValue({
@@ -1589,8 +1652,6 @@ describe("useVaultActions — handleBroadcast Ethereum finality gate", () => {
   });
 
   it("applies the gate on a cross-device resume that has no local record", async () => {
-    mockIsEthRegistrationFinal.mockResolvedValue(false);
-
     const { result } = renderHook(() => useVaultActions());
 
     await act(async () => {
@@ -1606,7 +1667,6 @@ describe("useVaultActions — handleBroadcast Ethereum finality gate", () => {
   });
 
   it("surfaces a depth timeout as an error and keeps the pending entry", async () => {
-    mockIsEthRegistrationFinal.mockResolvedValue(false);
     mockWaitForEthRegistrationDepth.mockRejectedValue(
       new Error("Peg-in registration did not reach 8 Ethereum confirmations"),
     );

--- a/services/vault/src/hooks/deposit/__tests__/useVaultActions.test.ts
+++ b/services/vault/src/hooks/deposit/__tests__/useVaultActions.test.ts
@@ -13,7 +13,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { getVaultFromChain } from "@/clients/eth-contract/btc-vault-registry/query";
 import { getVaultRegistryReader } from "@/clients/eth-contract/sdk-readers";
 import { ContractStatus } from "@/models/peginStateMachine";
-import { broadcastPrePeginTransaction, fetchVaultById } from "@/services/vault";
+import {
+  assertUtxosAvailable,
+  broadcastPrePeginTransaction,
+  fetchVaultById,
+} from "@/services/vault";
 import { waitForEthRegistrationDepth } from "@/services/vault/ethConfirmationGate";
 import { rebuildDepositTerms } from "@/services/vault/rebuildDepositTerms";
 import { resolveFundedTxFeeAndUtxos } from "@/services/vault/resolveFundedTxFee";
@@ -199,6 +203,7 @@ const mockGetVaultFromChain = vi.mocked(getVaultFromChain);
 const mockGetVaultRegistryReader = vi.mocked(getVaultRegistryReader);
 const mockActivateVaultWithSecret = vi.mocked(activateVaultWithSecret);
 const mockWaitForEthRegistrationDepth = vi.mocked(waitForEthRegistrationDepth);
+const mockAssertUtxosAvailable = vi.mocked(assertUtxosAvailable);
 
 /**
  * Build a fake reader that returns a combined basic+protocol payload from
@@ -1460,6 +1465,10 @@ describe("useVaultActions — handleBroadcast Ethereum finality gate", () => {
     } as unknown as ReturnType<typeof getVaultRegistryReader>);
     mockVerifyResumeParticipantKeys.mockResolvedValue(undefined);
     mockFetchVaultById.mockResolvedValue(baseVault as never);
+    // Implementations survive clearAllMocks, so re-assert the default here
+    // rather than at the end of the test that overrides it — a failing test
+    // would otherwise leak a never-resolving mock into the rest of the file.
+    mockAssertUtxosAvailable.mockResolvedValue(undefined);
     mockWaitForEthRegistrationDepth.mockResolvedValue({
       confirmations: 8,
       basicInfo: { status: OnChainBtcVaultStatus.PENDING },
@@ -1623,6 +1632,42 @@ describe("useVaultActions — handleBroadcast Ethereum finality gate", () => {
 
     await act(async () => {
       releaseWait?.();
+      await broadcastPromise;
+    });
+
+    expect(mockSignPsbt).not.toHaveBeenCalled();
+    expect(mockBroadcastPrePeginTransaction).not.toHaveBeenCalled();
+  });
+
+  it("does not start signing when the modal unmounts after finality but before the broadcast", async () => {
+    // Several network round-trips sit between the finality gate and the
+    // signature (UTXO availability, version and key re-checks). Unmounting
+    // during one of them must not still raise a signing popup.
+    let releaseUtxoCheck: (() => void) | undefined;
+    mockAssertUtxosAvailable.mockImplementation((async () => {
+      await new Promise<void>((resolve) => {
+        releaseUtxoCheck = resolve;
+      });
+    }) as never);
+
+    const { result, unmount } = renderHook(() => useVaultActions());
+
+    let broadcastPromise: Promise<void> | undefined;
+    await act(async () => {
+      broadcastPromise = result.current.handleBroadcast({
+        ...baseBroadcastParams,
+        pendingPegin: { ...basePendingPegin },
+      });
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      unmount();
+      await new Promise((resolve) => queueMicrotask(() => resolve(null)));
+    });
+
+    await act(async () => {
+      releaseUtxoCheck?.();
       await broadcastPromise;
     });
 

--- a/services/vault/src/hooks/deposit/useBroadcastState.ts
+++ b/services/vault/src/hooks/deposit/useBroadcastState.ts
@@ -16,6 +16,7 @@ import { logger } from "@/infrastructure";
 import { shortId, TELEMETRY_EVENT } from "@/infrastructure/telemetryEvents";
 import { LocalStorageStatus } from "@/models/peginStateMachine";
 import type { RegistrationDepthProgress } from "@/services/vault/ethConfirmationGate";
+import type { DepositErrorContent } from "@/utils/errors";
 import { usePeginStorage } from "@/storage/usePeginStorage";
 import type { VaultActivity } from "@/types/activity";
 
@@ -39,8 +40,8 @@ export interface UseBroadcastStateProps {
 export interface UseBroadcastStateResult {
   /** Whether a broadcast is in progress */
   broadcasting: boolean;
-  /** Error message if broadcast failed */
-  error: string | null;
+  /** Broadcast failure, already classified into user-facing copy. */
+  error: DepositErrorContent | null;
   /**
    * Live Ethereum confirmation depth while the finality gate holds this
    * broadcast. `null` for any deposit already past the required depth, which

--- a/services/vault/src/hooks/deposit/useBroadcastState.ts
+++ b/services/vault/src/hooks/deposit/useBroadcastState.ts
@@ -15,6 +15,7 @@ import { usePeginPolling } from "@/context/deposit/PeginPollingContext";
 import { logger } from "@/infrastructure";
 import { shortId, TELEMETRY_EVENT } from "@/infrastructure/telemetryEvents";
 import { LocalStorageStatus } from "@/models/peginStateMachine";
+import type { RegistrationDepthProgress } from "@/services/vault/ethConfirmationGate";
 import { usePeginStorage } from "@/storage/usePeginStorage";
 import type { VaultActivity } from "@/types/activity";
 
@@ -40,6 +41,12 @@ export interface UseBroadcastStateResult {
   broadcasting: boolean;
   /** Error message if broadcast failed */
   error: string | null;
+  /**
+   * Live Ethereum confirmation depth while the finality gate holds this
+   * broadcast. `null` for any deposit already past the required depth, which
+   * is nearly every resume.
+   */
+  ethConfirmationDetail: RegistrationDepthProgress | null;
   /** Handler to initiate broadcast */
   handleBroadcast: () => Promise<void>;
 }
@@ -53,6 +60,7 @@ export function useBroadcastState({
   const {
     broadcasting: vaultBroadcasting,
     broadcastError,
+    ethConfirmationDetail,
     handleBroadcast: vaultHandleBroadcast,
   } = useVaultActions();
   const [localBroadcasting, setLocalBroadcasting] = useState(false);
@@ -126,6 +134,7 @@ export function useBroadcastState({
   return {
     broadcasting: isBroadcasting,
     error: broadcastError,
+    ethConfirmationDetail,
     handleBroadcast,
   };
 }

--- a/services/vault/src/hooks/deposit/useBroadcastState.ts
+++ b/services/vault/src/hooks/deposit/useBroadcastState.ts
@@ -16,9 +16,9 @@ import { logger } from "@/infrastructure";
 import { shortId, TELEMETRY_EVENT } from "@/infrastructure/telemetryEvents";
 import { LocalStorageStatus } from "@/models/peginStateMachine";
 import type { RegistrationDepthProgress } from "@/services/vault/ethConfirmationGate";
-import type { DepositErrorContent } from "@/utils/errors";
 import { usePeginStorage } from "@/storage/usePeginStorage";
 import type { VaultActivity } from "@/types/activity";
+import type { DepositErrorContent } from "@/utils/errors";
 
 import { useVaultActions } from "./useVaultActions";
 

--- a/services/vault/src/hooks/deposit/useDepositFlow.ts
+++ b/services/vault/src/hooks/deposit/useDepositFlow.ts
@@ -56,6 +56,10 @@ import {
 } from "@/infrastructure/telemetryEvents";
 import { LocalStorageStatus } from "@/models/peginStateMachine";
 import { validateMultiVaultDepositInputs } from "@/services/deposit/validations";
+import {
+  waitForEthRegistrationDepth,
+  type RegistrationDepthProgress,
+} from "@/services/vault/ethConfirmationGate";
 import type { PayoutSigningProgress } from "@/services/vault/vaultPayoutSignatureService";
 import {
   broadcastPrePeginTransaction,
@@ -179,6 +183,12 @@ export interface UseDepositFlowReturn {
     requiredDepth: number;
     depositIds: readonly string[];
   } | null;
+  /**
+   * Live depth of the Ethereum registration while the finality gate holds the
+   * flow between the ETH receipt and the Pre-PegIn broadcast. `null` outside
+   * that window — the flow is only here for ~1.6 min per deposit.
+   */
+  ethConfirmationDetail: RegistrationDepthProgress | null;
 }
 
 export interface PeginCreationResult {
@@ -271,6 +281,8 @@ export function useDepositFlow(
     requiredDepth: number;
     depositIds: readonly string[];
   } | null>(null);
+  const [ethConfirmationDetail, setEthConfirmationDetail] =
+    useState<RegistrationDepthProgress | null>(null);
 
   const payoutClaimersDoneRef = useRef(false);
 
@@ -750,6 +762,30 @@ export function useDepositFlow(
               });
             }
           }
+        }
+
+        // ========================================================================
+        // Ethereum finality gate. Committing BTC to the HTLC while the
+        // registration is still reorg-exposed can strand the deposit: the vault
+        // record vanishes from the chain while the BTC stays locked until the
+        // HTLC refund timelock (~3 days).
+        //
+        // Placed AFTER the pending records are persisted above. Those records
+        // carry the build-version and participant-key stamps, and the resume
+        // path SKIPS both of those checks when the stamp is absent — so a tab
+        // close during this ~1.6 min wait must not be able to leave a
+        // stamp-less record behind. As a bonus, the two verification reads
+        // below now run against state that is itself 8 blocks past the
+        // registration instead of racing it.
+        // ========================================================================
+        try {
+          await waitForEthRegistrationDepth({
+            vaultIds: batchRegistration.vaults.map((v) => v.vaultId as Hex),
+            onProgress: setEthConfirmationDetail,
+            signal,
+          });
+        } finally {
+          setEthConfirmationDetail(null);
         }
 
         // Verify on-chain registration locked under the same versions we built scripts against.
@@ -1383,5 +1419,6 @@ export function useDepositFlow(
     peginSigningProgress,
     perVaultSteps,
     btcConfirmationDetail,
+    ethConfirmationDetail,
   };
 }

--- a/services/vault/src/hooks/deposit/useVaultActions.ts
+++ b/services/vault/src/hooks/deposit/useVaultActions.ts
@@ -44,7 +44,6 @@ import {
   TELEMETRY_STAGE,
 } from "@/infrastructure/telemetryEvents";
 import {
-  isEthRegistrationFinal,
   waitForEthRegistrationDepth,
   type RegistrationDepthProgress,
 } from "@/services/vault/ethConfirmationGate";
@@ -171,10 +170,25 @@ export function useVaultActions(): UseVaultActionsReturn {
   // the deposit modal) can unmount mid-flight; without this guard those
   // post-await setters fire on an unmounted component.
   const mountedRef = useRef(true);
+  // Cancels an in-flight broadcast. `mountedRef` only suppresses setState — it
+  // does not stop the flow, and the Ethereum finality gate can hold
+  // `handleBroadcast` for ~1.6 min, which is ample time for the user to close
+  // the modal. Without this the abandoned flow would carry on and raise a BTC
+  // wallet popup with no UI behind it.
+  const broadcastAbortRef = useRef<AbortController | null>(null);
   useEffect(() => {
     mountedRef.current = true; // reset on remount (StrictMode setup→cleanup→setup)
     return () => {
       mountedRef.current = false;
+      // Abort on real unmount only. StrictMode re-runs the effect synchronously
+      // in the same task, so this microtask fires after the remount has already
+      // set mountedRef back to true — matching useDepositFlow's abort seam.
+      queueMicrotask(() => {
+        if (!mountedRef.current) {
+          broadcastAbortRef.current?.abort();
+          broadcastAbortRef.current = null;
+        }
+      });
     };
   }, []);
 
@@ -197,6 +211,10 @@ export function useVaultActions(): UseVaultActionsReturn {
 
     setBroadcasting(true);
     setBroadcastError(null);
+
+    const abortController = new AbortController();
+    broadcastAbortRef.current = abortController;
+    const { signal } = abortController;
 
     try {
       // Fetch vault data from GraphQL
@@ -271,31 +289,48 @@ export function useVaultActions(): UseVaultActionsReturn {
       //
       // Deliberately ahead of the wallet-liveness probe and everything after
       // it: no popup, no UTXO read and no signing should happen for a deposit
-      // we may refuse to broadcast. Any deposit registered more than ~2 min ago
-      // clears the fast path below without a poll or a progress panel.
-      if (!(await isEthRegistrationFinal(onChainVault.createdAt))) {
-        let finalBasicInfo;
-        try {
-          ({ basicInfo: finalBasicInfo } = await waitForEthRegistrationDepth({
-            vaultIds: [vaultId],
-            onProgress: setEthConfirmationDetail,
-          }));
-        } finally {
-          if (mountedRef.current) setEthConfirmationDetail(null);
-        }
+      // we may refuse to broadcast.
+      //
+      // Runs unconditionally, with no "already deep enough" shortcut computed
+      // from the `createdAt` read above. A shortcut would authorise the
+      // broadcast from a vault reading taken several RPC round-trips earlier
+      // and never look at the registry again; the wait re-reads live vault
+      // state and hands back the observation the status check below uses. For
+      // an already-final deposit — nearly every resume — it costs one extra
+      // contract read and returns without polling or rendering a counter.
+      let finalBasicInfo;
+      try {
+        ({ basicInfo: finalBasicInfo } = await waitForEthRegistrationDepth({
+          vaultIds: [vaultId],
+          // Publish only while the gate is actually holding. An already-final
+          // deposit reports its (large) depth once on the way out, and
+          // rendering that would flash a nonsensical "50000 of 8" counter.
+          onProgress: (progress) => {
+            if (progress.confirmations < progress.required) {
+              setEthConfirmationDetail(progress);
+            }
+          },
+          signal,
+        }));
+      } finally {
+        if (mountedRef.current) setEthConfirmationDetail(null);
+      }
 
-        // The PENDING gate above read pre-wait state and the wait can span
-        // minutes. `prePeginTxHash` cannot go stale — vaultId commits to it,
-        // so any re-mined registration under this id carries the same hash —
-        // but `status` can, so re-assert it on the post-wait observation.
-        if (finalBasicInfo.status !== OnChainBtcVaultStatus.PENDING) {
-          const label =
-            OnChainBtcVaultStatus[finalBasicInfo.status] ??
-            `UNKNOWN(${finalBasicInfo.status})`;
-          throw new Error(
-            `Cannot broadcast: on-chain BTC Vault is in ${label} state. Broadcast is only valid during PENDING.`,
-          );
-        }
+      // The modal can be dismissed during a wait that spans minutes. Stop here
+      // rather than surfacing a BTC wallet popup for a flow whose UI is gone.
+      if (signal.aborted) return;
+
+      // The PENDING gate above read pre-wait state and the wait can span
+      // minutes. `prePeginTxHash` cannot go stale — vaultId commits to it, so
+      // any re-mined registration under this id carries the same hash — but
+      // `status` can, so re-assert it on the post-wait observation.
+      if (finalBasicInfo.status !== OnChainBtcVaultStatus.PENDING) {
+        const label =
+          OnChainBtcVaultStatus[finalBasicInfo.status] ??
+          `UNKNOWN(${finalBasicInfo.status})`;
+        throw new Error(
+          `Cannot broadcast: on-chain BTC Vault is in ${label} state. Broadcast is only valid during PENDING.`,
+        );
       }
 
       // Get BTC wallet provider

--- a/services/vault/src/hooks/deposit/useVaultActions.ts
+++ b/services/vault/src/hooks/deposit/useVaultActions.ts
@@ -231,7 +231,9 @@ export function useVaultActions(): UseVaultActionsReturn {
 
       if (vault.status !== ContractStatus.PENDING) {
         throw new Error(
-          `Cannot continue: BTC Vault is in ${ContractStatus[vault.status]} state. This step is only valid while the vault is PENDING.`,
+          COPY.deposit.errors.cannotBroadcastInState(
+            ContractStatus[vault.status],
+          ),
         );
       }
 
@@ -281,7 +283,7 @@ export function useVaultActions(): UseVaultActionsReturn {
           OnChainBtcVaultStatus[onChainVault.status] ??
           `UNKNOWN(${onChainVault.status})`;
         throw new Error(
-          `Cannot continue: on-chain BTC Vault is in ${label} state. This step is only valid while the vault is PENDING.`,
+          COPY.deposit.errors.cannotBroadcastInOnChainState(label),
         );
       }
 
@@ -334,7 +336,7 @@ export function useVaultActions(): UseVaultActionsReturn {
           OnChainBtcVaultStatus[finalBasicInfo.status] ??
           `UNKNOWN(${finalBasicInfo.status})`;
         throw new Error(
-          `Cannot continue: on-chain BTC Vault is in ${label} state. This step is only valid while the vault is PENDING.`,
+          COPY.deposit.errors.cannotBroadcastInOnChainState(label),
         );
       }
 

--- a/services/vault/src/hooks/deposit/useVaultActions.ts
+++ b/services/vault/src/hooks/deposit/useVaultActions.ts
@@ -44,6 +44,11 @@ import {
   TELEMETRY_STAGE,
 } from "@/infrastructure/telemetryEvents";
 import {
+  isEthRegistrationFinal,
+  waitForEthRegistrationDepth,
+  type RegistrationDepthProgress,
+} from "@/services/vault/ethConfirmationGate";
+import {
   ActivationNotPossibleError,
   isTerminalActivationError,
 } from "@/utils/errors";
@@ -129,6 +134,12 @@ export interface UseVaultActionsReturn {
   // Broadcast state
   broadcasting: boolean;
   broadcastError: string | null;
+  /**
+   * Live Ethereum confirmation depth while the finality gate holds a resume
+   * broadcast. `null` outside that window — which is the overwhelmingly common
+   * case, since a resumed deposit is usually long past the required depth.
+   */
+  ethConfirmationDetail: RegistrationDepthProgress | null;
   handleBroadcast: (params: BroadcastPrePeginParams) => Promise<void>;
   // Activation state
   activating: boolean;
@@ -147,6 +158,8 @@ export function useVaultActions(): UseVaultActionsReturn {
   // Broadcast state
   const [broadcasting, setBroadcasting] = useState(false);
   const [broadcastError, setBroadcastError] = useState<string | null>(null);
+  const [ethConfirmationDetail, setEthConfirmationDetail] =
+    useState<RegistrationDepthProgress | null>(null);
 
   // Activation state
   const [activating, setActivating] = useState(false);
@@ -247,6 +260,42 @@ export function useVaultActions(): UseVaultActionsReturn {
         throw new Error(
           `Cannot broadcast: on-chain BTC Vault is in ${label} state. Broadcast is only valid during PENDING.`,
         );
+      }
+
+      // Ethereum finality gate. Same rule as the inline deposit flow: the
+      // Pre-PegIn must not be broadcast while the registration is still
+      // reorg-exposed, or a reorg leaves the BTC locked in an HTLC whose vault
+      // record no longer exists. Depth comes from `createdAt` (the ETH block
+      // the registration mined at), which needs no transaction hash — the
+      // reason this works on a cross-device resume with no local record.
+      //
+      // Deliberately ahead of the wallet-liveness probe and everything after
+      // it: no popup, no UTXO read and no signing should happen for a deposit
+      // we may refuse to broadcast. Any deposit registered more than ~2 min ago
+      // clears the fast path below without a poll or a progress panel.
+      if (!(await isEthRegistrationFinal(onChainVault.createdAt))) {
+        let finalBasicInfo;
+        try {
+          ({ basicInfo: finalBasicInfo } = await waitForEthRegistrationDepth({
+            vaultIds: [vaultId],
+            onProgress: setEthConfirmationDetail,
+          }));
+        } finally {
+          if (mountedRef.current) setEthConfirmationDetail(null);
+        }
+
+        // The PENDING gate above read pre-wait state and the wait can span
+        // minutes. `prePeginTxHash` cannot go stale — vaultId commits to it,
+        // so any re-mined registration under this id carries the same hash —
+        // but `status` can, so re-assert it on the post-wait observation.
+        if (finalBasicInfo.status !== OnChainBtcVaultStatus.PENDING) {
+          const label =
+            OnChainBtcVaultStatus[finalBasicInfo.status] ??
+            `UNKNOWN(${finalBasicInfo.status})`;
+          throw new Error(
+            `Cannot broadcast: on-chain BTC Vault is in ${label} state. Broadcast is only valid during PENDING.`,
+          );
+        }
       }
 
       // Get BTC wallet provider
@@ -664,6 +713,7 @@ export function useVaultActions(): UseVaultActionsReturn {
   return {
     broadcasting,
     broadcastError,
+    ethConfirmationDetail,
     handleBroadcast,
     activating,
     activationError,

--- a/services/vault/src/hooks/deposit/useVaultActions.ts
+++ b/services/vault/src/hooks/deposit/useVaultActions.ts
@@ -458,6 +458,14 @@ export function useVaultActions(): UseVaultActionsReturn {
           depositorBtcPubkey,
           fundedTxFee,
         });
+        // Last cancellation point before the wallet signs. Several network
+        // round-trips (UTXO availability, version/key re-checks, and on the
+        // intent path the terms rebuild) sit between the finality gate and
+        // here, and the modal can be dismissed during any of them. Past this
+        // line the flow is committed: aborting mid-signature would leave the
+        // device ceremony half-run for no benefit.
+        if (signal.aborted) return;
+
         await broadcastPrePeginTransaction({
           unsignedTxHex,
           btcWalletProvider: {
@@ -482,6 +490,14 @@ export function useVaultActions(): UseVaultActionsReturn {
           localUnsignedTxHex && pendingPegin?.selectedUTXOs?.length
             ? utxosToExpectedRecord(pendingPegin.selectedUTXOs)
             : undefined;
+        // Last cancellation point before the wallet signs. Several network
+        // round-trips (UTXO availability, version/key re-checks, and on the
+        // intent path the terms rebuild) sit between the finality gate and
+        // here, and the modal can be dismissed during any of them. Past this
+        // line the flow is committed: aborting mid-signature would leave the
+        // device ceremony half-run for no benefit.
+        if (signal.aborted) return;
+
         await broadcastPrePeginTransaction({
           unsignedTxHex,
           btcWalletProvider: {

--- a/services/vault/src/hooks/deposit/useVaultActions.ts
+++ b/services/vault/src/hooks/deposit/useVaultActions.ts
@@ -16,10 +16,7 @@ import {
   vpTokenRegistry,
 } from "@babylonlabs-io/ts-sdk/tbv/core/clients";
 import { validateSecretAgainstHashlock } from "@babylonlabs-io/ts-sdk/tbv/core/services";
-import {
-  calculateBtcTxHash,
-  UtxoNotAvailableError,
-} from "@babylonlabs-io/ts-sdk/tbv/core/utils";
+import { calculateBtcTxHash } from "@babylonlabs-io/ts-sdk/tbv/core/utils";
 import {
   getSharedWagmiConfig,
   useChainConnector,
@@ -50,6 +47,8 @@ import {
 import {
   ActivationNotPossibleError,
   isTerminalActivationError,
+  mapDepositError,
+  type DepositErrorContent,
 } from "@/utils/errors";
 import { assertVaultCoreVersionSupported } from "@/utils/vaultCoreVersionSupport";
 
@@ -132,7 +131,12 @@ export interface ActivateVaultParams {
 export interface UseVaultActionsReturn {
   // Broadcast state
   broadcasting: boolean;
-  broadcastError: string | null;
+  /**
+   * Broadcast failure, already classified into user-facing copy. Mapped at the
+   * catch site rather than stored as a string, so typed errors reach the
+   * mapper with their prototype intact.
+   */
+  broadcastError: DepositErrorContent | null;
   /**
    * Live Ethereum confirmation depth while the finality gate holds a resume
    * broadcast. `null` outside that window — which is the overwhelmingly common
@@ -156,7 +160,8 @@ export function useVaultActions(): UseVaultActionsReturn {
 
   // Broadcast state
   const [broadcasting, setBroadcasting] = useState(false);
-  const [broadcastError, setBroadcastError] = useState<string | null>(null);
+  const [broadcastError, setBroadcastError] =
+    useState<DepositErrorContent | null>(null);
   const [ethConfirmationDetail, setEthConfirmationDetail] =
     useState<RegistrationDepthProgress | null>(null);
 
@@ -226,7 +231,7 @@ export function useVaultActions(): UseVaultActionsReturn {
 
       if (vault.status !== ContractStatus.PENDING) {
         throw new Error(
-          `Cannot broadcast: BTC Vault is in ${ContractStatus[vault.status]} state. Broadcast is only valid during PENDING.`,
+          `Cannot continue: BTC Vault is in ${ContractStatus[vault.status]} state. This step is only valid while the vault is PENDING.`,
         );
       }
 
@@ -276,7 +281,7 @@ export function useVaultActions(): UseVaultActionsReturn {
           OnChainBtcVaultStatus[onChainVault.status] ??
           `UNKNOWN(${onChainVault.status})`;
         throw new Error(
-          `Cannot broadcast: on-chain BTC Vault is in ${label} state. Broadcast is only valid during PENDING.`,
+          `Cannot continue: on-chain BTC Vault is in ${label} state. This step is only valid while the vault is PENDING.`,
         );
       }
 
@@ -329,7 +334,7 @@ export function useVaultActions(): UseVaultActionsReturn {
           OnChainBtcVaultStatus[finalBasicInfo.status] ??
           `UNKNOWN(${finalBasicInfo.status})`;
         throw new Error(
-          `Cannot broadcast: on-chain BTC Vault is in ${label} state. Broadcast is only valid during PENDING.`,
+          `Cannot continue: on-chain BTC Vault is in ${label} state. This step is only valid while the vault is PENDING.`,
         );
       }
 
@@ -528,22 +533,22 @@ export function useVaultActions(): UseVaultActionsReturn {
       if (mountedRef.current) setBroadcasting(false);
     } catch (err) {
       if (mountedRef.current) {
-        let errorMessage: string;
-
-        // DepositTermsRejectedError arrives message-preserved, so mapDepositError
-        // classifies it like the fresh path today. broadcastError is string by
-        // contract; when #2110 adds a typed branch, thread the typed error to
-        // the mapper here (as useDepositFlow does).
-        if (err instanceof UtxoNotAvailableError) {
-          // UTXO not available - provide specific error message
-          errorMessage = err.message;
-        } else if (err instanceof Error) {
-          errorMessage = err.message;
-        } else {
-          errorMessage = "Failed to broadcast transaction";
-        }
-
-        setBroadcastError(errorMessage);
+        // Classify here, while the typed error is still intact — the same seam
+        // useDepositFlow uses. Flattening to `err.message` first would strip
+        // the prototype and name that every `instanceof` branch in the mapper
+        // narrows on, silently downgrading precise errors to message matching:
+        // a finality-gate timeout would land in the "broadcast failed" bucket
+        // and tell the user their Bitcoin broadcast failed when nothing was
+        // ever sent.
+        setBroadcastError(mapDepositError(err));
+        // Mapping replaces the raw message with friendly copy, and only the
+        // fallback branch carries `diagnostics`. Log the original so a mapped
+        // failure is still diagnosable — `useBroadcastState`'s catch cannot do
+        // it, because this function resolves rather than rethrowing.
+        logger.error(err instanceof Error ? err : new Error(String(err)), {
+          tags: { vaultId: shortId(vaultId) },
+          data: { context: "Resume broadcast failed" },
+        });
         setBroadcasting(false);
       }
     }

--- a/services/vault/src/services/vault/ethConfirmationGate.ts
+++ b/services/vault/src/services/vault/ethConfirmationGate.ts
@@ -14,7 +14,6 @@
  */
 
 import {
-  isPeginRegistrationFinal,
   waitForPeginRegistrationDepth,
   type PeginRegistrationDepthResult,
   type RegistrationDepthProgress,
@@ -51,19 +50,4 @@ export async function waitForEthRegistrationDepth(
     onProgress,
     signal,
   });
-}
-
-/**
- * Cheap pre-check for a `createdAt` already in hand.
- *
- * The resume path reads the vault before it reaches the gate, so any deposit
- * registered more than ~2 minutes ago short-circuits here — no extra contract
- * read, no poll loop, and no confirmation panel flashing on screen for a
- * deposit that has been final for hours.
- */
-export async function isEthRegistrationFinal(
-  createdAtBlock: bigint,
-): Promise<boolean> {
-  const currentBlock = await ethClient.getPublicClient().getBlockNumber();
-  return isPeginRegistrationFinal({ currentBlock, createdAtBlock });
 }

--- a/services/vault/src/services/vault/ethConfirmationGate.ts
+++ b/services/vault/src/services/vault/ethConfirmationGate.ts
@@ -1,0 +1,69 @@
+/**
+ * App-side binding for the SDK's peg-in registration finality gate.
+ *
+ * Both Pre-PegIn broadcast paths — the inline deposit flow and the resume /
+ * cross-device flow — must prove the Ethereum registration is buried
+ * deep enough before any BTC is committed to the HTLC (the required depth is
+ * the SDK's `PEGIN_ETH_CONFIRMATIONS`). This module supplies the two chain readers the SDK primitive
+ * needs so neither call site has to.
+ *
+ * Import this by its own path, never through the `@/services/vault` barrel:
+ * that barrel is factory-mocked with a fixed export list in the deposit hook
+ * tests, and a new barrel export would break them for reasons unrelated to
+ * what they assert.
+ */
+
+import {
+  isPeginRegistrationFinal,
+  waitForPeginRegistrationDepth,
+  type PeginRegistrationDepthResult,
+  type RegistrationDepthProgress,
+} from "@babylonlabs-io/ts-sdk/tbv/core/services";
+import type { Hex } from "viem";
+
+import { ethClient } from "@/clients/eth-contract/client";
+import { getVaultRegistryReader } from "@/clients/eth-contract/sdk-readers";
+
+export type { RegistrationDepthProgress };
+
+export interface WaitForEthRegistrationDepthParams {
+  /** Every vault registered by the same ETH transaction; the shallowest gates. */
+  vaultIds: readonly Hex[];
+  onProgress?: (progress: RegistrationDepthProgress) => void;
+  signal?: AbortSignal;
+}
+
+/**
+ * Block until the peg-in registration for `vaultIds` is final.
+ *
+ * @throws {PeginRegistrationMissingError} the vault is not registered on-chain.
+ * @throws {PeginRegistrationNotFinalError} the depth was not reached in budget.
+ */
+export async function waitForEthRegistrationDepth(
+  params: WaitForEthRegistrationDepthParams,
+): Promise<PeginRegistrationDepthResult> {
+  const { vaultIds, onProgress, signal } = params;
+
+  return waitForPeginRegistrationDepth({
+    vaultRegistryReader: getVaultRegistryReader(),
+    getBlockNumber: () => ethClient.getPublicClient().getBlockNumber(),
+    vaultIds,
+    onProgress,
+    signal,
+  });
+}
+
+/**
+ * Cheap pre-check for a `createdAt` already in hand.
+ *
+ * The resume path reads the vault before it reaches the gate, so any deposit
+ * registered more than ~2 minutes ago short-circuits here — no extra contract
+ * read, no poll loop, and no confirmation panel flashing on screen for a
+ * deposit that has been final for hours.
+ */
+export async function isEthRegistrationFinal(
+  createdAtBlock: bigint,
+): Promise<boolean> {
+  const currentBlock = await ethClient.getPublicClient().getBlockNumber();
+  return isPeginRegistrationFinal({ currentBlock, createdAtBlock });
+}

--- a/services/vault/src/utils/activationDeadline.ts
+++ b/services/vault/src/utils/activationDeadline.ts
@@ -1,5 +1,5 @@
 // Ethereum L1 consensus slot time; missed slots only make real intervals >= 12s, so 12s yields a safe UPPER bound on elapsed blocks.
-const ETH_SLOT_SECONDS = 12;
+export const ETH_SLOT_SECONDS = 12;
 
 const MILLISECONDS_PER_SECOND = 1000;
 

--- a/services/vault/src/utils/errors/__tests__/depositErrors.test.ts
+++ b/services/vault/src/utils/errors/__tests__/depositErrors.test.ts
@@ -6,6 +6,10 @@
  */
 
 import {
+  PeginRegistrationMissingError,
+  PeginRegistrationNotFinalError,
+} from "@babylonlabs-io/ts-sdk/tbv/core";
+import {
   JsonRpcError,
   RpcErrorCode,
 } from "@babylonlabs-io/ts-sdk/tbv/core/clients";
@@ -36,6 +40,39 @@ describe("mapDepositError", () => {
       "User rejected the PSBT signing request",
     );
     expect(mapDepositError(err)).toEqual(ERRORS.signingRejected);
+  });
+
+  it("maps a finality-gate timeout to the Ethereum-confirmation callout", () => {
+    const err = new PeginRegistrationNotFinalError(
+      "Peg-in registration did not reach 8 Ethereum confirmations within 600000ms.",
+    );
+    expect(mapDepositError(err)).toEqual(ERRORS.ethRegistrationNotFinal);
+  });
+
+  it("does NOT classify a finality-gate timeout as a broadcast failure", () => {
+    // The gate stops the flow before anything reaches Bitcoin. Telling the
+    // user their broadcast failed would be the opposite of what happened, and
+    // would invite a retry of something that never ran. This is the exact
+    // inversion that shipped when the typed error was flattened to a string
+    // before reaching the mapper.
+    const err = new PeginRegistrationNotFinalError(
+      "Peg-in registration did not reach 8 Ethereum confirmations within 600000ms.",
+    );
+    expect(mapDepositError(err)).not.toEqual(ERRORS.broadcastFailed);
+  });
+
+  it("maps a missing registration to the not-visible-on-chain callout", () => {
+    const err = new PeginRegistrationMissingError(
+      "Vault 0xabc is still not visible on-chain after 11 reads.",
+    );
+    expect(mapDepositError(err)).toEqual(ERRORS.ethRegistrationMissing);
+  });
+
+  it("does not leak the raw vault id for a missing registration", () => {
+    const err = new PeginRegistrationMissingError(
+      "Vault 0xdeadbeefdeadbeef is still not visible on-chain after 11 reads.",
+    );
+    expect(JSON.stringify(mapDepositError(err))).not.toContain("0xdeadbeef");
   });
 
   it("maps a vault-provider JsonRpcError to its VP title and body", () => {

--- a/services/vault/src/utils/errors/depositErrors.ts
+++ b/services/vault/src/utils/errors/depositErrors.ts
@@ -14,6 +14,8 @@
  *  - Vault-provider RPC — JsonRpcError from the VP (syncing, timeout, network,
  *    proxy timeout/unavailable, generic). Delegated to `mapVpRpcError`.
  *  - Registered-version mismatch — protocol params rotated mid-deposit.
+ *  - Ethereum registration finality — the registration never reached the
+ *    required confirmation depth, or disappeared from chain state entirely.
  *  - Wallet not connected / wallet client missing.
  *  - Wallet account changed mid-flow (the WOTS-vs-PoP key guard).
  *  - Wrong wallet connected on resume (WOTS hash mismatch).
@@ -29,6 +31,8 @@
 
 import {
   isParticipantKeyDriftError,
+  isPeginRegistrationMissingError,
+  isPeginRegistrationNotFinalError,
   isRegisteredVaultVersionMismatchError,
 } from "@babylonlabs-io/ts-sdk/tbv/core";
 import { JsonRpcError } from "@babylonlabs-io/ts-sdk/tbv/core/clients";
@@ -123,6 +127,16 @@ export function mapDepositError(err: unknown): DepositErrorContent {
   // inviting a retry.
   if (isParticipantKeyDriftError(err)) {
     return ERRORS.participantKeyDrift;
+  }
+
+  // 3c. Ethereum registration finality gate. Both cases stop the flow BEFORE
+  // the Pre-PegIn is broadcast, so no Bitcoin has moved — the copy leads with
+  // that, because a failure at this point looks alarming and is not.
+  if (isPeginRegistrationNotFinalError(err)) {
+    return ERRORS.ethRegistrationNotFinal;
+  }
+  if (isPeginRegistrationMissingError(err)) {
+    return ERRORS.ethRegistrationMissing;
   }
 
   const msg = lowerMessage(err);


### PR DESCRIPTION
# Wait 8 ETH confirmations before broadcasting the Pre-PegIn

Closes https://github.com/babylonlabs-io/babylon-toolkit/issues/2202. Decision record: https://github.com/babylonlabs-io/babylon-toolkit/issues/1463.

## The problem

A deposit happens in two steps: first we register the vault on Ethereum, then we broadcast the Pre-PegIn transaction that locks the user's BTC into the HTLC.

Today nothing sits between those two steps. We broadcast the BTC as soon as the Ethereum transaction has **one** confirmation.

If Ethereum reorgs and drops the block holding that registration, we end up in the worst combination: the vault record is gone from the chain, but the user's BTC is already locked. The app thinks the deposit succeeded. The only way out is the HTLC refund path after roughly three days.

This is a **liveness** fix — the deposit gets stuck, funds are not stealable. Issue https://github.com/babylonlabs-io/babylon-toolkit/issues/1463 has the full analysis, including why the original "an attacker takes over the HTLC" framing was wrong.

## What this PR does

Waits until the Ethereum registration is **8 blocks deep** before broadcasting the Pre-PegIn. That is about 1.6 minutes, and 8 is one more than the deepest reorg ever seen on Ethereum (7).

The wait is applied at both places that can broadcast a Pre-PegIn:

- the normal deposit flow (`useDepositFlow.ts`)
- the resume / "Broadcast" button flow, including resuming from a different device (`useVaultActions.ts`)

The user sees a live `3 of 8` counter with a time estimate and a short sentence explaining the pause, so 1.6 minutes of waiting does not look like a frozen app.

## How we measure the 8 confirmations

We use `createdAt` from `getBtcVaultBasicInfo`. Despite the name it is **not a timestamp** — it is the Ethereum block number the registration was mined in. The contract itself compares it against `block.number`, and `useActivationDeadlineGate` already relies on that.

So the depth is just:

```
confirmations = currentBlock - createdAt + 1
```

Both reads are plain `latest` reads, and we re-read on every poll.

## Approaches considered

**1. Pass `confirmations: 8` to viem's `waitForTransactionReceipt`** — this is what the issue suggested, and it is a one-line change. **We did not do this, because it does not work.**

I read the viem source (`viem@2.38.2`, `actions/public/waitForTransactionReceipt.js`). It fetches the receipt once and caches it. After that, on every new block it only does arithmetic against that cached copy:

```js
if (receipt) {
  if (confirmations > 1 && (blockNumber - receipt.blockNumber + 1n < confirmations)) return
  done(() => emit.resolve(receipt))   // never re-fetches, never re-checks the chain
}
```

If the block holding our transaction gets orphaned, the chain tip keeps rising, the subtraction keeps growing, and viem happily resolves with a receipt for a transaction that is **no longer on the chain**. It buys a 96 second delay and zero protection — which is worse than no fix, because it looks like a fix.

**2. Read the vault at an older block (`blockNumber = tip - 7`)** — if the vault exists 7 blocks back, it is 8 deep. This works, but it depends on the RPC still holding state from 8 blocks ago. Regular nodes usually do, but a node that just restarted, or a lagging node behind a load balancer, answers with an error — and "RPC failed" and "vault not deep enough yet" are hard to tell apart, which is exactly the kind of silent fallback we do not want on this path. It also opts out of our multicall batching. Rejected as unnecessary risk.

**3. Use the block number the indexer reports** — simple, but we deliberately do not trust the indexer for decisions that gate signing or broadcasting. Rejected.

**4. Compare `createdAt` against the current block (chosen).** Two normal `latest` reads, no transaction hash needed, and it re-reads real contract state each poll. If the registration gets reorged out, the vault reads back as an empty record and we see it immediately.

## Why approach 4 won

- **It works on the resume path.** That path has no Ethereum transaction hash at all — the user may be on a different device with empty local storage. Anything receipt-based simply cannot be used there. `createdAt` comes from the vault itself, so one mechanism covers both flows.
- **Reorg detection is real, not assumed.** Every poll asks the chain again. Orphaned registration means an empty record, and the counter honestly rewinds to 0 and waits for it to come back (which is the normal outcome — dropped transactions usually get re-included within a block or two).
- **It survives the user speeding up their transaction.** If the wallet replaces the ETH transaction with a higher gas price, a receipt-based wait would hang on a hash that never lands. Here the replacement registers the same vault, and we just keep counting.

## Where the wait sits (this part matters for review)

On the normal flow the wait happens **after** we save the pending deposit record to local storage, not before.

That record holds the build-version and participant-key stamps, and the resume path **skips** those safety checks when the stamp is missing. If we waited first, a user closing the tab during those 1.6 minutes would leave behind a record with no stamp, quietly weakening the checks on their next attempt.

On the resume path the wait sits **before** we touch the BTC wallet. If we are going to refuse the broadcast, the user should never see a wallet popup for it.

## Note: `PeginManager` is intentionally unchanged

The issue lists three places to fix, one being `PeginManager`'s receipt wait. I left it alone on purpose.

`PeginManager` waits for the receipt — it does not broadcast BTC. The two places that actually broadcast are both gated here. And the specific change suggested for it (`confirmations: 8`) is the viem approach above, which does not do what it looks like it does.

Instead I added a comment on that `confirmations` parameter explaining why it must not be used for finality, so nobody re-adds it later thinking it helps.

## Files changed

| Area | What |
|---|---|
| `packages/babylon-ts-sdk/.../deposit/peginRegistrationDepth.ts` | New. The constant (`PEGIN_ETH_CONFIRMATIONS = 8`), the depth maths, and the polling loop. |
| `services/vault/src/services/vault/ethConfirmationGate.ts` | New. Small app-side wrapper that plugs in our chain readers. |
| `useDepositFlow.ts` / `useVaultActions.ts` | The two gates. |
| `btc-vault-registry/query.ts` | Surfaces `createdAt` (no extra RPC call — we already fetched it and threw it away). |
| `EthConfirmationDetail.tsx`, `steps.ts`, `DepositProgressView.tsx`, `copy.ts` | The `3 of 8` counter and its panel. |
| `waitForTransactionReceiptSmartAware.ts`, `PeginManager.ts`, `e2e/real/timing.ts` | Comments only — warnings so this does not get "helpfully" undone later. |

No new step was added to `DepositFlowStep`. Adding one would renumber everything that reads `getVisualStep`, including the E2E step machine that finds steps by their `Step N active` label, and this is really a sub-state of an existing step. It reuses the same `description` counter that peg-in and payout signing already use.

## Testing

- 17 new SDK tests: the depth maths, the poll loop, timeout, abort, transient RPC failure, and a full reorg-and-recover sequence (seen at 5 → drops out → comes back → reaches 8).
- 20 new app tests, covering the resume path specifically as the issue asked: cross-device resume with no local record, wallet never touched while waiting, on-chain status re-checked after the wait, and the fast path where an older deposit broadcasts with no wait at all.
- **Mutation checked**: deleting the resume gate fails exactly the 7 new resume tests; deleting the normal-flow gate fails exactly the 3 new flow tests. They are not passing by accident.
- Full suites green: 1541 SDK, 3280 vault. Lint clean, all packages build.

## What to check when reviewing

- The wait is placed after the pending record is saved on the normal flow, and before the BTC wallet is touched on the resume path.
- After the wait, the resume path re-checks the vault status. The earlier status check can be minutes stale by then. The `prePeginTxHash` check does not need re-checking, because the vault ID is derived from that hash and cannot change under it.
- A missing or zero `createdAt` throws rather than defaulting to `0`. Defaulting would read as "infinitely deep" and pass the gate — the one dangerous mistake available here, and there is a test pinning it.

## Not in this PR

Recovery for a registration that has *already* been orphaned is https://github.com/babylonlabs-io/babylon-toolkit/issues/2203, which is waiting on a script from the protocol team.