### PR TITLE
fix(e2e): restore unisat

### DIFF
--- a/packages/babylon-wallet-connector/tests/e2e/fixtures/wallets/metamask.ts
+++ b/packages/babylon-wallet-connector/tests/e2e/fixtures/wallets/metamask.ts
@@ -14,14 +14,16 @@
  *  - Onboarding does NOT auto-complete: the wallet stays stuck at /onboarding/completion until
  *    "Open wallet" is clicked (which also opens the side panel).
  *  - The side panel (`sidepanel.html`) is invisible to context.pages() and in-page window.close() is
- *    blocked by LavaMoat — close it at the browser level via CDP Target.closeTarget.
+ *    blocked by LavaMoat — close it at the browser level via CDP Target.closeTarget. Since 13.44
+ *    MetaMask opens there BY DEFAULT, which hides every approval from the approver, so the import
+ *    switches it back to pop-up mode (see `usePopupApprovals`).
  *  - A fresh home.html tab opens locked/at a residual onboarding step — settle it (unlock/passkey).
  */
 import { type BrowserContext, type Page } from "@playwright/test";
 
 import { EXTENSION_CHROME_STORE_IDS } from "../../setup/downloadExtensions";
 import { runtimeExtensionId } from "../../utils/extensionId";
-import { SETTLE, TYPE_DELAY_MS } from "../../utils/timing";
+import { SETTLE, TYPE_DELAY_MS, WAIT_FOR } from "../../utils/timing";
 import { clickText, clickWhenEnabled, scanEthAddress } from "../../utils/walletUi";
 
 /** MetaMask-specific timeouts/loop bounds (values preserved from the verified onboarding flow). */
@@ -100,42 +102,52 @@ async function readAddress(page: Page): Promise<string | null> {
   return truncated ? truncated[0] : null;
 }
 
+/** Account-menu item that toggles between popup and side-panel view; its label names the TARGET view. */
+const MM_VIEW_TOGGLE_TESTID = "global-menu-toggle-view";
+
+/**
+ * Where to click inside the 32x32 account-options button. MetaMask overlays an unread-notifications
+ * badge (`notifications-tag-counter__unread-dot`) at the button's top-right, which intercepts a normal
+ * centre click; the bottom-left corner is clear of it.
+ */
+const MM_MENU_CLICK_POSITION = { x: 4, y: 28 } as const;
+
 /** The auto-lock value MetaMask ships with (its Security settings show it as a word, not minutes). */
 const MM_EXPECTED_AUTO_LOCK = "Never";
 
