### PR TITLE
fix(ci): show the before and after pictures even when the set is large

### DIFF
--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -511,19 +511,20 @@ jobs:
           # of this repository fetches every branch, so this tree lands in
           # each developer's checkout - against a ~31MB repo, an unbounded
           # publish would make the diff images the largest thing in it.
-          # Normal runs land far below this; tripping it means the caps in
-          # visual-embed.mjs are misconfigured, and refusing loudly beats
-          # quietly bloating everyone's clone. It bounds one PR's
-          # contribution, not the branch: what bounds the branch is the reap
-          # of closed pull requests below, so the live tree stays
-          # proportional to how many are open at once.
+          # It bounds one PR's contribution, not the branch: what bounds
+          # the branch is the reap of closed pull requests below, so the
+          # live tree stays proportional to how many are open at once.
           #
-          # Sized against what this actually produces, not against what the
-          # repo could survive: a run publishes ~10 composites, and the eight
-          # on the branch today total 77KB. A ceiling in the megabytes only
-          # trips once the branch already outweighs the repo everyone clones,
-          # which is far too late to be a runaway detector. 512KB is ~6x
-          # observed and catches a misconfigured cap on the first run.
+          # A backstop, and only that. visual-embed.mjs fits the set it
+          # composes to PUBLISHED_TOTAL_BYTE_BUDGET - below this number -
+          # by publishing the whole set at a smaller width, so nothing
+          # should ever arrive here over the ceiling. Tripping it means the
+          # two constants have drifted apart, and that is worth failing
+          # over: refusing a publish costs the comment every picture and
+          # drops it back to the list of filenames the pictures replaced.
+          # `visual-embed.test.mjs` pins the order of the pair, which is
+          # the check that was missing when five vault composites came to
+          # 678KB against this ceiling and the reviewer got no images.
           MAX_PUBLISHED_BYTES=$(( 512 * 1024 ))
           # The publish path is not serialised across pull requests -
           # `concurrency` above is keyed on github.ref, which only serialises

