### PR TITLE
feat(ledger-vault-signer): wire provider signPsbt/signPsbts onto sign…

### DIFF
--- a/packages/babylon-ledger-vault-signer/src/__tests__/expectedSignatures.test.ts
+++ b/packages/babylon-ledger-vault-signer/src/__tests__/expectedSignatures.test.ts
@@ -21,7 +21,7 @@ import { describe, expect, it } from "vitest";
 
 import { isLedgerSignPsbtProtocolError } from "../errors";
 import { buildExpectedSignatureTable, type ExpectedSignaturePsbt } from "../expectedSignatures";
-import { prepareSignPsbt } from "../signPsbtPrepare";
+import { getPreparedSignPsbtState, prepareSignPsbt } from "../signPsbtPrepare";
 
 initEccLib(ecc);
 
@@ -449,10 +449,12 @@ describe("tapscript control block must commit to its leaf, driven by PegIn fixtu
 describe("YieldCollector treats a short signature as a malformed payload", () => {
   it("raises a protocol error, not a yield mismatch, for a signature shorter than 64 bytes", () => {
     const vector = loadVector("generated__deposit-flow__pegin__0");
-    const { collector, table } = prepareSignPsbt({
+    const prepared = prepareSignPsbt({
       psbtHex: vector.psbt_hex,
       depositorXOnlyHex: TEST_DEPOSITOR_KEY_HEX,
     });
+    const { collector } = getPreparedSignPsbtState(prepared);
+    const { table } = prepared;
     const expectation = table.byInput.get(0);
     if (expectation?.kind !== "tapscript") throw new Error("input 0 must classify tapscript");
     // Tapscript YIELD payload (0x10 code byte already stripped by the interpreter):

--- a/packages/babylon-ledger-vault-signer/src/__tests__/signPsbt.test.ts
+++ b/packages/babylon-ledger-vault-signer/src/__tests__/signPsbt.test.ts
@@ -163,7 +163,7 @@ describe("signVaultPsbt", () => {
     expect(isLedgerSignPsbtAbortedError(outcome)).toBe(true);
     if (!isLedgerSignPsbtAbortedError(outcome)) throw new Error("expected an aborted error");
     // No dispatcher was interrupted — the caller must not arm resend-once.
-    expect(outcome.sentInitialApdu).toBe(false);
+    expect(outcome.dispatcherInterrupted).toBe(false);
     expect(sent()).toBe(0);
   });
 
@@ -190,7 +190,8 @@ describe("signVaultPsbt", () => {
 
     expect(isLedgerSignPsbtAbortedError(outcome)).toBe(true);
     if (!isLedgerSignPsbtAbortedError(outcome)) throw new Error("expected an aborted error");
-    expect(outcome.sentInitialApdu).toBe(true);
+    // The 0xE000 arrived, so a dispatcher is mid-interruption awaiting CONTINUE.
+    expect(outcome.dispatcherInterrupted).toBe(true);
     expect(sent()).toBe(1);
   });
 
@@ -213,6 +214,29 @@ describe("signVaultPsbt", () => {
     expect(stagedSender.sent()).toBe(script.length);
     expect(staged.signedPsbtHex).toBe(composed.signedPsbtHex);
     expect(staged.yields).toEqual(composed.yields);
+  });
+
+  it("threads resendOnceOnIncorrectData through the composed entry point", async () => {
+    // Pins the options forwarding: a first-exchange 0x6A80 with the recovery
+    // armed resends the identical APDU once, then the ceremony completes.
+    const leafHashHex = fixtureLeafHashHex();
+    const script = peginScript(leafHashHex);
+    const initialHex = script[0].expectApduHex;
+    const withEatenFirst: ScriptedExchange[] = [
+      { expectApduHex: initialHex, respondSw: 0x6a80, respondDataHex: "" },
+      ...script,
+    ];
+    const { send, sent } = createScriptedSender(withEatenFirst);
+
+    const result = await signVaultPsbt(send, {
+      psbtHex: vector.psbt_hex,
+      depositorXOnlyHex: TEST_DEPOSITOR_KEY_HEX,
+      signal: new AbortController().signal,
+      resendOnceOnIncorrectData: true,
+    });
+
+    expect(sent()).toBe(withEatenFirst.length);
+    expect(result.yields).toHaveLength(1);
   });
 
   it("rejects reuse of a prepared signing state after success, with zero device I/O", async () => {

--- a/packages/babylon-ledger-vault-signer/src/__tests__/signPsbt.test.ts
+++ b/packages/babylon-ledger-vault-signer/src/__tests__/signPsbt.test.ts
@@ -17,7 +17,8 @@ import { describe, expect, it } from "vitest";
 
 import { isLedgerSignPsbtAbortedError } from "../errors";
 import type { RawApduSender } from "../rawApdu";
-import { signVaultPsbt, type SignVaultPsbtParams } from "../signPsbt";
+import { signPreparedVaultPsbt, signVaultPsbt, type SignVaultPsbtParams } from "../signPsbt";
+import { prepareSignPsbt } from "../signPsbtPrepare";
 import { tapLeafHash } from "../tapLeafHash";
 
 const VECTORS_DIR = join(__dirname, "..", "vendor", "ledger-bitcoin", "__tests__", "vectors", "signpsbt");
@@ -160,6 +161,9 @@ describe("signVaultPsbt", () => {
     );
 
     expect(isLedgerSignPsbtAbortedError(outcome)).toBe(true);
+    if (!isLedgerSignPsbtAbortedError(outcome)) throw new Error("expected an aborted error");
+    // No dispatcher was interrupted — the caller must not arm resend-once.
+    expect(outcome.sentInitialApdu).toBe(false);
     expect(sent()).toBe(0);
   });
 
@@ -185,7 +189,30 @@ describe("signVaultPsbt", () => {
     );
 
     expect(isLedgerSignPsbtAbortedError(outcome)).toBe(true);
+    if (!isLedgerSignPsbtAbortedError(outcome)) throw new Error("expected an aborted error");
+    expect(outcome.sentInitialApdu).toBe(true);
     expect(sent()).toBe(1);
+  });
+
+  it("staged API signs identically: prepareSignPsbt + signPreparedVaultPsbt === signVaultPsbt", async () => {
+    const script = peginScript(fixtureLeafHashHex());
+    const composedSender = createScriptedSender(script);
+    const composed = await signVaultPsbt(composedSender.send, {
+      psbtHex: vector.psbt_hex,
+      depositorXOnlyHex: TEST_DEPOSITOR_KEY_HEX,
+      signal: new AbortController().signal,
+    });
+
+    const prepared = prepareSignPsbt({ psbtHex: vector.psbt_hex, depositorXOnlyHex: TEST_DEPOSITOR_KEY_HEX });
+    const stagedSender = createScriptedSender(script);
+    const staged = await signPreparedVaultPsbt(stagedSender.send, prepared, {
+      signal: new AbortController().signal,
+    });
+
+    expect(composedSender.sent()).toBe(script.length);
+    expect(stagedSender.sent()).toBe(script.length);
+    expect(staged.signedPsbtHex).toBe(composed.signedPsbtHex);
+    expect(staged.yields).toEqual(composed.yields);
   });
 
   it("requires a signal — params without one must not typecheck", () => {

--- a/packages/babylon-ledger-vault-signer/src/__tests__/signPsbt.test.ts
+++ b/packages/babylon-ledger-vault-signer/src/__tests__/signPsbt.test.ts
@@ -215,6 +215,37 @@ describe("signVaultPsbt", () => {
     expect(staged.yields).toEqual(composed.yields);
   });
 
+  it("rejects reuse of a prepared signing state after success, with zero device I/O", async () => {
+    // The prepared object's collector/interpreter are mutable ceremony state —
+    // a second run would repeat a non-idempotent ceremony with stale yields.
+    const script = peginScript(fixtureLeafHashHex());
+    const prepared = prepareSignPsbt({ psbtHex: vector.psbt_hex, depositorXOnlyHex: TEST_DEPOSITOR_KEY_HEX });
+    await signPreparedVaultPsbt(createScriptedSender(script).send, prepared, {
+      signal: new AbortController().signal,
+    });
+
+    const { send, sent } = createScriptedSender(script);
+    await expect(signPreparedVaultPsbt(send, prepared, { signal: new AbortController().signal })).rejects.toThrow(
+      /already used/,
+    );
+    expect(sent()).toBe(0);
+  });
+
+  it("rejects reuse of a prepared signing state after an abort", async () => {
+    const prepared = prepareSignPsbt({ psbtHex: vector.psbt_hex, depositorXOnlyHex: TEST_DEPOSITOR_KEY_HEX });
+    const aborted = new AbortController();
+    aborted.abort();
+    await expect(
+      signPreparedVaultPsbt(createScriptedSender([]).send, prepared, { signal: aborted.signal }),
+    ).rejects.toThrow(/abandoned/);
+
+    const { send, sent } = createScriptedSender([]);
+    await expect(signPreparedVaultPsbt(send, prepared, { signal: new AbortController().signal })).rejects.toThrow(
+      /already used/,
+    );
+    expect(sent()).toBe(0);
+  });
+
   it("requires a signal — params without one must not typecheck", () => {
     // @ts-expect-error `signal` is required; the loop has no round cap and no
     // internal timeout, so a caller without a signal cannot bound the ceremony.

--- a/packages/babylon-ledger-vault-signer/src/__tests__/signPsbtLoop.test.ts
+++ b/packages/babylon-ledger-vault-signer/src/__tests__/signPsbtLoop.test.ts
@@ -475,6 +475,35 @@ describe("abort signal (T7 + entry check)", () => {
     expect(withoutSignal.resendOnceOnIncorrectData).toBe(true);
   });
 
+  it("an abort racing the armed resend skips the recovery resend, sentInitialApdu true", async () => {
+    // The one 0x6A80 site with resend-once armed: the initial APDU went out,
+    // so the abort must report an interrupted dispatcher — but never resend.
+    const prepared = prepareFromVector("generated__deposit-flow__pegin__0");
+    const controller = new AbortController();
+    const script: ScriptedExchange[] = [
+      {
+        expectApduHex: initialApduHexOf(prepared),
+        respondSw: 0x6a80,
+        respondDataHex: "",
+        onRespond: () => controller.abort(),
+      },
+    ];
+    const { send, sent } = createScriptedSender(script);
+
+    const outcome = await runSignPsbtLoop(send, prepared, {
+      signal: controller.signal,
+      resendOnceOnIncorrectData: true,
+    }).then(
+      () => undefined,
+      (error: unknown) => error,
+    );
+
+    expect(isLedgerSignPsbtAbortedError(outcome)).toBe(true);
+    if (!isLedgerSignPsbtAbortedError(outcome)) throw new Error("expected an aborted error");
+    expect(outcome.sentInitialApdu).toBe(true);
+    expect(sent()).toBe(1);
+  });
+
   it("reports how many yields had already arrived when the host aborted", async () => {
     const prepared = prepareFromVector("generated__deposit-flow__pegin__0");
     const controller = new AbortController();

--- a/packages/babylon-ledger-vault-signer/src/__tests__/signPsbtLoop.test.ts
+++ b/packages/babylon-ledger-vault-signer/src/__tests__/signPsbtLoop.test.ts
@@ -32,7 +32,12 @@ import {
 import { createYieldCollector, type ExpectedSignatureTable } from "../expectedSignatures";
 import type { Apdu, RawApduSender } from "../rawApdu";
 import { runSignPsbtLoop, type RunSignPsbtLoopOptions, type SignPsbtProgress } from "../signPsbtLoop";
-import { prepareSignPsbt, type PreparedSignPsbt } from "../signPsbtPrepare";
+import {
+  getPreparedSignPsbtState,
+  makePreparedSignPsbt,
+  prepareSignPsbt,
+  type PreparedSignPsbt,
+} from "../signPsbtPrepare";
 import { ClientCommandInterpreter } from "../vendor/ledger-bitcoin/clientCommands";
 import { createVarint } from "../vendor/ledger-bitcoin/varint";
 
@@ -91,7 +96,7 @@ function createScriptedSender(script: readonly ScriptedExchange[]): { send: RawA
 }
 
 function initialApduHexOf(prepared: PreparedSignPsbt): string {
-  return SIGN_PSBT_HEADER_HEX + Buffer.from(prepared.cdata).toString("hex");
+  return SIGN_PSBT_HEADER_HEX + Buffer.from(getPreparedSignPsbtState(prepared).cdata).toString("hex");
 }
 
 /** `0x10 ‖ varint(i) ‖ 0x40 ‖ signer(32) ‖ leaf(32) ‖ sig(64)` — wire-spec §5 tapscript YIELD. */
@@ -219,13 +224,10 @@ describe("happy-path trace replay through the loop (T1, T11, T12)", () => {
     const collector = createYieldCollector(table);
     const interpreter = new ClientCommandInterpreter(undefined, (payload) => collector.assertAndRecord(payload));
     interpreter.addKnownList(elements);
-    const prepared: PreparedSignPsbt = {
-      cdata: Uint8Array.from(Buffer.alloc(4, 0x11)),
-      interpreter,
-      collector,
-      table,
-      originalPsbtHex: "",
-    };
+    const prepared = makePreparedSignPsbt(
+      { table, unsignedTxid: "00".repeat(32) },
+      { cdata: Uint8Array.from(Buffer.alloc(4, 0x11)), interpreter, collector, originalPsbtHex: "" },
+    );
 
     const traces = [
       ...traceFile.traces,
@@ -287,7 +289,7 @@ describe("resend-once on 0x6A80 (T2-T5)", () => {
         resendOnceOnIncorrectData: true,
         signal: controller.signal,
       }),
-    ).rejects.toMatchObject({ name: LedgerSignPsbtAbortedError.name });
+    ).rejects.toMatchObject({ name: LedgerSignPsbtAbortedError.name, dispatcherInterrupted: false });
     expect(sent()).toBe(1);
   });
 
@@ -473,35 +475,6 @@ describe("abort signal (T7 + entry check)", () => {
     const withoutSignal: RunSignPsbtLoopOptions = { resendOnceOnIncorrectData: true };
 
     expect(withoutSignal.resendOnceOnIncorrectData).toBe(true);
-  });
-
-  it("an abort racing the armed resend skips the recovery resend, sentInitialApdu true", async () => {
-    // The one 0x6A80 site with resend-once armed: the initial APDU went out,
-    // so the abort must report an interrupted dispatcher — but never resend.
-    const prepared = prepareFromVector("generated__deposit-flow__pegin__0");
-    const controller = new AbortController();
-    const script: ScriptedExchange[] = [
-      {
-        expectApduHex: initialApduHexOf(prepared),
-        respondSw: 0x6a80,
-        respondDataHex: "",
-        onRespond: () => controller.abort(),
-      },
-    ];
-    const { send, sent } = createScriptedSender(script);
-
-    const outcome = await runSignPsbtLoop(send, prepared, {
-      signal: controller.signal,
-      resendOnceOnIncorrectData: true,
-    }).then(
-      () => undefined,
-      (error: unknown) => error,
-    );
-
-    expect(isLedgerSignPsbtAbortedError(outcome)).toBe(true);
-    if (!isLedgerSignPsbtAbortedError(outcome)) throw new Error("expected an aborted error");
-    expect(outcome.sentInitialApdu).toBe(true);
-    expect(sent()).toBe(1);
   });
 
   it("reports how many yields had already arrived when the host aborted", async () => {

--- a/packages/babylon-ledger-vault-signer/src/__tests__/signPsbtPrepare.test.ts
+++ b/packages/babylon-ledger-vault-signer/src/__tests__/signPsbtPrepare.test.ts
@@ -7,14 +7,14 @@
  * - §2.2 rejections: every prepare-time throw is typed and pre-I/O.
  */
 
-import { crypto as bcrypto, Psbt } from "bitcoinjs-lib";
+import { crypto as bcrypto, Psbt, Transaction } from "bitcoinjs-lib";
 import { Buffer } from "buffer";
 import { readFileSync } from "fs";
 import { join } from "path";
 import { describe, expect, it } from "vitest";
 
 import { isLedgerSignPsbtProtocolError } from "../errors";
-import { buildSignPsbtApdu, prepareSignPsbt } from "../signPsbtPrepare";
+import { buildSignPsbtApdu, getPreparedSignPsbtState, prepareSignPsbt } from "../signPsbtPrepare";
 import { MerkelizedPsbt } from "../vendor/ledger-bitcoin/merkelizedPsbt";
 import { hashLeaf, Merkle } from "../vendor/ledger-bitcoin/merkle";
 import { PsbtV2 } from "../vendor/ledger-bitcoin/psbtv2";
@@ -84,12 +84,30 @@ describe("SIGN_PSBT cdata + APDU golden (G1, 22 fixtures)", () => {
     const vector = loadVector(name);
     const prepared = prepareSignPsbt({ psbtHex: vector.psbt_hex, depositorXOnlyHex: depositorKeyFor(name, vector) });
 
-    expect(Buffer.from(prepared.cdata).toString("hex")).toBe(vector.sign_psbt_cdata_hex);
-    expect(prepared.originalPsbtHex).toBe(vector.psbt_hex);
+    const state = getPreparedSignPsbtState(prepared);
+    expect(Buffer.from(state.cdata).toString("hex")).toBe(vector.sign_psbt_cdata_hex);
+    expect(state.originalPsbtHex).toBe(vector.psbt_hex);
+    // Display-order txid of the unsigned tx — the replay guard's identity key.
+    expect(prepared.unsignedTxid).toBe(
+      Transaction.fromBuffer(Psbt.fromHex(vector.psbt_hex).data.globalMap.unsignedTx.toBuffer()).getId(),
+    );
 
-    const apdu = buildSignPsbtApdu(prepared.cdata);
+    const apdu = buildSignPsbtApdu(state.cdata);
     expect({ cla: apdu.cla, ins: apdu.ins, p1: apdu.p1, p2: apdu.p2 }).toEqual(vector.apdu);
     expect(Buffer.from(apdu.data).toString("hex")).toBe(vector.sign_psbt_cdata_hex);
+  });
+
+  it("unsignedTxid is serialization-insensitive — hex casing must not change the identity", () => {
+    // The provider's replay guard keys on this; a case-variant of the same
+    // bytes reaching a different key would reopen the NoPayout replay hole.
+    const vector = loadVector("generated__deposit-flow__pegin__0");
+    const lower = prepareSignPsbt({ psbtHex: vector.psbt_hex, depositorXOnlyHex: TEST_DEPOSITOR_KEY_HEX });
+    const upper = prepareSignPsbt({
+      psbtHex: vector.psbt_hex.toUpperCase(),
+      depositorXOnlyHex: TEST_DEPOSITOR_KEY_HEX,
+    });
+
+    expect(upper.unsignedTxid).toBe(lower.unsignedTxid);
   });
 });
 
@@ -144,7 +162,7 @@ describe("interpreter completeness after seeding (G4, 22 fixtures)", () => {
   it.each(ALL_VECTOR_NAMES.map((name) => [name]))("%s: every committed element and tree is answerable", (name) => {
     const vector = loadVector(name);
     const prepared = prepareSignPsbt({ psbtHex: vector.psbt_hex, depositorXOnlyHex: depositorKeyFor(name, vector) });
-    const { interpreter } = prepared;
+    const { interpreter } = getPreparedSignPsbtState(prepared);
 
     // Independent reconstruction of what the device may ask for.
     const psbt = new PsbtV2();
@@ -193,9 +211,9 @@ describe("prepare-time rejections (§2.2 — all typed, all pre-I/O)", () => {
     expectPrepareRejects(VALID_PSBT_HEX, badKey, /64 lowercase hex/);
   });
 
-  it("rejects a psbtHex that is not even-length hex", () => {
-    expectPrepareRejects(VALID_PSBT_HEX + "z", TEST_DEPOSITOR_KEY_HEX, /not even-length hex/);
-    expectPrepareRejects(VALID_PSBT_HEX.slice(0, -1), TEST_DEPOSITOR_KEY_HEX, /not even-length hex/);
+  it("rejects a psbtHex that is not even-length hexadecimal", () => {
+    expectPrepareRejects(VALID_PSBT_HEX + "z", TEST_DEPOSITOR_KEY_HEX, /not even-length hexadecimal/);
+    expectPrepareRejects(VALID_PSBT_HEX.slice(0, -1), TEST_DEPOSITOR_KEY_HEX, /not even-length hexadecimal/);
   });
 
   it("rejects a tapscript input with no witnessUtxo before any device work", () => {

--- a/packages/babylon-ledger-vault-signer/src/errors.ts
+++ b/packages/babylon-ledger-vault-signer/src/errors.ts
@@ -189,9 +189,8 @@ export class LedgerSignPsbtAbortedError extends Error {
   /** Yields the device had already delivered when the host stopped sending. */
   readonly yieldedCount: number;
   /**
-   * False only when the abort fired BEFORE the initial SIGN_PSBT APDU went
-   * out: no dispatcher was interrupted, so the caller must NOT arm the
-   * resend-once recovery (it would mask one genuine 0x6A80 later).
+   * False only when the abort fired before the initial APDU went out — no
+   * dispatcher was interrupted, so callers must not arm the resend-once recovery.
    */
   readonly sentInitialApdu: boolean;
 

--- a/packages/babylon-ledger-vault-signer/src/errors.ts
+++ b/packages/babylon-ledger-vault-signer/src/errors.ts
@@ -188,11 +188,18 @@ export class LedgerSignPsbtProtocolError extends Error {
 export class LedgerSignPsbtAbortedError extends Error {
   /** Yields the device had already delivered when the host stopped sending. */
   readonly yieldedCount: number;
+  /**
+   * False only when the abort fired BEFORE the initial SIGN_PSBT APDU went
+   * out: no dispatcher was interrupted, so the caller must NOT arm the
+   * resend-once recovery (it would mask one genuine 0x6A80 later).
+   */
+  readonly sentInitialApdu: boolean;
 
-  constructor(yieldedCount: number) {
+  constructor(yieldedCount: number, sentInitialApdu: boolean) {
     super("SIGN_PSBT was abandoned host-side before completion");
     this.name = LEDGER_SIGN_PSBT_ABORTED_ERROR_NAME;
     this.yieldedCount = yieldedCount;
+    this.sentInitialApdu = sentInitialApdu;
   }
 }
 

--- a/packages/babylon-ledger-vault-signer/src/errors.ts
+++ b/packages/babylon-ledger-vault-signer/src/errors.ts
@@ -189,16 +189,16 @@ export class LedgerSignPsbtAbortedError extends Error {
   /** Yields the device had already delivered when the host stopped sending. */
   readonly yieldedCount: number;
   /**
-   * False only when the abort fired before the initial APDU went out — no
-   * dispatcher was interrupted, so callers must not arm the resend-once recovery.
+   * True only when the abort left a dispatcher mid-interruption (device
+   * awaiting CONTINUE) — the one state the resend-once recovery exists for.
    */
-  readonly sentInitialApdu: boolean;
+  readonly dispatcherInterrupted: boolean;
 
-  constructor(yieldedCount: number, sentInitialApdu: boolean) {
+  constructor(yieldedCount: number, dispatcherInterrupted: boolean) {
     super("SIGN_PSBT was abandoned host-side before completion");
     this.name = LEDGER_SIGN_PSBT_ABORTED_ERROR_NAME;
     this.yieldedCount = yieldedCount;
-    this.sentInitialApdu = sentInitialApdu;
+    this.dispatcherInterrupted = dispatcherInterrupted;
   }
 }
 

--- a/packages/babylon-ledger-vault-signer/src/index.ts
+++ b/packages/babylon-ledger-vault-signer/src/index.ts
@@ -39,6 +39,7 @@ export {
   type CollectedYieldRef,
   type LedgerYieldMismatchKind,
 } from "./errors";
+export type { ExpectedSignatureTable, InputSigExpectation } from "./expectedSignatures";
 export {
   encodeIntentGroup,
   encodeIntentScalars,
@@ -46,7 +47,14 @@ export {
   type IntentScalars,
   type IntentVaultGroup,
 } from "./intentTlv";
-export { type Apdu, type AppIdentity, type RawApduResponse, type RawApduSender } from "./rawApdu";
+export {
+  SW_BAD_STATE,
+  SW_CAP_EXCEEDED,
+  type Apdu,
+  type AppIdentity,
+  type RawApduResponse,
+  type RawApduSender,
+} from "./rawApdu";
 export {
   signPreparedVaultPsbt,
   signVaultPsbt,

--- a/packages/babylon-ledger-vault-signer/src/index.ts
+++ b/packages/babylon-ledger-vault-signer/src/index.ts
@@ -11,7 +11,7 @@
  */
 
 export { getXOnlyPublicKeyHex } from "./derivation";
-export { createDmkApduSender } from "./dmkApduSender";
+export { createDmkApduSender, createDmkRawApduSender } from "./dmkApduSender";
 export { closeDmk, connectDmkSession, disconnectDmkSession, isSessionAlive, type DmkSessionHandle } from "./dmkSession";
 export { assertDepositTermsDeviceCompatible } from "./envelope";
 export {
@@ -48,12 +48,15 @@ export {
 } from "./intentTlv";
 export { type Apdu, type AppIdentity, type RawApduResponse, type RawApduSender } from "./rawApdu";
 export {
+  signPreparedVaultPsbt,
   signVaultPsbt,
   type CollectedYield,
+  type SignPreparedVaultPsbtOptions,
   type SignPsbtProgress,
   type SignVaultPsbtParams,
   type SignVaultPsbtResult,
 } from "./signPsbt";
+export { prepareSignPsbt, type PreparedSignPsbt } from "./signPsbtPrepare";
 export {
   DEPOSIT_TERMS_REJECTED_ERROR_NAME,
   DepositTermsRejectedError,

--- a/packages/babylon-ledger-vault-signer/src/rawApdu.ts
+++ b/packages/babylon-ledger-vault-signer/src/rawApdu.ts
@@ -58,6 +58,11 @@ const SW_DEVICE_LOCKED = new Set([0x5515, 0x6982, 0x5303]);
 /** CLA not supported — what the dashboard or a wrong app returns. */
 const SW_CLA_NOT_SUPPORTED = 0x6e00;
 
+/** SW_BAD_STATE — the loaded intent/root is gone (`fw:sw.h` via `base:src/boilerplate/sw.h:80` @ e400d8d8). */
+export const SW_BAD_STATE = 0xb007;
+/** SW_CAP_EXCEEDED — per-type signature cap or dedup-mask breach; intent nullified (`fw:sign_psbt_validate.c:50` @ 90cf41f1). */
+export const SW_CAP_EXCEEDED = 0xb00a;
+
 /**
  * Vault status words (`app-babylon-vault` `sw.h`, #2110) plus the base-app
  * codes from the signer kit's published `BTC_APP_ERRORS`, mirrored so nothing
@@ -73,10 +78,10 @@ const STATUS_WORDS: Record<number, string> = {
   0x6d00: "The running app does not support this instruction",
   [SW_CLA_NOT_SUPPORTED]: "The running app does not handle vault instructions — open the Babylon Vault app",
   0xb000: "The device reported a wrong response length",
-  0xb007: "The device is not in the expected state for this step",
+  [SW_BAD_STATE]: "The device is not in the expected state for this step",
   0xb008: "The device rejected a signature or HMAC as invalid",
   0xb009: "The device rejected the CPFP anchor",
-  0xb00a: "The device has already signed the maximum number of these transactions",
+  [SW_CAP_EXCEEDED]: "The device has already signed the maximum number of these transactions",
   0x6f00: "The device reported an internal error",
 };
 

--- a/packages/babylon-ledger-vault-signer/src/signPsbt.ts
+++ b/packages/babylon-ledger-vault-signer/src/signPsbt.ts
@@ -16,7 +16,7 @@ import type { CollectedYield } from "./expectedSignatures";
 import type { AppIdentity, RawApduSender } from "./rawApdu";
 import { runSignPsbtLoop, type SignPsbtProgress } from "./signPsbtLoop";
 import { mergeYields } from "./signPsbtMerge";
-import { prepareSignPsbt } from "./signPsbtPrepare";
+import { prepareSignPsbt, type PreparedSignPsbt } from "./signPsbtPrepare";
 
 export type { CollectedYield } from "./expectedSignatures";
 export type { SignPsbtProgress } from "./signPsbtLoop";
@@ -63,25 +63,29 @@ export interface SignVaultPsbtResult {
   readonly yields: readonly CollectedYield[];
 }
 
+/** The device-facing half of {@link SignVaultPsbtParams} — everything but the PSBT itself. */
+export type SignPreparedVaultPsbtOptions = Omit<SignVaultPsbtParams, "psbtHex" | "depositorXOnlyHex">;
+
 /**
- * Sign a vault PSBT on the device: build the expected-signature table (zero
- * device I/O on any rejection), drive the interrupt/continue loop with
- * per-YIELD assertions, check set-equal completion, then merge the yields
- * into the original PSBT. Throws the typed SIGN_PSBT errors from `errors.ts`.
- *
- * `params.signal` is required: the loop is unbounded by design (no round cap,
- * no internal timeout), so the abort signal is the only way to stop a device
- * that never answers 0x9000. It is observed between exchanges — a transport
- * call that itself hangs is not cancelled.
+ * Device half of the staged API: drive the interrupt/continue loop for an
+ * already-prepared PSBT, then merge. A caller that needs the expected-signature
+ * table BEFORE any device I/O (e.g. the provider's keypath pre-rejection,
+ * #2219 B3 plan D5/D7) prepares via `prepareSignPsbt`, inspects
+ * `prepared.table`, and hands the SAME object here — no double-prepare, no
+ * parse gap. Everything a prepared object signs, this signs identically to
+ * {@link signVaultPsbt}.
  */
-export async function signVaultPsbt(send: RawApduSender, params: SignVaultPsbtParams): Promise<SignVaultPsbtResult> {
-  const prepared = prepareSignPsbt({ psbtHex: params.psbtHex, depositorXOnlyHex: params.depositorXOnlyHex });
+export async function signPreparedVaultPsbt(
+  send: RawApduSender,
+  prepared: PreparedSignPsbt,
+  options: SignPreparedVaultPsbtOptions,
+): Promise<SignVaultPsbtResult> {
   // Completion (collector.assertComplete) runs inside the loop's completing state.
   const yields = await runSignPsbtLoop(send, prepared, {
-    onProgress: params.onProgress,
-    signal: params.signal,
-    appIdentity: params.appIdentity,
-    resendOnceOnIncorrectData: params.resendOnceOnIncorrectData,
+    onProgress: options.onProgress,
+    signal: options.signal,
+    appIdentity: options.appIdentity,
+    resendOnceOnIncorrectData: options.resendOnceOnIncorrectData,
   });
   let signedPsbtHex: string;
   try {
@@ -96,4 +100,20 @@ export async function signVaultPsbt(send: RawApduSender, params: SignVaultPsbtPa
   }
   // Finding-3 hardening: detach from the collector's live backing array.
   return { signedPsbtHex, yields: [...yields] };
+}
+
+/**
+ * Sign a vault PSBT on the device: build the expected-signature table (zero
+ * device I/O on any rejection), drive the interrupt/continue loop with
+ * per-YIELD assertions, check set-equal completion, then merge the yields
+ * into the original PSBT. Throws the typed SIGN_PSBT errors from `errors.ts`.
+ *
+ * `params.signal` is required: the loop is unbounded by design (no round cap,
+ * no internal timeout), so the abort signal is the only way to stop a device
+ * that never answers 0x9000. It is observed between exchanges — a transport
+ * call that itself hangs is not cancelled.
+ */
+export async function signVaultPsbt(send: RawApduSender, params: SignVaultPsbtParams): Promise<SignVaultPsbtResult> {
+  const prepared = prepareSignPsbt({ psbtHex: params.psbtHex, depositorXOnlyHex: params.depositorXOnlyHex });
+  return signPreparedVaultPsbt(send, prepared, params);
 }

--- a/packages/babylon-ledger-vault-signer/src/signPsbt.ts
+++ b/packages/babylon-ledger-vault-signer/src/signPsbt.ts
@@ -16,7 +16,7 @@ import type { CollectedYield } from "./expectedSignatures";
 import type { AppIdentity, RawApduSender } from "./rawApdu";
 import { runSignPsbtLoop, type SignPsbtProgress } from "./signPsbtLoop";
 import { mergeYields } from "./signPsbtMerge";
-import { prepareSignPsbt, type PreparedSignPsbt } from "./signPsbtPrepare";
+import { getPreparedSignPsbtState, prepareSignPsbt, type PreparedSignPsbt } from "./signPsbtPrepare";
 
 export type { CollectedYield } from "./expectedSignatures";
 export type { SignPsbtProgress } from "./signPsbtLoop";
@@ -84,8 +84,10 @@ export async function signPreparedVaultPsbt(
   prepared: PreparedSignPsbt,
   options: SignPreparedVaultPsbtOptions,
 ): Promise<SignVaultPsbtResult> {
-  // Claimed synchronously BEFORE the first await, so success, abort, and
-  // concurrent reuse are all rejected with zero device I/O.
+  // Resolve first so a forged handle dies as "unrecognised", then claim —
+  // synchronously BEFORE the first await, so success, abort, and concurrent
+  // reuse are all rejected with zero device I/O.
+  const { originalPsbtHex } = getPreparedSignPsbtState(prepared);
   if (consumedPrepared.has(prepared)) {
     throw new LedgerSignPsbtProtocolError(
       "prepared signing state was already used — call prepareSignPsbt again for a retry",
@@ -93,15 +95,10 @@ export async function signPreparedVaultPsbt(
   }
   consumedPrepared.add(prepared);
   // Completion (collector.assertComplete) runs inside the loop's completing state.
-  const yields = await runSignPsbtLoop(send, prepared, {
-    onProgress: options.onProgress,
-    signal: options.signal,
-    appIdentity: options.appIdentity,
-    resendOnceOnIncorrectData: options.resendOnceOnIncorrectData,
-  });
+  const yields = await runSignPsbtLoop(send, prepared, options);
   let signedPsbtHex: string;
   try {
-    signedPsbtHex = mergeYields(prepared.originalPsbtHex, yields);
+    signedPsbtHex = mergeYields(originalPsbtHex, yields);
   } catch (error) {
     // Post-ceremony merge failures stay inside the typed contract. The error
     // names WHICH yields arrived, never their bytes (CLAUDE.md §7).
@@ -126,6 +123,7 @@ export async function signPreparedVaultPsbt(
  * call that itself hangs is not cancelled.
  */
 export async function signVaultPsbt(send: RawApduSender, params: SignVaultPsbtParams): Promise<SignVaultPsbtResult> {
-  const prepared = prepareSignPsbt({ psbtHex: params.psbtHex, depositorXOnlyHex: params.depositorXOnlyHex });
-  return signPreparedVaultPsbt(send, prepared, params);
+  const { psbtHex, depositorXOnlyHex, ...options } = params;
+  const prepared = prepareSignPsbt({ psbtHex, depositorXOnlyHex });
+  return signPreparedVaultPsbt(send, prepared, options);
 }

--- a/packages/babylon-ledger-vault-signer/src/signPsbt.ts
+++ b/packages/babylon-ledger-vault-signer/src/signPsbt.ts
@@ -66,6 +66,11 @@ export interface SignVaultPsbtResult {
 /** The device-facing half of {@link SignVaultPsbtParams} — everything but the PSBT itself. */
 export type SignPreparedVaultPsbtOptions = Omit<SignVaultPsbtParams, "psbtHex" | "depositorXOnlyHex">;
 
+// A prepared object is single-use: its collector and interpreter are mutable
+// ceremony state, so a second run would re-send SIGN_PSBT with stale yields —
+// repeating a non-idempotent device ceremony before any host check could fire.
+const consumedPrepared = new WeakSet<PreparedSignPsbt>();
+
 /**
  * Device half of the staged API: drive the interrupt/continue loop for an
  * already-prepared PSBT, then merge. A caller that needs the expected-signature
@@ -80,6 +85,14 @@ export async function signPreparedVaultPsbt(
   prepared: PreparedSignPsbt,
   options: SignPreparedVaultPsbtOptions,
 ): Promise<SignVaultPsbtResult> {
+  // Claimed synchronously BEFORE the first await, so success, abort, and
+  // concurrent reuse are all rejected with zero device I/O.
+  if (consumedPrepared.has(prepared)) {
+    throw new LedgerSignPsbtProtocolError(
+      "prepared signing state was already used — call prepareSignPsbt again for a retry",
+    );
+  }
+  consumedPrepared.add(prepared);
   // Completion (collector.assertComplete) runs inside the loop's completing state.
   const yields = await runSignPsbtLoop(send, prepared, {
     onProgress: options.onProgress,

--- a/packages/babylon-ledger-vault-signer/src/signPsbt.ts
+++ b/packages/babylon-ledger-vault-signer/src/signPsbt.ts
@@ -66,9 +66,8 @@ export interface SignVaultPsbtResult {
 /** The device-facing half of {@link SignVaultPsbtParams} — everything but the PSBT itself. */
 export type SignPreparedVaultPsbtOptions = Omit<SignVaultPsbtParams, "psbtHex" | "depositorXOnlyHex">;
 
-// A prepared object is single-use: its collector and interpreter are mutable
-// ceremony state, so a second run would re-send SIGN_PSBT with stale yields —
-// repeating a non-idempotent device ceremony before any host check could fire.
+// Single-use: a prepared object's mutable collector/interpreter would replay a
+// non-idempotent device ceremony with stale yields on a second run.
 const consumedPrepared = new WeakSet<PreparedSignPsbt>();
 
 /**

--- a/packages/babylon-ledger-vault-signer/src/signPsbtLoop.ts
+++ b/packages/babylon-ledger-vault-signer/src/signPsbtLoop.ts
@@ -91,8 +91,8 @@ export async function runSignPsbtLoop(
 ): Promise<readonly CollectedYield[]> {
   const { collector, interpreter, table } = prepared;
   if (opts.signal.aborted) {
-    // Abandoned before any I/O.
-    throw new LedgerSignPsbtAbortedError(collector.yields.length);
+    // Abandoned before any I/O — no dispatcher interrupted (sentInitialApdu false).
+    throw new LedgerSignPsbtAbortedError(collector.yields.length, false);
   }
 
   const signPsbtApdu = buildSignPsbtApdu(prepared.cdata);
@@ -101,7 +101,7 @@ export async function runSignPsbtLoop(
   if (response.sw === SW_INCORRECT_DATA && opts.resendOnceOnIncorrectData === true) {
     if (opts.signal.aborted) {
       // Abort raced the first exchange — do not issue the recovery resend.
-      throw new LedgerSignPsbtAbortedError(collector.yields.length);
+      throw new LedgerSignPsbtAbortedError(collector.yields.length, true);
     }
     // Resend the SAME APDU once; this branch is structurally unreachable a
     // second time — any later 0x6A80 (including on the resend) is terminal.
@@ -147,7 +147,7 @@ export async function runSignPsbtLoop(
     }
     if (opts.signal.aborted) {
       // Stop sending — the CONTINUE for this round is never sent.
-      throw new LedgerSignPsbtAbortedError(collector.yields.length);
+      throw new LedgerSignPsbtAbortedError(collector.yields.length, true);
     }
     lastSentApdu = { cla: CLA_FRAMEWORK, ins: INS_CONTINUE, p1: P1_CONTINUE, p2: P2_CONTINUE, data: continueData };
     response = await send(lastSentApdu);

--- a/packages/babylon-ledger-vault-signer/src/signPsbtLoop.ts
+++ b/packages/babylon-ledger-vault-signer/src/signPsbtLoop.ts
@@ -28,7 +28,7 @@ import {
 } from "./errors";
 import type { CollectedYield } from "./expectedSignatures";
 import { classifyStatusWord, type Apdu, type AppIdentity, type RawApduSender } from "./rawApdu";
-import { buildSignPsbtApdu, type PreparedSignPsbt } from "./signPsbtPrepare";
+import { buildSignPsbtApdu, getPreparedSignPsbtState, type PreparedSignPsbt } from "./signPsbtPrepare";
 
 /** Framework CLA / CONTINUE INS (`base:constants.h:15,20`). */
 const CLA_FRAMEWORK = 0xf8;
@@ -89,19 +89,21 @@ export async function runSignPsbtLoop(
   prepared: PreparedSignPsbt,
   opts: RunSignPsbtLoopOptions,
 ): Promise<readonly CollectedYield[]> {
-  const { collector, interpreter, table } = prepared;
+  const { collector, interpreter, cdata } = getPreparedSignPsbtState(prepared);
+  const { table } = prepared;
   if (opts.signal.aborted) {
-    // Abandoned before any I/O — no dispatcher interrupted (sentInitialApdu false).
+    // Abandoned before any I/O — no dispatcher interrupted.
     throw new LedgerSignPsbtAbortedError(collector.yields.length, false);
   }
 
-  const signPsbtApdu = buildSignPsbtApdu(prepared.cdata);
+  const signPsbtApdu = buildSignPsbtApdu(cdata);
   let lastSentApdu: Apdu = signPsbtApdu;
   let response = await send(signPsbtApdu);
   if (response.sw === SW_INCORRECT_DATA && opts.resendOnceOnIncorrectData === true) {
     if (opts.signal.aborted) {
-      // Abort raced the first exchange — do not issue the recovery resend.
-      throw new LedgerSignPsbtAbortedError(collector.yields.length, true);
+      // Abort raced the first exchange. The 0x6A80 either consumed the eaten
+      // slot or was a genuine rejection — either way the dispatcher is clean.
+      throw new LedgerSignPsbtAbortedError(collector.yields.length, false);
     }
     // Resend the SAME APDU once; this branch is structurally unreachable a
     // second time — any later 0x6A80 (including on the resend) is terminal.
@@ -146,7 +148,8 @@ export async function runSignPsbtLoop(
       }
     }
     if (opts.signal.aborted) {
-      // Stop sending — the CONTINUE for this round is never sent.
+      // Stop sending — the CONTINUE for this round is never sent, so the
+      // interrupted dispatcher will eat exactly one later non-CONTINUE APDU.
       throw new LedgerSignPsbtAbortedError(collector.yields.length, true);
     }
     lastSentApdu = { cla: CLA_FRAMEWORK, ins: INS_CONTINUE, p1: P1_CONTINUE, p2: P2_CONTINUE, data: continueData };

--- a/packages/babylon-ledger-vault-signer/src/signPsbtPrepare.ts
+++ b/packages/babylon-ledger-vault-signer/src/signPsbtPrepare.ts
@@ -14,7 +14,7 @@
  * @module ledger-vault-signer/signPsbtPrepare
  */
 
-import { Psbt as BitcoinjsPsbt } from "bitcoinjs-lib";
+import { Psbt as BitcoinjsPsbt, Transaction as BitcoinjsTransaction } from "bitcoinjs-lib";
 import { Buffer } from "buffer";
 
 import { LedgerSignPsbtProtocolError } from "./errors";
@@ -186,16 +186,50 @@ export interface PrepareSignPsbtParams {
   readonly depositorXOnlyHex: string;
 }
 
+declare const preparedSignPsbtBrand: unique symbol;
+
+/**
+ * Opaque handle from `prepareSignPsbt`: only `table` and `unsignedTxid` are
+ * public — the live ceremony state (interpreter, collector, cdata) is held
+ * module-privately so external callers cannot touch or serialize it.
+ */
 export interface PreparedSignPsbt {
+  /** The expected-signature table, for pre-I/O policy checks and progress totals. */
+  readonly table: ExpectedSignatureTable;
+  /** Display-order txid of the unsigned tx — a stable signing-request identity. */
+  readonly unsignedTxid: string;
+  readonly [preparedSignPsbtBrand]: true;
+}
+
+interface PreparedSignPsbtState {
   readonly cdata: Uint8Array;
-  /** Seeded; onYield wired to the collector. Discard on abort — never reuse. */
+  /** Seeded; onYield wired to the collector. Single-use ceremony state. */
   readonly interpreter: SignPsbtInterpreter;
   /** Owns table + seen set + per-YIELD/completion assertions. */
   readonly collector: YieldCollector;
-  /** The collector's table, exposed for tests and progress totals. */
-  readonly table: ExpectedSignatureTable;
   /** Merge target — the v0 bytes, untouched. */
   readonly originalPsbtHex: string;
+}
+
+const preparedStates = new WeakMap<PreparedSignPsbt, PreparedSignPsbtState>();
+
+/** @internal Package-only: assemble a prepared handle over explicit ceremony state. */
+export function makePreparedSignPsbt(
+  publicPart: { table: ExpectedSignatureTable; unsignedTxid: string },
+  state: PreparedSignPsbtState,
+): PreparedSignPsbt {
+  const prepared = { ...publicPart } as PreparedSignPsbt;
+  preparedStates.set(prepared, state);
+  return prepared;
+}
+
+/** @internal Package-only: resolve the ceremony state behind a prepared handle. */
+export function getPreparedSignPsbtState(prepared: PreparedSignPsbt): PreparedSignPsbtState {
+  const state = preparedStates.get(prepared);
+  if (!state) {
+    throw new LedgerSignPsbtProtocolError("unrecognised prepared signing state — use prepareSignPsbt's return value");
+  }
+  return state;
 }
 
 /**
@@ -211,7 +245,7 @@ export function prepareSignPsbt(params: PrepareSignPsbtParams): PreparedSignPsbt
   }
   // Buffer.from(hex) silently truncates at the first invalid character.
   if (!PSBT_HEX_RE.test(psbtHex)) {
-    throw new LedgerSignPsbtProtocolError("psbtHex is not even-length hex");
+    throw new LedgerSignPsbtProtocolError("psbtHex is not even-length hexadecimal");
   }
 
   // The merge stage folds signatures back via bitcoinjs Psbt — assert
@@ -269,11 +303,9 @@ export function prepareSignPsbt(params: PrepareSignPsbtParams): PreparedSignPsbt
   interpreter.addKnownList(merkelized.inputMapCommitments);
   interpreter.addKnownList(merkelized.outputMapCommitments);
 
-  return {
-    cdata: buildSignPsbtCdata(merkelized),
-    interpreter,
-    collector,
-    table,
-    originalPsbtHex: psbtHex,
-  };
+  // The brand is type-only; forged objects miss the WeakMap and die typed.
+  return makePreparedSignPsbt(
+    { table, unsignedTxid: BitcoinjsTransaction.fromBuffer(mergeTarget.data.globalMap.unsignedTx.toBuffer()).getId() },
+    { cdata: buildSignPsbtCdata(merkelized), interpreter, collector, originalPsbtHex: psbtHex },
+  );
 }

--- a/packages/babylon-wallet-connector/src/core/wallets/btc/ledger-vault/__tests__/provider.test.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/ledger-vault/__tests__/provider.test.ts
@@ -15,6 +15,8 @@ import type { DepositTerms } from "@babylonlabs-io/ledger-vault-signer";
 import {
   LedgerDeviceError,
   LedgerDeviceLockedError,
+  LedgerSignPsbtAbortedError,
+  LedgerSignPsbtProtocolError,
   LedgerUserRefusedError,
 } from "@babylonlabs-io/ledger-vault-signer";
 import * as ecc from "@bitcoin-js/tiny-secp256k1-asmjs";
@@ -33,7 +35,7 @@ const VECTOR_XONLY = "cc8a4bc64d897bddc5fbc2f670f7a8ba0b386779106cf1223c6fc5d7cd
 const VECTOR_MAINNET_ADDRESS = "bc1p5cyxnuxmeuwuvkwfem96lqzszd02n6xdcjrs20cac6yqjjwudpxqkedrcr";
 
 const h = vi.hoisted(() => ({
-  session: { dmk: {}, sessionId: "s1" },
+  session: { dmk: {}, sessionId: "s1", appName: "Babylon Vault", appVersion: "0.9.5" },
   sent: [] as { ins: number; p1: number; data: Uint8Array }[],
   failNext: undefined as Error | undefined,
 }));
@@ -48,17 +50,27 @@ const derivationMock = vi.hoisted(() => ({
   getXOnlyPublicKeyHex: vi.fn(async () => VECTOR_XONLY),
 }));
 
+// The SIGN_PSBT core is the signer package's own tested surface; here it is
+// stubbed so the tests pin the PROVIDER's orchestration around it (gates,
+// mirror transitions, fingerprints, the operation lock).
+const signMock = vi.hoisted(() => ({
+  prepareSignPsbt: vi.fn(),
+  signPreparedVaultPsbt: vi.fn(),
+}));
+
 // Partial mock: the DMK/device layers are stubbed, everything protocol-shaped
 // (envelope gate, TLV encoding, DepositTermsRejectedError) stays real.
 vi.mock("@babylonlabs-io/ledger-vault-signer", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@babylonlabs-io/ledger-vault-signer")>()),
   ...dmkSessionMock,
   ...derivationMock,
+  ...signMock,
   createDmkApduSender: () => async (apdu: { ins: number; p1: number; data: Uint8Array }) => {
     if (h.failNext) throw h.failNext;
     h.sent.push({ ins: apdu.ins, p1: apdu.p1, data: apdu.data });
     return new Uint8Array(32).fill(9);
   },
+  createDmkRawApduSender: () => async () => ({ sw: 0x9000, data: new Uint8Array(0) }),
 }));
 
 import { LedgerVaultProvider } from "../provider";
@@ -90,6 +102,11 @@ const INS_APPROVE_VAULT_INTENT = 0x80;
 /** APDUs belonging to the approval ceremony, in send order. */
 const approveApdus = () => h.sent.filter((a) => a.ins === INS_APPROVE_VAULT_INTENT);
 
+/** Minimal prepared shape the provider consumes: the table plus the merge source. */
+function fakePrepared(psbtHex: string, kind: "tapscript" | "taproot-keypath" = "tapscript") {
+  return { originalPsbtHex: psbtHex, table: { byInput: new Map([[0, { kind }]]), expectedYieldCount: 1 } };
+}
+
 beforeEach(() => {
   h.sent.length = 0;
   h.failNext = undefined;
@@ -98,6 +115,13 @@ beforeEach(() => {
   dmkSessionMock.connectDmkSession.mockResolvedValue(h.session);
   dmkSessionMock.isSessionAlive.mockReset();
   dmkSessionMock.isSessionAlive.mockResolvedValue(true);
+  signMock.prepareSignPsbt.mockReset();
+  signMock.prepareSignPsbt.mockImplementation(({ psbtHex }: { psbtHex: string }) => fakePrepared(psbtHex));
+  signMock.signPreparedVaultPsbt.mockReset();
+  signMock.signPreparedVaultPsbt.mockImplementation(async (_send, prepared: { originalPsbtHex: string }) => ({
+    signedPsbtHex: `signed:${prepared.originalPsbtHex}`,
+    yields: [],
+  }));
 });
 
 async function connected() {
@@ -247,22 +271,249 @@ describe("LedgerVaultProvider", () => {
     expect(dmkSessionMock.connectDmkSession).toHaveBeenCalledTimes(2);
   });
 
-  it.each(["signPsbt", "signPsbts", "signMessage"])(
-    "fails %s with a capability error rather than a wrong result",
-    async (method) => {
-      const provider = await connected();
-      const call =
-        method === "signPsbt"
-          ? provider.signPsbt("00")
-          : method === "signPsbts"
-            ? provider.signPsbts(["00"])
-            : provider.signMessage("m", "bip322-simple");
+  it("fails signMessage with a capability error rather than a wrong result", async () => {
+    const provider = await connected();
 
-      await expect(call).rejects.toMatchObject({
-        code: ERROR_CODES.WALLET_METHOD_NOT_SUPPORTED,
+    await expect(provider.signMessage("m", "bip322-simple")).rejects.toMatchObject({
+      code: ERROR_CODES.WALLET_METHOD_NOT_SUPPORTED,
+    });
+  });
+
+  describe("signPsbt/signPsbts (#2219 B3)", () => {
+    const PSBT_A = "aa".repeat(40);
+    const PSBT_B = "bb".repeat(40);
+    const PSBT_C = "c1".repeat(40);
+
+    /** Connect, derive, and approve — the state signing requires. */
+    async function approved() {
+      const provider = await derived();
+      await provider.approveDepositTerms(TERMS);
+      return provider;
+    }
+
+    /** The resendOnceOnIncorrectData the Nth device call received. */
+    function resendFlagOfCall(index: number): boolean | undefined {
+      return signMock.signPreparedVaultPsbt.mock.calls[index]?.[2]?.resendOnceOnIncorrectData;
+    }
+
+    it("signs under the loaded intent and keeps it loaded for further PSBTs", async () => {
+      const provider = await approved();
+
+      await expect(provider.signPsbt(PSBT_A)).resolves.toBe(`signed:${PSBT_A}`);
+      await expect(provider.signPsbt(PSBT_B)).resolves.toBe(`signed:${PSBT_B}`);
+      // The intent survived both signs: a byte-equal re-approval is a no-op.
+      await expect(provider.approveDepositTerms(TERMS)).resolves.toBeUndefined();
+      // The connect-time app identity reaches the loop's diagnostics.
+      expect(signMock.signPreparedVaultPsbt.mock.calls[0][2].appIdentity).toEqual({
+        appName: "Babylon Vault",
+        appVersion: "0.9.5",
       });
-    },
-  );
+    });
+
+    it("refuses to re-sign the same PSBT under one intent — case-insensitively", async () => {
+      const provider = await approved();
+      await provider.signPsbt(PSBT_A);
+
+      await expect(provider.signPsbt(PSBT_A)).rejects.toThrow(/already signed/);
+      await expect(provider.signPsbt(PSBT_A.toUpperCase())).rejects.toThrow(/already signed/);
+      expect(signMock.signPreparedVaultPsbt).toHaveBeenCalledTimes(1);
+    });
+
+    it("requires an approved intent before any device I/O", async () => {
+      const provider = await derived();
+
+      await expect(provider.signPsbt(PSBT_A)).rejects.toThrow(/no approved intent/);
+      expect(signMock.signPreparedVaultPsbt).not.toHaveBeenCalled();
+    });
+
+    it("throws on autoFinalized: true instead of silently not finalizing", async () => {
+      const provider = await approved();
+
+      await expect(provider.signPsbt(PSBT_A, { autoFinalized: true })).rejects.toThrow(/never finalizes/);
+      expect(signMock.signPreparedVaultPsbt).not.toHaveBeenCalled();
+    });
+
+    it("rejects malformed hex before hashing or device I/O", async () => {
+      const provider = await approved();
+
+      await expect(provider.signPsbt("zz")).rejects.toMatchObject({ code: ERROR_CODES.INVALID_PARAMS });
+      expect(signMock.signPreparedVaultPsbt).not.toHaveBeenCalled();
+    });
+
+    it("rejects a keypath table actionably — Pre-PegIn/PoP need the wallet-policy path", async () => {
+      const provider = await approved();
+      signMock.prepareSignPsbt.mockImplementationOnce(({ psbtHex }: { psbtHex: string }) =>
+        fakePrepared(psbtHex, "taproot-keypath"),
+      );
+
+      await expect(provider.signPsbt(PSBT_A)).rejects.toThrow(/wallet-policy path/);
+      expect(signMock.signPreparedVaultPsbt).not.toHaveBeenCalled();
+      // The rejection cost no ceremony: the intent still signs.
+      await expect(provider.signPsbt(PSBT_A)).resolves.toBe(`signed:${PSBT_A}`);
+    });
+
+    it("a prepare-time rejection leaves the mirror and the intent untouched", async () => {
+      const provider = await approved();
+      signMock.prepareSignPsbt.mockImplementationOnce(() => {
+        throw new LedgerSignPsbtProtocolError("input 0 already carries a tapScriptSig");
+      });
+
+      await expect(provider.signPsbt(PSBT_A)).rejects.toMatchObject({ code: ERROR_CODES.INVALID_PARAMS });
+      await expect(provider.signPsbt(PSBT_A)).resolves.toBe(`signed:${PSBT_A}`);
+    });
+
+    it("an intent-gone status word drops the mirror; a re-ceremony makes the same PSBT signable", async () => {
+      const provider = await approved();
+      signMock.signPreparedVaultPsbt.mockRejectedValueOnce(new LedgerDeviceError(0xb007, "SW_BAD_STATE"));
+
+      await expect(provider.signPsbt(PSBT_A)).rejects.toThrow(/no longer holds the approved intent/);
+      await expect(provider.signPsbt(PSBT_A)).rejects.toThrow(/no approved intent/);
+
+      await provider.deriveContextHash("app", "aa".repeat(32));
+      await provider.approveDepositTerms(TERMS);
+      await expect(provider.signPsbt(PSBT_A)).resolves.toBe(`signed:${PSBT_A}`);
+    });
+
+    it("an abandonment keeps the intent and arms the one-shot 0x6A80 recovery", async () => {
+      const provider = await approved();
+      signMock.signPreparedVaultPsbt.mockRejectedValueOnce(new LedgerSignPsbtAbortedError(0, true));
+
+      await expect(provider.signPsbt(PSBT_A)).rejects.toMatchObject({ code: ERROR_CODES.WALLET_NOT_CONNECTED });
+      // No re-ceremony needed; the retry passes the recovery flag, and a
+      // successful sign disarms it for the call after.
+      await expect(provider.signPsbt(PSBT_A)).resolves.toBe(`signed:${PSBT_A}`);
+      await provider.signPsbt(PSBT_B);
+      expect(resendFlagOfCall(0)).toBe(false);
+      expect(resendFlagOfCall(1)).toBe(true);
+      expect(resendFlagOfCall(2)).toBe(false);
+    });
+
+    it("a pre-send abort does not arm the recovery — no dispatcher was interrupted", async () => {
+      const provider = await approved();
+      signMock.signPreparedVaultPsbt.mockRejectedValueOnce(new LedgerSignPsbtAbortedError(0, false));
+
+      await expect(provider.signPsbt(PSBT_A)).rejects.toMatchObject({ code: ERROR_CODES.WALLET_NOT_CONNECTED });
+      await provider.signPsbt(PSBT_A);
+      expect(resendFlagOfCall(1)).toBe(false);
+    });
+
+    it("signPsbts signs a whole batch in order under one intent", async () => {
+      const provider = await approved();
+
+      // A shorter options array than the batch is fine — missing = defaults.
+      await expect(provider.signPsbts([PSBT_A, PSBT_B, PSBT_C], [{}])).resolves.toEqual([
+        `signed:${PSBT_A}`,
+        `signed:${PSBT_B}`,
+        `signed:${PSBT_C}`,
+      ]);
+      expect(signMock.prepareSignPsbt.mock.calls.map((c) => c[0].psbtHex)).toEqual([PSBT_A, PSBT_B, PSBT_C]);
+      await expect(provider.approveDepositTerms(TERMS)).resolves.toBeUndefined();
+    });
+
+    it("signPsbts signs sequentially in array order, fails fast, and names the failing index", async () => {
+      const provider = await approved();
+      signMock.signPreparedVaultPsbt
+        .mockImplementationOnce(async (_send, prepared: { originalPsbtHex: string }) => ({
+          signedPsbtHex: `signed:${prepared.originalPsbtHex}`,
+          yields: [],
+        }))
+        .mockRejectedValueOnce(new LedgerDeviceError(0xb00a, "SW_CAP_EXCEEDED"));
+
+      await expect(provider.signPsbts([PSBT_A, PSBT_B, PSBT_C])).rejects.toThrow(/signPsbts\[1\].*no longer holds/);
+      expect(signMock.signPreparedVaultPsbt).toHaveBeenCalledTimes(2);
+      expect(signMock.prepareSignPsbt.mock.calls.map((c) => c[0].psbtHex)).toEqual([PSBT_A, PSBT_B]);
+    });
+
+    it("signPsbts checks options at the failing batch index and spends no ceremony on it", async () => {
+      const provider = await approved();
+
+      await expect(provider.signPsbts([PSBT_A, PSBT_B], [{}, { autoFinalized: true }])).rejects.toThrow(
+        /signPsbts\[1\]/,
+      );
+      // A was signed before the gate stopped B; the intent is untouched.
+      expect(signMock.signPreparedVaultPsbt).toHaveBeenCalledTimes(1);
+      await expect(provider.signPsbt(PSBT_C)).resolves.toBe(`signed:${PSBT_C}`);
+    });
+
+    it("admits one device ceremony at a time", async () => {
+      const provider = await approved();
+      signMock.signPreparedVaultPsbt.mockImplementationOnce(
+        (_send, _prepared, opts: { signal: AbortSignal }) =>
+          new Promise((_resolve, reject) => {
+            opts.signal.addEventListener("abort", () => reject(new LedgerSignPsbtAbortedError(0, true)));
+          }),
+      );
+      const inFlight = provider.signPsbt(PSBT_A);
+      inFlight.catch(() => {});
+      await vi.waitFor(() => expect(signMock.signPreparedVaultPsbt).toHaveBeenCalledTimes(1));
+
+      await expect(provider.signPsbt(PSBT_B)).rejects.toThrow(/already running a device ceremony/);
+      await expect(provider.deriveContextHash("app", "aa".repeat(32))).rejects.toThrow(/already running/);
+      await expect(provider.approveDepositTerms(TERMS)).rejects.toThrow(/already running/);
+
+      // Teardown releases the lock synchronously and aborts the loop; the
+      // stale call surfaces as a disconnection.
+      await provider.disconnect();
+      await expect(inFlight).rejects.toMatchObject({ code: ERROR_CODES.WALLET_NOT_CONNECTED });
+    });
+
+    it("a stale sign settling after reconnect commits nothing to the new connection", async () => {
+      const provider = await approved();
+      let resolveStale: (value: { signedPsbtHex: string; yields: never[] }) => void = () => {};
+      signMock.signPreparedVaultPsbt.mockImplementationOnce(
+        () =>
+          new Promise<{ signedPsbtHex: string; yields: never[] }>((resolve) => {
+            resolveStale = resolve;
+          }),
+      );
+      const stale = provider.signPsbt(PSBT_A);
+      stale.catch(() => {});
+      await vi.waitFor(() => expect(signMock.signPreparedVaultPsbt).toHaveBeenCalledTimes(1));
+
+      // The new connection establishes fresh intent state while the old call hangs.
+      await provider.disconnect();
+      await provider.connectWallet();
+      await provider.deriveContextHash("app", "aa".repeat(32));
+      await provider.approveDepositTerms(TERMS);
+      await provider.signPsbt(PSBT_B);
+
+      resolveStale({ signedPsbtHex: `signed:${PSBT_A}`, yields: [] });
+      await expect(stale).rejects.toThrow(/connection changed/);
+      // The stale settlement neither cleared the new fingerprints nor the mirror.
+      await expect(provider.signPsbt(PSBT_B)).rejects.toThrow(/already signed/);
+      await expect(provider.signPsbt(PSBT_C)).resolves.toBe(`signed:${PSBT_C}`);
+    });
+
+    it("a byte-equal re-approval preserves the replay guard — the device masks were untouched", async () => {
+      const provider = await approved();
+      await provider.signPsbt(PSBT_A);
+
+      await provider.approveDepositTerms(TERMS);
+
+      await expect(provider.signPsbt(PSBT_A)).rejects.toThrow(/already signed/);
+    });
+
+    it("a dead session invalidates the mirror and the replay guard", async () => {
+      // An unplug wipes the device's vault state — the host must not keep
+      // believing an intent is loaded, nor block re-signing after recovery.
+      const provider = await approved();
+      await provider.signPsbt(PSBT_A);
+      dmkSessionMock.isSessionAlive.mockResolvedValueOnce(false);
+
+      await expect(provider.signPsbt(PSBT_B)).rejects.toThrow(/was disconnected/);
+      await expect(provider.signPsbt(PSBT_B)).rejects.toThrow(/no approved intent/);
+    });
+
+    it("a fresh approval resets the replay guard — the device counters were reset too", async () => {
+      const provider = await approved();
+      await provider.signPsbt(PSBT_A);
+
+      await provider.deriveContextHash("app", "aa".repeat(32));
+      await provider.approveDepositTerms(TERMS);
+
+      await expect(provider.signPsbt(PSBT_A)).resolves.toBe(`signed:${PSBT_A}`);
+    });
+  });
 
   it("runs the envelope gate before any device I/O", async () => {
     // A v1 intent loads fine on-device and only fails at PSBT time — after the

--- a/packages/babylon-wallet-connector/src/core/wallets/btc/ledger-vault/__tests__/provider.test.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/ledger-vault/__tests__/provider.test.ts
@@ -323,6 +323,7 @@ describe("LedgerVaultProvider", () => {
       const provider = await derived();
 
       await expect(provider.signPsbt(PSBT_A)).rejects.toThrow(/no approved intent/);
+      expect(signMock.prepareSignPsbt).not.toHaveBeenCalled();
       expect(signMock.signPreparedVaultPsbt).not.toHaveBeenCalled();
     });
 
@@ -330,6 +331,7 @@ describe("LedgerVaultProvider", () => {
       const provider = await approved();
 
       await expect(provider.signPsbt(PSBT_A, { autoFinalized: true })).rejects.toThrow(/never finalizes/);
+      expect(signMock.prepareSignPsbt).not.toHaveBeenCalled();
       expect(signMock.signPreparedVaultPsbt).not.toHaveBeenCalled();
     });
 
@@ -337,6 +339,7 @@ describe("LedgerVaultProvider", () => {
       const provider = await approved();
 
       await expect(provider.signPsbt("zz")).rejects.toMatchObject({ code: ERROR_CODES.INVALID_PARAMS });
+      expect(signMock.prepareSignPsbt).not.toHaveBeenCalled();
       expect(signMock.signPreparedVaultPsbt).not.toHaveBeenCalled();
     });
 
@@ -433,6 +436,21 @@ describe("LedgerVaultProvider", () => {
       // A was signed before the gate stopped B; the intent is untouched.
       expect(signMock.signPreparedVaultPsbt).toHaveBeenCalledTimes(1);
       await expect(provider.signPsbt(PSBT_C)).resolves.toBe(`signed:${PSBT_C}`);
+      // A's signature is lost with the batch, and its fingerprint blocks a retry
+      // under this intent — the documented fail-fast contract.
+      await expect(provider.signPsbt(PSBT_A)).rejects.toThrow(/already signed/);
+    });
+
+    it("maps a throwing liveness probe onto a WalletError", async () => {
+      // isSessionAlive rethrows DMK's plain {_tag} objects — they must not
+      // escape signPsbt unmapped.
+      const provider = await approved();
+      dmkSessionMock.isSessionAlive.mockRejectedValueOnce({
+        _tag: "TransportError",
+        originalError: { message: "hid gone" },
+      });
+
+      await expect(provider.signPsbt(PSBT_A)).rejects.toMatchObject({ code: ERROR_CODES.CONNECTION_FAILED });
     });
 
     it("admits one device ceremony at a time", async () => {

--- a/packages/babylon-wallet-connector/src/core/wallets/btc/ledger-vault/__tests__/provider.test.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/ledger-vault/__tests__/provider.test.ts
@@ -11,7 +11,7 @@
 // passes under node (ts-sdk's setup.ts runs the identical init there). These
 // tests touch no DOM, so pin the file to node.
 
-import type { DepositTerms } from "@babylonlabs-io/ledger-vault-signer";
+import type { DepositTerms, InputSigExpectation } from "@babylonlabs-io/ledger-vault-signer";
 import {
   LedgerDeviceError,
   LedgerDeviceLockedError,
@@ -102,9 +102,22 @@ const INS_APPROVE_VAULT_INTENT = 0x80;
 /** APDUs belonging to the approval ceremony, in send order. */
 const approveApdus = () => h.sent.filter((a) => a.ins === INS_APPROVE_VAULT_INTENT);
 
-/** Minimal prepared shape the provider consumes: the table plus the merge source. */
-function fakePrepared(psbtHex: string, kind: "tapscript" | "taproot-keypath" = "tapscript") {
-  return { originalPsbtHex: psbtHex, table: { byInput: new Map([[0, { kind }]]), expectedYieldCount: 1 } };
+/**
+ * Minimal prepared shape the provider consumes: the table (typed against the
+ * signer's discriminant so a rename breaks this file's compile), the request
+ * identity, and the merge source the device mock echoes back.
+ */
+function fakePrepared(psbtHex: string, kind: InputSigExpectation["kind"] = "tapscript", unsignedTxid?: string) {
+  const expectation =
+    kind === "tapscript"
+      ? { kind, expectedLeafHashHexes: new Set(["ef".repeat(32)]), expectedSignerXOnlyHex: "ab".repeat(32) }
+      : { kind, expectedOutputKeyHex: "cd".repeat(32) };
+  return {
+    originalPsbtHex: psbtHex,
+    // Case-insensitive like the real txid (decoded bytes, not hex casing).
+    unsignedTxid: unsignedTxid ?? `txid-${psbtHex.toLowerCase()}`,
+    table: { byInput: new Map([[0, expectation]]), expectedYieldCount: 1 },
+  };
 }
 
 beforeEach(() => {
@@ -424,21 +437,52 @@ describe("LedgerVaultProvider", () => {
 
       await expect(provider.signPsbts([PSBT_A, PSBT_B, PSBT_C])).rejects.toThrow(/signPsbts\[1\].*no longer holds/);
       expect(signMock.signPreparedVaultPsbt).toHaveBeenCalledTimes(2);
-      expect(signMock.prepareSignPsbt.mock.calls.map((c) => c[0].psbtHex)).toEqual([PSBT_A, PSBT_B]);
+      // Staging prepared the whole batch up front, before the first ceremony.
+      expect(signMock.prepareSignPsbt.mock.calls.map((c) => c[0].psbtHex)).toEqual([PSBT_A, PSBT_B, PSBT_C]);
     });
 
-    it("signPsbts checks options at the failing batch index and spends no ceremony on it", async () => {
+    it("signPsbts gates the whole batch before the first ceremony", async () => {
       const provider = await approved();
 
       await expect(provider.signPsbts([PSBT_A, PSBT_B], [{}, { autoFinalized: true }])).rejects.toThrow(
         /signPsbts\[1\]/,
       );
-      // A was signed before the gate stopped B; the intent is untouched.
+      // A host-detectable defect at element 1 burned zero approvals: nothing
+      // reached the device, nothing was fingerprinted, the intent is untouched.
+      expect(signMock.signPreparedVaultPsbt).not.toHaveBeenCalled();
+      await expect(provider.signPsbt(PSBT_A)).resolves.toBe(`signed:${PSBT_A}`);
+    });
+
+    it("signPsbts requires at least one PSBT", async () => {
+      const provider = await approved();
+
+      await expect(provider.signPsbts([])).rejects.toMatchObject({ code: ERROR_CODES.PSBTS_HEXES_REQUIRED });
+    });
+
+    it("signPsbts rejects an intra-batch duplicate before any ceremony", async () => {
+      const provider = await approved();
+
+      await expect(provider.signPsbts([PSBT_A, PSBT_A])).rejects.toThrow(/signPsbts\[1\].*duplicated within the batch/);
+      expect(signMock.signPreparedVaultPsbt).not.toHaveBeenCalled();
+    });
+
+    it("a byte-variant serialization of a signed request is still blocked", async () => {
+      const provider = await approved();
+      await provider.signPsbt(PSBT_A);
+      // Different wire bytes, same unsigned tx and expectations (an extra
+      // unknown global, say) — identity keying catches what byte-hashing missed.
+      signMock.prepareSignPsbt.mockImplementationOnce(() => fakePrepared(PSBT_B, "tapscript", `txid-${PSBT_A}`));
+
+      await expect(provider.signPsbt(PSBT_B)).rejects.toThrow(/already signed/);
       expect(signMock.signPreparedVaultPsbt).toHaveBeenCalledTimes(1);
-      await expect(provider.signPsbt(PSBT_C)).resolves.toBe(`signed:${PSBT_C}`);
-      // A's signature is lost with the batch, and its fingerprint blocks a retry
-      // under this intent — the documented fail-fast contract.
-      await expect(provider.signPsbt(PSBT_A)).rejects.toThrow(/already signed/);
+    });
+
+    it("hex validation speaks before prepare and the replay guard", async () => {
+      const provider = await approved();
+      await provider.signPsbt("aabb");
+
+      await expect(provider.signPsbt("aabbzz")).rejects.toThrow(/needs even-length hex/);
+      expect(signMock.prepareSignPsbt).toHaveBeenCalledTimes(1);
     });
 
     it("maps a throwing liveness probe onto a WalletError", async () => {
@@ -453,14 +497,19 @@ describe("LedgerVaultProvider", () => {
       await expect(provider.signPsbt(PSBT_A)).rejects.toMatchObject({ code: ERROR_CODES.CONNECTION_FAILED });
     });
 
-    it("admits one device ceremony at a time", async () => {
-      const provider = await approved();
+    /** Hung device mock whose promise rejects only when the signal aborts. */
+    function hangUntilAborted(): void {
       signMock.signPreparedVaultPsbt.mockImplementationOnce(
         (_send, _prepared, opts: { signal: AbortSignal }) =>
           new Promise((_resolve, reject) => {
             opts.signal.addEventListener("abort", () => reject(new LedgerSignPsbtAbortedError(0, true)));
           }),
       );
+    }
+
+    it("admits one device ceremony at a time", async () => {
+      const provider = await approved();
+      hangUntilAborted();
       const inFlight = provider.signPsbt(PSBT_A);
       inFlight.catch(() => {});
       await vi.waitFor(() => expect(signMock.signPreparedVaultPsbt).toHaveBeenCalledTimes(1));
@@ -468,6 +517,17 @@ describe("LedgerVaultProvider", () => {
       await expect(provider.signPsbt(PSBT_B)).rejects.toThrow(/already running a device ceremony/);
       await expect(provider.deriveContextHash("app", "aa".repeat(32))).rejects.toThrow(/already running/);
       await expect(provider.approveDepositTerms(TERMS)).rejects.toThrow(/already running/);
+
+      await provider.disconnect();
+      await inFlight.catch(() => {});
+    });
+
+    it("disconnect aborts the in-flight signing loop and surfaces it as a disconnection", async () => {
+      const provider = await approved();
+      hangUntilAborted();
+      const inFlight = provider.signPsbt(PSBT_A);
+      inFlight.catch(() => {});
+      await vi.waitFor(() => expect(signMock.signPreparedVaultPsbt).toHaveBeenCalledTimes(1));
 
       // Teardown releases the lock synchronously and aborts the loop; the
       // stale call surfaces as a disconnection.
@@ -511,15 +571,55 @@ describe("LedgerVaultProvider", () => {
       await expect(provider.signPsbt(PSBT_A)).rejects.toThrow(/already signed/);
     });
 
-    it("a dead session invalidates the mirror and the replay guard", async () => {
-      // An unplug wipes the device's vault state — the host must not keep
-      // believing an intent is loaded, nor block re-signing after recovery.
+    it("a dead session tears everything down, not just the mirror", async () => {
+      // An unplug wipes the device's vault state — a partial reset would leave
+      // a half-connected provider whose next call fails confusingly.
       const provider = await approved();
       await provider.signPsbt(PSBT_A);
       dmkSessionMock.isSessionAlive.mockResolvedValueOnce(false);
 
       await expect(provider.signPsbt(PSBT_B)).rejects.toThrow(/was disconnected/);
-      await expect(provider.signPsbt(PSBT_B)).rejects.toThrow(/no approved intent/);
+      await expect(provider.getAddress()).rejects.toThrow(/not connected/);
+      await expect(provider.signPsbt(PSBT_B)).rejects.toThrow(/not connected/);
+    });
+
+    it("a stale liveness probe settling after reconnect cannot tear down the new session", async () => {
+      const provider = await approved();
+      let resolveProbe: (alive: boolean) => void = () => {};
+      dmkSessionMock.isSessionAlive.mockImplementationOnce(
+        () =>
+          new Promise<boolean>((resolve) => {
+            resolveProbe = resolve;
+          }),
+      );
+      const stale = provider.signPsbt(PSBT_A);
+      stale.catch(() => {});
+      await vi.waitFor(() => expect(dmkSessionMock.isSessionAlive).toHaveBeenCalled());
+
+      await provider.disconnect();
+      await provider.connectWallet();
+      await provider.deriveContextHash("app", "aa".repeat(32));
+      await provider.approveDepositTerms(TERMS);
+      await provider.signPsbt(PSBT_B);
+
+      resolveProbe(false);
+      await expect(stale).rejects.toThrow(/was disconnected|connection changed/);
+      // The stale dead-probe verdict must not have torn down the fresh session.
+      await expect(provider.signPsbt(PSBT_C)).resolves.toBe(`signed:${PSBT_C}`);
+      await expect(provider.signPsbt(PSBT_B)).rejects.toThrow(/already signed/);
+    });
+
+    it("a fresh derive disarms the resend-once recovery", async () => {
+      const provider = await approved();
+      signMock.signPreparedVaultPsbt.mockRejectedValueOnce(new LedgerSignPsbtAbortedError(0, true));
+      await expect(provider.signPsbt(PSBT_A)).rejects.toMatchObject({ code: ERROR_CODES.WALLET_NOT_CONNECTED });
+
+      await provider.deriveContextHash("app", "aa".repeat(32));
+      await provider.approveDepositTerms(TERMS);
+      await provider.signPsbt(PSBT_A);
+
+      // The armed flag died with the old intent — the fresh sign must not resend.
+      expect(resendFlagOfCall(1)).toBe(false);
     });
 
     it("a fresh approval resets the replay guard — the device counters were reset too", async () => {
@@ -653,13 +753,16 @@ describe("LedgerVaultProvider", () => {
     await expect(call).rejects.toThrow(/permissions policy/);
   });
 
-  it("refuses the ceremony when the session has died", async () => {
+  it("refuses the ceremony when the session has died, and tears everything down", async () => {
     const provider = await derived();
     dmkSessionMock.isSessionAlive.mockResolvedValue(false);
     h.sent.length = 0;
 
     await expect(provider.approveDepositTerms(TERMS)).rejects.toThrow(/was disconnected/);
     expect(h.sent).toHaveLength(0);
+    // A dead session means the device state is gone — a partial reset would
+    // leave a half-connected provider behind.
+    await expect(provider.getAddress()).rejects.toThrow(/not connected/);
   });
 
   it("treats a reordered-but-identical roster as the same intent", async () => {

--- a/packages/babylon-wallet-connector/src/core/wallets/btc/ledger-vault/provider.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/ledger-vault/provider.ts
@@ -14,10 +14,15 @@ import {
   isLedgerDeviceError,
   isLedgerDeviceLockedError,
   isLedgerSignPsbtAbortedError,
+  isLedgerSignPsbtIncompleteError,
+  isLedgerSignPsbtProtocolError,
   isLedgerUserRefusedError,
+  isLedgerYieldMismatchError,
   isSessionAlive,
   prepareSignPsbt,
   signPreparedVaultPsbt,
+  SW_BAD_STATE,
+  SW_CAP_EXCEEDED,
   type ApduSender,
   type DepositTerms,
   type DmkSessionHandle,
@@ -26,7 +31,6 @@ import {
   type PreparedSignPsbt,
   type RawApduSender,
 } from "@babylonlabs-io/ledger-vault-signer";
-import { crypto as bcrypto } from "bitcoinjs-lib";
 
 import type { IBTCProvider, InscriptionIdentifier, SignPsbtOptions } from "@/core/types";
 import { Network } from "@/core/types";
@@ -61,9 +65,36 @@ const HARDENED = 0x80000000;
  */
 type DeviceIntentState = { phase: "idle" } | { phase: "derived" } | { phase: "intent-loaded"; termsKey: string };
 
-/** Device answers when the loaded intent is gone (SW_BAD_STATE) or a cap/dedup mask tripped (SW_CAP_EXCEEDED). */
-const SW_BAD_STATE = 0xb007;
-const SW_CAP_EXCEEDED = 0xb00a;
+/** Batch-level gate output, shared by every element of one public sign call. */
+interface SignContext {
+  readonly session: DmkSessionHandle;
+  readonly rawSend: RawApduSender;
+  readonly generation: number;
+  readonly depositorXOnlyHex: string;
+}
+
+/** One host-gated PSBT, ready for its device ceremony. */
+interface StagedPsbt {
+  readonly prepared: PreparedSignPsbt;
+  readonly fingerprintKey: string;
+  readonly label: string;
+}
+
+/** Request identity for the replay guard: unsigned txid + the expectation pairs. */
+function signingRequestKey(prepared: PreparedSignPsbt): string {
+  const pairs = [...prepared.table.byInput.entries()]
+    .map(([inputIndex, expectation]) =>
+      expectation.kind === "tapscript"
+        ? [...expectation.expectedLeafHashHexes]
+            .sort()
+            .map((leaf) => `${inputIndex}:${leaf}`)
+            .join(",")
+        : `${inputIndex}:keypath`,
+    )
+    .sort()
+    .join("|");
+  return `${prepared.unsignedTxid}|${pairs}`;
+}
 
 /**
  * Ledger's dedicated vault app over the DMK. Distinct from the legacy
@@ -109,7 +140,7 @@ export class LedgerVaultProvider implements IBTCProvider {
   private disconnectToken = 0;
   /** Non-throwing sender for the SIGN_PSBT loop; recreated per session like {@link send}. */
   private rawSend: RawApduSender | undefined;
-  /** sha256 of each PSBT's decoded bytes signed under the CURRENT loaded intent. */
+  /** Request-identity keys ({@link signingRequestKey}) signed under the CURRENT loaded intent. */
   private signedFingerprints = new Set<string>();
   /** A host abandonment interrupted the dispatcher — the next sign resends once on 0x6A80. */
   private loopAbandoned = false;
@@ -212,7 +243,7 @@ export class LedgerVaultProvider implements IBTCProvider {
     // Idempotent while the session lives: visibility checks re-call this
     // outside a user gesture, where WebHID's requestDevice rejects — tearing
     // down a healthy session would turn an alt-tab into a forced disconnect.
-    if (this.session && (await isSessionAlive(this.session))) return;
+    if (this.session && (await this.probeSessionAlive(this.session))) return;
     // A disconnect during the probe means the caller no longer wants a
     // session — skip opening one at all.
     if (token !== this.disconnectToken) return;
@@ -371,7 +402,10 @@ export class LedgerVaultProvider implements IBTCProvider {
     const generation = this.connectionGeneration;
     const send = this.requireSender();
     // Fail actionably now rather than with an opaque status word mid-ceremony.
+    // A dead session means the device state is gone — tear down fully
+    // (generation-guarded: a racing reconnect's fresh session must survive).
     if (!(await this.probeSessionAlive(this.requireSession()))) {
+      if (generation === this.connectionGeneration) await this.teardownSession();
       throw new WalletError({
         code: ERROR_CODES.WALLET_NOT_CONNECTED,
         message: `${WALLET_PROVIDER_NAME} was disconnected; reconnect the device and retry.`,
@@ -490,30 +524,50 @@ export class LedgerVaultProvider implements IBTCProvider {
    */
   signPsbt = async (psbtHex: string, options?: SignPsbtOptions): Promise<string> =>
     this.withDeviceOperation("signPsbt", () =>
-      this.withSignAbort((controller) => this.signOnePsbt(psbtHex, options, controller)),
+      this.withSignAbort(async (controller) => {
+        const ctx = await this.gateSignContext();
+        const staged = this.stagePsbt(psbtHex, options, "signPsbt", new Set(), ctx.depositorXOnlyHex);
+        return this.signStaged(staged, ctx, controller);
+      }),
     );
 
   /**
-   * Strictly sequential, array order, fail-fast — one interrupt loop at a
-   * time; a concurrent APDU would be eaten with 0x6A80 and desync the loop.
-   * A mid-batch failure rejects the whole batch (no partial results); the
-   * error's mirror rule decides whether a full re-ceremony is needed.
+   * Device ceremonies run strictly sequentially, array order, fail-fast — a
+   * concurrent APDU would be eaten with 0x6A80 and desync the loop. All
+   * host-only gates run for the WHOLE batch before the first ceremony, so a
+   * host-detectable defect at element k cannot burn k approvals whose
+   * signatures the fail-fast reject would discard.
    */
   signPsbts = async (psbtsHexes: string[], options?: SignPsbtOptions[]): Promise<string[]> =>
     this.withDeviceOperation("signPsbts", () =>
       this.withSignAbort(async (controller) => {
+        if (psbtsHexes.length === 0) {
+          throw new WalletError({
+            code: ERROR_CODES.PSBTS_HEXES_REQUIRED,
+            message: `${WALLET_PROVIDER_NAME} signPsbts requires at least one PSBT.`,
+            wallet: WALLET_PROVIDER_NAME,
+          });
+        }
+        const ctx = await this.gateSignContext();
+        const stagedKeys = new Set<string>();
+        const staged = psbtsHexes.map((hex, index) => {
+          const one = this.stagePsbt(hex, options?.[index], `signPsbts[${index}]`, stagedKeys, ctx.depositorXOnlyHex);
+          stagedKeys.add(one.fingerprintKey);
+          return one;
+        });
         const signed: string[] = [];
-        for (let index = 0; index < psbtsHexes.length; index += 1) {
+        for (const one of staged) {
           // A cancel landing BETWEEN elements must stop the batch — inside an
           // element the loop's own signal checks cover it.
           if (controller.signal.aborted) {
             throw new WalletError({
               code: ERROR_CODES.WALLET_NOT_CONNECTED,
-              message: `${WALLET_PROVIDER_NAME} stopped signing (disconnected) after ${index} of ${psbtsHexes.length} PSBT(s).`,
+              message: `${WALLET_PROVIDER_NAME} stopped signing (disconnected) after ${signed.length} of ${psbtsHexes.length} PSBT(s).`,
               wallet: WALLET_PROVIDER_NAME,
             });
           }
-          signed.push(await this.signOnePsbt(psbtsHexes[index], options?.[index], controller, index));
+          this.assertSameConnection(ctx.generation);
+          signed.push(await this.signStaged(one, ctx, controller));
         }
         return signed;
       }),
@@ -533,26 +587,17 @@ export class LedgerVaultProvider implements IBTCProvider {
     }
   }
 
-  private async signOnePsbt(
-    psbtHex: string,
-    options: SignPsbtOptions | undefined,
-    controller: AbortController,
-    batchIndex?: number,
-  ): Promise<string> {
-    const label = batchIndex === undefined ? "signPsbt" : `signPsbts[${batchIndex}]`;
-    const session = this.requireSession();
-    const rawSend = this.requireRawSender();
+  /**
+   * Batch-level gates, once per public sign call: live session, loaded
+   * intent, cached depositor key. A dead session tears everything down —
+   * the device state is gone with it (generation-guarded against a racing
+   * reconnect's fresh state).
+   */
+  private async gateSignContext(): Promise<SignContext> {
+    const { session, rawSend } = this.requireSignContext();
     const generation = this.connectionGeneration;
-    // Fail actionably now rather than with an opaque status word mid-loop. A
-    // dead session means the device state is gone (unplug wipes it) — the
-    // mirror and replay bookkeeping must not survive it. Generation-guarded:
-    // a reconnect may already have re-established fresh state.
     if (!(await this.probeSessionAlive(session))) {
-      if (generation === this.connectionGeneration) {
-        this.deviceState = { phase: "idle" };
-        this.signedFingerprints = new Set();
-        this.loopAbandoned = false;
-      }
+      if (generation === this.connectionGeneration) await this.teardownSession();
       throw new WalletError({
         code: ERROR_CODES.WALLET_NOT_CONNECTED,
         message: `${WALLET_PROVIDER_NAME} was disconnected; reconnect the device and restart the flow from derivation.`,
@@ -565,15 +610,29 @@ export class LedgerVaultProvider implements IBTCProvider {
         code: ERROR_CODES.WALLET_NOT_CONNECTED,
         message:
           `${WALLET_PROVIDER_NAME} holds no approved intent on this ` +
-          `connection — ${label} requires DERIVE_CONTEXT_HASH and an approved ` +
+          `connection — signing requires DERIVE_CONTEXT_HASH and an approved ` +
           `intent first. Restart the flow from derivation.`,
         wallet: WALLET_PROVIDER_NAME,
       });
     }
-    // The SDK's contract is sign-then-extract-then-finalize; honoring
-    // autoFinalized:true silently would hand back a different contract, and
-    // silently NOT honoring it would be worse. Tweak flags are ignored: the
-    // device rebuilds every script from the approved intent.
+    const depositorXOnlyHex = await this.getDevicePubkeyHex();
+    this.assertSameConnection(generation);
+    return { session, rawSend, generation, depositorXOnlyHex };
+  }
+
+  /**
+   * Host-only gates for one PSBT — pure, zero device I/O, and every throw
+   * leaves the mirror and the loaded intent untouched (plan D7).
+   */
+  private stagePsbt(
+    psbtHex: string,
+    options: SignPsbtOptions | undefined,
+    label: string,
+    stagedKeys: ReadonlySet<string>,
+    depositorXOnlyHex: string,
+  ): StagedPsbt {
+    // Never finalize, and never silently ignore a request to — the SDK
+    // extracts signatures and finalizes itself.
     if (options?.autoFinalized === true) {
       throw new WalletError({
         code: ERROR_CODES.INVALID_PARAMS,
@@ -583,34 +642,14 @@ export class LedgerVaultProvider implements IBTCProvider {
         wallet: WALLET_PROVIDER_NAME,
       });
     }
-    // Canonical fingerprint over DECODED bytes — a case-variant hex of the
-    // same PSBT must not bypass the replay guard.
+    // Buffer.from(hex) truncates silently — reject malformed input loudly.
     if (!/^(?:[0-9a-fA-F]{2})+$/.test(psbtHex)) {
       throw new WalletError({
         code: ERROR_CODES.INVALID_PARAMS,
-        message: `${label} needs even-length hex; got ${psbtHex.length} chars.`,
+        message: `${label} needs even-length hexadecimal; got ${psbtHex.length} chars.`,
         wallet: WALLET_PROVIDER_NAME,
       });
     }
-    const fingerprint = bcrypto.sha256(Buffer.from(psbtHex, "hex")).toString("hex");
-    // NEVER resubmit a signed PSBT: the device dedup mask answers 0xB00A and
-    // nullifies the intent — and NoPayout has NO mask, so a replay there
-    // silently steals quota. This host guard is the only defense for that class.
-    if (this.signedFingerprints.has(fingerprint)) {
-      throw new WalletError({
-        code: ERROR_CODES.INVALID_PARAMS,
-        message:
-          `${label}: this PSBT was already signed under the loaded intent — ` +
-          `re-signing it would nullify the intent on the device. Restart the ` +
-          `flow from derivation to sign it again.`,
-        wallet: WALLET_PROVIDER_NAME,
-      });
-    }
-
-    // Stage 1 — host-only prepare: typed rejections cost zero device I/O and
-    // leave the mirror and the loaded intent UNTOUCHED (plan D7).
-    const depositorXOnlyHex = await this.getDevicePubkeyHex();
-    this.assertSameConnection(generation);
     let prepared: PreparedSignPsbt;
     try {
       prepared = prepareSignPsbt({ psbtHex, depositorXOnlyHex });
@@ -638,9 +677,35 @@ export class LedgerVaultProvider implements IBTCProvider {
         });
       }
     }
+    // NEVER resubmit a signed request: the device dedup mask answers 0xB00A
+    // and nullifies the intent — and NoPayout has NO mask, so this host guard
+    // is the only defense there. Keyed on request identity (unsigned txid +
+    // expectation pairs), not wire bytes — a byte-variant must not slip past.
+    const fingerprintKey = signingRequestKey(prepared);
+    if (stagedKeys.has(fingerprintKey)) {
+      throw new WalletError({
+        code: ERROR_CODES.INVALID_PARAMS,
+        message: `${label}: this PSBT is duplicated within the batch — the device would sign the same request twice.`,
+        wallet: WALLET_PROVIDER_NAME,
+      });
+    }
+    if (this.signedFingerprints.has(fingerprintKey)) {
+      throw new WalletError({
+        code: ERROR_CODES.INVALID_PARAMS,
+        message:
+          `${label}: this PSBT was already signed under the loaded intent — ` +
+          `re-signing it would nullify the intent on the device. Restart the ` +
+          `flow from derivation to sign it again.`,
+        wallet: WALLET_PROVIDER_NAME,
+      });
+    }
+    return { prepared, fingerprintKey, label };
+  }
 
-    // Stage 2 — the device loop. From here every error is classified against
-    // the mirror; the controller is teardown's handle into the unbounded loop.
+  /** One device ceremony; every failure is classified against the mirror. */
+  private async signStaged(staged: StagedPsbt, ctx: SignContext, controller: AbortController): Promise<string> {
+    const { prepared, fingerprintKey, label } = staged;
+    const { session, rawSend, generation } = ctx;
     try {
       const result = await signPreparedVaultPsbt(rawSend, prepared, {
         signal: controller.signal,
@@ -651,7 +716,7 @@ export class LedgerVaultProvider implements IBTCProvider {
       this.assertSameConnection(generation);
       // Success never consumes the intent: further (different) PSBTs sign
       // under the same approval; this one never again.
-      this.signedFingerprints.add(fingerprint);
+      this.signedFingerprints.add(fingerprintKey);
       this.loopAbandoned = false;
       return result.signedPsbtHex;
     } catch (error) {
@@ -668,16 +733,14 @@ export class LedgerVaultProvider implements IBTCProvider {
       }
       if (isLedgerSignPsbtAbortedError(error)) {
         // The intent MAY survive an abandonment (hint only) — keep the mirror.
-        // Arm the one-shot 0x6A80 recovery only if a dispatcher was actually
-        // interrupted; a pre-send abort left nothing to recover from. NB: in
-        // B3 the only abort source is teardown, which bumps the generation
-        // FIRST — so this branch goes live only when a non-teardown abort
-        // source (a #2110 UI cancel) is added.
-        if (error.sentInitialApdu) this.loopAbandoned = true;
+        // Arm the one-shot 0x6A80 recovery only if a dispatcher is actually
+        // mid-interruption. NB: unreachable in B3 — teardown (the only abort
+        // source) bumps the generation first; goes live with #2110's cancel.
+        if (error.dispatcherInterrupted) this.loopAbandoned = true;
         throw new WalletError(
           {
             code: ERROR_CODES.WALLET_NOT_CONNECTED,
-            message: `${WALLET_PROVIDER_NAME} stopped signing (disconnected); reconnect and retry.`,
+            message: `${label === "signPsbt" ? "" : `${label}: `}${WALLET_PROVIDER_NAME} stopped signing (disconnected); reconnect and retry.`,
             wallet: WALLET_PROVIDER_NAME,
           },
           { cause: error },
@@ -688,25 +751,7 @@ export class LedgerVaultProvider implements IBTCProvider {
       this.deviceState = { phase: "idle" };
       this.signedFingerprints = new Set();
       this.loopAbandoned = false;
-      const mapped = toSignerWalletError(error);
-      if (mapped) {
-        // A batch caller needs to know WHICH element failed. The cast matches
-        // the mapper's own dmk branch: DMK objects don't extend Error.
-        throw batchIndex === undefined
-          ? mapped
-          : new WalletError(
-              { code: mapped.code, message: `${label}: ${mapped.message}`, wallet: WALLET_PROVIDER_NAME },
-              { cause: error as Error },
-            );
-      }
-      throw new WalletError(
-        {
-          code: ERROR_CODES.UNKNOWN_ERROR,
-          message: `${label} failed: ${error instanceof Error ? error.message : String(error)}`,
-          wallet: WALLET_PROVIDER_NAME,
-        },
-        { cause: error instanceof Error ? error : undefined },
-      );
+      throw toSignFailureWalletError(error, label);
     }
   }
 
@@ -722,15 +767,17 @@ export class LedgerVaultProvider implements IBTCProvider {
     }
   }
 
-  private requireRawSender(): RawApduSender {
-    if (!this.rawSend) {
+  /** Session + raw sender travel together (assigned/cleared as a unit in connect/teardown). */
+  private requireSignContext(): { session: DmkSessionHandle; rawSend: RawApduSender } {
+    const { session, rawSend } = this;
+    if (!session || !rawSend) {
       throw new WalletError({
         code: ERROR_CODES.WALLET_NOT_CONNECTED,
         message: `${WALLET_PROVIDER_NAME} is not connected`,
         wallet: WALLET_PROVIDER_NAME,
       });
     }
-    return this.rawSend;
+    return { session, rawSend };
   }
 
   // TODO(#2221): BIP-322 PoP — a SIGN_PSBT with tx_version 0, not the base
@@ -759,6 +806,58 @@ export class LedgerVaultProvider implements IBTCProvider {
  * Shared by the ceremony sender wrapper and the SIGN_PSBT seam — the raw
  * sender's loop errors never pass through {@link withWalletErrorMapping}.
  */
+/**
+ * Sign-seam failure mapping: the two "intent gone" status words and the
+ * signer's own typed sign errors get the stable restart-from-derivation
+ * suffix #2110's UX routes on; everything else reuses the shared mapper.
+ * The ceremony sender keeps verbatim messages — derive/approve failures are
+ * not phase-wise "restart from derivation" beyond what their own copy says.
+ */
+function toSignFailureWalletError(error: unknown, label: string): WalletError {
+  const prefix = label === "signPsbt" ? "" : `${label}: `;
+  if (isLedgerDeviceError(error) && (error.statusWord === SW_BAD_STATE || error.statusWord === SW_CAP_EXCEEDED)) {
+    return new WalletError(
+      {
+        code: ERROR_CODES.UNKNOWN_ERROR,
+        message: `${prefix}The device no longer holds the approved intent (${error.message}) — restart the flow from derivation.`,
+        wallet: WALLET_PROVIDER_NAME,
+      },
+      { cause: error },
+    );
+  }
+  if (
+    isLedgerYieldMismatchError(error) ||
+    isLedgerSignPsbtIncompleteError(error) ||
+    isLedgerSignPsbtProtocolError(error)
+  ) {
+    return new WalletError(
+      {
+        code: ERROR_CODES.UNKNOWN_ERROR,
+        message: `${prefix}${error.message} — restart the flow from derivation.`,
+        wallet: WALLET_PROVIDER_NAME,
+      },
+      { cause: error },
+    );
+  }
+  const mapped = toSignerWalletError(error);
+  if (mapped) {
+    if (label === "signPsbt") return mapped;
+    // The cast matches the mapper's own dmk branch: DMK objects don't extend Error.
+    return new WalletError(
+      { code: mapped.code, message: `${prefix}${mapped.message}`, wallet: WALLET_PROVIDER_NAME },
+      { cause: error as Error },
+    );
+  }
+  return new WalletError(
+    {
+      code: ERROR_CODES.UNKNOWN_ERROR,
+      message: `${label} failed: ${error instanceof Error ? error.message : String(error)}`,
+      wallet: WALLET_PROVIDER_NAME,
+    },
+    { cause: error instanceof Error ? error : undefined },
+  );
+}
+
 function toSignerWalletError(error: unknown): WalletError | undefined {
   if (isLedgerUserRefusedError(error)) {
     return new WalletError(
@@ -773,17 +872,8 @@ function toSignerWalletError(error: unknown): WalletError | undefined {
     );
   }
   if (isLedgerDeviceError(error)) {
-    // A stable, distinguishable message for the two "intent gone" words —
-    // #2110's UX routes these to a restart-from-derivation screen.
-    const intentGone = error.statusWord === SW_BAD_STATE || error.statusWord === SW_CAP_EXCEEDED;
     return new WalletError(
-      {
-        code: ERROR_CODES.UNKNOWN_ERROR,
-        message: intentGone
-          ? `The device no longer holds the approved intent (${error.message}) — restart the flow from derivation.`
-          : error.message,
-        wallet: WALLET_PROVIDER_NAME,
-      },
+      { code: ERROR_CODES.UNKNOWN_ERROR, message: error.message, wallet: WALLET_PROVIDER_NAME },
       { cause: error },
     );
   }

--- a/packages/babylon-wallet-connector/src/core/wallets/btc/ledger-vault/provider.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/ledger-vault/provider.ts
@@ -371,7 +371,7 @@ export class LedgerVaultProvider implements IBTCProvider {
     const generation = this.connectionGeneration;
     const send = this.requireSender();
     // Fail actionably now rather than with an opaque status word mid-ceremony.
-    if (!(await isSessionAlive(this.requireSession()))) {
+    if (!(await this.probeSessionAlive(this.requireSession()))) {
       throw new WalletError({
         code: ERROR_CODES.WALLET_NOT_CONNECTED,
         message: `${WALLET_PROVIDER_NAME} was disconnected; reconnect the device and retry.`,
@@ -547,7 +547,7 @@ export class LedgerVaultProvider implements IBTCProvider {
     // dead session means the device state is gone (unplug wipes it) — the
     // mirror and replay bookkeeping must not survive it. Generation-guarded:
     // a reconnect may already have re-established fresh state.
-    if (!(await isSessionAlive(session))) {
+    if (!(await this.probeSessionAlive(session))) {
       if (generation === this.connectionGeneration) {
         this.deviceState = { phase: "idle" };
         this.signedFingerprints = new Set();
@@ -707,6 +707,18 @@ export class LedgerVaultProvider implements IBTCProvider {
         },
         { cause: error instanceof Error ? error : undefined },
       );
+    }
+  }
+
+  /**
+   * Liveness probe for the ceremony gates: `isSessionAlive` rethrows DMK's
+   * plain `{_tag}` objects, which would otherwise escape unmapped.
+   */
+  private async probeSessionAlive(session: DmkSessionHandle): Promise<boolean> {
+    try {
+      return await isSessionAlive(session);
+    } catch (error) {
+      throw toSignerWalletError(error) ?? error;
     }
   }
 

--- a/packages/babylon-wallet-connector/src/core/wallets/btc/ledger-vault/provider.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/ledger-vault/provider.ts
@@ -3,6 +3,7 @@ import {
   assertDepositTermsDeviceCompatible,
   connectDmkSession,
   createDmkApduSender,
+  createDmkRawApduSender,
   DepositTermsRejectedError,
   deriveContextHash,
   disconnectDmkSession,
@@ -12,16 +13,22 @@ import {
   getXOnlyPublicKeyHex,
   isLedgerDeviceError,
   isLedgerDeviceLockedError,
+  isLedgerSignPsbtAbortedError,
   isLedgerUserRefusedError,
   isSessionAlive,
+  prepareSignPsbt,
+  signPreparedVaultPsbt,
   type ApduSender,
   type DepositTerms,
   type DmkSessionHandle,
   type IntentScalars,
   type IntentVaultGroup,
+  type PreparedSignPsbt,
+  type RawApduSender,
 } from "@babylonlabs-io/ledger-vault-signer";
+import { crypto as bcrypto } from "bitcoinjs-lib";
 
-import type { IBTCProvider, InscriptionIdentifier } from "@/core/types";
+import type { IBTCProvider, InscriptionIdentifier, SignPsbtOptions } from "@/core/types";
 import { Network } from "@/core/types";
 import { getTaprootAddress, toNetwork } from "@/core/utils/wallet";
 import { ERROR_CODES, WalletError } from "@/error";
@@ -54,15 +61,19 @@ const HARDENED = 0x80000000;
  */
 type DeviceIntentState = { phase: "idle" } | { phase: "derived" } | { phase: "intent-loaded"; termsKey: string };
 
+/** Device answers when the loaded intent is gone (SW_BAD_STATE) or a cap/dedup mask tripped (SW_CAP_EXCEEDED). */
+const SW_BAD_STATE = 0xb007;
+const SW_CAP_EXCEEDED = 0xb00a;
+
 /**
  * Ledger's dedicated vault app over the DMK. Distinct from the legacy
  * `ledger_btc*` staking adapters: different device app, different transport,
  * intent ceremony instead of wallet policies.
  *
  * Ships behind `NEXT_PUBLIC_FF_ENABLE_LEDGER_VAULT_WALLET` (default off).
- * Covers connect, the key read, and the intent ceremony; signing needs the
- * host-side SIGN_PSBT client (#2219) — the published Bitcoin signer kit
- * cannot express the vault's no-policy flows.
+ * Covers connect, the key read, the intent ceremony, and SIGN_PSBT for the
+ * no-policy tapscript flows (#2219). Key-path signing (Pre-PegIn, PoP) needs
+ * the wallet-policy path (#2222/#2221).
  */
 export class LedgerVaultProvider implements IBTCProvider {
   private session: DmkSessionHandle | undefined;
@@ -96,8 +107,45 @@ export class LedgerVaultProvider implements IBTCProvider {
    * own dead-session cleanup also bumps (that is not a cancellation).
    */
   private disconnectToken = 0;
+  /** Non-throwing sender for the SIGN_PSBT loop; recreated per session like {@link send}. */
+  private rawSend: RawApduSender | undefined;
+  /** sha256 of each PSBT's decoded bytes signed under the CURRENT loaded intent. */
+  private signedFingerprints = new Set<string>();
+  /** A host abandonment interrupted the dispatcher — the next sign resends once on 0x6A80. */
+  private loopAbandoned = false;
+  /**
+   * ONE in-flight device ceremony (derive/approve/sign) at a time — a
+   * concurrent APDU would be eaten with 0x6A80 and desync the interrupt loop.
+   * Token-scoped: teardown clears it SYNCHRONOUSLY so a new connection can
+   * operate while a stale call is still settling; that call's finally
+   * releases only its own token.
+   */
+  private activeOperation: symbol | undefined;
+  /** Abort handle into the in-flight signing loop; fired by teardown (B3's only abort source). */
+  private signAbortController: AbortController | undefined;
 
   constructor(private readonly network: Network = Network.MAINNET) {}
+
+  /**
+   * See {@link activeOperation}. The busy throw costs zero device I/O; it
+   * fires only on a caller bug (two overlapping ceremonies).
+   */
+  private async withDeviceOperation<T>(operation: string, fn: () => Promise<T>): Promise<T> {
+    if (this.activeOperation) {
+      throw new WalletError({
+        code: ERROR_CODES.INVALID_PARAMS,
+        message: `${WALLET_PROVIDER_NAME} is already running a device ceremony; wait for it to finish before calling ${operation}.`,
+        wallet: WALLET_PROVIDER_NAME,
+      });
+    }
+    const token = Symbol(operation);
+    this.activeOperation = token;
+    try {
+      return await fn();
+    } finally {
+      if (this.activeOperation === token) this.activeOperation = undefined;
+    }
+  }
 
   private get depositorPath(): number[] {
     return [
@@ -134,10 +182,7 @@ export class LedgerVaultProvider implements IBTCProvider {
   private notWired(method: string): never {
     throw new WalletError({
       code: ERROR_CODES.WALLET_METHOD_NOT_SUPPORTED,
-      message:
-        `${WALLET_PROVIDER_NAME} does not implement ${method} yet. This build ` +
-        `covers connect and the intent ceremony only; SIGN_PSBT for the ` +
-        `vault's no-policy flows is not implemented (#2219).`,
+      message: `${WALLET_PROVIDER_NAME} does not implement ${method} yet.`,
       wallet: WALLET_PROVIDER_NAME,
     });
   }
@@ -187,6 +232,7 @@ export class LedgerVaultProvider implements IBTCProvider {
       }
       this.session = session;
       this.send = withWalletErrorMapping(createDmkApduSender(session));
+      this.rawSend = createDmkRawApduSender(session);
       this.connectionGeneration += 1;
     } catch (error) {
       // DMK errors don't extend Error — classify on `_tag`/`originalError`.
@@ -226,10 +272,19 @@ export class LedgerVaultProvider implements IBTCProvider {
     const session = this.session;
     this.session = undefined;
     this.send = undefined;
+    this.rawSend = undefined;
     this.connectionGeneration += 1;
     // Next connect may be a different device: reset state and the pubkey cache.
     this.deviceState = { phase: "idle" };
     this.pubkeyHexPromise = undefined;
+    this.signedFingerprints = new Set();
+    this.loopAbandoned = false;
+    // Release the ceremony lock and stop an in-flight signing loop NOW — the
+    // stale call's finally only releases its own token, and its rejection
+    // commits nothing (the generation just changed).
+    this.activeOperation = undefined;
+    this.signAbortController?.abort();
+    this.signAbortController = undefined;
     if (session) await disconnectDmkSession(session);
   };
 
@@ -264,7 +319,10 @@ export class LedgerVaultProvider implements IBTCProvider {
    * Derive the 32-byte context root, always with the approval screen — a
    * silent derivation produces a root that can never load an intent.
    */
-  deriveContextHash = async (appName: string, context: string): Promise<string> => {
+  deriveContextHash = async (appName: string, context: string): Promise<string> =>
+    this.withDeviceOperation("deriveContextHash", () => this.doDeriveContextHash(appName, context));
+
+  private doDeriveContextHash = async (appName: string, context: string): Promise<string> => {
     // Buffer.from(str, "hex") truncates silently, so a malformed context
     // would derive a root over a SHORTER preimage — every secret wrong, with
     // nothing on the device screen to reveal it.
@@ -279,8 +337,11 @@ export class LedgerVaultProvider implements IBTCProvider {
     }
 
     // Deriving invalidates whatever the device held; drop to "idle" BEFORE
-    // the call so host and device stay in lockstep if it fails partway.
+    // the call so host and device stay in lockstep if it fails partway. The
+    // old intent's dedup state dies with it — clear the sign bookkeeping too.
     this.deviceState = { phase: "idle" };
+    this.signedFingerprints = new Set();
+    this.loopAbandoned = false;
 
     const generation = this.connectionGeneration;
     const root = await deriveContextHash(this.requireSender(), {
@@ -298,7 +359,10 @@ export class LedgerVaultProvider implements IBTCProvider {
    * The envelope gate runs BEFORE any device I/O — the firmware answers an
    * out-of-range intent with an opaque status word and a dead session.
    */
-  approveDepositTerms = async (terms: DepositTerms): Promise<void> => {
+  approveDepositTerms = async (terms: DepositTerms): Promise<void> =>
+    this.withDeviceOperation("approveDepositTerms", () => this.doApproveDepositTerms(terms));
+
+  private doApproveDepositTerms = async (terms: DepositTerms): Promise<void> => {
     assertDepositTermsDeviceCompatible(terms);
 
     // Capture BEFORE the first await so a disconnect/reconnect during any of
@@ -397,6 +461,11 @@ export class LedgerVaultProvider implements IBTCProvider {
     await approveVaultIntent(send, intent);
     this.assertSameConnection(generation);
     this.deviceState = { phase: "intent-loaded", termsKey: key };
+    // A NEW ceremony ran: the device's signature counters and dedup masks are
+    // fresh, so the same PSBT bytes are legitimately signable again. (The
+    // byte-equal re-approval no-op above returns earlier and keeps both.)
+    this.signedFingerprints = new Set();
+    this.loopAbandoned = false;
   };
 
   /**
@@ -414,12 +483,243 @@ export class LedgerVaultProvider implements IBTCProvider {
     }
   }
 
-  // TODO(#2219): implement via the SIGN_PSBT host protocol; signPsbts becomes
-  // a sequential loop. The input is named in the error so logs identify the caller.
-  signPsbt = async (psbtHex: string): Promise<string> => this.notWired(`signPsbt (${psbtHex.length / 2} bytes)`);
+  /**
+   * SIGN_PSBT under the loaded intent (#2219 B3). Never finalizes — the SDK
+   * extracts signatures and finalizes itself. Every rejection before the
+   * device loop starts leaves the mirror and the loaded intent untouched.
+   */
+  signPsbt = async (psbtHex: string, options?: SignPsbtOptions): Promise<string> =>
+    this.withDeviceOperation("signPsbt", () =>
+      this.withSignAbort((controller) => this.signOnePsbt(psbtHex, options, controller)),
+    );
 
-  signPsbts = async (psbtsHexes: string[]): Promise<string[]> =>
-    this.notWired(`signPsbts (${psbtsHexes.length} psbt(s))`);
+  /**
+   * Strictly sequential, array order, fail-fast — one interrupt loop at a
+   * time; a concurrent APDU would be eaten with 0x6A80 and desync the loop.
+   * A mid-batch failure rejects the whole batch (no partial results); the
+   * error's mirror rule decides whether a full re-ceremony is needed.
+   */
+  signPsbts = async (psbtsHexes: string[], options?: SignPsbtOptions[]): Promise<string[]> =>
+    this.withDeviceOperation("signPsbts", () =>
+      this.withSignAbort(async (controller) => {
+        const signed: string[] = [];
+        for (let index = 0; index < psbtsHexes.length; index += 1) {
+          // A cancel landing BETWEEN elements must stop the batch — inside an
+          // element the loop's own signal checks cover it.
+          if (controller.signal.aborted) {
+            throw new WalletError({
+              code: ERROR_CODES.WALLET_NOT_CONNECTED,
+              message: `${WALLET_PROVIDER_NAME} stopped signing (disconnected) after ${index} of ${psbtsHexes.length} PSBT(s).`,
+              wallet: WALLET_PROVIDER_NAME,
+            });
+          }
+          signed.push(await this.signOnePsbt(psbtsHexes[index], options?.[index], controller, index));
+        }
+        return signed;
+      }),
+    );
+
+  /**
+   * ONE AbortController per public sign call (plan D1) — it spans a whole
+   * batch, so teardown's abort also stops the between-elements window.
+   */
+  private async withSignAbort<T>(fn: (controller: AbortController) => Promise<T>): Promise<T> {
+    const controller = new AbortController();
+    this.signAbortController = controller;
+    try {
+      return await fn(controller);
+    } finally {
+      if (this.signAbortController === controller) this.signAbortController = undefined;
+    }
+  }
+
+  private async signOnePsbt(
+    psbtHex: string,
+    options: SignPsbtOptions | undefined,
+    controller: AbortController,
+    batchIndex?: number,
+  ): Promise<string> {
+    const label = batchIndex === undefined ? "signPsbt" : `signPsbts[${batchIndex}]`;
+    const session = this.requireSession();
+    const rawSend = this.requireRawSender();
+    const generation = this.connectionGeneration;
+    // Fail actionably now rather than with an opaque status word mid-loop. A
+    // dead session means the device state is gone (unplug wipes it) — the
+    // mirror and replay bookkeeping must not survive it. Generation-guarded:
+    // a reconnect may already have re-established fresh state.
+    if (!(await isSessionAlive(session))) {
+      if (generation === this.connectionGeneration) {
+        this.deviceState = { phase: "idle" };
+        this.signedFingerprints = new Set();
+        this.loopAbandoned = false;
+      }
+      throw new WalletError({
+        code: ERROR_CODES.WALLET_NOT_CONNECTED,
+        message: `${WALLET_PROVIDER_NAME} was disconnected; reconnect the device and restart the flow from derivation.`,
+        wallet: WALLET_PROVIDER_NAME,
+      });
+    }
+    this.assertSameConnection(generation);
+    if (this.deviceState.phase !== "intent-loaded") {
+      throw new WalletError({
+        code: ERROR_CODES.WALLET_NOT_CONNECTED,
+        message:
+          `${WALLET_PROVIDER_NAME} holds no approved intent on this ` +
+          `connection — ${label} requires DERIVE_CONTEXT_HASH and an approved ` +
+          `intent first. Restart the flow from derivation.`,
+        wallet: WALLET_PROVIDER_NAME,
+      });
+    }
+    // The SDK's contract is sign-then-extract-then-finalize; honoring
+    // autoFinalized:true silently would hand back a different contract, and
+    // silently NOT honoring it would be worse. Tweak flags are ignored: the
+    // device rebuilds every script from the approved intent.
+    if (options?.autoFinalized === true) {
+      throw new WalletError({
+        code: ERROR_CODES.INVALID_PARAMS,
+        message:
+          `${WALLET_PROVIDER_NAME} never finalizes; call ${label} with ` +
+          `autoFinalized: false and finalize after signature extraction.`,
+        wallet: WALLET_PROVIDER_NAME,
+      });
+    }
+    // Canonical fingerprint over DECODED bytes — a case-variant hex of the
+    // same PSBT must not bypass the replay guard.
+    if (!/^(?:[0-9a-fA-F]{2})+$/.test(psbtHex)) {
+      throw new WalletError({
+        code: ERROR_CODES.INVALID_PARAMS,
+        message: `${label} needs even-length hex; got ${psbtHex.length} chars.`,
+        wallet: WALLET_PROVIDER_NAME,
+      });
+    }
+    const fingerprint = bcrypto.sha256(Buffer.from(psbtHex, "hex")).toString("hex");
+    // NEVER resubmit a signed PSBT: the device dedup mask answers 0xB00A and
+    // nullifies the intent — and NoPayout has NO mask, so a replay there
+    // silently steals quota. This host guard is the only defense for that class.
+    if (this.signedFingerprints.has(fingerprint)) {
+      throw new WalletError({
+        code: ERROR_CODES.INVALID_PARAMS,
+        message:
+          `${label}: this PSBT was already signed under the loaded intent — ` +
+          `re-signing it would nullify the intent on the device. Restart the ` +
+          `flow from derivation to sign it again.`,
+        wallet: WALLET_PROVIDER_NAME,
+      });
+    }
+
+    // Stage 1 — host-only prepare: typed rejections cost zero device I/O and
+    // leave the mirror and the loaded intent UNTOUCHED (plan D7).
+    const depositorXOnlyHex = await this.getDevicePubkeyHex();
+    this.assertSameConnection(generation);
+    let prepared: PreparedSignPsbt;
+    try {
+      prepared = prepareSignPsbt({ psbtHex, depositorXOnlyHex });
+    } catch (error) {
+      throw new WalletError(
+        {
+          code: ERROR_CODES.INVALID_PARAMS,
+          message: `${label} rejected before device I/O: ${error instanceof Error ? error.message : String(error)}`,
+          wallet: WALLET_PROVIDER_NAME,
+        },
+        { cause: error instanceof Error ? error : undefined },
+      );
+    }
+    // B1 signs the no-policy tapscript flows only: a keypath expectation means
+    // Pre-PegIn/PoP, which need the wallet-policy path. Reject actionably here
+    // instead of letting the device answer an opaque 0x6A80 mid-loop.
+    for (const expectation of prepared.table.byInput.values()) {
+      if (expectation.kind === "taproot-keypath") {
+        throw new WalletError({
+          code: ERROR_CODES.WALLET_METHOD_NOT_SUPPORTED,
+          message:
+            `${WALLET_PROVIDER_NAME} cannot sign key-path inputs (${label}) yet — ` +
+            `Pre-PegIn and proof-of-possession need the wallet-policy path (#2222/#2221).`,
+          wallet: WALLET_PROVIDER_NAME,
+        });
+      }
+    }
+
+    // Stage 2 — the device loop. From here every error is classified against
+    // the mirror; the controller is teardown's handle into the unbounded loop.
+    try {
+      const result = await signPreparedVaultPsbt(rawSend, prepared, {
+        signal: controller.signal,
+        appIdentity:
+          session.appName !== undefined ? { appName: session.appName, appVersion: session.appVersion } : undefined,
+        resendOnceOnIncorrectData: this.loopAbandoned,
+      });
+      this.assertSameConnection(generation);
+      // Success never consumes the intent: further (different) PSBTs sign
+      // under the same approval; this one never again.
+      this.signedFingerprints.add(fingerprint);
+      this.loopAbandoned = false;
+      return result.signedPsbtHex;
+    } catch (error) {
+      // A stale rejection must not touch the new connection's state.
+      if (generation !== this.connectionGeneration) {
+        throw new WalletError(
+          {
+            code: ERROR_CODES.WALLET_NOT_CONNECTED,
+            message: `${WALLET_PROVIDER_NAME} connection changed during signing; restart from derivation.`,
+            wallet: WALLET_PROVIDER_NAME,
+          },
+          { cause: error instanceof Error ? error : undefined },
+        );
+      }
+      if (isLedgerSignPsbtAbortedError(error)) {
+        // The intent MAY survive an abandonment (hint only) — keep the mirror.
+        // Arm the one-shot 0x6A80 recovery only if a dispatcher was actually
+        // interrupted; a pre-send abort left nothing to recover from. NB: in
+        // B3 the only abort source is teardown, which bumps the generation
+        // FIRST — so this branch goes live only when a non-teardown abort
+        // source (a #2110 UI cancel) is added.
+        if (error.sentInitialApdu) this.loopAbandoned = true;
+        throw new WalletError(
+          {
+            code: ERROR_CODES.WALLET_NOT_CONNECTED,
+            message: `${WALLET_PROVIDER_NAME} stopped signing (disconnected); reconnect and retry.`,
+            wallet: WALLET_PROVIDER_NAME,
+          },
+          { cause: error },
+        );
+      }
+      // Everything else: pessimistically assume the device dropped the intent
+      // (error-path invalidation is mixed in firmware — never assume survival).
+      this.deviceState = { phase: "idle" };
+      this.signedFingerprints = new Set();
+      this.loopAbandoned = false;
+      const mapped = toSignerWalletError(error);
+      if (mapped) {
+        // A batch caller needs to know WHICH element failed. The cast matches
+        // the mapper's own dmk branch: DMK objects don't extend Error.
+        throw batchIndex === undefined
+          ? mapped
+          : new WalletError(
+              { code: mapped.code, message: `${label}: ${mapped.message}`, wallet: WALLET_PROVIDER_NAME },
+              { cause: error as Error },
+            );
+      }
+      throw new WalletError(
+        {
+          code: ERROR_CODES.UNKNOWN_ERROR,
+          message: `${label} failed: ${error instanceof Error ? error.message : String(error)}`,
+          wallet: WALLET_PROVIDER_NAME,
+        },
+        { cause: error instanceof Error ? error : undefined },
+      );
+    }
+  }
+
+  private requireRawSender(): RawApduSender {
+    if (!this.rawSend) {
+      throw new WalletError({
+        code: ERROR_CODES.WALLET_NOT_CONNECTED,
+        message: `${WALLET_PROVIDER_NAME} is not connected`,
+        wallet: WALLET_PROVIDER_NAME,
+      });
+    }
+    return this.rawSend;
+  }
 
   // TODO(#2221): BIP-322 PoP — a SIGN_PSBT with tx_version 0, not the base
   // app's SIGN_MESSAGE.
@@ -443,46 +743,61 @@ export class LedgerVaultProvider implements IBTCProvider {
 /**
  * Map the signer package's typed device outcomes onto the connector's
  * WalletError taxonomy; the messages (with their "User rejected" prefix)
- * pass through unchanged. Anything unrecognised propagates untouched.
+ * pass through unchanged. Returns undefined for anything unrecognised.
+ * Shared by the ceremony sender wrapper and the SIGN_PSBT seam — the raw
+ * sender's loop errors never pass through {@link withWalletErrorMapping}.
  */
+function toSignerWalletError(error: unknown): WalletError | undefined {
+  if (isLedgerUserRefusedError(error)) {
+    return new WalletError(
+      { code: ERROR_CODES.CONNECTION_REJECTED, message: error.message, wallet: WALLET_PROVIDER_NAME },
+      { cause: error },
+    );
+  }
+  if (isLedgerDeviceLockedError(error)) {
+    return new WalletError(
+      { code: ERROR_CODES.CONNECTION_FAILED, message: error.message, wallet: WALLET_PROVIDER_NAME },
+      { cause: error },
+    );
+  }
+  if (isLedgerDeviceError(error)) {
+    // A stable, distinguishable message for the two "intent gone" words —
+    // #2110's UX routes these to a restart-from-derivation screen.
+    const intentGone = error.statusWord === SW_BAD_STATE || error.statusWord === SW_CAP_EXCEEDED;
+    return new WalletError(
+      {
+        code: ERROR_CODES.UNKNOWN_ERROR,
+        message: intentGone
+          ? `The device no longer holds the approved intent (${error.message}) — restart the flow from derivation.`
+          : error.message,
+        wallet: WALLET_PROVIDER_NAME,
+      },
+      { cause: error },
+    );
+  }
+  // DMK transport/session errors do not extend Error (plain {_tag,
+  // originalError}); without this a mid-ceremony unplug propagates as a
+  // raw object — instanceof Error misses, String(err) is "[object Object]".
+  const dmk = error as { _tag?: string; originalError?: { message?: string } } | undefined;
+  if (dmk?._tag) {
+    return new WalletError(
+      {
+        code: ERROR_CODES.CONNECTION_FAILED,
+        message: dmk.originalError?.message ?? dmk._tag,
+        wallet: WALLET_PROVIDER_NAME,
+      },
+      { cause: error as Error },
+    );
+  }
+  return undefined;
+}
+
 function withWalletErrorMapping(send: ApduSender): ApduSender {
   return async (apdu) => {
     try {
       return await send(apdu);
     } catch (error) {
-      if (isLedgerUserRefusedError(error)) {
-        throw new WalletError(
-          { code: ERROR_CODES.CONNECTION_REJECTED, message: error.message, wallet: WALLET_PROVIDER_NAME },
-          { cause: error },
-        );
-      }
-      if (isLedgerDeviceLockedError(error)) {
-        throw new WalletError(
-          { code: ERROR_CODES.CONNECTION_FAILED, message: error.message, wallet: WALLET_PROVIDER_NAME },
-          { cause: error },
-        );
-      }
-      if (isLedgerDeviceError(error)) {
-        throw new WalletError(
-          { code: ERROR_CODES.UNKNOWN_ERROR, message: error.message, wallet: WALLET_PROVIDER_NAME },
-          { cause: error },
-        );
-      }
-      // DMK transport/session errors do not extend Error (plain {_tag,
-      // originalError}); without this a mid-ceremony unplug propagates as a
-      // raw object — instanceof Error misses, String(err) is "[object Object]".
-      const dmk = error as { _tag?: string; originalError?: { message?: string } } | undefined;
-      if (dmk?._tag) {
-        throw new WalletError(
-          {
-            code: ERROR_CODES.CONNECTION_FAILED,
-            message: dmk.originalError?.message ?? dmk._tag,
-            wallet: WALLET_PROVIDER_NAME,
-          },
-          { cause: error as Error },
-        );
-      }
-      throw error;
+      throw toSignerWalletError(error) ?? error;
     }
   };
 }

--- a/services/vault/src/hooks/deposit/depositFlowSteps/__tests__/ensureAuthenticatedVpClient.test.ts
+++ b/services/vault/src/hooks/deposit/depositFlowSteps/__tests__/ensureAuthenticatedVpClient.test.ts
@@ -141,4 +141,74 @@ describe("ensureAuthenticatedVpClient", () => {
     expect(mockGetVaultProtocolInfo).not.toHaveBeenCalled();
     expect(mockGetCurrentVaultProviderOperationBtcKey).not.toHaveBeenCalled();
   });
+
+  it("approval wallet without the flag keeps the cache hit — WOTS/resume stay popup-free", async () => {
+    const approvalWallet = {
+      deriveContextHash: vi.fn(),
+      approveDepositTerms: vi.fn(),
+    } as never;
+    await ensureAuthenticatedVpClient({
+      btcWallet: approvalWallet,
+      vaultId: VAULT_ID,
+      unsignedPrePeginTxHex: "deadbeef",
+      peginTxHash: PEGIN_TX_HASH,
+      providerAddress: PROVIDER_ADDRESS,
+      depositorBtcPubkey: "ab".repeat(32),
+    });
+    vi.clearAllMocks();
+
+    await ensureAuthenticatedVpClient({
+      btcWallet: approvalWallet,
+      vaultId: VAULT_ID,
+      unsignedPrePeginTxHex: "deadbeef",
+      peginTxHash: PEGIN_TX_HASH,
+      providerAddress: PROVIDER_ADDRESS,
+      depositorBtcPubkey: "ab".repeat(32),
+    });
+
+    expect(deriveVaultRoot).not.toHaveBeenCalled();
+  });
+
+  it("approval wallet: bypasses the token cache so every attempt re-derives", async () => {
+    // For approval wallets the derive is also the device-ceremony
+    // precondition — a cache hit here would strand a retry after a signing
+    // failure at "no approved intent" forever.
+    const approvalWallet = {
+      deriveContextHash: vi.fn(),
+      approveDepositTerms: vi.fn(),
+    } as never;
+    await ensureAuthenticatedVpClient({
+      btcWallet: approvalWallet,
+      vaultId: VAULT_ID,
+      unsignedPrePeginTxHex: "deadbeef",
+      peginTxHash: PEGIN_TX_HASH,
+      providerAddress: PROVIDER_ADDRESS,
+      depositorBtcPubkey: "ab".repeat(32),
+      requireFreshDeviceCeremony: true,
+    });
+    vi.clearAllMocks();
+    (deriveVaultRoot as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
+      new Uint8Array(32).fill(0xcc),
+    );
+    (expandAuthAnchor as unknown as ReturnType<typeof vi.fn>).mockReturnValue(
+      new Uint8Array(32).fill(0xab),
+    );
+    mockGetCurrentVaultProviderOperationBtcKey.mockResolvedValue(VALID_XONLY);
+    mockGetVaultProtocolInfo.mockResolvedValue({
+      prePeginTxHash: ON_CHAIN_PRE_PEGIN_HASH,
+    });
+    vi.mocked(calculateBtcTxHash).mockReturnValue(ON_CHAIN_PRE_PEGIN_HASH);
+
+    await ensureAuthenticatedVpClient({
+      btcWallet: approvalWallet,
+      vaultId: VAULT_ID,
+      unsignedPrePeginTxHex: "deadbeef",
+      peginTxHash: PEGIN_TX_HASH,
+      providerAddress: PROVIDER_ADDRESS,
+      depositorBtcPubkey: "ab".repeat(32),
+      requireFreshDeviceCeremony: true,
+    });
+
+    expect(deriveVaultRoot).toHaveBeenCalledTimes(1);
+  });
 });

--- a/services/vault/src/hooks/deposit/depositFlowSteps/ensureAuthenticatedVpClient.ts
+++ b/services/vault/src/hooks/deposit/depositFlowSteps/ensureAuthenticatedVpClient.ts
@@ -17,6 +17,7 @@ import {
   hexToUint8Array,
   parseFundingOutpointsFromTx,
   stripHexPrefix,
+  supportsDepositApproval,
   uint8ArrayToHex,
 } from "@babylonlabs-io/ts-sdk/tbv/core";
 import {
@@ -43,6 +44,14 @@ export interface EnsureAuthenticatedVpClientParams {
   peginTxHash: string;
   providerAddress: string;
   depositorBtcPubkey: string;
+  /**
+   * Payout-signing retry path only: for approval wallets the derive is ALSO
+   * the device-ceremony precondition (mirror: idle → derived), so a cached
+   * token would strand every retry after a signing failure at "no approved
+   * intent". Leave unset elsewhere — the cache hit is what keeps WOTS submit,
+   * resume, and artifact download popup-free.
+   */
+  requireFreshDeviceCeremony?: boolean;
 }
 
 export async function ensureAuthenticatedVpClient(
@@ -51,9 +60,17 @@ export async function ensureAuthenticatedVpClient(
   const peginTxid = stripHexPrefix(params.peginTxHash);
   const baseUrl = getVpProxyUrl(params.providerAddress);
 
-  const cached = vpTokenRegistry.peek(peginTxid);
-  if (cached) {
-    return new VaultProviderRpcClient(baseUrl, { tokenProvider: cached });
+  // See {@link EnsureAuthenticatedVpClientParams.requireFreshDeviceCeremony}.
+  if (
+    params.requireFreshDeviceCeremony &&
+    supportsDepositApproval(params.btcWallet)
+  ) {
+    vpTokenRegistry.release(peginTxid);
+  } else {
+    const cached = vpTokenRegistry.peek(peginTxid);
+    if (cached) {
+      return new VaultProviderRpcClient(baseUrl, { tokenProvider: cached });
+    }
   }
 
   // Cold path only: validate the indexer-supplied Pre-PegIn tx against

--- a/services/vault/src/hooks/deposit/depositFlowSteps/payoutSigning.ts
+++ b/services/vault/src/hooks/deposit/depositFlowSteps/payoutSigning.ts
@@ -98,6 +98,9 @@ export async function signAndSubmitPayouts(
     peginTxHash,
     providerAddress: vaultProviderAddress,
     depositorBtcPubkey,
+    // A signing failure idles the device mirror; the retry must re-derive or
+    // approval wallets strand at "no approved intent" forever.
+    requireFreshDeviceCeremony: true,
   });
 
   await runDepositorPresignFlow({


### PR DESCRIPTION
Closes the B3 remainder of #2219: the Ledger vault provider's signPsbt/signPsbts
(previously notWired) now drive the merged SIGN_PSBT core.

The provider holds a mirror of the device's intent state around the signing loop:
before any device I/O it requires a loaded intent, rejects replays (sha256 over
decoded PSBT bytes — the device dedup mask would nullify the intent, and NoPayout
has no mask at all), rejects key-path tables (Pre-PegIn/PoP need the wallet-policy
path, #2222/#2221) and autoFinalized:true. On success the intent stays loaded for
further PSBTs; on any device error the mirror drops pessimistically to idle
(firmware error-path invalidation is mixed — never assume survival). One ceremony
runs at a time (a concurrent APDU would be eaten with 0x6A80 and desync the
interrupt loop), with a generation-scoped lock that teardown releases synchronously
so a stale settling call can never touch a new connection's state. signPsbts is
strictly sequential, array-order, fail-fast, naming the failing index.

Signer-side, the entry point is split into exported stages (prepareSignPsbt +
signPreparedVaultPsbt; signVaultPsbt is their composition — an equivalence test
pins zero drift) so the provider inspects the expectation table before I/O, and
LedgerSignPsbtAbortedError now reports whether the initial APDU went out (breaking
constructor change; required so a pre-send abort doesn't arm the 0x6A80 resend
recovery). The abort→retry recovery path is intentionally unreachable until #2110
adds a UI cancel — teardown bumps the generation before aborting (documented
in-code and in the plan).