+/** MetaMask's Security-and-password settings route, navigated to directly (see `verifyAutoLockNever`). */
+const MM_SECURITY_SETTINGS_ROUTE = "#/settings/security-and-password";
+
 /**
  * Verify MetaMask's auto-lock is "Never" so the wallet doesn't re-lock during a run (steps 4 and 14 of
- * a peg-in are MetaMask transactions; a locked wallet stalls them). Path: account options
- * (account-options-menu-button) → Settings (global-menu-settings) → "Security and password" → the
- * "Auto lock" row. Fails loudly if it isn't "Never" (or the row can't be found) — that's the signal to
- * capture MetaMask's auto-lock SETTER and switch this from a verify to a set. The per-wallet spec
+ * a peg-in are MetaMask transactions; a locked wallet stalls them).
+ *
+ * Goes straight to the Security settings ROUTE rather than driving account options → Settings →
+ * "Security and password". MetaMask renders an unread-notifications badge that intermittently
+ * overlays the account-options button and swallows the click (Playwright reports
+ * `notifications-tag-counter__unread-dot … intercepts pointer events`), and LavaMoat's scuttling
+ * blocks the usual `dispatchEvent` escape hatch — so the menu path is a race we cannot win. The route
+ * reaches the same screen with nothing to intercept.
+ *
+ * Fails loudly if it isn't "Never" (or the row can't be found) — that's the signal to capture
+ * MetaMask's auto-lock SETTER and switch this from a verify to a set. The per-wallet spec
  * (test:e2e:metamask) exercises this.
  */
 async function verifyAutoLockNever(page: Page): Promise<void> {
-  await page
-    .getByTestId("account-options-menu-button")
-    .first()
-    .click()
-    .catch(() => {});
-  await page.waitForTimeout(SETTLE.SHORT);
-  const settings = page.getByTestId("global-menu-settings").first();
-  if ((await settings.count()) === 0)
+  const base = (page.url().match(/^(chrome-extension:\/\/[a-p]{32})\//) ?? [])[1];
+  if (!base)
     throw new Error(
-      "MetaMask auto-lock: Settings menu item (global-menu-settings) not found",
+      `MetaMask auto-lock: expected a chrome-extension wallet page, got "${page.url()}"`,
     );
-  await settings.click().catch(() => {});
-  await page.waitForTimeout(SETTLE.MODAL);
-  const section = page.getByText("Security and password", { exact: true }).first();
-  if ((await section.count()) === 0)
-    throw new Error(
-      'MetaMask auto-lock: "Security and password" section not found',
-    );
-  await section.click().catch(() => {});
+  await page.goto(`${base}/home.html${MM_SECURITY_SETTINGS_ROUTE}`).catch(() => {});
   await page.waitForTimeout(SETTLE.MODAL);
 
   const label = page.getByText("Auto lock", { exact: true }).first();
+  await label.waitFor({ state: "visible", timeout: WAIT_FOR.ELEMENT_MS }).catch(() => {});
   if ((await label.count()) === 0)
-    throw new Error('MetaMask auto-lock: "Auto lock" row not found');
+    throw new Error(
+      `MetaMask auto-lock: "Auto lock" row not found at ${MM_SECURITY_SETTINGS_ROUTE} — the settings route or layout changed`,
+    );
   // The row div holds the label <p> and the current-value <p> side by side; read the whole row.
   const rowText = (await label.locator("xpath=..").innerText().catch(() => ""))
     .replace(/\s+/g, " ")
@@ -144,6 +156,58 @@ async function verifyAutoLockNever(page: Page): Promise<void> {
     throw new Error(
       `MetaMask auto-lock: expected "${MM_EXPECTED_AUTO_LOCK}" but the Auto lock row reads "${rowText}"`,
     );
+}
+
+/**
+ * Put MetaMask back into POPUP mode, so approvals open as `notification.html` windows.
+ *
+ * As of 13.44 MetaMask "opens in the side panel by default" (its own migration toast). Chrome does not
+ * expose a side panel as a Playwright page — no `page` event fires and it never appears in
+ * `context.pages()` — so an approval raised there is invisible to the pop-up approver and a run simply
+ * stalls with the request unconfirmed. Flipping the preference restores the pre-13.44 behaviour, which
+ * every approval path in this harness is already built around.
+ *
+ * The toggle only renders in the popup/side-panel view (never in the expanded tab), so this drives it
+ * from `sidepanel.html` opened AS A TAB — the same trick that makes the panel reachable at all. The
+ * account-options button needs an off-centre click to dodge the unread-notifications badge.
+ *
+ * Confirmed by the panel document closing itself, which is what switching view modes does. Note the
+ * toggle's LABEL cannot be used: it names the current view, and read from `sidepanel.html` that is
+ * always "Switch to popup" whatever the stored preference is. Failing silently here would reintroduce
+ * an invisible-approval stall that only surfaces much later as an unexplained timeout, so it throws.
+ */
+async function usePopupApprovals(
+  context: BrowserContext,
+  base: string,
+): Promise<void> {
+  const panel = await context.newPage();
+  try {
+    await panel.goto(`${base}/sidepanel.html`).catch(() => {});
+    await panel.waitForTimeout(SETTLE.LONG);
+    await panel
+      .getByTestId("account-options-menu-button")
+      .first()
+      .click({ position: MM_MENU_CLICK_POSITION, timeout: WAIT_FOR.ELEMENT_MS })
+      .catch(() => {});
+    await panel.waitForTimeout(SETTLE.MODAL);
+
+    const toggle = panel
+      .locator(`[data-testid="${MM_VIEW_TOGGLE_TESTID}"]`)
+      .first();
+    if ((await toggle.count().catch(() => 0)) === 0)
+      throw new Error(
+        `MetaMask: view toggle (${MM_VIEW_TOGGLE_TESTID}) not found in the side-panel view — cannot put approvals into pop-ups, which the approver requires.`,
+      );
+    await toggle.click({ timeout: WAIT_FOR.ELEMENT_MS }).catch(() => {});
+    await panel.waitForTimeout(SETTLE.MODAL).catch(() => {});
+
+    if (!panel.isClosed())
+      throw new Error(
+        "MetaMask: failed to switch to pop-up mode — the side-panel document is still open. Approvals would open in the side panel, where the approver cannot reach them.",
+      );
+  } finally {
+    await panel.close().catch(() => {});
+  }
 }
 
 /**
@@ -252,6 +316,9 @@ export async function setupMetaMaskWallet(context: BrowserContext, mnemonic: str
 
   // Confirm auto-lock won't re-lock the wallet mid-run (expected to already be "Never").
   await verifyAutoLockNever(walletPage);
+
+  // Approvals must open as pop-up windows; the side panel is invisible to Playwright.
+  await usePopupApprovals(context, base);
 
   await walletPage.close().catch(() => {}); // done — the wallet persists in the profile
   if (!address) throw new Error("MetaMask: could not read an address after import");

--- a/packages/babylon-wallet-connector/tests/e2e/fixtures/wallets/unisat.ts
+++ b/packages/babylon-wallet-connector/tests/e2e/fixtures/wallets/unisat.ts
@@ -18,7 +18,7 @@
  *  - The receive address is truncated in the DOM — read the full value via the clipboard, validated
  *    against the on-screen truncation so a stale clipboard can't yield a false result.
  */
-import { type BrowserContext, type Page } from "@playwright/test";
+import { type BrowserContext, type Locator, type Page } from "@playwright/test";
 
 import { EXTENSION_CHROME_STORE_IDS } from "../../setup/downloadExtensions";
 import { runtimeExtensionId } from "../../utils/extensionId";
@@ -109,16 +109,24 @@ async function enterMnemonic(page: Page, words: string[]): Promise<void> {
  */
 async function advanceFromImport(page: Page): Promise<void> {
   const addressTypeScreen = page.getByText(TAPROOT_ROW);
+  let everClicked = false;
   for (let i = 0; i < IMPORT_CONTINUE_ATTEMPTS; i++) {
     if ((await addressTypeScreen.count()) > 0) return;
-    await clickTestId(page, IMPORT_TESTID.CONTINUE);
+    everClicked = (await clickTestId(page, IMPORT_TESTID.CONTINUE)) || everClicked;
     await page.waitForTimeout(SETTLE.MEDIUM);
   }
-  if ((await addressTypeScreen.count()) === 0)
+  if ((await addressTypeScreen.count()) > 0) return;
+  // Separate causes, separate messages: a Continue we never found is a renamed testid, whereas one we
+  // clicked without advancing means UniSat rejected the phrase.
+  if (!everClicked)
     throw new Error(
-      `UniSat: Continue ([data-testid="${IMPORT_TESTID.CONTINUE}"]) did not advance past the import ` +
-        "screen — the phrase was rejected, or the address-type screen changed.",
+      `UniSat: Continue ([data-testid="${IMPORT_TESTID.CONTINUE}"]) was never present on the import ` +
+        "screen — its testid likely changed.",
     );
+  throw new Error(
+    `UniSat: Continue ([data-testid="${IMPORT_TESTID.CONTINUE}"]) did not advance past the import ` +
+      "screen — the phrase was rejected, or the address-type screen changed.",
+  );
 }
 
 /**
@@ -161,7 +169,15 @@ async function selectSignetTaproot(page: Page): Promise<void> {
         `UniSat: the Taproot card derives at a path other than ${UNISAT_TAPROOT_RECEIVE_PATH} — the custom ` +
           `derivation path did not take. Card label: ${label.replace(/\s+/g, " ").trim()}`,
       );
-    await clickTestId(page, `${ADDRESS_TYPE_TESTID.CARD_PREFIX}${i}`);
+    // Click the card we just validated, NOT `${CARD_PREFIX}${i}`: the testid suffix is the index of
+    // UniSat's own render loop, which emits `null` for cards it hides (a legacy type with no assets,
+    // or a scanned type with no funded address). Those gaps leave the suffixes out of step with DOM
+    // position, so rebuilding the selector from `i` can select a different card — silently picking the
+    // wrong address type.
+    if (!(await clickLocator(page, cards.nth(i))))
+      throw new Error(
+        "UniSat: the Taproot card matched but could not be clicked (no bounding box).",
+      );
     await page.waitForTimeout(SETTLE.SHORT);
     return;
   }
@@ -210,18 +226,19 @@ async function readReceiveAddress(page: Page): Promise<string | null> {
 /** UniSat's longest "Automatic Lock Time" option (its dropdown tops out here). */
 const UNISAT_MAX_AUTO_LOCK = "4Hours";
 
-/** Coordinate-click a UniSat control by testid (its buttons are pointer-events:none div/span). */
-async function clickTestId(page: Page, testid: string): Promise<boolean> {
-  const box = await page
-    .locator(`[data-testid="${testid}"]`)
-    .first()
-    .boundingBox()
-    .catch(() => null);
+/** Coordinate-click a located UniSat control (its buttons are pointer-events:none div/span). */
+async function clickLocator(page: Page, locator: Locator): Promise<boolean> {
+  const box = await locator.boundingBox().catch(() => null);
   if (!box) return false;
   await page.mouse
     .click(box.x + box.width / 2, box.y + box.height / 2)
     .catch(() => {});
   return true;
+}
+
+/** Coordinate-click a UniSat control by testid. */
+async function clickTestId(page: Page, testid: string): Promise<boolean> {
+  return clickLocator(page, page.locator(`[data-testid="${testid}"]`).first());
 }
 
 /**

--- a/packages/babylon-wallet-connector/tests/e2e/fixtures/wallets/unisat.ts
+++ b/packages/babylon-wallet-connector/tests/e2e/fixtures/wallets/unisat.ts
@@ -7,7 +7,12 @@
  * Hard-won gotchas (see also the headed inspector `setup/inspectWallets.ts`):
  *  - UniSat derives taproot with coin type 0' even on signet; force the signet-correct account path
  *    `m/86'/1'/0'/0` (UniSat appends the `/0` index) and explicitly select the Taproot (P2TR) row.
- *  - Seed boxes need real key events — use pressSequentially, not fill().
+ *    That path field is behind an opt-in checkbox, and skipping it fails SILENTLY — the import still
+ *    yields a well-formed `tb1p…` address, just at the wrong path — so the card label is asserted.
+ *  - The import screen has no 12/24 selector: it auto-detects the word count. Before any word is
+ *    committed it is a single textarea that commits on Space/Enter (splitting on whitespace), and
+ *    once words exist that textarea unmounts in favour of a chip grid — so the whole phrase goes in
+ *    as one fill+Enter, never word by word.
  *  - Its buttons are <div>/<span> with pointer-events:none text — click by coordinates (tap/advance).
  *  - The "Compatibility Tips" modal must have its checkbox ticked before OK is honored.
  *  - The receive address is truncated in the DOM — read the full value via the clipboard, validated
@@ -17,11 +22,26 @@ import { type BrowserContext, type Page } from "@playwright/test";
 
 import { EXTENSION_CHROME_STORE_IDS } from "../../setup/downloadExtensions";
 import { runtimeExtensionId } from "../../utils/extensionId";
-import { CLIPBOARD_POLL, SETTLE, TYPE_DELAY_MS } from "../../utils/timing";
+import { CLIPBOARD_POLL, SETTLE, WAIT_FOR } from "../../utils/timing";
 import { addrMatches, advance, clickText, tap, tapTopmost } from "../../utils/walletUi";
 
 /** Signet-correct BIP86 account path; UniSat appends the `/0` receive index → m/86'/1'/0'/0/0. */
 const UNISAT_TAPROOT_ACCOUNT_PATH = "m/86'/1'/0'/0";
+
+/** The Taproot row on the address-type screen — also that screen's marker (see `advanceFromImport`). */
+const TAPROOT_ROW = /Taproot \(P2TR\)/i;
+
+/** The receive path the Taproot card must show once the signet account path has been applied. */
+const UNISAT_TAPROOT_RECEIVE_PATH = `${UNISAT_TAPROOT_ACCOUNT_PATH}/0`;
+
+/** Testids on UniSat's address-type screen. */
+const ADDRESS_TYPE_TESTID = {
+  /** Opt-in for the custom derivation path; the input below is only mounted once it is ticked. */
+  CUSTOM_PATH_TOGGLE: "custom-hdpath-enabled-checkbox-input",
+  CUSTOM_PATH_INPUT: "custom-hdpath-input",
+  /** Prefix of the per-address-type cards; each label carries the path it would derive at. */
+  CARD_PREFIX: "address-type-card-",
+} as const;
 
 /** How many times to re-try dismissing the "Compatibility Tips" modal before giving up. */
 const MODAL_DISMISS_ATTEMPTS = 4;
@@ -39,23 +59,115 @@ async function dismissModals(page: Page): Promise<void> {
   }
 }
 
+/** Testids on UniSat's mnemonic-import screen. */
+const IMPORT_TESTID = {
+  /** The single textarea rendered while no word has been committed yet. */
+  INITIAL_INPUT: "mnemonic-import-initial-input",
+  /** Prefix of the per-word chips rendered once words have been committed. */
+  WORD_PREFIX: "mnemonic-import-word-",
+  CONTINUE: "mnemonic-import-continue-button",
+} as const;
+
+/** How many times to click the import screen's Continue before giving up. */
+const IMPORT_CONTINUE_ATTEMPTS = 4;
+
 /**
- * Switch UniSat's restore-screen seed grid to `count` words. The screen defaults to a 12-input grid and
- * exposes a word-count selector, but its options are bare <span>s with no testid/role/class — so we
- * can't target them structurally. The option LABEL always contains the count as digits, though ("24
- * words" / "24 слова" / "24 词"), so we match the DIGITS — which are the same in every UI language — and
- * exclude the numbered seed-row labels ("24."). Picking the option resizes the grid.
+ * Enter the whole recovery phrase on UniSat's import screen.
+ *
+ * There is no word-count selector to drive: the screen auto-detects 12 vs 24. Until a word is
+ * committed it renders a single textarea whose Space/Enter handler commits its buffer, splitting on
+ * whitespace — and that first commit unmounts the textarea in favour of a grid of per-word chips.
+ * So the phrase goes in as ONE fill + Enter (typing it word by word would lose the textarea after
+ * the first space), and the chip count is what proves every word actually landed.
  */
-async function selectSeedWordCount(page: Page, count: number): Promise<void> {
-  // \b<count>\b not followed by a "." (so a "24." row label can't match), anywhere in the label.
-  const target = new RegExp(`\\b${count}\\b(?!\\.)`);
-  const option = page.getByText(target).first();
-  await option.click({ force: true }).catch(() => {});
+async function enterMnemonic(page: Page, words: string[]): Promise<void> {
+  const initial = page.locator(`[data-testid="${IMPORT_TESTID.INITIAL_INPUT}"]`);
+  await initial.waitFor({ state: "visible", timeout: WAIT_FOR.ELEMENT_MS }).catch(() => {});
+  if ((await initial.count()) === 0)
+    throw new Error(
+      `UniSat: the seed textarea ([data-testid="${IMPORT_TESTID.INITIAL_INPUT}"]) never appeared. Its ` +
+        "restore UI likely changed; re-derive enterMnemonic (unisat.ts) against the installed extension.",
+    );
+
+  await initial.fill(words.join(" "));
+  await initial.press("Enter");
+  await page.waitForTimeout(SETTLE.BRIEF);
+
+  const committed = await page.locator(`[data-testid^="${IMPORT_TESTID.WORD_PREFIX}"]`).count();
+  if (committed !== words.length)
+    throw new Error(
+      `UniSat: the import screen committed ${committed} seed words but the phrase has ${words.length} — ` +
+        "the whole phrase was not accepted.",
+    );
+}
+
+/**
+ * Leave the import screen for the address-type screen. Continue stays disabled until UniSat has
+ * validated the phrase, and it is a pointer-events:none div — so click by coordinates and confirm we
+ * actually advanced (the Taproot row is the address-type screen's marker) instead of assuming a click
+ * on a still-disabled button did anything.
+ */
+async function advanceFromImport(page: Page): Promise<void> {
+  const addressTypeScreen = page.getByText(TAPROOT_ROW);
+  for (let i = 0; i < IMPORT_CONTINUE_ATTEMPTS; i++) {
+    if ((await addressTypeScreen.count()) > 0) return;
+    await clickTestId(page, IMPORT_TESTID.CONTINUE);
+    await page.waitForTimeout(SETTLE.MEDIUM);
+  }
+  if ((await addressTypeScreen.count()) === 0)
+    throw new Error(
+      `UniSat: Continue ([data-testid="${IMPORT_TESTID.CONTINUE}"]) did not advance past the import ` +
+        "screen — the phrase was rejected, or the address-type screen changed.",
+    );
+}
+
+/**
+ * Address-type screen: force the signet-correct derivation path, then select the Taproot (P2TR) card.
+ *
+ * UniSat derives taproot with coin type 0' even on signet, so the custom path has to be set — and it
+ * sits behind an opt-in checkbox whose input is only mounted once ticked. Getting this wrong is
+ * silent: the import still succeeds and still yields a well-formed `tb1p…` address, just at the wrong
+ * path. So both controls are required, and the chosen card's own label — which renders the path it
+ * would derive at — is asserted before the row is picked.
+ */
+async function selectSignetTaproot(page: Page): Promise<void> {
+  const toggle = page.locator(`[data-testid="${ADDRESS_TYPE_TESTID.CUSTOM_PATH_TOGGLE}"]`);
+  if ((await toggle.count()) === 0)
+    throw new Error(
+      `UniSat: the custom-derivation-path opt-in ([data-testid="${ADDRESS_TYPE_TESTID.CUSTOM_PATH_TOGGLE}"]) ` +
+        "is missing from the address-type screen; without it the wallet derives taproot at coin type 0'.",
+    );
+  await toggle.first().check({ force: true });
   await page.waitForTimeout(SETTLE.SHORT);
-  if ((await page.locator("input:visible, textarea:visible").count()) >= count) return;
-  // Fallback: the selector may be a closed dropdown — click it again after a settle to open + pick.
-  await option.click({ force: true }).catch(() => {});
-  await page.waitForTimeout(SETTLE.SHORT);
+
+  const customPath = page.locator(`[data-testid="${ADDRESS_TYPE_TESTID.CUSTOM_PATH_INPUT}"]`);
+  await customPath.first().waitFor({ state: "visible", timeout: WAIT_FOR.ELEMENT_MS }).catch(() => {});
+  if ((await customPath.count()) === 0)
+    throw new Error(
+      `UniSat: the derivation-path field ([data-testid="${ADDRESS_TYPE_TESTID.CUSTOM_PATH_INPUT}"]) did not ` +
+        "appear after enabling the custom path.",
+    );
+  await customPath.first().fill(UNISAT_TAPROOT_ACCOUNT_PATH);
+  // The cards re-derive their addresses off the new path before their labels update.
+  await page.waitForTimeout(SETTLE.MEDIUM);
+
+  const cards = page.locator(`[data-testid^="${ADDRESS_TYPE_TESTID.CARD_PREFIX}"]`);
+  const cardCount = await cards.count();
+  for (let i = 0; i < cardCount; i++) {
+    const label = await cards.nth(i).innerText().catch(() => "");
+    if (!TAPROOT_ROW.test(label)) continue;
+    if (!label.includes(UNISAT_TAPROOT_RECEIVE_PATH))
+      throw new Error(
+        `UniSat: the Taproot card derives at a path other than ${UNISAT_TAPROOT_RECEIVE_PATH} — the custom ` +
+          `derivation path did not take. Card label: ${label.replace(/\s+/g, " ").trim()}`,
+      );
+    await clickTestId(page, `${ADDRESS_TYPE_TESTID.CARD_PREFIX}${i}`);
+    await page.waitForTimeout(SETTLE.SHORT);
+    return;
+  }
+  throw new Error(
+    `UniSat: no Taproot (P2TR) card on the address-type screen (${cardCount} cards found).`,
+  );
 }
 
 /** Switch the network to Bitcoin Signet: pill → expand "Bitcoin Testnet" → "Bitcoin Signet". */
@@ -180,37 +292,14 @@ export async function setupUnisatWallet(context: BrowserContext, mnemonic: strin
   await page.waitForTimeout(SETTLE.BRIEF);
   await clickText(page, /^UniSat Wallet$/);
 
-  // Seed-entry screen — type each word with real key events.
+  // Seed-entry screen — the phrase goes in as one commit; UniSat auto-detects 12 vs 24 words.
   await page.waitForTimeout(SETTLE.BRIEF);
   const words = mnemonic.trim().split(/\s+/).filter(Boolean);
-  // The restore screen defaults to a 12-input grid with a "<n> words" selector. A 24-word phrase needs
-  // the grid switched to 24 first, or the extra words are dropped — so match the grid to the phrase.
-  let seedInputs = page.locator("input:visible, textarea:visible");
-  if ((await seedInputs.count()) !== words.length) {
-    await selectSeedWordCount(page, words.length);
-    seedInputs = page.locator("input:visible, textarea:visible");
-  }
-  const seedCount = await seedInputs.count();
-  if (seedCount < words.length)
-    throw new Error(
-      `UniSat: seed grid shows ${seedCount} inputs but the phrase has ${words.length} words — the word-count selector did not switch. Its restore UI likely changed; re-derive selectSeedWordCount (unisat.ts).`,
-    );
-  for (let i = 0; i < words.length; i++) {
-    await seedInputs.nth(i).click();
-    await seedInputs.nth(i).pressSequentially(words[i], { delay: TYPE_DELAY_MS });
-  }
-  await page.waitForTimeout(SETTLE.BRIEF);
-  await advance(page, /continue|import|next|confirm/i);
+  await enterMnemonic(page, words);
+  await advanceFromImport(page);
 
   // Address-type screen — force the signet-correct path and select the Taproot (P2TR) row.
-  await page.waitForTimeout(SETTLE.MODAL);
-  const customPath = page.getByPlaceholder(/Custom HD Wallet Derivation Path/i);
-  if ((await customPath.count()) > 0) {
-    await customPath.first().click();
-    await customPath.first().fill(UNISAT_TAPROOT_ACCOUNT_PATH);
-    await page.waitForTimeout(SETTLE.BRIEF);
-  }
-  await tap(page, /Taproot \(P2TR\)/i);
+  await selectSignetTaproot(page);
   await advance(page, /continue|import|confirm|next|ok|done/i);
 
   // Wallet home (mainnet by default) → switch to signet and read the taproot address.

--- a/services/vault/e2e/real/actions/walletConnect.ts
+++ b/services/vault/e2e/real/actions/walletConnect.ts
@@ -17,7 +17,7 @@
  * it running afterwards (pegin) or uninstall it (observe, where the human then drives the peg-in).
  * Address verification is NOT done here — that is the `connect` action's own success check.
  */
-import type { Page } from "@playwright/test";
+import type { BrowserContext, Page } from "@playwright/test";
 
 import type { BtcWalletId, EthWalletId } from "../config";
 import {
@@ -33,6 +33,20 @@ import type { ActionContext } from "./types";
 
 /** The Reown AppKit list entry to click per ETH wallet. */
 const ETH_APPKIT_NAME: Record<EthWalletId, RegExp> = { metamask: /metamask/i };
+
+/** Sweep approvals repeatedly for `durationMs` — a wait that also clears anything sitting pending. */
+async function sweepUntil(
+  context: BrowserContext,
+  page: Page,
+  log: (m: string) => void,
+  durationMs: number,
+): Promise<void> {
+  const deadline = Date.now() + durationMs;
+  while (Date.now() < deadline) {
+    await sweepApprovals(context, page, log);
+    await page.waitForTimeout(CONNECT_STATE_POLL_MS);
+  }
+}
 
 /**
  * The header's connected wallet menu (the avatar-group trigger, src/components/Wallet/Connect.tsx). It
@@ -72,30 +86,43 @@ export async function connectWallets(ctx: ActionContext): Promise<void> {
     .getByText(ETH_APPKIT_NAME[ctx.eth.id] ?? /metamask/i, { exact: false })
     .first()
     .click({ timeout: STEP_TIMEOUT_MS });
-  await page.waitForTimeout(APPROVAL_WAIT_MS);
+  // Sweep DURING this wait rather than sleeping through it. MetaMask's connect approval is not
+  // reliably picked up by the event approver — in practice it is this sweep that clears it (its log
+  // lines come from `sweepApprovals`, not the 'page' handler), most likely because the window is
+  // reused rather than opened fresh. Sleeping here left the approval pending long enough for the
+  // dApp's own connect modal to fall back to "Try again", and that modal then stayed up as a
+  // portal-root overlay covering the nav — so the run died on the NEXT click, far from the cause.
+  await sweepUntil(context, page, log, APPROVAL_WAIT_MS);
 
   log("Finalizing (Connect)");
-  await page
-    .locator('[data-testid="chains-connect-button"]')
-    .click({ timeout: STEP_TIMEOUT_MS })
-    .catch(() => {});
 
-  log("Waiting for connected state (header wallet menu)");
   // Poll for the connected state while actively sweeping approval popups. MetaMask can insert an EXTRA
   // approval AFTER the initial connect — a "Review permissions / Use your enabled networks" prompt whose
   // Confirm (page-container-footer-next) must be clicked before the app flips to connected. That prompt
   // can land after the popup approver's per-window rounds have ended (or in a reused window that fires no
   // 'page' event), so a one-shot waitFor would just time out with it hanging. Sweeping each tick clicks
   // it (clickApprove already matches that Confirm), the same way the borrow/repay confirm loops do.
+  //
+  // The modal's own Connect is retried each tick rather than clicked once up front: it stays disabled
+  // until BOTH wallets have reported in, so a single early click is silently dropped and the modal then
+  // sits open forever. The header can already show the connected wallet menu at that point, so the menu
+  // alone is not proof of success — this only returns once the modal is actually GONE. Leaving it open
+  // is what covered the app in a portal-root overlay and broke the first click after connect.
+  const finalize = page.locator('[data-testid="chains-connect-button"]');
   const walletMenu = page.locator(WALLET_MENU_TRIGGER_TESTID).first();
   const deadline = Date.now() + CONNECT_STATE_TIMEOUT_MS;
   while (Date.now() < deadline) {
-    if (await walletMenu.isVisible().catch(() => false)) return;
+    const modalOpen = await finalize.isVisible().catch(() => false);
+    if (!modalOpen && (await walletMenu.isVisible().catch(() => false))) return;
+    // Short timeout on purpose: the button is visible-but-disabled until both wallets report in, and
+    // a full STEP_TIMEOUT_MS wait here would block the tick and starve the approval sweep below.
+    if (modalOpen)
+      await finalize.click({ timeout: CONNECT_STATE_POLL_MS }).catch(() => {});
     await sweepApprovals(context, page, log);
     await page.waitForTimeout(CONNECT_STATE_POLL_MS);
   }
   throw new Error(
-    `connect: the connected state (header wallet menu) did not appear within ${Math.round(CONNECT_STATE_TIMEOUT_MS / MS_PER_SECOND)}s — a wallet approval popup (e.g. MetaMask "Review permissions") may be unconfirmed.`,
+    `connect: the Connect Wallets modal did not close into the connected state (header wallet menu) within ${Math.round(CONNECT_STATE_TIMEOUT_MS / MS_PER_SECOND)}s — a wallet approval (e.g. MetaMask "Review permissions") may be unconfirmed.`,
   );
 }
 


### PR DESCRIPTION
# Fix the real-wallet E2E connect flow after UniSat and MetaMask auto-updated

## The problem

The real-wallet E2E CLI (`pnpm --filter vault run e2e:cli`) stopped working. A peg-in run died during wallet setup, before any peg-in work started:

```
[12:06:11] ❌ Action "pegin" failed
Run failed: UniSat: seed grid shows 3 inputs but the phrase has 12 words — the word-count selector did not switch.
```

This was never a CI failure — every check on the branch was green. It only affected the local real-extension runner.

## Why it broke

`services/vault/e2e/real/provision.ts` checks the Chrome Web Store for a newer extension version on **every run**, and `getExtensionPath` loads the highest version found on disk. Nothing is pinned. On the day this was investigated, three wallet extensions published updates and the runner silently picked all of them up: UniSat 1.7.19 → 1.7.20, MetaMask 13.43.0 → 13.44.0, and OneKey. Both new versions changed UI that our automation drives, so the harness was clicking controls that no longer existed.

Because the old bundles were still on disk, the exact changes could be confirmed by diffing the two versions of each extension rather than guessing from the error message.

## What actually changed in the wallets

**UniSat 1.7.20 — two separate changes, one of them silent.**

1. The mnemonic import screen was rewritten. The `12 words / 24 words` selector is gone; the screen now auto-detects the length. Before any word is entered it is a single textarea (`mnemonic-import-initial-input`) that commits its contents on Space or Enter, and that first commit replaces the textarea with a grid of per-word chips. Our `selectSeedWordCount` was looking for a control that no longer exists, which produced the error above.
2. The custom derivation path field is now hidden behind an opt-in checkbox (`custom-hdpath-enabled-checkbox`). **This one failed silently.** The old code skipped the field when it could not find it, so the import still "succeeded" and still produced a well-formed `tb1p…` address — just derived at coin type `0'` instead of signet's `1'`. Nothing in the flow complained; only the address assertion in the spec caught it.

**MetaMask 13.44.0 — confirmations moved to the Chrome side panel.** MetaMask now "opens in the side panel by default" (its own migration toast says so). Chrome does not expose a side panel as a Playwright page: no `page` event fires and it never appears in `context.pages()`. Our whole approval system (`approver.ts`) is built on exactly those two things, so a MetaMask approval raised in the side panel was invisible to the automation and the run just sat there until it timed out.

Separately, MetaMask renders an unread-notifications badge on top of the account-options button, which swallows a normal click on it. That is what broke the auto-lock check with a misleading "Settings menu item not found" error — the click was silently timing out 30 seconds earlier.

## Approaches considered for MetaMask

This was the hard part, so it is worth recording what was tried.

**1. Drive the side panel directly — rejected.** Playwright cannot click a side panel, and the usual escape hatch (`dispatchEvent`) is blocked by MetaMask's LavaMoat scuttling, which also blocks `page.evaluate` on MetaMask pages. Making this work would have meant rebuilding the approver on raw CDP calls (`DOM.getBoxModel` + `Input.dispatchMouseEvent`). That is a lot of fragile new machinery to absorb a wallet-side default change.

**2. Remove the `sidePanel` permission from the extension manifest — tried, and reverted.** The extension is loaded unpacked from disk, so stripping `sidePanel` from `permissions` and the `side_panel` key looked like a clean way to force the old behaviour. It is not: it destabilises MetaMask. With the patch applied the MetaMask spec went from passing 3/3 to failing 3/3, and passed again immediately once the manifest was restored. The extension is left completely untouched.

**3. Re-open the side panel document as an ordinary tab and approve there — worked, then removed.** MetaMask keeps pending approvals in background state, so opening `sidepanel.html` in a normal tab re-renders the pending approval and Playwright can click it. This was implemented and did drive a real connect end to end. It was dropped in favour of option 4, which is simpler and leaves nothing unusual in the hot path.

**4. Switch MetaMask back to popup mode — chosen.** MetaMask still ships the toggle, and it persists the preference. The import now flips it once, right after onboarding, and every approval for the rest of the run opens as a normal `notification.html` popup — exactly as before 13.44 — so the existing approver handles the entire peg-in with no new machinery at all.

Two details that make it work: the toggle only renders in the popup or side-panel view (never in the expanded tab), so it is driven from `sidepanel.html` opened as a tab; and the account-options button needs an off-centre click to dodge the notifications badge.

The switch is verified, not assumed — it throws if the side-panel document does not tear itself down. Worth noting for reviewers: the toggle's **label** cannot be used to verify this. The label names the current view, so read from `sidepanel.html` it always says "Switch to popup" no matter what the stored preference is. A check based on it can never detect failure.

## Changes in this PR

**`packages/babylon-wallet-connector/tests/e2e/fixtures/wallets/unisat.ts`**

- Replaced `selectSeedWordCount` with `enterMnemonic`: the phrase goes in as one `fill()` + Enter, then the number of committed word chips is asserted against the phrase length. Typing word by word would now be wrong, because the textarea unmounts after the first space.
- Added `selectSignetTaproot`: ticks the custom-path opt-in, fills the signet path, and then **asserts the chosen Taproot card's own label carries `m/86'/1'/0'/0/0`** before selecting it. This replaces the old silent `if (found) { … }` skip, and is the guard that would have caught the wrong-path bug on its own.
- Added a loud error to the Continue step so a rejected phrase reports itself instead of failing later.

**`packages/babylon-wallet-connector/tests/e2e/fixtures/wallets/metamask.ts`**

- Added `usePopupApprovals`, called at the end of the import, which switches MetaMask into popup mode and fails loudly if the switch does not take.
- Reworked the auto-lock check to navigate straight to `#/settings/security-and-password` instead of driving the account menu, so it no longer depends on a button the notifications badge can cover.

**`services/vault/e2e/real/actions/walletConnect.ts`**

- The wait after picking the ETH wallet now sweeps for approvals instead of sleeping through it. In practice it is this sweep that clears MetaMask's connect approval (its log lines come from `sweepApprovals`, not the `page` handler), most likely because the approval window is reused rather than opened fresh.
- The modal's own Connect button is now retried on each tick rather than clicked once up front. It stays disabled until both wallets have reported in, so the single early click was being silently dropped and the modal then sat open forever.
- Success now requires the modal to actually be **gone**, not just the header wallet menu to appear. The header can show the connected menu while the modal is still open, and that stale modal covered the app in a `portal-root` overlay — which made the *next* click fail, 30 seconds later and far from the real cause.

## How this was verified

- `pnpm --filter @babylonlabs-io/wallet-connector run test:e2e:unisat` — passes (address matches the locally derived signet taproot).
- `pnpm --filter @babylonlabs-io/wallet-connector run test:e2e:metamask` — passes, repeatedly. The MetaMask bug was a race (the badge only sometimes loaded in time), so this was run multiple times rather than once.
- `pnpm --filter @babylonlabs-io/wallet-connector run test:e2e:okx` — passes, unchanged. OKX was not affected.
- The combined `walletsSession` spec (UniSat + MetaMask in one browser session) — passes. This is the closest match to what the CLI actually does.
- `e2e:cli --action=connect` on devnet/localhost — green on four consecutive runs, with both addresses checked against locally derived ground truth.
- A **full peg-in** on devnet/localhost, start to finish: all 14 steps, Pre-PegIn txid `6c9e8ff8313345f507b5e47765eeee086ebca4c9d14ab6817d9eeb7711961cf4`, ending in `✅ On-chain vaults rose: 2 → 3 (+1, expected +1)`. The success check is an on-chain vault count, not a UI assertion.

Lint and TypeScript are clean on the touched packages.

## Not in this PR

**Extension versions are still unpinned.** This is the root cause and it is deliberately left alone here, because deciding how the suite should track wallet releases is a separate call. It is worth doing: three extensions broke in a single day, one of them silently, and a peg-in run is long enough that a mid-run break is expensive. Pinning known-good versions with a deliberate bump step would turn "the peg-in dies at minute 20" into a controlled upgrade.

**OneKey is still broken.** It fails in its own auto-lock check (`OneKey auto-lock: sidebar menu (bottom-menu-container) not found`) — the same kind of drift, from the same day's updates. It was left untouched by request and is not needed for the UniSat + MetaMask peg-in path.

## Related

- Builds on [#2078](https://github.com/babylonlabs-io/babylon-toolkit/pull/2078), which added the 24-word import support and the self-provisioning setup that auto-updates the extensions.
- The wallet importers were originally added in [#2000](https://github.com/babylonlabs-io/babylon-toolkit/pull/2000).