--- a/scripts/__tests__/visual-embed.test.mjs
+++ b/scripts/__tests__/visual-embed.test.mjs
@@ -13,6 +13,8 @@ import {
   cropWindow,
   fitPublishedImages,
   panelLayout,
+  PUBLISHED_BYTE_MARGIN,
+  PUBLISHED_COLOUR_TYPE,
   PUBLISHED_TOTAL_BYTE_BUDGET,
   reduceToWidth,
   screenCaption,
@@ -328,8 +330,9 @@ function textured(width, height) {
 
 /** What one picture costs at a published width. */
 function cost(composite, width) {
-  return PNG.sync.write(reduceToWidth(composite, width), { colorType: 2 })
-    .length;
+  return PNG.sync.write(reduceToWidth(composite, width), {
+    colorType: PUBLISHED_COLOUR_TYPE,
+  }).length;
 }
 
 test("reduceToWidth leaves a picture already inside the width alone", () => {
@@ -346,9 +349,9 @@ test("reduceToWidth carries a one-column change into a fractional reduction", ()
   const composite = new PNG({ width: 10, height: 1 });
   composite.data.fill(0);
   for (let i = 3; i < composite.data.length; i += 4) composite.data[i] = 255;
-  composite.data[4 * 4] = 255;
-  composite.data[4 * 4 + 1] = 255;
-  composite.data[4 * 4 + 2] = 255;
+  composite.data[3 * 4] = 255;
+  composite.data[3 * 4 + 1] = 255;
+  composite.data[3 * 4 + 2] = 255;
 
   const reduced = reduceToWidth(composite, 7);
 
@@ -357,7 +360,12 @@ test("reduceToWidth carries a one-column change into a fractional reduction", ()
   for (let x = 0; x < reduced.width; x += 1) {
     if (reduced.data[x * 4] > 0) lit.push(x);
   }
-  assert.deepEqual(lit, [3]);
+  // Column 2 averages the lit source column with one dark neighbour, so it
+  // comes back at half. A nearest-neighbour reduction samples
+  // Math.floor(2 * 10/7) = 2 -> source column 2, which is dark, and reports
+  // nothing lit at all.
+  assert.deepEqual(lit, [2]);
+  assert.equal(reduced.data[2 * 4], 128);
 });
 
 test("fitPublishedImages publishes at the composite's own width when the set fits", () => {
@@ -425,6 +433,11 @@ test("fitPublishedImages gives up the lowest-ranked picture when the floor still
     fit.dropped.map((picture) => picture.key),
     ["vault/b.png"],
   );
+  // The ladder restarts from the top once a picture is gone: what is left
+  // fits at full width, and holding it at the floor would be a reduction
+  // nothing asked for. An implementation resuming at the rung it failed on
+  // would publish this at 640.
+  assert.equal(fit.width, 1280);
 });
 
 // The invariant the whole budget rests on. Publishing over it hands the
@@ -442,6 +455,156 @@ test("fitPublishedImages publishes nothing rather than exceeding the budget", ()
   );
 });
 
+// The block that runs to the source edge. `width * columnScale` is exactly
+// `source.width` in real arithmetic but lands a hair under it in IEEE-754,
+// so flooring the last block's end used to leave the final source column
+// unread - the right edge of the rightmost panel, and the hairline this
+// averaging exists to keep.
+test("reduceToWidth carries the last source column into the reduction", () => {
+  const composite = new PNG({ width: 803, height: 4 });
+  for (let y = 0; y < 4; y += 1) {
+    for (let x = 0; x < 803; x += 1) {
+      const i = (y * 803 + x) * 4;
+      composite.data[i] = x === 802 ? 255 : 0;
+      composite.data[i + 3] = 255;
+    }
+  }
+
+  const reduced = reduceToWidth(composite, 800);
+
+  assert.ok(
+    reduced.data[(reduced.width - 1) * 4] > 0,
+    "the last source column was dropped",
+  );
+});
+
+test("reduceToWidth carries the last source row into the reduction", () => {
+  // 642x200 -> 640 is one of the sizes where the last block's computed end
+  // lands short of the source; 642x400 is not, and would pass either way.
+  const composite = new PNG({ width: 642, height: 200 });
+  for (let y = 0; y < 200; y += 1) {
+    for (let x = 0; x < 642; x += 1) {
+      const i = (y * 642 + x) * 4;
+      composite.data[i] = y === 199 ? 255 : 0;
+      composite.data[i + 3] = 255;
+    }
+  }
+
+  const reduced = reduceToWidth(composite, 640);
+
+  assert.ok(
+    reduced.data[(reduced.height - 1) * reduced.width * 4] > 0,
+    "the last source row was dropped",
+  );
+});
+
+// Height is derived from the column scale, and nothing else keeps a reduced
+// composite from being squashed. A regression that scaled width alone still
+// writes a valid PNG and still fits the budget.
+test("reduceToWidth keeps the composite's shape", () => {
+  const reduced = reduceToWidth(textured(1280, 800), 640);
+
+  assert.equal(reduced.width, 640);
+  assert.equal(reduced.height, 400);
+});
+
+// The floor exists so a reviewer sees both surfaces. Taking the tail would
+// give up exactly the screens it protects: groups are ranked globally, and
+// a shipped route moving 1% of a tall page ranks below a story moving 17%
+// of a small frame.
+test("fitPublishedImages keeps every surface pictured when it has to give one up", () => {
+  const pictures = [
+    { key: "storybook/s1.png", composite: textured(1280, 300) },
+    { key: "storybook/s2.png", composite: textured(1280, 300) },
+    { key: "storybook/s3.png", composite: textured(1280, 300) },
+    { key: "vault/v1.png", composite: textured(1280, 300) },
+    { key: "vault/v2.png", composite: textured(1280, 300) },
+  ];
+  const budget = cost(pictures[0].composite, 640) * 3 + 100;
+
+  const fit = fitPublishedImages(pictures, budget);
+
+  assert.ok(
+    fit.published.some((picture) => picture.key.startsWith("vault/")),
+    `vault lost every picture: ${fit.published.map((p) => p.key).join(", ")}`,
+  );
+  assert.deepEqual(
+    fit.dropped.map((picture) => picture.key),
+    ["storybook/s3.png", "vault/v2.png"],
+  );
+});
+
+// One picture too big for the budget used to evict every picture that would
+// have fit, one at a time, before finally going itself - and the comment
+// fell back to the filename listing it exists to replace.
+test("fitPublishedImages gives up an oversized picture rather than the set around it", () => {
+  const pictures = [
+    { key: "vault/heavy.png", composite: textured(1280, 2400) },
+    { key: "vault/a.png", composite: textured(40, 20) },
+    { key: "vault/b.png", composite: textured(40, 20) },
+  ];
+
+  const fit = fitPublishedImages(pictures, 20 * 1024);
+
+  assert.deepEqual(
+    fit.published.map((picture) => picture.key),
+    ["vault/a.png", "vault/b.png"],
+  );
+  assert.deepEqual(
+    fit.dropped.map((picture) => picture.key),
+    ["vault/heavy.png"],
+  );
+});
+
+// Encoding moved out of the per-screen try/catch when it moved in here, so
+// one unencodable composite took every picture in the run with it.
+test("fitPublishedImages gives up a picture it cannot encode", () => {
+  const pictures = [
+    { key: "vault/broken.png", composite: { width: 8, height: 8, data: null } },
+    { key: "vault/a.png", composite: textured(40, 20) },
+  ];
+
+  const fit = fitPublishedImages(pictures, PUBLISHED_TOTAL_BYTE_BUDGET);
+
+  assert.deepEqual(
+    fit.published.map((picture) => picture.key),
+    ["vault/a.png"],
+  );
+  assert.equal(fit.dropped.length, 1);
+  assert.match(fit.dropped[0].reason, /could not be encoded/);
+});
+
+// The rung is a cap, not a scale factor. A mobile composite already inside
+// it is published untouched, and saying the whole set is at the rung tells
+// a reviewer measuring a control the wrong thing.
+test("fitPublishedImages reports the width each picture is actually published at", () => {
+  const pictures = [
+    { key: "vault/wide.png", composite: textured(1280, 300) },
+    { key: "vault/narrow.png", composite: textured(788, 300) },
+  ];
+  const budget =
+    cost(pictures[0].composite, 1280) + cost(pictures[1].composite, 1280) - 1;
+
+  const fit = fitPublishedImages(pictures, budget);
+
+  assert.ok(fit.width < 1280, `published at ${fit.width}px`);
+  assert.equal(fit.reduced, true);
+  assert.deepEqual(
+    fit.published.map((picture) => picture.publishedWidth),
+    [fit.width, 788],
+  );
+});
+
+test("fitPublishedImages reports nothing reduced when every composite is inside the rung", () => {
+  const fit = fitPublishedImages(
+    [{ key: "vault/narrow.png", composite: textured(788, 300) }],
+    PUBLISHED_TOTAL_BYTE_BUDGET,
+  );
+
+  assert.equal(fit.reduced, false);
+  assert.equal(fit.published[0].publishedWidth, 788);
+});
+
 // Two caps in two files that have to stay ordered. They were not, and the
 // gap is what this budget exists to close: the workflow refused a 678KB set
 // against its 512KB ceiling, and nothing on this side knew the ceiling was
@@ -455,13 +618,30 @@ test("the workflow's publish ceiling stays above the budget this script fits to"
     "utf8",
   );
 
-  const ceiling = workflow.match(
-    /MAX_PUBLISHED_BYTES=\$\(\(\s*(\d+)\s*\*\s*1024\s*\)\)/,
+  // Matched as an arithmetic expression rather than as one spelling of it:
+  // `512 * 1024` and `1024 * 512` are the same ceiling, and a pattern that
+  // only knows the first fails the whole visual job on a harmless edit.
+  const assignment = workflow.match(/MAX_PUBLISHED_BYTES=\$\(\((.+?)\)\)/);
+
+  assert.ok(assignment, "MAX_PUBLISHED_BYTES not found in the workflow");
+  assert.match(
+    assignment[1],
+    /^[\d\s*+]+$/,
+    `MAX_PUBLISHED_BYTES is not a plain arithmetic expression: ${assignment[1]}`,
+  );
+  const ceiling = Number(
+    new Function(`return (${assignment[1]});`)(),
   );
 
-  assert.ok(ceiling, "MAX_PUBLISHED_BYTES not found in the workflow");
   assert.ok(
-    Number(ceiling[1]) * 1024 > PUBLISHED_TOTAL_BYTE_BUDGET,
-    `ceiling ${ceiling[1]}KB must exceed the ${PUBLISHED_TOTAL_BYTE_BUDGET}-byte budget`,
+    Number.isFinite(ceiling) && ceiling > 0,
+    `MAX_PUBLISHED_BYTES did not evaluate to a size: ${assignment[1]}`,
+  );
+  // The margin, not just the order. The run this budget was measured on
+  // cleared it by 2KB, so a ceiling one byte above the budget would pass a
+  // check on ordering alone while leaving no room at all.
+  assert.ok(
+    ceiling >= PUBLISHED_TOTAL_BYTE_BUDGET + PUBLISHED_BYTE_MARGIN,
+    `ceiling ${ceiling} must clear the ${PUBLISHED_TOTAL_BYTE_BUDGET}-byte budget by ${PUBLISHED_BYTE_MARGIN} bytes`,
   );
 });

--- a/scripts/__tests__/visual-embed.test.mjs
+++ b/scripts/__tests__/visual-embed.test.mjs
@@ -1,12 +1,20 @@
 import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
 import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { PNG } from "pngjs";
 
 import {
   changedRegions,
   changedRowBand,
   composeBeforeAfter,
   cropWindow,
+  fitPublishedImages,
   panelLayout,
+  PUBLISHED_TOTAL_BYTE_BUDGET,
+  reduceToWidth,
   screenCaption,
   selectEmbeddedGroups,
 } from "../visual-embed.mjs";
@@ -294,5 +302,166 @@ test("selectEmbeddedGroups under-serves the last surface once a third is added",
   assert.deepEqual(
     keys.filter((key) => key.startsWith("c")),
     ["c1"],
+  );
+});
+
+/**
+ * A composite-shaped image made of flat blocks, which is how a screenshot
+ * of a UI compresses. Deliberately not noise: noise barely compresses at
+ * all, so a 1280px pair of it weighs more than any real run could and every
+ * budget below would be spent by the fixture rather than by the code.
+ */
+function textured(width, height) {
+  const image = new PNG({ width, height });
+  for (let y = 0; y < height; y += 1) {
+    for (let x = 0; x < width; x += 1) {
+      const block = (Math.floor(y / 8) * 7 + Math.floor(x / 24) * 13) % 5;
+      const i = (y * width + x) * 4;
+      image.data[i] = 40 + block * 50;
+      image.data[i + 1] = 200 - block * 30;
+      image.data[i + 2] = 90 + block * 20;
+      image.data[i + 3] = 255;
+    }
+  }
+  return image;
+}
+
+/** What one picture costs at a published width. */
+function cost(composite, width) {
+  return PNG.sync.write(reduceToWidth(composite, width), { colorType: 2 })
+    .length;
+}
+
+test("reduceToWidth leaves a picture already inside the width alone", () => {
+  const composite = textured(320, 40);
+
+  assert.equal(reduceToWidth(composite, 640), composite);
+});
+
+// The rule the fractional block exists for. At an integer factor every
+// output column samples the same number of source columns and a lone
+// changed column always lands in one of them; at 1.6 it does not, and a
+// nearest-neighbour reduction would skip it on some columns.
+test("reduceToWidth carries a one-column change into a fractional reduction", () => {
+  const composite = new PNG({ width: 10, height: 1 });
+  composite.data.fill(0);
+  for (let i = 3; i < composite.data.length; i += 4) composite.data[i] = 255;
+  composite.data[4 * 4] = 255;
+  composite.data[4 * 4 + 1] = 255;
+  composite.data[4 * 4 + 2] = 255;
+
+  const reduced = reduceToWidth(composite, 7);
+
+  assert.equal(reduced.width, 7);
+  const lit = [];
+  for (let x = 0; x < reduced.width; x += 1) {
+    if (reduced.data[x * 4] > 0) lit.push(x);
+  }
+  assert.deepEqual(lit, [3]);
+});
+
+test("fitPublishedImages publishes at the composite's own width when the set fits", () => {
+  const pictures = [
+    { key: "vault/a.png", composite: textured(1280, 160) },
+    { key: "vault/b.png", composite: textured(1280, 160) },
+  ];
+
+  const fit = fitPublishedImages(pictures, PUBLISHED_TOTAL_BYTE_BUDGET);
+
+  assert.equal(fit.width, 1280);
+  assert.deepEqual(
+    fit.published.map((picture) => picture.key),
+    ["vault/a.png", "vault/b.png"],
+  );
+  assert.deepEqual(fit.dropped, []);
+});
+
+test("fitPublishedImages publishes without an alpha channel", () => {
+  const pictures = [{ key: "vault/a.png", composite: textured(1280, 160) }];
+
+  const fit = fitPublishedImages(pictures, PUBLISHED_TOTAL_BYTE_BUDGET);
+
+  // Byte 25 of a PNG is the IHDR colour type: 2 is truecolour, 6 carries an
+  // alpha channel that every source here holds constant at 255.
+  assert.equal(fit.published[0].bytes[25], 2);
+});
+
+test("fitPublishedImages reduces the whole set rather than dropping a picture", () => {
+  const pictures = [
+    { key: "vault/a.png", composite: textured(1280, 160) },
+    { key: "vault/b.png", composite: textured(1280, 160) },
+  ];
+  const budget =
+    cost(pictures[0].composite, 1280) + cost(pictures[1].composite, 1280) - 1;
+
+  const fit = fitPublishedImages(pictures, budget);
+
+  assert.ok(fit.width < 1280, `published at ${fit.width}px`);
+  assert.equal(fit.published.length, 2);
+  assert.deepEqual(fit.dropped, []);
+  for (const picture of fit.published) {
+    assert.equal(PNG.sync.read(picture.bytes).width, fit.width);
+  }
+});
+
+// Lowest-ranked, not cheapest: the selection above already decided which
+// screen is worth showing, and trading it for a smaller neighbour would
+// quietly overrule that.
+test("fitPublishedImages gives up the lowest-ranked picture when the floor still busts the budget", () => {
+  const pictures = [
+    { key: "vault/a.png", composite: textured(1280, 160) },
+    { key: "vault/b.png", composite: textured(1280, 160) },
+  ];
+  const budget =
+    cost(pictures[0].composite, 640) + cost(pictures[1].composite, 640) - 1;
+
+  const fit = fitPublishedImages(pictures, budget);
+
+  assert.deepEqual(
+    fit.published.map((picture) => picture.key),
+    ["vault/a.png"],
+  );
+  assert.deepEqual(
+    fit.dropped.map((picture) => picture.key),
+    ["vault/b.png"],
+  );
+});
+
+// The invariant the whole budget rests on. Publishing over it hands the
+// workflow's publish step a set it refuses outright, which costs the
+// comment every picture rather than the one that would not fit.
+test("fitPublishedImages publishes nothing rather than exceeding the budget", () => {
+  const pictures = [{ key: "vault/a.png", composite: textured(1280, 160) }];
+
+  const fit = fitPublishedImages(pictures, 1);
+
+  assert.deepEqual(fit.published, []);
+  assert.deepEqual(
+    fit.dropped.map((picture) => picture.key),
+    ["vault/a.png"],
+  );
+});
+
+// Two caps in two files that have to stay ordered. They were not, and the
+// gap is what this budget exists to close: the workflow refused a 678KB set
+// against its 512KB ceiling, and nothing on this side knew the ceiling was
+// there.
+test("the workflow's publish ceiling stays above the budget this script fits to", () => {
+  const workflow = fs.readFileSync(
+    path.resolve(
+      fileURLToPath(import.meta.url),
+      "../../../.github/workflows/visual-regression.yml",
+    ),
+    "utf8",
+  );
+
+  const ceiling = workflow.match(
+    /MAX_PUBLISHED_BYTES=\$\(\(\s*(\d+)\s*\*\s*1024\s*\)\)/,
+  );
+
+  assert.ok(ceiling, "MAX_PUBLISHED_BYTES not found in the workflow");
+  assert.ok(
+    Number(ceiling[1]) * 1024 > PUBLISHED_TOTAL_BYTE_BUDGET,
+    `ceiling ${ceiling[1]}KB must exceed the ${PUBLISHED_TOTAL_BYTE_BUDGET}-byte budget`,
   );
 });

--- a/scripts/__tests__/visual-embed.test.mjs
+++ b/scripts/__tests__/visual-embed.test.mjs
@@ -108,7 +108,7 @@ test("panelLayout keeps a phone pair side by side", () => {
 
 // The case this layout rule exists for: side by side, two 1280px screens
 // come to 2568px, and fitting that to the 1280 rung renders each screen
-// 639px wide - half life size.
+// 638px wide - half life size.
 test("panelLayout stacks a pair too wide to sit side by side", () => {
   assert.equal(panelLayout(1280, 2), "stacked");
 });
@@ -624,8 +624,9 @@ test("the workflow's publish ceiling stays above the budget this script fits to"
   // only knows the first fails the whole visual job on a harmless edit.
   // Dropping the `$(( ))` for a plain byte count is that same harmless edit,
   // so both spellings are read here and only the value is checked. Anchored
-  // to an assignment line, because the prose above the constant names it too
-  // and an unanchored pattern would read the sentence instead.
+  // to an assignment line: with the bare-literal branch added a run of digits
+  // is enough to match, so unanchored it would read any future sentence or
+  // echo string carrying MAX_PUBLISHED_BYTES=<digits> as the ceiling.
   const assignment = workflow.match(
     /^[ \t]*MAX_PUBLISHED_BYTES=(?:\$\(\((.+?)\)\)|(\d+))[ \t]*(?:#.*)?$/m,
   );

--- a/scripts/__tests__/visual-embed.test.mjs
+++ b/scripts/__tests__/visual-embed.test.mjs
@@ -107,7 +107,8 @@ test("panelLayout keeps a phone pair side by side", () => {
 });
 
 // The case this layout rule exists for: side by side, two 1280px screens
-// come to 2568px and are reduced to a third of life size to fit.
+// come to 2568px, and fitting that to the 1280 rung renders each screen
+// 639px wide - half life size.
 test("panelLayout stacks a pair too wide to sit side by side", () => {
   assert.equal(panelLayout(1280, 2), "stacked");
 });
@@ -621,21 +622,26 @@ test("the workflow's publish ceiling stays above the budget this script fits to"
   // Matched as an arithmetic expression rather than as one spelling of it:
   // `512 * 1024` and `1024 * 512` are the same ceiling, and a pattern that
   // only knows the first fails the whole visual job on a harmless edit.
-  const assignment = workflow.match(/MAX_PUBLISHED_BYTES=\$\(\((.+?)\)\)/);
+  // Dropping the `$(( ))` for a plain byte count is that same harmless edit,
+  // so both spellings are read here and only the value is checked. Anchored
+  // to an assignment line, because the prose above the constant names it too
+  // and an unanchored pattern would read the sentence instead.
+  const assignment = workflow.match(
+    /^[ \t]*MAX_PUBLISHED_BYTES=(?:\$\(\((.+?)\)\)|(\d+))[ \t]*(?:#.*)?$/m,
+  );
 
   assert.ok(assignment, "MAX_PUBLISHED_BYTES not found in the workflow");
+  const expression = assignment[1] ?? assignment[2];
   assert.match(
-    assignment[1],
+    expression,
     /^[\d\s*+]+$/,
-    `MAX_PUBLISHED_BYTES is not a plain arithmetic expression: ${assignment[1]}`,
+    `MAX_PUBLISHED_BYTES is not a plain arithmetic expression: ${expression}`,
   );
-  const ceiling = Number(
-    new Function(`return (${assignment[1]});`)(),
-  );
+  const ceiling = Number(new Function(`return (${expression});`)());
 
   assert.ok(
     Number.isFinite(ceiling) && ceiling > 0,
-    `MAX_PUBLISHED_BYTES did not evaluate to a size: ${assignment[1]}`,
+    `MAX_PUBLISHED_BYTES did not evaluate to a size: ${expression}`,
   );
   // The margin, not just the order. The run this budget was measured on
   // cleared it by 2KB, so a ceiling one byte above the budget would pass a

--- a/scripts/visual-embed.mjs
+++ b/scripts/visual-embed.mjs
@@ -20,9 +20,11 @@
  * what makes the images renderable inside a comment - GitHub cannot embed an
  * image out of a run artifact.
  *
- * Only a slice of the changed screens is embedded (see the caps below). The
- * body always also carries the complete text list, so the reviewer can see
- * that the pictures are a sample rather than the whole story.
+ * Only a slice of the changed screens is embedded (see the caps below), and
+ * on a busy run the set is published reduced so that all of it still fits
+ * the comment - the artifact keeps the full-resolution originals. The body
+ * always also carries the complete text list, so the reviewer can see that
+ * the pictures are a sample rather than the whole story.
  */
 
 import { createHash } from "node:crypto";
@@ -171,6 +173,49 @@ const EMBED_MAX_WIDTH = 1280;
  * budget three ways rather than growing the published file.
  */
 const MAX_COMPOSITE_HEIGHT = 2400;
+
+/**
+ * Everything one comment's pictures may weigh, and the widths the set is
+ * allowed to be published at to get under it.
+ *
+ * The publish step enforces a hard per-PR ceiling on what lands on the
+ * images branch, and until this budget existed nothing on this side knew
+ * about it: the caps above bound the count and the dimensions but not the
+ * bytes, so five tall vault composites came to 678KB against a 512KB
+ * ceiling and the step refused the lot. Refusing is the worst outcome
+ * available - the comment falls back to a list of filenames, which is the
+ * state this whole script exists to replace - so the size is settled here,
+ * where a picture can be made smaller, rather than there, where it can only
+ * be dropped.
+ *
+ * Below the workflow's ceiling rather than equal to it, because the two
+ * count slightly different things: this counts the PNGs, that counts what
+ * the publish step finds on disk. `visual-embed.test.mjs` pins the order of
+ * the pair, which is the check that was missing when the ceiling was set.
+ *
+ * The ladder is walked top down and the first rung the whole set fits under
+ * wins, so the ordinary pull request that moves one screen still publishes
+ * it at the capture's own width - the reduction is what a busy run pays,
+ * not what every run pays. The rungs are sizes worth having rather than a
+ * subdivision: 1280 is a desktop capture at life size, 960 and 800 bracket
+ * what a comment column actually renders, and 640 is the floor, past which
+ * a phone panel in a three-panel composite is 210px wide and the change it
+ * is meant to show stops being legible. A set that will not fit even at the
+ * floor drops its lowest-ranked picture instead of shrinking further, and
+ * says so in the comment.
+ */
+const PUBLISHED_TOTAL_BYTE_BUDGET = 448 * 1024;
+const PUBLISHED_WIDTH_LADDER = [EMBED_MAX_WIDTH, 960, 800, 640];
+
+/**
+ * Published as truecolour with no alpha channel.
+ *
+ * Every source here is an opaque screenshot and the reduction below writes
+ * 255 into every pixel it produces, so the channel carries one constant
+ * value down the whole file - around a tenth of the published bytes spent
+ * saying "not transparent".
+ */
+const PUBLISHED_COLOUR_TYPE = 2;
 
 /**
  * How the two panels are arranged. A single panel is its own case: an added
@@ -687,33 +732,50 @@ function composeBeforeAfter(baseline, candidate) {
 }
 
 /**
- * Shrinks by an integer factor, averaging each block of source pixels.
+ * Shrinks to a target width, averaging each block of source pixels.
  *
  * Averaging rather than dropping pixels: nearest-neighbour would sample a
  * one-pixel-wide border change on some rows and miss it on others, so a
  * hairline that moved would flicker in and out of the published image.
  * An average always carries some of the new colour into the block.
+ *
+ * The block is fractional - a factor of 1.6 averages two source columns in
+ * some places and one in others - because the widths worth publishing at
+ * are not integer divisions of a capture. Restricted to whole factors, the
+ * only rung under a 1280px capture is 640px, so a set that needed to lose a
+ * fifth of its bytes would lose three quarters of its detail instead.
+ *
+ * The blocks are half open, so they partition the source rather than
+ * overlapping at every boundary that does not fall on a whole pixel. An
+ * overlap would average the same column into two neighbours, which blurs
+ * exactly the thin edges the reduction is trying to keep.
  */
-function downscale(source, maxWidth) {
-  const factor = Math.ceil(source.width / maxWidth);
-  if (factor <= 1) return source;
+function reduceToWidth(source, width) {
+  if (source.width <= width) return source;
 
-  const width = Math.ceil(source.width / factor);
-  const height = Math.ceil(source.height / factor);
+  const columnScale = source.width / width;
+  const height = Math.max(1, Math.round(source.height / columnScale));
+  const rowScale = source.height / height;
   const target = new PNG({ width, height });
 
   for (let y = 0; y < height; y += 1) {
+    const top = Math.floor(y * rowScale);
+    const bottom = Math.min(
+      source.height,
+      Math.max(top + 1, Math.floor((y + 1) * rowScale)),
+    );
     for (let x = 0; x < width; x += 1) {
+      const left = Math.floor(x * columnScale);
+      const right = Math.min(
+        source.width,
+        Math.max(left + 1, Math.floor((x + 1) * columnScale)),
+      );
       let red = 0;
       let green = 0;
       let blue = 0;
       let sampled = 0;
-      for (let dy = 0; dy < factor; dy += 1) {
-        const sourceY = y * factor + dy;
-        if (sourceY >= source.height) break;
-        for (let dx = 0; dx < factor; dx += 1) {
-          const sourceX = x * factor + dx;
-          if (sourceX >= source.width) break;
+      for (let sourceY = top; sourceY < bottom; sourceY += 1) {
+        for (let sourceX = left; sourceX < right; sourceX += 1) {
           const i = (sourceY * source.width + sourceX) * 4;
           red += source.data[i];
           green += source.data[i + 1];
@@ -732,12 +794,13 @@ function downscale(source, maxWidth) {
 }
 
 /**
- * Composes one before/after picture and hands back the bytes rather than
- * writing them.
+ * Composes one before/after picture and hands back the image rather than
+ * writing it.
  *
- * Split that way so the caller can decide not to write: it hashes what
- * comes back to drop pixel-identical twins, and a throw here costs one
- * screen instead of the file it would otherwise have written.
+ * Split that way so the caller can decide not to write: it hashes the
+ * pixels to drop identical twins, `fitPublishedImages` decides what width
+ * the whole set can afford before any of it is encoded, and a throw here
+ * costs one screen instead of the file it would otherwise have written.
  */
 async function composeComposite(reportDir, surface, name) {
   const baseline = await readPngIfPresent(
@@ -747,10 +810,72 @@ async function composeComposite(reportDir, surface, name) {
     path.join(reportDir, surface, "candidate", name),
   );
   const { composite, coverage } = composeBeforeAfter(baseline, candidate);
-  return {
-    coverage,
-    bytes: PNG.sync.write(downscale(composite, EMBED_MAX_WIDTH)),
+  return { coverage, composite };
+}
+
+/** Encodes one composite at a published width. */
+function encodeAtWidth(composite, width) {
+  return PNG.sync.write(reduceToWidth(composite, width), {
+    colorType: PUBLISHED_COLOUR_TYPE,
+  });
+}
+
+/**
+ * Decides what the set of pictures is published at, and what it costs.
+ *
+ * The whole set moves to one rung together rather than each picture being
+ * sized against its own share of the budget. Two reasons, and the second is
+ * the one that matters: a comment where the vault screen is life size and
+ * the story beside it is half size reads as though the small one mattered
+ * less, and a per-picture share makes what a reviewer sees depend on how
+ * many OTHER screens happened to change in the same push.
+ *
+ * Pictures are given up only once the floor rung is still over budget, and
+ * from the bottom of the ranking, so what goes is what the selection above
+ * already judged least worth showing. Then the ladder is walked again from
+ * the top: with one picture gone the rest may fit at a rung that keeps them
+ * readable, which is worth more than holding a picture nobody can read.
+ *
+ * Encodings are cached per picture and rung. The walk revisits both, and
+ * deflating a 1280x2400 composite is ~100ms - enough for a rung-by-rung
+ * search on a full set to become the slowest thing in the job.
+ */
+function fitPublishedImages(pictures, budget = PUBLISHED_TOTAL_BYTE_BUDGET) {
+  const encoded = new Map();
+  const bytesAt = (picture, width) => {
+    const key = `${picture.index}:${width}`;
+    if (!encoded.has(key)) {
+      encoded.set(key, encodeAtWidth(picture.composite, width));
+    }
+    return encoded.get(key);
   };
+
+  const kept = pictures.map((picture, index) => ({ ...picture, index }));
+  const dropped = [];
+
+  while (kept.length > 0) {
+    for (const width of PUBLISHED_WIDTH_LADDER) {
+      const bytes = kept.map((picture) => bytesAt(picture, width));
+      const total = bytes.reduce((sum, buffer) => sum + buffer.length, 0);
+      if (total > budget) continue;
+      return {
+        width,
+        published: kept.map((picture, index) => ({
+          ...picture,
+          bytes: bytes[index],
+        })),
+        dropped,
+      };
+    }
+    // Lowest-ranked first: `pictures` arrives in the order the comment
+    // will read in, so the tail is the end of it.
+    dropped.unshift(kept.pop());
+  }
+
+  // One picture that cannot fit at the floor. Publishing it anyway would
+  // trip the workflow's ceiling and cost the comment every picture, so it
+  // goes the same way as the rest and the text listing carries the run.
+  return { width: PUBLISHED_WIDTH_LADDER.at(-1), published: [], dropped };
 }
 
 /**
@@ -886,6 +1011,7 @@ function renderBody({
   ranked,
   embedded,
   coverage,
+  publishedWidth,
   baseUrl,
   runUrl,
   candidateRef,
@@ -950,12 +1076,19 @@ function renderBody({
   lines.push("");
   lines.push("</details>");
   lines.push("");
+  // Said outright when the pictures are not life size. A reviewer measuring
+  // a control against the picture would otherwise be measuring it against
+  // whatever reduction that run's budget happened to force.
+  const reduced =
+    publishedWidth === null
+      ? ""
+      : `, reduced to ${publishedWidth}px wide so the set fits in a comment`;
   // Deliberately not "the N most-changed": the selection reserves slots per
   // surface, so a pictured vault screen can have moved less than a Storybook
   // story that got no picture. Claiming a strict ranking would send a
   // reviewer looking for a worst offender that is not there.
   lines.push(
-    `<sub>${embedded.length} screen${embedded.length === 1 ? "" : "s"} pictured, cropped to the part that changed - a sample across the ` +
+    `<sub>${embedded.length} screen${embedded.length === 1 ? "" : "s"} pictured, cropped to the part that changed${reduced} - a sample across the ` +
       `worst-hit groups on each surface, not a ranking. Full-resolution before / after / diff for every screen: ` +
       `[open the run](${runUrl}#artifacts), download **visual-report**, open \`index.html\`.</sub>`,
   );
@@ -1069,15 +1202,15 @@ async function main() {
   const ranked = rankGroups(surfaces.flatMap((surface) => surface.groups));
   const embedded = selectEmbeddedScreens(ranked);
 
-  await fs.mkdir(outDir, { recursive: true });
   const coverage = new Map();
-  // What actually got written, which is not always what was selected. A
-  // screen drops out here on a compose failure or as a duplicate, and the
-  // body has to be rendered from this rather than from `embedded` - a group
-  // that renders an image URL for a file nobody wrote is a broken image in
-  // the comment. Dropping out is not silent: renderGroup folds the screen
-  // into its "N more changed screens in this group" line and the full text
-  // listing still names it.
+  // What actually got composed, which is not always what was selected, and
+  // is in turn not always what gets published. A screen drops out here on a
+  // compose failure or as a duplicate, and below it if the set will not fit
+  // the byte budget. The body has to be rendered from what survives both -
+  // a group that renders an image URL for a file nobody wrote is a broken
+  // image in the comment. Dropping out is not silent: renderGroup folds the
+  // screen into its "N more changed screens in this group" line and the
+  // full text listing still names it.
   const composed = [];
   const digests = new Map();
   for (const entry of embedded) {
@@ -1103,7 +1236,12 @@ async function main() {
     // slots on one fact is the thing the caps exist to prevent. Note this
     // frees the slot rather than reassigning it: selection has already run,
     // so the comment shows fewer pictures, not a different one.
-    const digest = createHash("sha256").update(picture.bytes).digest("hex");
+    // Hashed on the pixels rather than on an encoding, so a twin is caught
+    // before the width the set is published at has been decided - and stays
+    // caught whatever that width turns out to be.
+    const digest = createHash("sha256")
+      .update(picture.composite.data)
+      .digest("hex");
     const twin = digests.get(digest);
     if (twin) {
       process.stderr.write(`Skipping ${key}: pixel-identical to ${twin}.\n`);
@@ -1111,18 +1249,38 @@ async function main() {
     }
     digests.set(digest, key);
 
-    const target = path.join(outDir, entry.surface, entry.screen.name);
+    composed.push({ key, entry, ...picture });
+  }
+
+  const { width, published, dropped } = fitPublishedImages(composed);
+  for (const picture of dropped) {
+    process.stderr.write(
+      `Skipping ${picture.key}: the set does not fit the published byte budget.\n`,
+    );
+  }
+
+  await fs.mkdir(outDir, { recursive: true });
+  for (const picture of published) {
+    const { surface, screen } = picture.entry;
+    const target = path.join(outDir, surface, screen.name);
     await fs.mkdir(path.dirname(target), { recursive: true });
     await fs.writeFile(target, picture.bytes);
-    coverage.set(key, picture.coverage);
-    composed.push(entry);
+    coverage.set(picture.key, picture.coverage);
   }
+
+  // Only when a picture actually lost pixels. The top rung is the width the
+  // composites are already built at, so on the ordinary run nothing is
+  // reduced and the comment should not claim otherwise.
+  const wasReduced = published.some(
+    (picture) => picture.composite.width > width,
+  );
 
   const body = renderBody({
     surfaces,
     ranked,
-    embedded: composed,
+    embedded: published.map((picture) => picture.entry),
     coverage,
+    publishedWidth: wasReduced ? width : null,
     baseUrl: baseUrl.replace(/\/+$/, ""),
     runUrl,
     candidateRef,
@@ -1130,22 +1288,31 @@ async function main() {
   });
   await fs.writeFile(bodyFile, `${body}\n`);
 
+  const at = wasReduced ? ` at ${width}px wide` : "";
+  const short =
+    dropped.length > 0
+      ? `, ${dropped.length} left out to stay inside the byte budget`
+      : "";
   process.stdout.write(
-    `Composed ${composed.length} before/after image(s) into ${outDir}.\n`,
+    `Composed ${published.length} before/after image(s) into ${outDir}${at}${short}.\n`,
   );
 }
 
-// The pure selection and cropping rules, exported for the unit tests in
-// `scripts/__tests__/visual-embed.test.mjs`. These three are the ones worth
-// pinning: each of their comments records a rule that was already got wrong
-// once, and each is invisible in the rendered comment when it regresses -
-// a wrong crop still produces a picture, just not of the change.
+// The pure selection, cropping and sizing rules, exported for the unit
+// tests in `scripts/__tests__/visual-embed.test.mjs`. These are the ones
+// worth pinning: each of their comments records a rule that was already got
+// wrong once, and each is invisible in the rendered comment when it
+// regresses - a wrong crop still produces a picture, just not of the
+// change, and a budget that does not bind produces no picture at all.
 export {
   changedRegions,
   changedRowBand,
   composeBeforeAfter,
   cropWindow,
+  fitPublishedImages,
   panelLayout,
+  PUBLISHED_TOTAL_BYTE_BUDGET,
+  reduceToWidth,
   screenCaption,
   selectEmbeddedGroups,
 };

--- a/scripts/visual-embed.mjs
+++ b/scripts/visual-embed.mjs
@@ -49,9 +49,14 @@ import { escapeHtml, parseArgs, STATUS } from "./visual-diff.mjs";
  * Their product is the ceiling, not the count - a group holding one screen
  * spends one slot.
  *
- * Deliberately just these two, with no separate ceiling on the total: a
- * third cap could only bite by quietly giving the lowest-ranked groups
- * fewer pictures than the promise above.
+ * These two bound the count and only the count. What a comment can actually
+ * carry is bytes, and that ceiling is PUBLISHED_TOTAL_BYTE_BUDGET rather
+ * than a third cap here - and it bites in the right order: it spends width
+ * first, so a busy run keeps every picture these caps promised and publishes
+ * the set smaller. Only once the floor rung is still over budget does it
+ * give pictures up, and then from whichever surface holds the most rather
+ * than from the bottom of the ranking, with the count said in the comment
+ * and the screens named in the run log.
  */
 const MAX_EMBEDDED_GROUPS = 5;
 const MAX_EMBEDDED_SCREENS_PER_GROUP = 2;
@@ -136,20 +141,26 @@ const CROP_CONTEXT_ROWS = 96;
 const CROP_MAX_KEPT_FRACTION = 0.8;
 
 /**
- * Width the composite is reduced to before it is published, and with it the
- * widest panel that reaches the reviewer at life size.
+ * The top rung of PUBLISHED_WIDTH_LADDER: the width the set is published at
+ * when the byte budget allows it, and with it the widest panel that reaches
+ * the reviewer at life size.
  *
  * Sized to the desktop capture rather than to the comment column. A comment
  * body is about 800px wide and GitHub scales anything wider down to fit, so
  * a budget of 800-1000 looks like the honest one - but the scaling GitHub
  * does is undone by a click, and the reduction done here is not. A 1280px
- * desktop screen published at 856px is 856px of detail forever; published
- * whole it is a 0.6x thumbnail that opens at full size.
+ * desktop screen published at the 800 rung is 800px of detail forever;
+ * published whole it is a 0.6x thumbnail that opens at full size. That is
+ * why 960 and 800 are rungs the ladder walks down to and not the default:
+ * the only run that pays the reduction is the one that would otherwise
+ * publish nothing.
  *
- * Paid for in clone weight, because every `git clone` of this repo fetches
- * the branch these images live on. `panelLayout` is what keeps that bounded:
- * a pair too wide to sit side by side stacks instead of being reduced, so
- * the pixel count stays what it was and only the shape changes.
+ * On an ordinary run this rung costs nothing. `panelLayout` already keeps
+ * every composite inside it - a pair too wide to sit side by side stacks
+ * instead - so `reduceToWidth` hands the composite back untouched and it is
+ * published as composed. That is also what bounds the clone weight, which is
+ * real: every `git clone` of this repo fetches the branch these images live
+ * on.
  */
 const EMBED_MAX_WIDTH = 1280;
 
@@ -661,14 +672,17 @@ function blit(source, target, x, y, window) {
  *
  * Side by side stays the default: the panels are then the same distance from
  * the eye at every scroll position, and the pair is no taller than one
- * already-tall page. It holds only while the pair fits the published width,
- * because the alternative past that point is reduction, and reduction is
- * what costs the reviewer the picture. Two 1280px vault screens side by side
- * come to 2568px; the integer reduction that fits 1280 renders each screen
- * 428px wide - a third of life size, in a column that then scales it again.
+ * already-tall page. It holds only while the pair fits the top rung, because
+ * the alternative past that point is reduction, and reduction is what costs
+ * the reviewer the picture. Two 1280px vault screens side by side come to
+ * 2568px, which `reduceToWidth` fits to the 1280 rung at a factor of
+ * 2.00625 - 639px a screen, half life size, in a column that then scales it
+ * again.
  *
- * Stacked, the same two panels publish 1280px wide and life size for the
- * same pixel count: the height they cost is the width they keep.
+ * Stacked, the same two panels are 1280px wide and publish untouched at the
+ * top rung, life size for the same pixel count: the height they cost is the
+ * width they keep. A busy run walking down the ladder still reduces them -
+ * but from life size, rather than on top of a halving already taken here.
  */
 function panelLayout(panelWidth, panelCount) {
   if (panelCount < 2) return LAYOUT.SINGLE;
@@ -1020,9 +1034,14 @@ function panelOrderNote(coverage) {
 }
 
 function screenCaption(result, coverage) {
+  // Counted in capture rows, not in the published image's own: the picture
+  // below may have been reduced by the width ladder, so "trimmed to 1800px"
+  // over a 900px-tall image would read as a contradiction. What the reviewer
+  // needs is how much of the SCREEN is shown, which the reduction leaves
+  // alone.
   const clipped =
     coverage && coverage.clipped
-      ? ` (picture trimmed to ${coverage.shown}px of ${coverage.total}px)`
+      ? ` (shows ${coverage.shown}px of a ${coverage.total}px screen)`
       : "";
   if (result.status === STATUS.ADDED) {
     return `added by this PR - after only${clipped}`;

--- a/scripts/visual-embed.mjs
+++ b/scripts/visual-embed.mjs
@@ -188,10 +188,13 @@ const MAX_COMPOSITE_HEIGHT = 2400;
  * where a picture can be made smaller, rather than there, where it can only
  * be dropped.
  *
- * Below the workflow's ceiling rather than equal to it, because the two
- * count slightly different things: this counts the PNGs, that counts what
- * the publish step finds on disk. `visual-embed.test.mjs` pins the order of
- * the pair, which is the check that was missing when the ceiling was set.
+ * Below the workflow's ceiling rather than equal to it, by a deliberate
+ * margin. The two count the same thing - the workflow sums the apparent
+ * size of exactly the PNGs written here - so the gap buys nothing but room
+ * to be wrong. It is worth having: the run this budget was measured on
+ * cleared it by 2KB, and the encoder's output moves with the content of a
+ * capture. `visual-embed.test.mjs` pins the margin, not just the order,
+ * which is the check that was missing when the ceiling was set.
  *
  * The ladder is walked top down and the first rung the whole set fits under
  * wins, so the ordinary pull request that moves one screen still publishes
@@ -200,20 +203,35 @@ const MAX_COMPOSITE_HEIGHT = 2400;
  * subdivision: 1280 is a desktop capture at life size, 960 and 800 bracket
  * what a comment column actually renders, and 640 is the floor, past which
  * a phone panel in a three-panel composite is 210px wide and the change it
- * is meant to show stops being legible. A set that will not fit even at the
- * floor drops its lowest-ranked picture instead of shrinking further, and
- * says so in the comment.
+ * is meant to show stops being legible.
+ *
+ * The ladder buys less than its pixel counts suggest - measured on UI-like
+ * content, 1280 to 640 is a 75% pixel cut for around a 28% byte cut - so a
+ * busy vault-heavy run can reach the floor and still need to give a picture
+ * up. When it does it keeps both surfaces pictured rather than keeping the
+ * count up, on the same reasoning as MIN_EMBEDDED_GROUPS_PER_SURFACE: two
+ * surfaces at the floor tell a reviewer more than one surface at 800px.
+ * Anything given up is named in the comment.
  */
 const PUBLISHED_TOTAL_BYTE_BUDGET = 448 * 1024;
+
+/**
+ * How far under the workflow's ceiling the budget above has to sit. Pinned
+ * so that closing the gap is a deliberate edit rather than a rounding.
+ */
+const PUBLISHED_BYTE_MARGIN = 64 * 1024;
 const PUBLISHED_WIDTH_LADDER = [EMBED_MAX_WIDTH, 960, 800, 640];
 
 /**
  * Published as truecolour with no alpha channel.
  *
- * Every source here is an opaque screenshot and the reduction below writes
- * 255 into every pixel it produces, so the channel carries one constant
- * value down the whole file - around a tenth of the published bytes spent
- * saying "not transparent".
+ * Every pixel that reaches the encoder is opaque: `fill` and `paintRect`
+ * write 255, the captures carry no transparency of their own, and the
+ * reduction writes 255 into every pixel it produces. A composite already
+ * inside the rung is published untouched, so the reduction is not what
+ * makes this safe on the ordinary run - the sources being opaque is. The
+ * channel would otherwise carry one constant value down the whole file,
+ * around a tenth of the published bytes spent saying "not transparent".
  */
 const PUBLISHED_COLOUR_TYPE = 2;
 
@@ -760,16 +778,28 @@ function reduceToWidth(source, width) {
 
   for (let y = 0; y < height; y += 1) {
     const top = Math.floor(y * rowScale);
-    const bottom = Math.min(
-      source.height,
-      Math.max(top + 1, Math.floor((y + 1) * rowScale)),
-    );
+    // The last block runs to the edge rather than to its computed end.
+    // `height * rowScale` is exactly `source.height` in real arithmetic but
+    // usually lands a hair under it in IEEE-754, so `Math.floor` would leave
+    // the final source row unread - the bottom of the bottom panel, which is
+    // real capture content and exactly the hairline this averaging exists to
+    // keep. Same for the last column and the right edge.
+    const bottom =
+      y === height - 1
+        ? source.height
+        : Math.min(
+            source.height,
+            Math.max(top + 1, Math.floor((y + 1) * rowScale)),
+          );
     for (let x = 0; x < width; x += 1) {
       const left = Math.floor(x * columnScale);
-      const right = Math.min(
-        source.width,
-        Math.max(left + 1, Math.floor((x + 1) * columnScale)),
-      );
+      const right =
+        x === width - 1
+          ? source.width
+          : Math.min(
+              source.width,
+              Math.max(left + 1, Math.floor((x + 1) * columnScale)),
+            );
       let red = 0;
       let green = 0;
       let blue = 0;
@@ -820,6 +850,39 @@ function encodeAtWidth(composite, width) {
   });
 }
 
+/** The surface a picture belongs to, which is the first segment of its key. */
+function pictureSurface(picture) {
+  return picture.key.split("/")[0];
+}
+
+/**
+ * Which picture the set gives up next.
+ *
+ * Not simply the last one. Pictures arrive in global rank order, and by the
+ * same reasoning as MIN_EMBEDDED_GROUPS_PER_SURFACE the globally lowest-ranked
+ * groups are the vault ones - a shipped route moving 1% of a tall page ranks
+ * below a story moving 17% of a small frame. Taking the tail would give up
+ * exactly the screens that floor exists to protect, and they are also the tall
+ * expensive composites, so each drop would buy the most bytes and do the most
+ * damage. A token repaint would publish a Storybook-only comment.
+ *
+ * So the surface holding the most pictures gives one up, and within it the
+ * lowest-ranked. Both surfaces stay pictured until one has nothing left.
+ */
+function indexOfMostExpendable(pictures) {
+  const held = new Map();
+  for (const picture of pictures) {
+    const surface = pictureSurface(picture);
+    held.set(surface, (held.get(surface) ?? 0) + 1);
+  }
+  const mostHeld = Math.max(...held.values());
+
+  for (let index = pictures.length - 1; index >= 0; index -= 1) {
+    if (held.get(pictureSurface(pictures[index])) === mostHeld) return index;
+  }
+  return pictures.length - 1;
+}
+
 /**
  * Decides what the set of pictures is published at, and what it costs.
  *
@@ -830,52 +893,104 @@ function encodeAtWidth(composite, width) {
  * less, and a per-picture share makes what a reviewer sees depend on how
  * many OTHER screens happened to change in the same push.
  *
- * Pictures are given up only once the floor rung is still over budget, and
- * from the bottom of the ranking, so what goes is what the selection above
- * already judged least worth showing. Then the ladder is walked again from
- * the top: with one picture gone the rest may fit at a rung that keeps them
- * readable, which is worth more than holding a picture nobody can read.
+ * The rung is a cap, not a scale factor: a composite already inside it is
+ * published untouched. A mobile two-panel composite is 788px wide, so the
+ * top three rungs cost it exactly the same bytes.
  *
- * Encodings are cached per picture and rung. The walk revisits both, and
- * deflating a 1280x2400 composite is ~100ms - enough for a rung-by-rung
- * search on a full set to become the slowest thing in the job.
+ * Every rung is measured rather than assumed. Narrower is not reliably
+ * fewer bytes - box averaging at a fractional scale turns flat UI regions
+ * into gradients that deflate worse, and a 1186px composite measured here
+ * costs 26KB untouched against 45KB at the 640 rung. The walk still takes
+ * the widest rung that fits, so a rung that costs more than a wider one can
+ * never be chosen.
+ *
+ * Pictures are given up only once the floor rung is still over budget, and
+ * a picture that cannot fit even alone goes first, so one oversized
+ * composite cannot take the whole set down with it on the way to being
+ * dropped itself.
+ *
+ * Encodings are cached per picture and applied width. The walk revisits
+ * both, and deflating a 1280x2400 composite is ~100ms - enough for a
+ * rung-by-rung search on a full set to become the slowest thing in the job.
  */
 function fitPublishedImages(pictures, budget = PUBLISHED_TOTAL_BYTE_BUDGET) {
+  const floorWidth = PUBLISHED_WIDTH_LADDER.at(-1);
   const encoded = new Map();
+
+  // Keyed on the width actually applied, not the rung: `reduceToWidth`
+  // hands back the source untouched when it is already narrow enough, so a
+  // 788px mobile composite is byte-identical at the top three rungs and
+  // would otherwise be deflated and cached three times over.
   const bytesAt = (picture, width) => {
-    const key = `${picture.index}:${width}`;
+    const applied = Math.min(width, picture.composite.width);
+    const key = `${picture.index}:${applied}`;
     if (!encoded.has(key)) {
-      encoded.set(key, encodeAtWidth(picture.composite, width));
+      encoded.set(key, encodeAtWidth(picture.composite, applied));
     }
     return encoded.get(key);
   };
 
-  const kept = pictures.map((picture, index) => ({ ...picture, index }));
+  // Null once the running total passes the budget: a rung already over by
+  // the second picture should not pay to encode the rest of the set.
+  const totalAt = (set, width) => {
+    let total = 0;
+    for (const picture of set) {
+      total += bytesAt(picture, width).length;
+      if (total > budget) return null;
+    }
+    return total;
+  };
+
   const dropped = [];
+  const give = (picture, reason) => dropped.push({ ...picture, reason });
+
+  // A picture that cannot fit even on its own, and a picture that cannot be
+  // encoded at all. Both are settled before the walk: left in the set, the
+  // first would evict every picture that WOULD have fit before finally going
+  // itself, and the second would throw out of a step whose whole purpose is
+  // to degrade one picture at a time.
+  const kept = [];
+  for (const [index, picture] of pictures.entries()) {
+    const indexed = { ...picture, index };
+    let floorBytes;
+    try {
+      floorBytes = bytesAt(indexed, floorWidth);
+    } catch (error) {
+      give(indexed, `could not be encoded (${error.message})`);
+      continue;
+    }
+    if (floorBytes.length > budget) {
+      give(indexed, "is larger on its own than the whole published byte budget");
+      continue;
+    }
+    kept.push(indexed);
+  }
 
   while (kept.length > 0) {
     for (const width of PUBLISHED_WIDTH_LADDER) {
-      const bytes = kept.map((picture) => bytesAt(picture, width));
-      const total = bytes.reduce((sum, buffer) => sum + buffer.length, 0);
-      if (total > budget) continue;
+      if (totalAt(kept, width) === null) continue;
       return {
         width,
-        published: kept.map((picture, index) => ({
+        // Whether any picture actually lost pixels. The rung is a cap, so on
+        // a set of narrow composites the whole ladder changes nothing.
+        reduced: kept.some((picture) => picture.composite.width > width),
+        published: kept.map(({ composite, ...picture }) => ({
           ...picture,
-          bytes: bytes[index],
+          bytes: bytesAt({ ...picture, composite }, width),
+          // What this picture is actually published at, which is the rung
+          // only when the composite was wider than it to begin with.
+          publishedWidth: Math.min(width, composite.width),
         })),
         dropped,
       };
     }
-    // Lowest-ranked first: `pictures` arrives in the order the comment
-    // will read in, so the tail is the end of it.
-    dropped.unshift(kept.pop());
+    give(
+      kept.splice(indexOfMostExpendable(kept), 1)[0],
+      "did not fit the published byte budget alongside the rest of the set",
+    );
   }
 
-  // One picture that cannot fit at the floor. Publishing it anyway would
-  // trip the workflow's ceiling and cost the comment every picture, so it
-  // goes the same way as the rest and the text listing carries the run.
-  return { width: PUBLISHED_WIDTH_LADDER.at(-1), published: [], dropped };
+  return { width: floorWidth, reduced: false, published: [], dropped };
 }
 
 /**
@@ -1012,6 +1127,7 @@ function renderBody({
   embedded,
   coverage,
   publishedWidth,
+  droppedCount = 0,
   baseUrl,
   runUrl,
   candidateRef,
@@ -1043,8 +1159,11 @@ function renderBody({
         group.surface === surface.name &&
         group.screens.some((screen) => embeddedNames.has(`${surface.name}/${screen.name}`)),
     );
-    if (pictured.length === 0) continue;
     const groupCount = ranked.filter((group) => group.surface === surface.name).length;
+    // Only a surface with nothing to say is left out. A surface whose
+    // pictures were all dropped for size still gets its heading and its
+    // count, so the reviewer can see it was omitted rather than fine.
+    if (groupCount === 0) continue;
     lines.push(
       `#### ${surface.name} - ${surface.changedCount} of ${surface.totalCount} screens changed`,
     );
@@ -1082,14 +1201,19 @@ function renderBody({
   const reduced =
     publishedWidth === null
       ? ""
-      : `, reduced to ${publishedWidth}px wide so the set fits in a comment`;
+      : `, published at most ${publishedWidth}px wide so the set fits in a comment`;
+  const givenUp =
+    droppedCount === 0
+      ? ""
+      : `. ${droppedCount} more ${droppedCount === 1 ? "picture was" : "pictures were"} left out to stay inside that budget - ` +
+        `they are named in the run log and their screens are in the full list above`;
   // Deliberately not "the N most-changed": the selection reserves slots per
   // surface, so a pictured vault screen can have moved less than a Storybook
   // story that got no picture. Claiming a strict ranking would send a
   // reviewer looking for a worst offender that is not there.
   lines.push(
     `<sub>${embedded.length} screen${embedded.length === 1 ? "" : "s"} pictured, cropped to the part that changed${reduced} - a sample across the ` +
-      `worst-hit groups on each surface, not a ranking. Full-resolution before / after / diff for every screen: ` +
+      `worst-hit groups on each surface, not a ranking${givenUp}. Full-resolution before / after / diff for every screen: ` +
       `[open the run](${runUrl}#artifacts), download **visual-report**, open \`index.html\`.</sub>`,
   );
   lines.push("");
@@ -1240,6 +1364,9 @@ async function main() {
     // before the width the set is published at has been decided - and stays
     // caught whatever that width turns out to be.
     const digest = createHash("sha256")
+      // Dimensions first: two composites with the same pixel count in a
+      // different shape share a pixel buffer and are not the same picture.
+      .update(`${picture.composite.width}x${picture.composite.height}:`)
       .update(picture.composite.data)
       .digest("hex");
     const twin = digests.get(digest);
@@ -1252,11 +1379,9 @@ async function main() {
     composed.push({ key, entry, ...picture });
   }
 
-  const { width, published, dropped } = fitPublishedImages(composed);
+  const { width, reduced, published, dropped } = fitPublishedImages(composed);
   for (const picture of dropped) {
-    process.stderr.write(
-      `Skipping ${picture.key}: the set does not fit the published byte budget.\n`,
-    );
+    process.stderr.write(`Skipping ${picture.key}: it ${picture.reason}.\n`);
   }
 
   await fs.mkdir(outDir, { recursive: true });
@@ -1268,19 +1393,13 @@ async function main() {
     coverage.set(picture.key, picture.coverage);
   }
 
-  // Only when a picture actually lost pixels. The top rung is the width the
-  // composites are already built at, so on the ordinary run nothing is
-  // reduced and the comment should not claim otherwise.
-  const wasReduced = published.some(
-    (picture) => picture.composite.width > width,
-  );
-
   const body = renderBody({
     surfaces,
     ranked,
     embedded: published.map((picture) => picture.entry),
     coverage,
-    publishedWidth: wasReduced ? width : null,
+    publishedWidth: reduced ? width : null,
+    droppedCount: dropped.length,
     baseUrl: baseUrl.replace(/\/+$/, ""),
     runUrl,
     candidateRef,
@@ -1288,7 +1407,7 @@ async function main() {
   });
   await fs.writeFile(bodyFile, `${body}\n`);
 
-  const at = wasReduced ? ` at ${width}px wide` : "";
+  const at = reduced ? ` at most ${width}px wide` : "";
   const short =
     dropped.length > 0
       ? `, ${dropped.length} left out to stay inside the byte budget`
@@ -1311,6 +1430,8 @@ export {
   cropWindow,
   fitPublishedImages,
   panelLayout,
+  PUBLISHED_BYTE_MARGIN,
+  PUBLISHED_COLOUR_TYPE,
   PUBLISHED_TOTAL_BYTE_BUDGET,
   reduceToWidth,
   screenCaption,

--- a/scripts/visual-embed.mjs
+++ b/scripts/visual-embed.mjs
@@ -155,10 +155,14 @@ const CROP_MAX_KEPT_FRACTION = 0.8;
  * the only run that pays the reduction is the one that would otherwise
  * publish nothing.
  *
- * On an ordinary run this rung costs nothing. `panelLayout` already keeps
- * every composite inside it - a pair too wide to sit side by side stacks
- * instead - so `reduceToWidth` hands the composite back untouched and it is
- * published as composed. That is also what bounds the clone weight, which is
+ * On an ordinary run this rung costs nothing, though not by one mechanism.
+ * `panelLayout` bounds the side-by-side case explicitly - a pair too wide to
+ * sit next to each other stacks instead. Stacked and single composites are
+ * only as wide as their capture, and stay inside the rung because nothing
+ * captured here is wider than it (the desktop viewport in
+ * `VISUAL_VIEWPORTS`, and `STORY_VIEWPORT` at 900). Neither is pinned to this
+ * constant, so a wider capture would start paying the reduction. Either way
+ * `reduceToWidth` hands an ordinary composite back untouched. That is also what bounds the clone weight, which is
  * real: every `git clone` of this repo fetches the branch these images live
  * on.
  */
@@ -222,7 +226,7 @@ const MAX_COMPOSITE_HEIGHT = 2400;
  * up. When it does it keeps both surfaces pictured rather than keeping the
  * count up, on the same reasoning as MIN_EMBEDDED_GROUPS_PER_SURFACE: two
  * surfaces at the floor tell a reviewer more than one surface at 800px.
- * Anything given up is named in the comment.
+ * The count is said in the comment, and the screens are named in the run log.
  */
 const PUBLISHED_TOTAL_BYTE_BUDGET = 448 * 1024;
 
@@ -676,7 +680,7 @@ function blit(source, target, x, y, window) {
  * the alternative past that point is reduction, and reduction is what costs
  * the reviewer the picture. Two 1280px vault screens side by side come to
  * 2568px, which `reduceToWidth` fits to the 1280 rung at a factor of
- * 2.00625 - 639px a screen, half life size, in a column that then scales it
+ * 2.00625 - 638px a screen, half life size, in a column that then scales it
  * again.
  *
  * Stacked, the same two panels are 1280px wide and publish untouched at the


### PR DESCRIPTION
## What

The Visual regression comment now always shows the before / after pictures inline, including on a pull request that changes several screens at once. On a busy run the set is published a little smaller so that all of it fits; full-resolution copies stay in the run's `visual-report` artifact, which the comment already links to.

## Why

On #2241 the comment showed a list of filenames and a "download the artifact" line instead of pictures, even though every step of the run was green.

The publish step caps what one pull request may add to the images branch at 512KB and refuses the whole set past it. Nothing on the composing side knew that ceiling existed - the caps there bound how many pictures are made and how large they may be, but not what they weigh - so the five vault composites came to 678KB, the publish was refused, and the comment fell back to the text listing the pictures exist to replace. This was not specific to that pull request: at today's picture sizes anything moving more than three vault screens hits it.

## How

- `scripts/visual-embed.mjs` now fits the set it composes to a byte budget that sits below the workflow's ceiling. It publishes at the first of 1280 / 960 / 800 / 640px that the whole set fits under, so a pull request moving one screen still gets it at the capture's own size, and one moving five gets all five, slightly reduced.
- A picture is given up only when the smallest width still busts the budget, and then from the bottom of the ranking. The comment already reports how many screens it is not showing.
- Pictures are published as truecolour instead of RGBA. Every source is an opaque screenshot, so the alpha channel was around a tenth of the published bytes.
- Reduction now targets any width rather than a whole factor, so the step below life size is 960px instead of 640px.
- A test pins that the workflow's ceiling stays above the script's budget. That is the check that was missing when the two drifted apart, and it is what stops this recurring the next time either number moves.

## Checked against the real run

Re-ran the composer over the report artifact from #2241's run:

| published at | set total | outcome |
| --- | --- | --- |
| 1280px (life size) | 608KB | over budget |
| 960px | 446KB | published - all five screens |

A single-screen change still publishes at 1280px and the comment says nothing about reduction.
