### PR TITLE
feat(vault): rebuild DepositTerms on presign resume; map typed deposi…

### DIFF
--- a/packages/babylon-ts-sdk/docs/api/services.md
+++ b/packages/babylon-ts-sdk/docs/api/services.md
@@ -1184,8 +1184,9 @@ optional depositTerms: DepositTerms;
 
 Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts)
 
-Required for approval-capable wallets; fresh flows thread
-PreparePeginResult.depositTerms. Resume-path rebuild is not wired yet.
+Required for approval-capable wallets. Fresh flows pass
+PreparePeginResult.depositTerms; resume flows rebuild them from
+on-chain state (the vault app's rebuildDepositTerms).
 
 ##### timeoutMs?
 

--- a/packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts
@@ -117,8 +117,9 @@ export interface RunDepositorPresignFlowParams {
   /** Signing context built from on-chain data */
   signingContext: PayoutSigningContext;
   /**
-   * Required for approval-capable wallets; fresh flows thread
-   * PreparePeginResult.depositTerms. Resume-path rebuild is not wired yet.
+   * Required for approval-capable wallets. Fresh flows pass
+   * PreparePeginResult.depositTerms; resume flows rebuild them from
+   * on-chain state (the vault app's rebuildDepositTerms).
    */
   depositTerms?: DepositTerms;
   /** Maximum polling timeout in milliseconds (default: 20 min) */
@@ -443,8 +444,8 @@ export async function runDepositorPresignFlow(
   signal?.throwIfAborted();
 
   // Approval-capable wallets must approve before any signing call they
-  // authorize, and the terms must match what we sign. Fresh-flow only — the
-  // resume path passes no depositTerms.
+  // authorize, and the terms must match what we sign. Conditional because
+  // non-approval wallets pass no terms.
   if (depositTerms !== undefined) {
     assertDepositTermsMatchSigningContext(depositTerms, signingContext);
   }
@@ -453,8 +454,8 @@ export async function runDepositorPresignFlow(
     if (!depositTerms) {
       throw new Error(
         "runDepositorPresignFlow: this wallet requires approved deposit terms but none were " +
-          "provided. Fresh deposits must pass PreparePeginResult.depositTerms; resume-path " +
-          "rebuild is not wired yet.",
+          "provided. Fresh deposits must pass PreparePeginResult.depositTerms; resume flows " +
+          "must rebuild them from on-chain state (the vault app's rebuildDepositTerms).",
       );
     }
     // The provider validates its own device envelope inside

--- a/services/vault/src/components/deposit/PayoutSignModal/__tests__/usePayoutSigningState.test.tsx
+++ b/services/vault/src/components/deposit/PayoutSignModal/__tests__/usePayoutSigningState.test.tsx
@@ -39,6 +39,24 @@ vi.mock("../../../../services/vault/fetchVaults", () => ({
     mockFetchVaultPayoutScriptPubKey(...args),
 }));
 
+// Presign terms-rebuild collaborators (approval wallets only). Mocked as
+// modules so the software-wallet path can assert they are never even called.
+const mockGetVaultFromChain = vi.fn();
+vi.mock("../../../../clients/eth-contract/btc-vault-registry/query", () => ({
+  getVaultFromChain: (...args: unknown[]) => mockGetVaultFromChain(...args),
+}));
+
+const mockResolveFundedTxFeeAndUtxos = vi.fn();
+vi.mock("../../../../services/vault/resolveFundedTxFee", () => ({
+  resolveFundedTxFeeAndUtxos: (...args: unknown[]) =>
+    mockResolveFundedTxFeeAndUtxos(...args),
+}));
+
+const mockRebuildDepositTerms = vi.fn();
+vi.mock("../../../../services/vault/rebuildDepositTerms", () => ({
+  rebuildDepositTerms: (...args: unknown[]) => mockRebuildDepositTerms(...args),
+}));
+
 let mockBtcConnector: {
   connectedWallet?: {
     account?: { address: string };
@@ -97,6 +115,10 @@ const PROVIDER = { btcPubKey: "0xvpkey" };
 const BTC_WALLET = { signPsbt: vi.fn() };
 const onSuccess = vi.fn();
 
+const ON_CHAIN_VAULT = { marker: "on-chain-vault" };
+const REBUILT_TERMS = { marker: "rebuilt-terms" };
+const FUNDED_TX_FEE = 1234n;
+
 function setupHappyPath() {
   mockFindProvider.mockReturnValue(PROVIDER);
   mockBtcConnector = {
@@ -133,6 +155,12 @@ describe("usePayoutSigningState", () => {
     mockSignAndSubmitPayouts.mockResolvedValue(undefined);
     mockVerifyBtcWalletLiveness.mockResolvedValue(undefined);
     mockFetchVaultPayoutScriptPubKey.mockResolvedValue(null);
+    mockGetVaultFromChain.mockResolvedValue(ON_CHAIN_VAULT);
+    mockResolveFundedTxFeeAndUtxos.mockResolvedValue({
+      expectedUtxos: {},
+      fundedTxFee: FUNDED_TX_FEE,
+    });
+    mockRebuildDepositTerms.mockResolvedValue(REBUILT_TERMS);
   });
 
   describe("happy path", () => {
@@ -717,6 +745,131 @@ describe("usePayoutSigningState", () => {
       const terms = { marker: "payout-wrapper-terms" };
       await call.btcWallet.approveDepositTerms(terms);
       expect(underlyingWallet.approvedWith).toEqual([terms]);
+    });
+  });
+
+  describe("presign deposit-terms rebuild (approval wallets)", () => {
+    // Minimal approval-capable wallet: supportsDepositApproval only probes
+    // for an approveDepositTerms function.
+    function connectApprovalWallet() {
+      mockBtcConnector = {
+        connectedWallet: {
+          account: { address: "tb1test" },
+          provider: { signPsbt: vi.fn(), approveDepositTerms: vi.fn() },
+        },
+      };
+    }
+
+    it("refuses to sign when an approval wallet has no funded Pre-PegIn hex to rebuild terms from", async () => {
+      connectApprovalWallet();
+
+      const { result } = renderHookWithProps({
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        activity: { ...ACTIVITY, unsignedPrePeginTx: undefined } as any,
+      });
+
+      await act(async () => {
+        await result.current.handleSign();
+      });
+
+      expect(result.current.error?.title).toBe("Missing Pre-Pegin transaction");
+      expect(mockGetVaultFromChain).not.toHaveBeenCalled();
+      expect(mockResolveFundedTxFeeAndUtxos).not.toHaveBeenCalled();
+      expect(mockRebuildDepositTerms).not.toHaveBeenCalled();
+      expect(mockSignAndSubmitPayouts).not.toHaveBeenCalled();
+    });
+
+    it("rebuilds presign terms chain-fresh and threads them into signAndSubmitPayouts", async () => {
+      connectApprovalWallet();
+
+      const { result } = renderHookWithProps();
+
+      await act(async () => {
+        await result.current.handleSign();
+      });
+
+      expect(mockGetVaultFromChain).toHaveBeenCalledWith(ACTIVITY.id);
+      expect(mockResolveFundedTxFeeAndUtxos).toHaveBeenCalledWith(
+        ACTIVITY.unsignedPrePeginTx,
+      );
+      expect(mockRebuildDepositTerms).toHaveBeenCalledWith({
+        vaultId: ACTIVITY.id,
+        target: ON_CHAIN_VAULT,
+        fundedPrePeginTxHex: ACTIVITY.unsignedPrePeginTx,
+        connectedDepositorAddress: "0xeth",
+        depositorBtcPubkey: "0x" + "ab".repeat(32),
+        fundedTxFee: FUNDED_TX_FEE,
+        lifecycle: "presign",
+      });
+      expect(mockSignAndSubmitPayouts).toHaveBeenCalledOnce();
+      expect(mockSignAndSubmitPayouts.mock.calls[0][0].depositTerms).toBe(
+        REBUILT_TERMS,
+      );
+      expect(result.current.isComplete).toBe(true);
+    });
+
+    it("adds no rebuild calls and no depositTerms key for software wallets", async () => {
+      // setupHappyPath (beforeEach) connects the plain signPsbt-only wallet.
+      const { result } = renderHookWithProps();
+
+      await act(async () => {
+        await result.current.handleSign();
+      });
+
+      expect(mockGetVaultFromChain).not.toHaveBeenCalled();
+      expect(mockResolveFundedTxFeeAndUtxos).not.toHaveBeenCalled();
+      expect(mockRebuildDepositTerms).not.toHaveBeenCalled();
+
+      // Pre-change param shape, key-identical: no depositTerms key at all
+      // (not even an explicit undefined).
+      const call = mockSignAndSubmitPayouts.mock.calls[0][0];
+      expect("depositTerms" in call).toBe(false);
+      expect(Object.keys(call).sort()).toEqual(
+        [
+          "btcWallet",
+          "depositorBtcPubkey",
+          "depositorEthAddress",
+          "onProgress",
+          "peginTxHash",
+          "providerBtcPubKey",
+          "registeredPayoutScriptPubKey",
+          "signal",
+          "unsignedPrePeginTxHex",
+          "vaultId",
+        ].sort(),
+      );
+      expect(call.vaultId).toBe(ACTIVITY.id);
+      expect(call.peginTxHash).toBe(ACTIVITY.peginTxHash);
+      expect(call.depositorBtcPubkey).toBe("0x" + "ab".repeat(32));
+      expect(call.providerBtcPubKey).toBe(PROVIDER.btcPubKey);
+      expect(call.registeredPayoutScriptPubKey).toBe(
+        ACTIVITY.depositorPayoutBtcAddress,
+      );
+      expect(call.depositorEthAddress).toBe("0xeth");
+      expect(call.unsignedPrePeginTxHex).toBe(ACTIVITY.unsignedPrePeginTx);
+      expect(result.current.isComplete).toBe(true);
+    });
+
+    it("surfaces a rebuild failure through the modal's mapped error state", async () => {
+      connectApprovalWallet();
+      mockRebuildDepositTerms.mockRejectedValueOnce(
+        new Error("resume refused"),
+      );
+
+      const { result } = renderHookWithProps();
+
+      await act(async () => {
+        await result.current.handleSign();
+      });
+
+      // Mapped by formatPayoutSignatureError (stubbed above), not a guard title.
+      expect(result.current.error).toEqual({
+        title: "Sign Error",
+        message: "resume refused",
+      });
+      expect(mockSignAndSubmitPayouts).not.toHaveBeenCalled();
+      expect(result.current.signing).toBe(false);
+      expect(result.current.isComplete).toBe(false);
     });
   });
 });

--- a/services/vault/src/components/deposit/PayoutSignModal/__tests__/usePayoutSigningState.test.tsx
+++ b/services/vault/src/components/deposit/PayoutSignModal/__tests__/usePayoutSigningState.test.tsx
@@ -1,9 +1,11 @@
+import { OnChainBtcVaultStatus } from "@babylonlabs-io/ts-sdk/tbv/core/clients";
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { StrictMode } from "react";
 import type { Hex } from "viem";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { LocalStorageStatus } from "../../../../models/peginStateMachine";
+import { VaultLifecycleStateError } from "../../../../utils/errors/vaultLifecycleStateError";
 import { usePayoutSigningState } from "../usePayoutSigningState";
 
 // Mock the SDK adapter the hook delegates to. We don't care here whether the
@@ -53,7 +55,10 @@ vi.mock("../../../../services/vault/resolveFundedTxFee", () => ({
 }));
 
 const mockRebuildDepositTerms = vi.fn();
+const mockAssertPresignTargetSignable = vi.fn();
 vi.mock("../../../../services/vault/rebuildDepositTerms", () => ({
+  assertPresignTargetSignable: (...args: unknown[]) =>
+    mockAssertPresignTargetSignable(...args),
   rebuildDepositTerms: (...args: unknown[]) => mockRebuildDepositTerms(...args),
 }));
 
@@ -156,11 +161,18 @@ describe("usePayoutSigningState", () => {
     mockVerifyBtcWalletLiveness.mockResolvedValue(undefined);
     mockFetchVaultPayoutScriptPubKey.mockResolvedValue(null);
     mockGetVaultFromChain.mockResolvedValue(ON_CHAIN_VAULT);
+    // `vi.clearAllMocks` does not drain queued `*Once` implementations; reset
+    // the mocks that tests arm with one-shot failures before re-installing
+    // their defaults so an unconsumed queue cannot leak across tests.
+    mockResolveFundedTxFeeAndUtxos.mockReset();
+    mockRebuildDepositTerms.mockReset();
+    mockAssertPresignTargetSignable.mockReset();
     mockResolveFundedTxFeeAndUtxos.mockResolvedValue({
       expectedUtxos: {},
       fundedTxFee: FUNDED_TX_FEE,
     });
     mockRebuildDepositTerms.mockResolvedValue(REBUILT_TERMS);
+    mockAssertPresignTargetSignable.mockResolvedValue(undefined);
   });
 
   describe("happy path", () => {
@@ -779,6 +791,146 @@ describe("usePayoutSigningState", () => {
       expect(mockSignAndSubmitPayouts).not.toHaveBeenCalled();
     });
 
+    it("refuses a software wallet without the funded Pre-PegIn hex too — the cold VP auth path needs it", async () => {
+      // setupHappyPath connects the plain signPsbt-only wallet; the cross-
+      // device resume's cold auth path hashes the hex and parses its funding
+      // outpoints unconditionally, so the guard is not approval-only.
+      const { result } = renderHookWithProps({
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        activity: { ...ACTIVITY, unsignedPrePeginTx: "" } as any,
+      });
+
+      await act(async () => {
+        await result.current.handleSign();
+      });
+
+      expect(result.current.error?.title).toBe("Missing Pre-Pegin transaction");
+      expect(mockSignAndSubmitPayouts).not.toHaveBeenCalled();
+    });
+
+    it("runs the target status/ack-window preflight BEFORE the mempool fee read, so a stalled deposit's refusal wins over a prevout read failure", async () => {
+      connectApprovalWallet();
+      const refusal = new VaultLifecycleStateError("ack window elapsed", {
+        reason: "ack-window-elapsed",
+        stage: "presign",
+        role: "target",
+        status: OnChainBtcVaultStatus.PENDING,
+        vaultId: ACTIVITY.id,
+      });
+      mockAssertPresignTargetSignable.mockRejectedValueOnce(refusal);
+
+      const { result } = renderHookWithProps();
+
+      await act(async () => {
+        await result.current.handleSign();
+      });
+
+      expect(mockAssertPresignTargetSignable).toHaveBeenCalledWith(
+        ACTIVITY.id,
+        ON_CHAIN_VAULT,
+      );
+      expect(mockResolveFundedTxFeeAndUtxos).not.toHaveBeenCalled();
+      expect(mockRebuildDepositTerms).not.toHaveBeenCalled();
+      expect(result.current.error?.message).toBe("ack window elapsed");
+    });
+
+    it("marks a presign lifecycle refusal terminal and keeps it out of the funnel-failure telemetry", async () => {
+      connectApprovalWallet();
+      mockAssertPresignTargetSignable.mockRejectedValueOnce(
+        new VaultLifecycleStateError("signing is over", {
+          reason: "invalid-status",
+          stage: "presign",
+          role: "target",
+          status: OnChainBtcVaultStatus.VERIFIED,
+          vaultId: ACTIVITY.id,
+        }),
+      );
+
+      const { result } = renderHookWithProps();
+
+      await act(async () => {
+        await result.current.handleSign();
+      });
+
+      expect(result.current.error?.message).toBe("signing is over");
+      expect(result.current.errorTerminal).toBe(true);
+      // Routine outcome for a stalled deposit, auto-fired on modal mount —
+      // it must not inflate the activation.payouts alert.
+      expect(mockLoggerError).not.toHaveBeenCalled();
+    });
+
+    it("keeps a rebuild integrity failure retryable and captured", async () => {
+      connectApprovalWallet();
+      mockRebuildDepositTerms.mockRejectedValueOnce(
+        new Error("sibling batch disagrees"),
+      );
+
+      const { result } = renderHookWithProps();
+
+      await act(async () => {
+        await result.current.handleSign();
+      });
+
+      expect(result.current.errorTerminal).toBe(false);
+      expect(mockLoggerError).toHaveBeenCalledTimes(1);
+    });
+
+    it("clears the terminal flag when a later attempt fails on a recoverable guard", async () => {
+      connectApprovalWallet();
+      mockAssertPresignTargetSignable.mockRejectedValueOnce(
+        new VaultLifecycleStateError("signing is over", {
+          reason: "invalid-status",
+          stage: "presign",
+          role: "target",
+          status: OnChainBtcVaultStatus.VERIFIED,
+          vaultId: ACTIVITY.id,
+        }),
+      );
+
+      const { result, rerender } = renderHookWithProps();
+
+      await act(async () => {
+        await result.current.handleSign();
+      });
+      expect(result.current.errorTerminal).toBe(true);
+
+      // Wallet disconnects before the retry — a guard error, recoverable.
+      // Re-render so the handler closes over the new connector state.
+      mockBtcConnector = { connectedWallet: undefined };
+      rerender();
+      await act(async () => {
+        await result.current.handleSign();
+      });
+      expect(result.current.error?.title).toBe("Wallet address unavailable");
+      expect(result.current.errorTerminal).toBe(false);
+    });
+
+    it("resets the terminal flag when a later handleSign starts", async () => {
+      connectApprovalWallet();
+      mockAssertPresignTargetSignable.mockRejectedValueOnce(
+        new VaultLifecycleStateError("signing is over", {
+          reason: "invalid-status",
+          stage: "presign",
+          role: "target",
+          status: OnChainBtcVaultStatus.VERIFIED,
+          vaultId: ACTIVITY.id,
+        }),
+      );
+
+      const { result } = renderHookWithProps();
+
+      await act(async () => {
+        await result.current.handleSign();
+      });
+      expect(result.current.errorTerminal).toBe(true);
+
+      await act(async () => {
+        await result.current.handleSign();
+      });
+      expect(result.current.errorTerminal).toBe(false);
+      expect(result.current.isComplete).toBe(true);
+    });
+
     it("rebuilds presign terms chain-fresh and threads them into signAndSubmitPayouts", async () => {
       connectApprovalWallet();
 
@@ -789,6 +941,10 @@ describe("usePayoutSigningState", () => {
       });
 
       expect(mockGetVaultFromChain).toHaveBeenCalledWith(ACTIVITY.id);
+      expect(mockAssertPresignTargetSignable).toHaveBeenCalledWith(
+        ACTIVITY.id,
+        ON_CHAIN_VAULT,
+      );
       expect(mockResolveFundedTxFeeAndUtxos).toHaveBeenCalledWith(
         ACTIVITY.unsignedPrePeginTx,
       );
@@ -817,6 +973,7 @@ describe("usePayoutSigningState", () => {
       });
 
       expect(mockGetVaultFromChain).not.toHaveBeenCalled();
+      expect(mockAssertPresignTargetSignable).not.toHaveBeenCalled();
       expect(mockResolveFundedTxFeeAndUtxos).not.toHaveBeenCalled();
       expect(mockRebuildDepositTerms).not.toHaveBeenCalled();
 

--- a/services/vault/src/components/deposit/PayoutSignModal/usePayoutSigningState.ts
+++ b/services/vault/src/components/deposit/PayoutSignModal/usePayoutSigningState.ts
@@ -10,6 +10,8 @@ import type { BitcoinWallet } from "@babylonlabs-io/ts-sdk/shared";
 import {
   forwardDepositApproval,
   stripHexPrefix,
+  supportsDepositApproval,
+  type DepositTerms,
   type DepositTermsApprover,
 } from "@babylonlabs-io/ts-sdk/tbv/core";
 import { useChainConnector } from "@babylonlabs-io/wallet-connector";
@@ -24,11 +26,14 @@ import {
 } from "@/infrastructure/telemetryEvents";
 import type { PayoutSigningProgress } from "@/services/vault/vaultPayoutSignatureService";
 
+import { getVaultFromChain } from "../../../clients/eth-contract/btc-vault-registry/query";
 import { usePeginPolling } from "../../../context/deposit/PeginPollingContext";
 import { signAndSubmitPayouts } from "../../../hooks/deposit/depositFlowSteps/payoutSigning";
 import { useVaultProviders } from "../../../hooks/deposit/useVaultProviders";
 import { LocalStorageStatus } from "../../../models/peginStateMachine";
 import { fetchVaultPayoutScriptPubKey } from "../../../services/vault/fetchVaults";
+import { rebuildDepositTerms } from "../../../services/vault/rebuildDepositTerms";
+import { resolveFundedTxFeeAndUtxos } from "../../../services/vault/resolveFundedTxFee";
 import type { VaultActivity } from "../../../types/activity";
 import {
   btcAddressToScriptPubKeyHex,
@@ -201,6 +206,14 @@ export function usePayoutSigningState({
         return;
       }
 
+      // Approval wallets rebuild deposit terms from the funded Pre-PegIn hex
+      // below; a localStorage-only merged activity shape can lack it.
+      const wallet = btcWalletProvider as BitcoinWallet;
+      if (supportsDepositApproval(wallet) && !activity.unsignedPrePeginTx) {
+        setError(COPY.deposit.payoutSigningGuards.missingPrePeginTransaction);
+        return;
+      }
+
       // The wallet may have locked/disconnected since the modal opened. Probe
       // it before signing so a locked wallet surfaces an actionable error
       // instead of a silent no-op (modal opens, no signing popup appears).
@@ -232,7 +245,6 @@ export function usePayoutSigningState({
       abortRef.current?.abort();
       abortRef.current = new AbortController();
 
-      const wallet = btcWalletProvider as BitcoinWallet;
       const graphProgressWallet: BitcoinWallet & Partial<DepositTermsApprover> =
         {
           ...wallet,
@@ -285,6 +297,31 @@ export function usePayoutSigningState({
         };
 
       try {
+        // Approval (intent) wallets have nothing in memory to approve on
+        // resume — rebuild the terms from chain + WASM, never browser storage.
+        let depositTerms: DepositTerms | undefined;
+        if (supportsDepositApproval(wallet)) {
+          const onChainVault = await getVaultFromChain(activity.id);
+          const { fundedTxFee } = await resolveFundedTxFeeAndUtxos(
+            activity.unsignedPrePeginTx,
+          );
+          depositTerms = await rebuildDepositTerms({
+            vaultId: activity.id,
+            target: onChainVault,
+            fundedPrePeginTxHex: activity.unsignedPrePeginTx,
+            connectedDepositorAddress: depositorEthAddress,
+            depositorBtcPubkey: btcPublicKey,
+            fundedTxFee,
+            lifecycle: "presign",
+          });
+          // Last cancellation point before wallet/device interaction — the
+          // rebuild's chain reads leave a window where the modal may close.
+          if (abortRef.current.signal.aborted) {
+            setSigning(false);
+            return;
+          }
+        }
+
         await signAndSubmitPayouts({
           vaultId: activity.id,
           peginTxHash: activity.peginTxHash,
@@ -294,6 +331,9 @@ export function usePayoutSigningState({
           btcWallet: graphProgressWallet,
           depositorEthAddress,
           unsignedPrePeginTxHex: activity.unsignedPrePeginTx,
+          // Spread keeps the software-wallet params identical to before —
+          // no `depositTerms` key at all rather than an explicit undefined.
+          ...(depositTerms ? { depositTerms } : {}),
           signal: abortRef.current.signal,
           onProgress: (next) => {
             if (next === null) return;

--- a/services/vault/src/components/deposit/PayoutSignModal/usePayoutSigningState.ts
+++ b/services/vault/src/components/deposit/PayoutSignModal/usePayoutSigningState.ts
@@ -9,6 +9,7 @@
 import type { BitcoinWallet } from "@babylonlabs-io/ts-sdk/shared";
 import {
   forwardDepositApproval,
+  isDepositTermsRejectedError,
   stripHexPrefix,
   supportsDepositApproval,
   type DepositTerms,
@@ -32,7 +33,10 @@ import { signAndSubmitPayouts } from "../../../hooks/deposit/depositFlowSteps/pa
 import { useVaultProviders } from "../../../hooks/deposit/useVaultProviders";
 import { LocalStorageStatus } from "../../../models/peginStateMachine";
 import { fetchVaultPayoutScriptPubKey } from "../../../services/vault/fetchVaults";
-import { rebuildDepositTerms } from "../../../services/vault/rebuildDepositTerms";
+import {
+  assertPresignTargetSignable,
+  rebuildDepositTerms,
+} from "../../../services/vault/rebuildDepositTerms";
 import { resolveFundedTxFeeAndUtxos } from "../../../services/vault/resolveFundedTxFee";
 import type { VaultActivity } from "../../../types/activity";
 import {
@@ -42,10 +46,13 @@ import {
   verifyBtcWalletLiveness,
 } from "../../../utils/btc";
 import { formatPayoutSignatureError } from "../../../utils/errors/formatting";
+import { isVaultLifecycleStateError } from "../../../utils/errors/vaultLifecycleStateError";
 
 export interface SigningError {
   title: string;
   message: string;
+  /** Raw error for the "copy details" action; only the generic fallback sets it. */
+  diagnostics?: string;
 }
 
 export interface UsePayoutSigningStateProps {
@@ -62,6 +69,11 @@ export interface UsePayoutSigningStateResult {
   progress: PayoutSigningProgress;
   /** Error state if signing failed */
   error: SigningError | null;
+  /**
+   * True when `error` is a refusal retrying cannot change (presign lifecycle
+   * refusal, device rejected the deposit terms) — callers hide the retry CTA.
+   */
+  errorTerminal: boolean;
   /** Whether signing completed successfully */
   isComplete: boolean;
   /** Handler to initiate signing */
@@ -86,6 +98,7 @@ export function usePayoutSigningState({
     total: 0,
   });
   const [error, setError] = useState<SigningError | null>(null);
+  const [errorTerminal, setErrorTerminal] = useState(false);
 
   const { findProvider } = useVaultProviders(activity.applicationEntryPoint);
   const btcConnector = useChainConnector("BTC");
@@ -126,6 +139,9 @@ export function usePayoutSigningState({
   const handleSign = useCallback(async () => {
     if (inFlightRef.current || signing) return;
     inFlightRef.current = true;
+    // A new attempt starts non-terminal: a guard error after a terminal
+    // refusal is a fresh, recoverable error and must get its Retry back.
+    setErrorTerminal(false);
 
     // Single outer try/finally so the reentrancy lock is always cleared —
     // including on synchronous throws from the guards (e.g.
@@ -206,13 +222,16 @@ export function usePayoutSigningState({
         return;
       }
 
-      // Approval wallets rebuild deposit terms from the funded Pre-PegIn hex
-      // below; a localStorage-only merged activity shape can lack it.
-      const wallet = btcWalletProvider as BitcoinWallet;
-      if (supportsDepositApproval(wallet) && !activity.unsignedPrePeginTx) {
+      // Every wallet needs the funded Pre-PegIn hex on this path: the cold VP
+      // auth path hashes it and parses funding outpoints from it, and approval
+      // wallets also rebuild deposit terms from it. A localStorage-only merged
+      // activity shape can lack it — guard once, for all wallets, like the
+      // WOTS and activation resume paths do.
+      if (!activity.unsignedPrePeginTx) {
         setError(COPY.deposit.payoutSigningGuards.missingPrePeginTransaction);
         return;
       }
+      const wallet = btcWalletProvider as BitcoinWallet;
 
       // The wallet may have locked/disconnected since the modal opened. Probe
       // it before signing so a locked wallet surfaces an actionable error
@@ -302,6 +321,9 @@ export function usePayoutSigningState({
         let depositTerms: DepositTerms | undefined;
         if (supportsDepositApproval(wallet)) {
           const onChainVault = await getVaultFromChain(activity.id);
+          // Cheap, decisive gates first: a stalled/ack-expired deposit must
+          // surface its refund copy even if a mempool prevout read fails.
+          await assertPresignTargetSignable(activity.id, onChainVault);
           const { fundedTxFee } = await resolveFundedTxFeeAndUtxos(
             activity.unsignedPrePeginTx,
           );
@@ -356,16 +378,28 @@ export function usePayoutSigningState({
           setSigning(false);
           return;
         }
-        // Critical-path #3 presign failure on the resume path — previously
-        // only surfaced to UI state, invisible to Sentry.
-        captureFunnelFailure(
-          TELEMETRY_STAGE.ACTIVATION_PAYOUTS,
-          err,
-          activity.id,
-          {
-            tags: { providerId: shortId(vaultProviderAddress) },
-          },
-        );
+        // A presign lifecycle refusal (ack window elapsed, target already
+        // past PENDING) is the routine outcome for a stalled deposit — and
+        // the resume modal auto-fires this handler on mount — so it is not a
+        // payout-signing failure and must not inflate the funnel-stage alert.
+        const presignRefusal =
+          isVaultLifecycleStateError(err) && err.stage === "presign";
+        if (!presignRefusal) {
+          // Critical-path #3 presign failure on the resume path — previously
+          // only surfaced to UI state, invisible to Sentry.
+          captureFunnelFailure(
+            TELEMETRY_STAGE.ACTIVATION_PAYOUTS,
+            err,
+            activity.id,
+            {
+              tags: { providerId: shortId(vaultProviderAddress) },
+            },
+          );
+        }
+        // Decide terminality from the typed error BEFORE formatting flattens
+        // it to copy: a lifecycle refusal or a device envelope rejection can
+        // never succeed on retry.
+        setErrorTerminal(presignRefusal || isDepositTermsRejectedError(err));
         setError(formatPayoutSignatureError(err));
         setSigning(false);
       }
@@ -389,5 +423,5 @@ export function usePayoutSigningState({
     onSuccess,
   ]);
 
-  return { signing, progress, error, isComplete, handleSign };
+  return { signing, progress, error, errorTerminal, isComplete, handleSign };
 }

--- a/services/vault/src/components/simple/ResumeDepositContent.tsx
+++ b/services/vault/src/components/simple/ResumeDepositContent.tsx
@@ -105,7 +105,7 @@ export function ResumeSignContent({
   onClose,
   onSuccess,
 }: ResumeSignContentProps) {
-  const { signing, progress, error, isComplete, handleSign } =
+  const { signing, progress, error, errorTerminal, isComplete, handleSign } =
     usePayoutSigningState({
       activity,
       btcPublicKey,
@@ -161,7 +161,15 @@ export function ResumeSignContent({
       // errors with actionable guard titles (missing/mismatched payout address,
       // wallet liveness, etc.). Pass them through directly so the callout keeps
       // that title instead of collapsing to the generic mapped fallback.
-      error={error ? { title: error.title, body: error.message } : null}
+      error={
+        error
+          ? {
+              title: error.title,
+              body: error.message,
+              diagnostics: error.diagnostics,
+            }
+          : null
+      }
       isComplete={derived.isComplete}
       isProcessing={derived.isProcessing}
       canClose={derived.canClose}
@@ -175,7 +183,10 @@ export function ResumeSignContent({
       currentVaultIndex={currentVaultIndex}
       perVaultSteps={perVaultSteps}
       onClose={onClose}
-      onRetry={error ? handleSign : undefined}
+      // A terminal refusal (ack window elapsed, signing already over, device
+      // rejected the terms) re-runs the whole chain-read chain and fails
+      // identically — no Retry CTA, same seam as the activation branch.
+      onRetry={error && !errorTerminal ? handleSign : undefined}
     />
   );
 }

--- a/services/vault/src/components/simple/ResumeDepositContent.tsx
+++ b/services/vault/src/components/simple/ResumeDepositContent.tsx
@@ -69,6 +69,15 @@ import { getVpProxyUrl } from "@/utils/rpc";
 import { DepositProgressView } from "./DepositProgressView";
 import { VaultActivatedView } from "./VaultActivatedView";
 
+/**
+ * Caught-error state wrapper: keeps the typed error intact for the render-seam
+ * `mapDepositError` call (flattening to `.message` loses wallet codes and
+ * `cause` chains) while giving `unknown` well-defined truthiness in state.
+ */
+interface CaughtError {
+  raw: unknown;
+}
+
 // ---------------------------------------------------------------------------
 // Sign Payouts Content
 // ---------------------------------------------------------------------------
@@ -309,7 +318,7 @@ export function ResumeWotsContent({
   // banner from `isComplete = !loading && !error`. A re-offer has not
   // submitted anything yet, so it starts idle.
   const [loading, setLoading] = useState(!isReoffer);
-  const [error, setError] = useState<string | null>(null);
+  const [error, setError] = useState<CaughtError | null>(null);
 
   // Track mount for setState guards after the long async chain below.
   // The hosting modal can be closed mid-flight (PostDepositContinuationView
@@ -330,7 +339,7 @@ export function ResumeWotsContent({
 
   const handleSubmit = useCallback(async () => {
     if (!btcWalletProvider || !connectedBtcAddress) {
-      setError("BTC wallet is not connected");
+      setError({ raw: COPY.deposit.resume.walletNotConnected });
       setLoading(false);
       return;
     }
@@ -473,15 +482,13 @@ export function ResumeWotsContent({
         extra: { wotsMismatch: isWotsMismatchError(err) },
       });
       if (mountedRef.current) {
-        const msg =
-          err instanceof Error ? err.message : "Failed to submit WOTS key";
         // VP-side mismatch gets the same wording as the local pre-flight
         // so the user can act on either path.
-        if (isWotsMismatchError(err)) {
-          setError(COPY.deposit.resume.wotsMismatchError);
-        } else {
-          setError(msg);
-        }
+        setError({
+          raw: isWotsMismatchError(err)
+            ? COPY.deposit.resume.wotsMismatchError
+            : err,
+        });
         setLoading(false);
       }
     } finally {
@@ -579,7 +586,7 @@ export function ResumeWotsContent({
   return (
     <DepositProgressView
       currentStep={renderStep}
-      error={error ? mapDepositError(error) : null}
+      error={error ? mapDepositError(error.raw) : null}
       isComplete={derived.isComplete}
       isProcessing={derived.isProcessing}
       canClose={derived.canClose}
@@ -630,7 +637,7 @@ export function ResumeActivationContent({
   // Starts true: useRunOnce auto-fires handleSubmit on mount, so the
   // first render must show processing.
   const [loading, setLoading] = useState(true);
-  const [localError, setLocalError] = useState<string | null>(null);
+  const [localError, setLocalError] = useState<CaughtError | null>(null);
 
   // Track mount for setState guards after the long async chain below.
   // The hosting modal can be closed mid-flight, so the post-await
@@ -657,14 +664,16 @@ export function ResumeActivationContent({
 
   const handleSubmit = useCallback(async () => {
     if (!btcWalletProvider || !connectedBtcAddress) {
-      setLocalError("BTC wallet is not connected");
+      setLocalError({
+        raw: COPY.deposit.resume.walletNotConnected,
+      });
       setLoading(false);
       return;
     }
     if (!activity.unsignedPrePeginTx) {
-      setLocalError(
-        "Missing Pre-Pegin transaction; cannot recover HTLC secret",
-      );
+      setLocalError({
+        raw: COPY.deposit.resume.secretRecoveryMissingPrePegin,
+      });
       setLoading(false);
       return;
     }
@@ -690,9 +699,7 @@ export function ResumeActivationContent({
       // never secret bytes. Only the UI update below is mount-gated.
       captureFunnelFailure(TELEMETRY_STAGE.ACTIVATION_SECRET, err, activity.id);
       if (mountedRef.current) {
-        const msg =
-          err instanceof Error ? err.message : "Failed to activate BTC Vault";
-        setLocalError(msg);
+        setLocalError({ raw: err });
       }
     } finally {
       if (mountedRef.current) setLoading(false);
@@ -710,7 +717,8 @@ export function ResumeActivationContent({
   // "not connected" error surfaces.
   useRunOnce(handleSubmit, !btcWalletProvider || Boolean(connectedBtcAddress));
 
-  const error = localError ?? activationError;
+  const error: CaughtError | null =
+    localError ?? (activationError != null ? { raw: activationError } : null);
   // Terminal only applies to the activation failure (deadline passed), never a
   // local pre-flight error — which localError would override via `??` above.
   const isTerminal = localError == null && errorTerminal;
@@ -751,7 +759,7 @@ export function ResumeActivationContent({
         error
           ? isTerminal
             ? COPY.deposit.errors.activationDeadlinePassed
-            : mapDepositError(error)
+            : mapDepositError(error.raw)
           : null
       }
       isComplete={derived.isComplete}

--- a/services/vault/src/components/simple/__tests__/ResumeDepositContent.test.tsx
+++ b/services/vault/src/components/simple/__tests__/ResumeDepositContent.test.tsx
@@ -134,6 +134,7 @@ vi.mock("@/components/deposit/PayoutSignModal/usePayoutSigningState", () => ({
     signing: false,
     progress: { phase: "claimers", completed: 0, total: 0 },
     error: null,
+    errorTerminal: false,
     isComplete: false,
     handleSign: vi.fn(),
   })),
@@ -674,6 +675,7 @@ describe("ResumeSignContent — reactive verification terminal", () => {
       signing: false,
       progress: { phase: "claimers", completed: 0, total: 0 },
       error: null,
+      errorTerminal: false,
       isComplete: true,
       handleSign: vi.fn(),
     });
@@ -727,6 +729,39 @@ describe("ResumeSignContent — reactive verification terminal", () => {
     // COMPLETED — the whole flow is done, so no stale "ready to activate".
     expect(getByTestId("step").textContent).toBe("16");
     expect(getByTestId("terminal").textContent).toBe("");
+  });
+
+  it("suppresses Retry on a terminal signing refusal and keeps the hook's title/body", () => {
+    vi.mocked(usePayoutSigningState).mockReturnValue({
+      signing: false,
+      progress: { phase: "auth", completed: 0, total: 0 },
+      error: COPY.deposit.payoutSignatureErrors.ackWindowElapsed,
+      errorTerminal: true,
+      isComplete: false,
+      handleSign: vi.fn(),
+    });
+
+    const { getByTestId } = renderSign();
+
+    expect(getByTestId("error-title").textContent).toBe(
+      COPY.deposit.payoutSignatureErrors.ackWindowElapsed.title,
+    );
+    expect(getByTestId("has-retry").textContent).toBe("false");
+  });
+
+  it("keeps Retry for a non-terminal signing failure", () => {
+    vi.mocked(usePayoutSigningState).mockReturnValue({
+      signing: false,
+      progress: { phase: "auth", completed: 0, total: 0 },
+      error: COPY.deposit.payoutSignatureErrors.unexpected,
+      errorTerminal: false,
+      isComplete: false,
+      handleSign: vi.fn(),
+    });
+
+    const { getByTestId } = renderSign();
+
+    expect(getByTestId("has-retry").textContent).toBe("true");
   });
 });
 

--- a/services/vault/src/components/simple/__tests__/ResumeDepositContent.test.tsx
+++ b/services/vault/src/components/simple/__tests__/ResumeDepositContent.test.tsx
@@ -48,6 +48,7 @@ vi.mock("@babylonlabs-io/ts-sdk/tbv/core", () => ({
   expandHashlockSecret: vi.fn(() => new Uint8Array(32)),
   expandWotsSeed: vi.fn(() => new Uint8Array(32)),
   hexToUint8Array: vi.fn(() => new Uint8Array(32)),
+  isDepositTermsRejectedError: vi.fn(() => false),
   isWotsMismatchError: vi.fn(() => false),
   isRegisteredVaultVersionMismatchError: vi.fn(() => false),
   isParticipantKeyDriftError: vi.fn(() => false),
@@ -440,6 +441,31 @@ describe("ResumeWotsContent — submission marker", () => {
     });
   });
 
+  it("maps a coded wallet rejection to the signing-rejected callout", async () => {
+    // The error state stores the caught value un-flattened, so the wallet
+    // code (not just the message) reaches mapDepositError at the render seam.
+    mockSubmitWotsPublicKey.mockRejectedValue(
+      Object.assign(new Error("nope"), { code: "CONNECTION_REJECTED" }),
+    );
+
+    const { getByTestId } = render(
+      <ResumeWotsContent
+        activity={baseActivity}
+        onClose={vi.fn()}
+        onSuccess={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(getByTestId("error-title").textContent).toBe(
+        COPY.deposit.errors.signingRejected.title,
+      );
+    });
+    expect(getByTestId("error").textContent).toBe(
+      COPY.deposit.errors.signingRejected.body,
+    );
+  });
+
   it("waits for a click instead of auto-submitting when the suppression lapsed", async () => {
     // The TTL expiring re-offers SUBMIT_WOTS_KEY, which remounts this
     // component. Auto-firing there would open a wallet prompt at a modal the
@@ -821,6 +847,25 @@ describe("ResumeActivationContent — activated success terminal", () => {
     );
     expect(getByTestId("error-title").textContent).not.toBe(
       COPY.deposit.errors.activationDeadlinePassed.title,
+    );
+  });
+
+  it("maps a coded wallet rejection during secret derivation to the signing-rejected callout", async () => {
+    // The local error state stores the caught value un-flattened, so the
+    // wallet code (not just the message) reaches mapDepositError at render.
+    mockDeriveVaultRoot.mockRejectedValue(
+      Object.assign(new Error("nope"), { code: "CONNECTION_REJECTED" }),
+    );
+
+    const { getByTestId } = renderActivation();
+
+    await waitFor(() => {
+      expect(getByTestId("error-title").textContent).toBe(
+        COPY.deposit.errors.signingRejected.title,
+      );
+    });
+    expect(getByTestId("error").textContent).toBe(
+      COPY.deposit.errors.signingRejected.body,
     );
   });
 });

--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -55,6 +55,9 @@ const TRANSACTION_FAILED_TITLE = "Transaction failed";
 // the wording stays in one place.
 const WRONG_WALLET_BODY =
   "WOTS public key hash does not match the on-chain commitment — the wrong wallet is connected.";
+// Shared by formatPayoutSignatureError's Error and non-Error fallbacks so the
+// generic payout-signing title can't drift between the two.
+const PAYOUT_SIGNING_ERROR_TITLE = "Payout signing error";
 // Action-required labels shared between the in-app badges
 // (`pegin.actionRequiredBadges`) and the browser-notification titles so the two
 // surfaces can't drift.
@@ -720,6 +723,12 @@ export const COPY = {
       readyToActivateMessage:
         "Your payout transactions are signed and verified. Your BTC Vault is ready to activate.",
       wotsMismatchError: WRONG_WALLET_BODY,
+      // Resume preflight guards (rendered via mapDepositError's pass-through,
+      // same pattern as wotsMismatchError above). walletNotConnected is shared
+      // by the WOTS and HTLC-secret-recovery submit handlers.
+      walletNotConnected: "BTC wallet is not connected",
+      secretRecoveryMissingPrePegin:
+        "Missing Pre-Pegin transaction; cannot recover HTLC secret",
       // Resume's cold path fires a wallet approval the WOTS step copy doesn't
       // mention, and some extensions queue it without surfacing a popup.
       wotsWalletApprovalHint:
@@ -866,6 +875,18 @@ export const COPY = {
         title: "Commission unavailable",
         body: "We couldn't confirm the vault provider's commission. Please refresh and try again before depositing.",
       },
+      // Device-envelope rejection of the deposit terms. Can be terminal for
+      // this deposit (terms outside the signing device's acceptable range can
+      // never be approved), so no "try again" — support and, once BTC has
+      // moved, the refund path.
+      depositTermsRejected: {
+        title: "Deposit terms not approved",
+        body: "Your signing device cannot approve this deposit's terms, so the deposit cannot continue with the connected wallet. Please contact support. If your Bitcoin has already been sent, it stays recoverable through the refund flow once its timelock opens.",
+      },
+      walletMethodNotSupported: {
+        title: "Wallet action not supported",
+        body: "Your connected wallet can't perform an action this deposit requires. Please reconnect with a supported wallet and try again.",
+      },
       // Vault-provider JSON-RPC error copy, consumed by `mapVpRpcError`
       // (utils/errors/formatting.ts). Title + message are both user-facing.
       vp: {
@@ -949,6 +970,60 @@ export const COPY = {
         title: "Missing peg-in transaction",
         message:
           "Peg-in transaction hash is not available yet. Please wait for indexer sync and try again.",
+      },
+      missingPrePeginTransaction: {
+        title: "Missing Pre-Pegin transaction",
+        message:
+          "The original Pre-Pegin transaction is not available yet, and your wallet requires it to approve payout signing. Please try again later.",
+      },
+    },
+    // ----------------------------------------------------------------------
+    // Payout-signing failure copy (title + message). Consumed by
+    // `formatPayoutSignatureError` (utils/errors/formatting.ts).
+    // ----------------------------------------------------------------------
+    payoutSignatureErrors: {
+      signingRejected: {
+        title: "Signing rejected",
+        message:
+          "You rejected the signing request in your wallet. Approve the request to continue, or click Retry to try again.",
+      },
+      providerNotFound: {
+        title: "Vault provider not found",
+        message:
+          "The vault provider for this deposit could not be found. Please contact support.",
+      },
+      walletNotConnected: {
+        title: "Wallet not connected",
+        message: "Please reconnect your Bitcoin wallet to continue.",
+      },
+      contractCallFailed: {
+        title: "Contract call failed",
+        message:
+          "A contract call failed during payout signing. The on-chain BTC Vault data may be unavailable. Please try again or contact support.",
+      },
+      // Presign lifecycle refusals (typed VaultLifecycleStateError). Timing
+      // out awaiting acknowledgments is routine for a stalled deposit, so the
+      // copy leads with the refund path rather than a retry.
+      ackWindowElapsed: {
+        title: "Deposit timed out",
+        message:
+          "This deposit timed out while awaiting acknowledgments, so payout signatures are no longer needed. Your Bitcoin stays recoverable through the refund flow once its timelock opens.",
+      },
+      signaturesNoLongerNeeded: {
+        title: "No signatures needed",
+        message:
+          "This deposit has already moved past payout signing, so no further signatures are needed. Check your dashboard for its current status.",
+      },
+      unexpected: {
+        title: PAYOUT_SIGNING_ERROR_TITLE,
+        message:
+          "An unexpected error occurred while signing payouts. Please try again or contact support.",
+      },
+      // Non-Error throws (strings / plain objects) surface their own extracted
+      // text; this pair is the fallback when none can be extracted.
+      fallback: {
+        title: PAYOUT_SIGNING_ERROR_TITLE,
+        message: "An unexpected error occurred while signing payouts.",
       },
     },
   },

--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -867,6 +867,12 @@ export const COPY = {
         title: "Wrong wallet account",
         body: WRONG_WALLET_BODY,
       },
+      // Typed DepositorWalletMismatchError from the terms rebuild (Ethereum
+      // account, not the BTC wallet the WOTS guard above covers).
+      wrongDepositorWallet: {
+        title: "Wrong wallet connected",
+        body: "This deposit belongs to a different Ethereum account. Connect the wallet that created the deposit to resume.",
+      },
       commissionChanged: {
         title: "Commission changed",
         body: "The vault provider raised its commission since you selected it. Please refresh to see the new commission and start the deposit again.",
@@ -974,7 +980,7 @@ export const COPY = {
       missingPrePeginTransaction: {
         title: "Missing Pre-Pegin transaction",
         message:
-          "The original Pre-Pegin transaction is not available yet, and your wallet requires it to approve payout signing. Please try again later.",
+          "The original Pre-Pegin transaction is not available yet, and payout signing cannot start without it. Please try again later.",
       },
     },
     // ----------------------------------------------------------------------
@@ -1013,6 +1019,21 @@ export const COPY = {
         title: "No signatures needed",
         message:
           "This deposit has already moved past payout signing, so no further signatures are needed. Check your dashboard for its current status.",
+      },
+      // Typed DepositorWalletMismatchError from the terms rebuild: the deposit
+      // is bound to the Ethereum account that registered it.
+      wrongDepositorWallet: {
+        title: "Wrong wallet connected",
+        message:
+          "This deposit belongs to a different Ethereum account. Connect the wallet that created the deposit to continue signing.",
+      },
+      // Resume-specific variant of deposit.errors.walletMethodNotSupported: an
+      // in-flight deposit is bound to the wallet that derived its secrets, so
+      // "reconnect with a supported wallet" is not a recovery path here.
+      walletMethodNotSupported: {
+        title: "Wallet action not supported",
+        message:
+          "Your connected wallet can't perform an action this deposit requires, and the deposit can only continue with the wallet that created it. Try again after updating the app or that wallet, or contact support.",
       },
       unexpected: {
         title: PAYOUT_SIGNING_ERROR_TITLE,

--- a/services/vault/src/hooks/deposit/__tests__/useVaultActions.test.ts
+++ b/services/vault/src/hooks/deposit/__tests__/useVaultActions.test.ts
@@ -1327,6 +1327,7 @@ describe("useVaultActions — handleBroadcast intent (Ledger) resume branch", ()
       connectedDepositorAddress: "0xconnected_depositor",
       depositorBtcPubkey: "depositorBtcPubkey",
       fundedTxFee: 1234n,
+      lifecycle: "broadcast",
     });
     expect(mockBroadcastPrePeginTransaction).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/services/vault/src/hooks/deposit/depositFlowSteps/payoutSigning.ts
+++ b/services/vault/src/hooks/deposit/depositFlowSteps/payoutSigning.ts
@@ -42,7 +42,7 @@ export interface SignAndSubmitPayoutsParams {
   btcWallet: BitcoinWallet;
   depositorEthAddress: Address;
   unsignedPrePeginTxHex: string;
-  /** Required for approval-capable wallets on a fresh flow; resume path omits it. */
+  /** Required for approval-capable wallets; the resume path rebuilds it from chain. */
   depositTerms?: DepositTerms;
   signal?: AbortSignal;
   onProgress?: (progress: PayoutSigningProgress | null) => void;

--- a/services/vault/src/hooks/deposit/useDepositFlow.ts
+++ b/services/vault/src/hooks/deposit/useDepositFlow.ts
@@ -870,8 +870,12 @@ export function useDepositFlow(
           }
           const errorMsg =
             error instanceof Error ? error.message : String(error);
+          // `cause` keeps the typed inner error visible to the cause-walking
+          // classifiers (user cancellation, method-not-supported) in the
+          // mappers.
           throw new Error(
             `Failed to broadcast batch Pre-PegIn transaction: ${errorMsg}`,
+            { cause: error },
           );
         }
 

--- a/services/vault/src/hooks/deposit/useVaultActions.ts
+++ b/services/vault/src/hooks/deposit/useVaultActions.ts
@@ -470,6 +470,7 @@ export function useVaultActions(): UseVaultActionsReturn {
           connectedDepositorAddress: depositorEthAddress as Hex,
           depositorBtcPubkey,
           fundedTxFee,
+          lifecycle: "broadcast",
         });
         // Last cancellation point before the wallet signs. Several network
         // round-trips (UTXO availability, version/key re-checks, and on the

--- a/services/vault/src/services/vault/__tests__/rebuildDepositTerms.test.ts
+++ b/services/vault/src/services/vault/__tests__/rebuildDepositTerms.test.ts
@@ -7,7 +7,10 @@ import { Transaction } from "bitcoinjs-lib";
 import type { Hex } from "viem";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { VaultLifecycleStateError } from "@/utils/errors";
+import {
+  DepositorWalletMismatchError,
+  VaultLifecycleStateError,
+} from "@/utils/errors";
 
 import {
   getVaultFromChain,
@@ -24,6 +27,7 @@ import { fetchVaultIdsByDepositor } from "../fetchVaults";
 import {
   assertBatchLifecycleStatus,
   assertContiguousHtlcVector,
+  assertPresignTargetSignable,
   assertSiblingBatchHomogeneous,
   rebuildDepositTerms,
 } from "../rebuildDepositTerms";
@@ -78,7 +82,7 @@ vi.mock("../vaultPayoutSignatureService", async (importOriginal) => ({
 // ETH block the registration mined at + the ack window read for presign mode.
 const TARGET_CREATED_AT_BLOCK = 1_000n;
 const PEGIN_ACK_TIMEOUT_BLOCKS = 144n;
-// Contract boundary (PeginLogic.sol:481/:807): expired iff block > deadline.
+// Contract boundary (PeginLogic.submitACK / reportExpired, vault-contracts-aave-v4 @ 2e87a85a): expired iff block > deadline.
 const ACK_DEADLINE_BLOCK = TARGET_CREATED_AT_BLOCK + PEGIN_ACK_TIMEOUT_BLOCKS;
 
 // Only the fields the lifecycle/homogeneity asserts read matter here; the cast
@@ -415,14 +419,23 @@ describe("rebuildDepositTerms orchestrator (mocked chain, real discovery + mappi
     expect(mockGetTBVProtocolParams).not.toHaveBeenCalled();
   });
 
-  it("refuses when the connected wallet is not the on-chain depositor", async () => {
-    await expect(
-      rebuildDepositTerms({
-        ...baseParams(),
-        connectedDepositorAddress:
-          "0x9999000000000000000000000000000000000099" as `0x${string}`,
-      }),
-    ).rejects.toThrow(/owned by/);
+  it("refuses with the typed depositor-mismatch error when the connected wallet is not the on-chain depositor", async () => {
+    const connected =
+      "0x9999000000000000000000000000000000000099" as `0x${string}`;
+    const caught = await rebuildDepositTerms({
+      ...baseParams(),
+      connectedDepositorAddress: connected,
+    }).then(
+      () => null,
+      (err: unknown) => err,
+    );
+
+    expect(caught).toBeInstanceOf(DepositorWalletMismatchError);
+    expect(caught).toMatchObject({
+      vaultId: TARGET_ID,
+      expectedDepositor: targetVault.depositor,
+      connectedDepositor: connected,
+    });
     expect(rebuildDepositTermsCore).not.toHaveBeenCalled();
   });
 
@@ -509,6 +522,52 @@ describe("rebuildDepositTerms orchestrator (mocked chain, real discovery + mappi
       rebuildDepositTerms({ ...baseParams(), lifecycle: "presign" }),
     ).rejects.toThrow(/rpc unavailable/);
     expect(rebuildDepositTermsCore).not.toHaveBeenCalled();
+  });
+
+  // The hoisted preflight: same two gates, same order, no sibling/mempool reads.
+  it("assertPresignTargetSignable passes a PENDING target inside the ack window without touching siblings", async () => {
+    await expect(
+      assertPresignTargetSignable(TARGET_ID, targetVault),
+    ).resolves.toBeUndefined();
+    expect(fetchVaultIdsByDepositor).not.toHaveBeenCalled();
+    expect(getVaultFromChain).not.toHaveBeenCalled();
+  });
+
+  it("assertPresignTargetSignable refuses a non-PENDING target before reading the ack window", async () => {
+    const caught = await assertPresignTargetSignable(TARGET_ID, {
+      ...targetVault,
+      status: OnChainBtcVaultStatus.VERIFIED,
+    }).then(
+      () => null,
+      (err: unknown) => err,
+    );
+
+    expect(caught).toBeInstanceOf(VaultLifecycleStateError);
+    expect(caught).toMatchObject({
+      reason: "invalid-status",
+      stage: "presign",
+      status: OnChainBtcVaultStatus.VERIFIED,
+    });
+    expect(mockGetBlockNumber).not.toHaveBeenCalled();
+  });
+
+  it("assertPresignTargetSignable refuses one block past the ack deadline with the still-PENDING status", async () => {
+    mockGetBlockNumber.mockResolvedValue(ACK_DEADLINE_BLOCK + 1n);
+
+    const caught = await assertPresignTargetSignable(
+      TARGET_ID,
+      targetVault,
+    ).then(
+      () => null,
+      (err: unknown) => err,
+    );
+
+    expect(caught).toBeInstanceOf(VaultLifecycleStateError);
+    expect(caught).toMatchObject({
+      reason: "ack-window-elapsed",
+      stage: "presign",
+      status: OnChainBtcVaultStatus.PENDING,
+    });
   });
 
   /** A funded Pre-PegIn tx with `htlcCount` HTLC outputs and the auth-anchor

--- a/services/vault/src/services/vault/__tests__/rebuildDepositTerms.test.ts
+++ b/services/vault/src/services/vault/__tests__/rebuildDepositTerms.test.ts
@@ -2,9 +2,12 @@ import {
   rebuildDepositTermsCore,
   resolveParticipantKeysAtEpochs,
 } from "@babylonlabs-io/ts-sdk/tbv/core";
+import { OnChainBtcVaultStatus } from "@babylonlabs-io/ts-sdk/tbv/core/clients";
 import { Transaction } from "bitcoinjs-lib";
 import type { Hex } from "viem";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { VaultLifecycleStateError } from "@/utils/errors";
 
 import {
   getVaultFromChain,
@@ -19,6 +22,7 @@ import {
 } from "../../../clients/eth-contract/sdk-readers";
 import { fetchVaultIdsByDepositor } from "../fetchVaults";
 import {
+  assertBatchLifecycleStatus,
   assertContiguousHtlcVector,
   assertSiblingBatchHomogeneous,
   rebuildDepositTerms,
@@ -49,6 +53,15 @@ vi.mock("../../../clients/eth-contract/sdk-readers", () => ({
   getVaultKeeperReader: vi.fn(),
   getVaultRegistryReader: vi.fn(),
 }));
+// Presign ack-window check reads the current block through ethClient.
+const { mockGetBlockNumber } = vi.hoisted(() => ({
+  mockGetBlockNumber: vi.fn(),
+}));
+vi.mock("../../../clients/eth-contract/client", () => ({
+  ethClient: {
+    getPublicClient: () => ({ getBlockNumber: mockGetBlockNumber }),
+  },
+}));
 vi.mock("../../../config/pegin", () => ({
   getBTCNetworkForWASM: vi.fn(() => "signet"),
 }));
@@ -62,12 +75,18 @@ vi.mock("../vaultPayoutSignatureService", async (importOriginal) => ({
   resolveVaultProviderBtcPubkey: vi.fn(),
 }));
 
-// Only the fields the homogeneity assert reads matter here; the cast keeps the
-// fixture minimal instead of faking the full on-chain record.
+// ETH block the registration mined at + the ack window read for presign mode.
+const TARGET_CREATED_AT_BLOCK = 1_000n;
+const PEGIN_ACK_TIMEOUT_BLOCKS = 144n;
+// Contract boundary (PeginLogic.sol:481/:807): expired iff block > deadline.
+const ACK_DEADLINE_BLOCK = TARGET_CREATED_AT_BLOCK + PEGIN_ACK_TIMEOUT_BLOCKS;
+
+// Only the fields the lifecycle/homogeneity asserts read matter here; the cast
+// keeps the fixture minimal instead of faking the full on-chain record.
 function makeVault(over: Partial<OnChainVaultData> = {}): OnChainVaultData {
   return {
-    // OnChainBtcVaultStatus.PENDING — the only broadcastable state.
-    status: 0,
+    status: OnChainBtcVaultStatus.PENDING,
+    createdAt: TARGET_CREATED_AT_BLOCK,
     vaultCoreVersion: 2,
     offchainParamsVersion: 3,
     appVaultKeepersVersion: 4,
@@ -79,28 +98,124 @@ function makeVault(over: Partial<OnChainVaultData> = {}): OnChainVaultData {
   } as OnChainVaultData;
 }
 
+describe("assertBatchLifecycleStatus", () => {
+  const TARGET_MEMBER_ID = "0xtarget_member" as Hex;
+  const SIBLING_MEMBER_ID = "0xsibling_member" as Hex;
+  const member = (vaultId: Hex, over: Partial<OnChainVaultData> = {}) => ({
+    vaultId,
+    vault: makeVault(over),
+  });
+
+  it("broadcast accepts an all-PENDING batch", () => {
+    expect(() =>
+      assertBatchLifecycleStatus("broadcast", member(TARGET_MEMBER_ID), [
+        member(SIBLING_MEMBER_ID),
+      ]),
+    ).not.toThrow();
+  });
+
+  it("broadcast rejects a non-PENDING sibling with the legacy message byte-identical", () => {
+    let caught: unknown;
+    try {
+      assertBatchLifecycleStatus("broadcast", member(TARGET_MEMBER_ID), [
+        member(SIBLING_MEMBER_ID, { status: OnChainBtcVaultStatus.EXPIRED }),
+      ]);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(VaultLifecycleStateError);
+    // Byte-identical to the pre-typed-error string: mapDepositError buckets
+    // this refusal on the word "broadcast".
+    expect((caught as VaultLifecycleStateError).message).toBe(
+      "A vault in this Pre-PegIn batch is no longer awaiting broadcast " +
+        "(on-chain status 4); the batch cannot be broadcast as one " +
+        "transaction. Resume refused.",
+    );
+    expect(caught).toMatchObject({
+      reason: "invalid-status",
+      stage: "broadcast",
+      role: "sibling",
+      status: OnChainBtcVaultStatus.EXPIRED,
+      vaultId: SIBLING_MEMBER_ID,
+    });
+  });
+
+  it("broadcast rejects a non-PENDING target with role target", () => {
+    let caught: unknown;
+    try {
+      assertBatchLifecycleStatus(
+        "broadcast",
+        member(TARGET_MEMBER_ID, { status: OnChainBtcVaultStatus.VERIFIED }),
+        [member(SIBLING_MEMBER_ID)],
+      );
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(VaultLifecycleStateError);
+    expect(caught).toMatchObject({
+      reason: "invalid-status",
+      stage: "broadcast",
+      role: "target",
+      status: OnChainBtcVaultStatus.VERIFIED,
+      vaultId: TARGET_MEMBER_ID,
+    });
+  });
+
+  it("presign accepts a VERIFIED sibling", () => {
+    expect(() =>
+      assertBatchLifecycleStatus("presign", member(TARGET_MEMBER_ID), [
+        member(SIBLING_MEMBER_ID, { status: OnChainBtcVaultStatus.VERIFIED }),
+      ]),
+    ).not.toThrow();
+  });
+
+  // Pins "sibling status unconstrained": siblings advance independently and no
+  // presigned byte depends on their status.
+  it("presign accepts EXPIRED and ACTIVE siblings", () => {
+    expect(() =>
+      assertBatchLifecycleStatus("presign", member(TARGET_MEMBER_ID), [
+        member(SIBLING_MEMBER_ID, { status: OnChainBtcVaultStatus.EXPIRED }),
+        member("0xsibling_member_2" as Hex, {
+          status: OnChainBtcVaultStatus.ACTIVE,
+        }),
+      ]),
+    ).not.toThrow();
+  });
+
+  // EXPIRED is the status a real stalled user hits (permissionless expiry
+  // reporting flips Pending → Expired past the ack window).
+  it("presign rejects an EXPIRED target with the typed error and all fields", () => {
+    let caught: unknown;
+    try {
+      assertBatchLifecycleStatus(
+        "presign",
+        member(TARGET_MEMBER_ID, { status: OnChainBtcVaultStatus.EXPIRED }),
+        [member(SIBLING_MEMBER_ID)],
+      );
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(VaultLifecycleStateError);
+    expect(caught).toMatchObject({
+      reason: "invalid-status",
+      stage: "presign",
+      role: "target",
+      status: OnChainBtcVaultStatus.EXPIRED,
+      vaultId: TARGET_MEMBER_ID,
+    });
+    // Lifecycle-neutral wording — must not fall into the "broadcast" bucket.
+    expect((caught as VaultLifecycleStateError).message).not.toMatch(
+      /broadcast/i,
+    );
+  });
+});
+
 describe("assertSiblingBatchHomogeneous", () => {
   it("accepts siblings whose stamps, provider, application, and commission match the target", () => {
     const target = makeVault();
     expect(() =>
       assertSiblingBatchHomogeneous(target, [makeVault(), makeVault()]),
     ).not.toThrow();
-  });
-
-  it("rejects a sibling that is no longer PENDING (would be silently funded)", () => {
-    const target = makeVault();
-    // On-chain Expired(4) — the indexer-facing gate only checks the target.
-    const sib = makeVault({ status: 4 });
-    expect(() => assertSiblingBatchHomogeneous(target, [sib])).toThrow(
-      /no longer awaiting broadcast/,
-    );
-  });
-
-  it("rejects a non-PENDING target (chain-read authority over the indexer gate)", () => {
-    const target = makeVault({ status: 4 });
-    expect(() => assertSiblingBatchHomogeneous(target, [makeVault()])).toThrow(
-      /no longer awaiting broadcast/,
-    );
   });
 
   it("accepts address fields that differ only by case", () => {
@@ -207,8 +322,13 @@ describe("rebuildDepositTerms orchestrator (mocked chain, real discovery + mappi
       connectedDepositorAddress: DEPOSITOR_ETH.toLowerCase() as `0x${string}`,
       depositorBtcPubkey: DEPOSITOR_BTC,
       fundedTxFee: 1234n,
+      lifecycle: "broadcast" as const,
     };
   }
+
+  // Module-level so tests can assert the ack timeout is sourced from
+  // ViemProtocolParamsReader.getTBVProtocolParams (the live contract read).
+  const mockGetTBVProtocolParams = vi.fn();
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -226,6 +346,12 @@ describe("rebuildDepositTerms orchestrator (mocked chain, real discovery + mappi
         .fn()
         .mockResolvedValue([{ prePeginTxHash: PRE_PEGIN_TX_HASH }]),
     } as never);
+    mockGetTBVProtocolParams.mockResolvedValue({
+      pegInAckTimeout: PEGIN_ACK_TIMEOUT_BLOCKS,
+    });
+    // Default: exactly at the ack deadline — the last block the contract
+    // still accepts, so in-window tests double as the boundary case.
+    mockGetBlockNumber.mockResolvedValue(ACK_DEADLINE_BLOCK);
     vi.mocked(getProtocolParamsReader).mockResolvedValue({
       getOffchainParamsByVersion: vi.fn().mockResolvedValue({
         feeRate: 3n,
@@ -237,6 +363,7 @@ describe("rebuildDepositTerms orchestrator (mocked chain, real discovery + mappi
         minVpCommissionBps: 10,
       }),
       getTimelockPeginByVersion: vi.fn().mockResolvedValue(100),
+      getTBVProtocolParams: mockGetTBVProtocolParams,
     } as never);
     vi.mocked(getVaultKeeperReader).mockResolvedValue({
       getVaultKeepersByVersion: vi.fn().mockResolvedValue(["vk-eth-1"]),
@@ -283,6 +410,9 @@ describe("rebuildDepositTerms orchestrator (mocked chain, real discovery + mappi
       maxAcceptableCommissionBps: 275, // stored 250 + 25 bps headroom (fresh-path cap policy, #2252 interim)
       network: "signet",
     });
+    // Broadcast mode is byte-identical to before: no ack-window reads added.
+    expect(mockGetBlockNumber).not.toHaveBeenCalled();
+    expect(mockGetTBVProtocolParams).not.toHaveBeenCalled();
   });
 
   it("refuses when the connected wallet is not the on-chain depositor", async () => {
@@ -317,6 +447,67 @@ describe("rebuildDepositTerms orchestrator (mocked chain, real discovery + mappi
     await expect(rebuildDepositTerms(baseParams())).rejects.toThrow(
       /disagree on offchainParamsVersion/,
     );
+    expect(rebuildDepositTermsCore).not.toHaveBeenCalled();
+  });
+
+  // Threads lifecycle through discovery: broadcast mode would refuse this
+  // sibling, so a successful rebuild proves the presign gate ran instead.
+  it("presign rebuilds terms with an EXPIRED sibling in the batch", async () => {
+    vi.mocked(getVaultFromChain).mockImplementation(async (id: Hex) => {
+      if (id === TARGET_ID) return targetVault;
+      return { ...siblingVault, status: OnChainBtcVaultStatus.EXPIRED };
+    });
+
+    const result = await rebuildDepositTerms({
+      ...baseParams(),
+      lifecycle: "presign",
+    });
+
+    expect(result).toEqual({ prepeginTxid: "sentinel" });
+    expect(rebuildDepositTermsCore).toHaveBeenCalledTimes(1);
+    // The ack timeout must come from the live getTBVProtocolParams read — the
+    // same source the contract consults when it evaluates the window.
+    expect(mockGetTBVProtocolParams).toHaveBeenCalledTimes(1);
+  });
+
+  it("presign accepts the ack-deadline boundary block (contract still accepts it)", async () => {
+    mockGetBlockNumber.mockResolvedValue(ACK_DEADLINE_BLOCK);
+
+    await expect(
+      rebuildDepositTerms({ ...baseParams(), lifecycle: "presign" }),
+    ).resolves.toEqual({ prepeginTxid: "sentinel" });
+  });
+
+  it("presign refuses one block past the ack deadline with the typed error", async () => {
+    mockGetBlockNumber.mockResolvedValue(ACK_DEADLINE_BLOCK + 1n);
+
+    const caught = await rebuildDepositTerms({
+      ...baseParams(),
+      lifecycle: "presign",
+    }).then(
+      () => null,
+      (err: unknown) => err,
+    );
+
+    expect(caught).toBeInstanceOf(VaultLifecycleStateError);
+    expect(caught).toMatchObject({
+      reason: "ack-window-elapsed",
+      stage: "presign",
+      role: "target",
+      // The ACTUAL on-chain status — report-lag leaves it PENDING, and the
+      // error must not falsify EXPIRED.
+      status: OnChainBtcVaultStatus.PENDING,
+      vaultId: TARGET_ID,
+    });
+    expect(rebuildDepositTermsCore).not.toHaveBeenCalled();
+  });
+
+  it("presign fails closed when the current-block read fails", async () => {
+    mockGetBlockNumber.mockRejectedValue(new Error("rpc unavailable"));
+
+    await expect(
+      rebuildDepositTerms({ ...baseParams(), lifecycle: "presign" }),
+    ).rejects.toThrow(/rpc unavailable/);
     expect(rebuildDepositTermsCore).not.toHaveBeenCalled();
   });
 

--- a/services/vault/src/services/vault/__tests__/vaultPeginBroadcastService.test.ts
+++ b/services/vault/src/services/vault/__tests__/vaultPeginBroadcastService.test.ts
@@ -347,6 +347,28 @@ describe("broadcastPrePeginTransaction — resolveInputUtxo behavior", () => {
     expect(mockSignedPsbt.extractTransaction).not.toHaveBeenCalled();
   });
 
+  it("attaches the original wallet error as the broadcast wrapper's cause", async () => {
+    // The cause-walking mappers (user cancellation, method-not-supported)
+    // classify by the inner error's code, which the wrapper message loses.
+    const inner = Object.assign(new Error("nope"), {
+      code: "CONNECTION_REJECTED",
+    });
+    const signPsbt = vi.fn().mockRejectedValue(inner);
+
+    await expect(
+      broadcastPrePeginTransaction({
+        ...baseParams,
+        btcWalletProvider: { signPsbt },
+        expectedUtxos: undefined,
+      }),
+    ).rejects.toMatchObject({
+      message: expect.stringContaining(
+        "Failed to broadcast Pre-PegIn transaction",
+      ),
+      cause: inner,
+    });
+  });
+
   it("preserves PSBT finalization errors when the wallet returns a partially signed PSBT", async () => {
     mockSignedPsbt.finalizeAllInputs.mockImplementationOnce(() => {
       throw new Error("Input #1 is not signed");

--- a/services/vault/src/services/vault/rebuildDepositTerms.ts
+++ b/services/vault/src/services/vault/rebuildDepositTerms.ts
@@ -1,5 +1,5 @@
 /**
- * Rebuild a {@link DepositTerms} on the resume-broadcast path (#2220 Part 2).
+ * Rebuild a {@link DepositTerms} on the resume paths (#2220 Part 2 + #2110).
  *
  * On resume (any browser) the in-memory terms from `preparePegin` are gone, so
  * an intent (Ledger) wallet has nothing to approve. Reconstructs them from
@@ -9,6 +9,14 @@
  * the chain reads + sibling discovery (mirrors `discoverBatch` /
  * `prepareSigningContext` — shared-helper dedupe deferred); the WASM recompute +
  * Gate 0/1 byte-checks live in ts-sdk `rebuildDepositTermsCore`.
+ *
+ * Two lifecycle modes, differing only in the status gate:
+ * - `"broadcast"` (resume Pre-PegIn broadcast): every batch member must still
+ *   be PENDING — a non-PENDING member would be silently funded by the shared tx.
+ * - `"presign"` (resume payout presigning): only the TARGET must be PENDING;
+ *   siblings advance independently and no presigned byte depends on their
+ *   status. Additionally refuses once the target's on-chain ack window has
+ *   elapsed (see {@link assertAckWindowOpen}).
  */
 
 import {
@@ -22,6 +30,10 @@ import {
 import { OnChainBtcVaultStatus } from "@babylonlabs-io/ts-sdk/tbv/core/clients";
 import type { Address, Hex } from "viem";
 
+import {
+  VaultLifecycleStateError,
+  type VaultLifecycleStage,
+} from "@/utils/errors";
 import { assertVaultCoreVersionSupported } from "@/utils/vaultCoreVersionSupport";
 
 import {
@@ -29,6 +41,7 @@ import {
   getVaultKeyEpochsFromChain,
   type OnChainVaultData,
 } from "../../clients/eth-contract/btc-vault-registry/query";
+import { ethClient } from "../../clients/eth-contract/client";
 import {
   getOperationKeyReader,
   getProtocolParamsReader,
@@ -45,7 +58,7 @@ import { resolveVaultProviderBtcPubkey } from "./vaultPayoutSignatureService";
 export interface RebuildDepositTermsParams {
   /** The vault being resumed (any sibling of a batch). */
   vaultId: Hex;
-  /** Caller's getVaultFromChain(vaultId) record, already hash-verified against fundedPrePeginTxHex. */
+  /** Caller's getVaultFromChain(vaultId) record. Callers need not pre-verify it against fundedPrePeginTxHex — the core self-verifies the hash (Gate 0). */
   target: OnChainVaultData;
   /** Funded Pre-PegIn tx hex — the core re-verifies it against the on-chain hash (Gate 0). */
   fundedPrePeginTxHex: string;
@@ -58,6 +71,11 @@ export interface RebuildDepositTermsParams {
    * prevouts the broadcast signs. Becomes the device's `prepegin_max_fee` bound.
    */
   fundedTxFee: bigint;
+  /**
+   * Which resume flow is running — decides the batch status gate (see module
+   * doc). Required so a new caller states its lifecycle explicitly.
+   */
+  lifecycle: VaultLifecycleStage;
 }
 
 interface OrderedSibling extends RebuildSibling {
@@ -78,22 +96,59 @@ const SIBLING_HOMOGENEOUS_FIELDS = [
   "vaultProviderCommissionBps",
 ] as const;
 
+/** Batch member paired with its registry id so a refusal can name the vault. */
+export interface LifecycleBatchMember {
+  vaultId: Hex;
+  vault: OnChainVaultData;
+}
+
+/**
+ * Exported for tests — pure, fail-closed. Chain-read PENDING gate: broadcast
+ * needs EVERY member PENDING (an expired/liquidated sibling would otherwise be
+ * silently funded by the shared tx); presign gates only the TARGET — siblings
+ * advance independently and no presigned byte depends on their status.
+ */
+export function assertBatchLifecycleStatus(
+  lifecycle: VaultLifecycleStage,
+  target: LifecycleBatchMember,
+  siblings: readonly LifecycleBatchMember[],
+): void {
+  const gated =
+    lifecycle === "broadcast"
+      ? [
+          { member: target, role: "target" as const },
+          ...siblings.map((member) => ({ member, role: "sibling" as const })),
+        ]
+      : [{ member: target, role: "target" as const }];
+
+  for (const { member, role } of gated) {
+    if (member.vault.status === OnChainBtcVaultStatus.PENDING) continue;
+    throw new VaultLifecycleStateError(
+      // The broadcast message is load-bearing: mapDepositError buckets on the
+      // word "broadcast" — keep it byte-identical.
+      lifecycle === "broadcast"
+        ? `A vault in this Pre-PegIn batch is no longer awaiting broadcast ` +
+          `(on-chain status ${member.vault.status}); the batch cannot be broadcast ` +
+          `as one transaction. Resume refused.`
+        : `Vault ${member.vaultId} is no longer awaiting payout signatures ` +
+          `(on-chain status ${member.vault.status}); deposit terms cannot ` +
+          `be rebuilt for signing. Resume refused.`,
+      {
+        reason: "invalid-status",
+        stage: lifecycle,
+        role,
+        status: member.vault.status,
+        vaultId: member.vaultId,
+      },
+    );
+  }
+}
+
 /** Exported for tests — pure, fail-closed. */
 export function assertSiblingBatchHomogeneous(
   target: OnChainVaultData,
   siblings: readonly OnChainVaultData[],
 ): void {
-  // Chain-read PENDING gate for EVERY member — an expired/liquidated sibling
-  // would otherwise be silently funded by the shared broadcast.
-  for (const vault of [target, ...siblings]) {
-    if (vault.status !== OnChainBtcVaultStatus.PENDING) {
-      throw new Error(
-        `A vault in this Pre-PegIn batch is no longer awaiting broadcast ` +
-          `(on-chain status ${vault.status}); the batch cannot be broadcast ` +
-          `as one transaction. Resume refused.`,
-      );
-    }
-  }
   for (const sib of siblings) {
     for (const field of SIBLING_HOMOGENEOUS_FIELDS) {
       if (sib[field] !== target[field]) {
@@ -138,6 +193,7 @@ export function assertContiguousHtlcVector(
  * anchor check.
  */
 async function discoverSiblings(
+  lifecycle: VaultLifecycleStage,
   targetVaultId: Hex,
   connectedDepositor: Address,
   target: OnChainVaultData,
@@ -163,10 +219,21 @@ async function discoverSiblings(
   const siblingIds = candidateIds.filter(
     (_, i) => candidateInfos[i].prePeginTxHash.toLowerCase() === txHashLower,
   );
-  const siblingOnChain = (
-    await Promise.all(siblingIds.map((id) => getVaultFromChain(id)))
-  ).filter((sib) => sib.prePeginTxHash.toLowerCase() === txHashLower);
+  const siblingMembers = (
+    await Promise.all(
+      siblingIds.map(async (id) => ({
+        vaultId: id,
+        vault: await getVaultFromChain(id),
+      })),
+    )
+  ).filter(({ vault }) => vault.prePeginTxHash.toLowerCase() === txHashLower);
+  const siblingOnChain = siblingMembers.map(({ vault }) => vault);
 
+  assertBatchLifecycleStatus(
+    lifecycle,
+    { vaultId: targetVaultId, vault: target },
+    siblingMembers,
+  );
   assertSiblingBatchHomogeneous(target, siblingOnChain);
 
   const siblings: OrderedSibling[] = [target, ...siblingOnChain].map((v) => ({
@@ -178,6 +245,41 @@ async function discoverSiblings(
   assertContiguousHtlcVector(siblings);
 
   return siblings;
+}
+
+/**
+ * Presign only: refuse before the device ceremony when the target's ack window
+ * has elapsed — report-lag can leave an ack-expired deposit reading PENDING for
+ * hours, and past the window `submitACK` reverts, so signing is futile.
+ * Any read failure propagates (fail closed).
+ */
+async function assertAckWindowOpen(
+  vaultId: Hex,
+  target: OnChainVaultData,
+): Promise<void> {
+  const paramsReader = await getProtocolParamsReader();
+  const [currentBlock, tbvParams] = await Promise.all([
+    ethClient.getPublicClient().getBlockNumber(),
+    paramsReader.getTBVProtocolParams(),
+  ]);
+  const ackDeadlineBlock = target.createdAt + tbvParams.pegInAckTimeout;
+  // Exact contract mirror, all block numbers: expired iff
+  // block.number > createdAt + pegInAckTimeout (PeginLogic.sol:481, :807).
+  if (currentBlock > ackDeadlineBlock) {
+    throw new VaultLifecycleStateError(
+      `Vault ${vaultId} passed its acknowledgment deadline at block ` +
+        `${ackDeadlineBlock} (current block ${currentBlock}); signing can no ` +
+        `longer complete this deposit. Resume refused.`,
+      {
+        reason: "ack-window-elapsed",
+        stage: "presign",
+        role: "target",
+        // The ACTUAL on-chain status (PENDING here) — never falsified to EXPIRED.
+        status: target.status,
+        vaultId,
+      },
+    );
+  }
 }
 
 /**
@@ -254,10 +356,15 @@ export async function rebuildDepositTerms(
   await assertVaultCoreVersionSupported(target.vaultCoreVersion);
 
   const siblings = await discoverSiblings(
+    params.lifecycle,
     params.vaultId,
     params.connectedDepositorAddress,
     target,
   );
+  // Runs after the status gate, so the refusal reports the still-PENDING status.
+  if (params.lifecycle === "presign") {
+    await assertAckWindowOpen(params.vaultId, target);
+  }
   const { offchainParams, timelockPegin, participantKeys } =
     await readStampedVaultContext(params.vaultId, target);
 

--- a/services/vault/src/services/vault/rebuildDepositTerms.ts
+++ b/services/vault/src/services/vault/rebuildDepositTerms.ts
@@ -31,6 +31,7 @@ import { OnChainBtcVaultStatus } from "@babylonlabs-io/ts-sdk/tbv/core/clients";
 import type { Address, Hex } from "viem";
 
 import {
+  DepositorWalletMismatchError,
   VaultLifecycleStateError,
   type VaultLifecycleStage,
 } from "@/utils/errors";
@@ -199,10 +200,11 @@ async function discoverSiblings(
   target: OnChainVaultData,
 ): Promise<OrderedSibling[]> {
   if (target.depositor.toLowerCase() !== connectedDepositor.toLowerCase()) {
-    throw new Error(
-      `Vault ${targetVaultId} is owned by ${target.depositor}, but the connected ` +
-        `wallet is ${connectedDepositor}. Connect with the depositor wallet to resume.`,
-    );
+    throw new DepositorWalletMismatchError({
+      vaultId: targetVaultId,
+      expectedDepositor: target.depositor,
+      connectedDepositor,
+    });
   }
 
   const txHashLower = target.prePeginTxHash.toLowerCase();
@@ -264,7 +266,8 @@ async function assertAckWindowOpen(
   ]);
   const ackDeadlineBlock = target.createdAt + tbvParams.pegInAckTimeout;
   // Exact contract mirror, all block numbers: expired iff
-  // block.number > createdAt + pegInAckTimeout (PeginLogic.sol:481, :807).
+  // block.number > createdAt + pegInAckTimeout (PeginLogic.submitACK, and the
+  // contrapositive in PeginLogic.reportExpired; vault-contracts-aave-v4 @ 2e87a85a).
   if (currentBlock > ackDeadlineBlock) {
     throw new VaultLifecycleStateError(
       `Vault ${vaultId} passed its acknowledgment deadline at block ` +
@@ -346,6 +349,24 @@ async function readStampedVaultContext(vaultId: Hex, target: OnChainVaultData) {
   return { offchainParams, timelockPegin, participantKeys };
 }
 
+/**
+ * Presign preflight: the two target-only gates `submitACK` itself enforces, in
+ * the contract's order — `status == Pending`, then the ack window
+ * (PeginLogic.submitACK, vault-contracts-aave-v4 @ 2e87a85a). Cheap (one block
+ * read + one params read) and decidable from the target alone, so callers run
+ * it BEFORE the mempool/indexer/sibling reads that precede the full rebuild:
+ * for a stalled deposit the refund copy must win over a transient read error.
+ * `rebuildDepositTerms` re-runs both gates itself — this is an early exit, not
+ * a substitute.
+ */
+export async function assertPresignTargetSignable(
+  vaultId: Hex,
+  target: OnChainVaultData,
+): Promise<void> {
+  assertBatchLifecycleStatus("presign", { vaultId, vault: target }, []);
+  await assertAckWindowOpen(vaultId, target);
+}
+
 export async function rebuildDepositTerms(
   params: RebuildDepositTermsParams,
 ): Promise<DepositTerms> {
@@ -361,7 +382,8 @@ export async function rebuildDepositTerms(
     params.connectedDepositorAddress,
     target,
   );
-  // Runs after the status gate, so the refusal reports the still-PENDING status.
+  // Runs after the status gate, so the refusal reports the still-PENDING
+  // status — the same order as submitACK's two preconditions.
   if (params.lifecycle === "presign") {
     await assertAckWindowOpen(params.vaultId, target);
   }

--- a/services/vault/src/services/vault/vaultPeginBroadcastService.ts
+++ b/services/vault/src/services/vault/vaultPeginBroadcastService.ts
@@ -348,6 +348,10 @@ export async function broadcastPrePeginTransaction(
       throw error;
     }
     const message = error == null ? "Unknown error" : formatError(error);
-    throw new Error(`Failed to broadcast Pre-PegIn transaction: ${message}`);
+    // `cause` keeps the typed inner error visible to the cause-walking
+    // classifiers (user cancellation, method-not-supported) in the mappers.
+    throw new Error(`Failed to broadcast Pre-PegIn transaction: ${message}`, {
+      cause: error,
+    });
   }
 }

--- a/services/vault/src/utils/errors/__tests__/depositErrors.test.ts
+++ b/services/vault/src/utils/errors/__tests__/depositErrors.test.ts
@@ -6,11 +6,13 @@
  */
 
 import {
+  DepositTermsRejectedError,
   PeginRegistrationMissingError,
   PeginRegistrationNotFinalError,
 } from "@babylonlabs-io/ts-sdk/tbv/core";
 import {
   JsonRpcError,
+  OnChainBtcVaultStatus,
   RpcErrorCode,
 } from "@babylonlabs-io/ts-sdk/tbv/core/clients";
 import { describe, expect, it } from "vitest";
@@ -21,6 +23,7 @@ import {
   COMMISSION_UNAVAILABLE_ERROR,
   mapDepositError,
 } from "../depositErrors";
+import { VaultLifecycleStateError } from "../vaultLifecycleStateError";
 
 const ERRORS = COPY.deposit.errors;
 
@@ -246,5 +249,135 @@ describe("mapDepositError", () => {
     expect(
       mapDepositError(new Error(COPY.deposit.resume.wotsMismatchError)),
     ).toEqual(ERRORS.wrongWalletAccount);
+  });
+
+  it("maps a DepositTermsRejectedError instance to the terms-rejected callout", () => {
+    const err = new DepositTermsRejectedError("terms outside device envelope");
+    expect(mapDepositError(err)).toEqual(ERRORS.depositTermsRejected);
+  });
+
+  it("maps the documented structural rejection shape (foreign realm) to the terms-rejected callout", () => {
+    // Providers cannot import the SDK class, so the wire contract is the
+    // shape: name + reason. The guard must match it without instanceof.
+    const err = {
+      name: "DepositTermsRejectedError",
+      reason: "device-envelope",
+      message: "terms outside device envelope",
+    };
+    expect(mapDepositError(err)).toEqual(ERRORS.depositTermsRejected);
+  });
+
+  it("lets a name-only DepositTermsRejectedError shape (contract violation) fall through", () => {
+    const err = {
+      name: "DepositTermsRejectedError",
+      message: "no reason field",
+    };
+    expect(mapDepositError(err)).not.toEqual(ERRORS.depositTermsRejected);
+  });
+
+  it("maps a broadcast-stage lifecycle refusal to the broadcast callout, by type not message", () => {
+    // Same user-visible outcome as the generic-message predecessor (whose
+    // message contained "broadcast"); the message here deliberately doesn't,
+    // so only the typed branch can produce this mapping.
+    const err = new VaultLifecycleStateError("resume refused", {
+      reason: "invalid-status",
+      stage: "broadcast",
+      role: "sibling",
+      status: OnChainBtcVaultStatus.EXPIRED,
+      vaultId: "0xabc",
+    });
+    expect(mapDepositError(err)).toEqual(ERRORS.broadcastFailed);
+  });
+
+  it("does NOT map a presign-stage lifecycle refusal to the broadcast callout", () => {
+    // Presign refusals belong to formatPayoutSignatureError; here they keep
+    // the raw-message fallback instead of claiming a broadcast failed.
+    const err = new VaultLifecycleStateError("presign refused", {
+      reason: "ack-window-elapsed",
+      stage: "presign",
+      role: "target",
+      status: OnChainBtcVaultStatus.PENDING,
+      vaultId: "0xabc",
+    });
+    const result = mapDepositError(err);
+    expect(result).not.toEqual(ERRORS.broadcastFailed);
+    expect(result.title).toBe(ERRORS.defaultTitle);
+  });
+
+  it("maps a top-level WALLET_METHOD_NOT_SUPPORTED code to the unsupported-wallet callout", () => {
+    const err = new FakeWalletError(
+      "WALLET_METHOD_NOT_SUPPORTED",
+      "SomeWallet does not support deriveContextHash",
+    );
+    expect(mapDepositError(err)).toEqual(ERRORS.walletMethodNotSupported);
+  });
+
+  it("finds WALLET_METHOD_NOT_SUPPORTED through a broadcast wrapper's cause chain", () => {
+    // The broadcast catch re-wraps with { cause }; the coded inner error must
+    // beat the "broadcast" substring bucket the wrapper message would hit.
+    const inner = new FakeWalletError(
+      "WALLET_METHOD_NOT_SUPPORTED",
+      "SomeWallet does not support deriveContextHash",
+    );
+    const wrapped = new Error(
+      "Failed to broadcast Pre-PegIn transaction: unsupported",
+      { cause: inner },
+    );
+    expect(mapDepositError(wrapped)).toEqual(ERRORS.walletMethodNotSupported);
+  });
+
+  it("keeps the VP mapping when a JsonRpcError carries an unrelated unsupported-method cause", () => {
+    // Precedence: typed classifications run before the cause walk, so the
+    // meaningful outer VP error must win over the nested code.
+    const err = Object.assign(
+      new JsonRpcError(RpcErrorCode.PEGIN_NOT_FOUND, "PegIn not found"),
+      { cause: { code: "WALLET_METHOD_NOT_SUPPORTED" } },
+    );
+    const result = mapDepositError(err);
+    expect(result.title).toBe("Vault provider syncing");
+  });
+
+  it("terminates on a cyclic cause chain without classifying it as unsupported-method", () => {
+    const err = new Error("cyclic failure");
+    (err as { cause?: unknown }).cause = err;
+    const result = mapDepositError(err);
+    expect(result).not.toEqual(ERRORS.walletMethodNotSupported);
+    expect(result.title).toBe(ERRORS.defaultTitle);
+  });
+
+  it("honors the cause-walk depth limit for the unsupported-method code", () => {
+    // Innermost frame carries the code; wrap it `depth` times so it sits at
+    // cause-depth `depth` from the mapped error.
+    const chainWithCodeAtDepth = (depth: number): Error => {
+      let cur: unknown = { code: "WALLET_METHOD_NOT_SUPPORTED" };
+      for (let i = 0; i < depth; i++) {
+        cur = new Error(`wrapper ${i}`, { cause: cur });
+      }
+      return cur as Error;
+    };
+
+    expect(mapDepositError(chainWithCodeAtDepth(10))).toEqual(
+      ERRORS.walletMethodNotSupported,
+    );
+    expect(mapDepositError(chainWithCodeAtDepth(11))).not.toEqual(
+      ERRORS.walletMethodNotSupported,
+    );
+  });
+
+  it("classifies a coded-only rejection preserved as a wrapper's cause as a signing rejection", () => {
+    // Pins the { cause } side effect at the broadcast wrap sites: a coded
+    // rejection whose message carries no cancellation wording used to flatten
+    // into the wrapper and read as a broadcast failure.
+    const rejection = new FakeWalletError("CONNECTION_REJECTED", "nope");
+    const withCause = new Error(
+      "Failed to broadcast batch Pre-PegIn transaction: nope",
+      { cause: rejection },
+    );
+    expect(mapDepositError(withCause)).toEqual(ERRORS.signingRejected);
+
+    const withoutCause = new Error(
+      "Failed to broadcast batch Pre-PegIn transaction: nope",
+    );
+    expect(mapDepositError(withoutCause)).toEqual(ERRORS.broadcastFailed);
   });
 });

--- a/services/vault/src/utils/errors/__tests__/depositErrors.test.ts
+++ b/services/vault/src/utils/errors/__tests__/depositErrors.test.ts
@@ -23,6 +23,7 @@ import {
   COMMISSION_UNAVAILABLE_ERROR,
   mapDepositError,
 } from "../depositErrors";
+import { DepositorWalletMismatchError } from "../depositorWalletMismatch";
 import { VaultLifecycleStateError } from "../vaultLifecycleStateError";
 
 const ERRORS = COPY.deposit.errors;
@@ -362,6 +363,41 @@ describe("mapDepositError", () => {
     expect(mapDepositError(chainWithCodeAtDepth(11))).not.toEqual(
       ERRORS.walletMethodNotSupported,
     );
+  });
+
+  it("lets a typed top-frame rejection win over an inner unsupported-method cause", () => {
+    // Outer frame is EIP-1193 4001 with no cancellation wording; the cause
+    // carries the unsupported-method code. The rejection is the accurate
+    // reading, and the documented invariant is that an inner unsupported
+    // code never overrides a meaningful outer error.
+    const err = Object.assign(new Error("request failed"), {
+      code: 4001,
+      cause: new FakeWalletError(
+        "WALLET_METHOD_NOT_SUPPORTED",
+        "SomeWallet does not support deriveContextHash",
+      ),
+    });
+    expect(mapDepositError(err)).toEqual(ERRORS.signingRejected);
+  });
+
+  it("keeps the VP mapping for the vault provider's PEGIN_NOT_FOUND (code 4001) — it is not an EIP-1193 rejection", () => {
+    const err = new JsonRpcError(
+      RpcErrorCode.PEGIN_NOT_FOUND,
+      "PegIn not found",
+    );
+    expect(mapDepositError(err)).not.toEqual(ERRORS.signingRejected);
+    expect(mapDepositError(err).title).toBe(
+      COPY.deposit.errors.vp.syncing.title,
+    );
+  });
+
+  it("maps the typed depositor-wallet mismatch from the terms rebuild to its own callout", () => {
+    const err = new DepositorWalletMismatchError({
+      vaultId: "0xabc",
+      expectedDepositor: "0x1111111111111111111111111111111111111111",
+      connectedDepositor: "0x2222222222222222222222222222222222222222",
+    });
+    expect(mapDepositError(err)).toEqual(ERRORS.wrongDepositorWallet);
   });
 
   it("classifies a coded-only rejection preserved as a wrapper's cause as a signing rejection", () => {

--- a/services/vault/src/utils/errors/__tests__/formatting.test.ts
+++ b/services/vault/src/utils/errors/__tests__/formatting.test.ts
@@ -22,6 +22,7 @@ import { describe, expect, it } from "vitest";
 
 import { COPY } from "@/copy";
 
+import { DepositorWalletMismatchError } from "../depositorWalletMismatch";
 import {
   formatErrorDiagnostics,
   formatErrorMessage,
@@ -770,7 +771,7 @@ describe("Error Formatting", () => {
         "SomeWallet does not support deriveContextHash",
       );
       expect(formatPayoutSignatureError(unsupported).title).toBe(
-        COPY.deposit.errors.walletMethodNotSupported.title,
+        COPY.deposit.payoutSignatureErrors.walletMethodNotSupported.title,
       );
     });
 
@@ -857,20 +858,25 @@ describe("Error Formatting", () => {
         status: OnChainBtcVaultStatus.EXPIRED,
         vaultId: "0xabc",
       });
-      expect(formatPayoutSignatureError(err)).toEqual(
+      expect(formatPayoutSignatureError(err)).toMatchObject(
         COPY.deposit.payoutSignatureErrors.unexpected,
       );
     });
 
-    it("maps a top-level WALLET_METHOD_NOT_SUPPORTED code to the unsupported-wallet copy", () => {
+    it("maps a top-level WALLET_METHOD_NOT_SUPPORTED code to the resume-specific unsupported-wallet copy", () => {
       const err = new FakeWalletError(
         "WALLET_METHOD_NOT_SUPPORTED",
         "SomeWallet does not support deriveContextHash",
       );
-      expect(formatPayoutSignatureError(err)).toEqual({
-        title: COPY.deposit.errors.walletMethodNotSupported.title,
-        message: COPY.deposit.errors.walletMethodNotSupported.body,
-      });
+      // Resume copy, not the fresh-deposit copy: an in-flight deposit cannot
+      // be moved to a different wallet, so it must not say "reconnect with a
+      // supported wallet".
+      expect(formatPayoutSignatureError(err)).toEqual(
+        COPY.deposit.payoutSignatureErrors.walletMethodNotSupported,
+      );
+      expect(
+        COPY.deposit.payoutSignatureErrors.walletMethodNotSupported.message,
+      ).not.toContain("supported wallet");
     });
 
     it("finds WALLET_METHOD_NOT_SUPPORTED nested in a wrapper's cause chain", () => {
@@ -880,8 +886,61 @@ describe("Error Formatting", () => {
       );
       const wrapped = new Error("payout signing failed", { cause: inner });
       expect(formatPayoutSignatureError(wrapped).title).toBe(
-        COPY.deposit.errors.walletMethodNotSupported.title,
+        COPY.deposit.payoutSignatureErrors.walletMethodNotSupported.title,
       );
+    });
+
+    it("lets a typed top-frame rejection win over an inner unsupported-method cause", () => {
+      // Outer frame is EIP-1193 4001; the inner cause carries the
+      // unsupported-method code. The rejection is the accurate reading.
+      const err = Object.assign(new Error("User rejected the request."), {
+        code: 4001,
+        cause: new FakeWalletError(
+          "WALLET_METHOD_NOT_SUPPORTED",
+          "SomeWallet does not support deriveContextHash",
+        ),
+      });
+      expect(formatPayoutSignatureError(err)).toEqual(
+        COPY.deposit.payoutSignatureErrors.signingRejected,
+      );
+    });
+
+    it("maps viem's UserRejectedRequestError to the rejection copy", () => {
+      const err = new UserRejectedRequestError(new Error("denied"));
+      expect(formatPayoutSignatureError(err)).toEqual(
+        COPY.deposit.payoutSignatureErrors.signingRejected,
+      );
+    });
+
+    it("maps the typed depositor-wallet mismatch to its own copy", () => {
+      const err = new DepositorWalletMismatchError({
+        vaultId: "0xabc",
+        expectedDepositor: "0x1111111111111111111111111111111111111111",
+        connectedDepositor: "0x2222222222222222222222222222222222222222",
+      });
+      expect(formatPayoutSignatureError(err)).toEqual(
+        COPY.deposit.payoutSignatureErrors.wrongDepositorWallet,
+      );
+    });
+
+    it("maps the app-version-unsupported throw to the app-update copy", () => {
+      const err = new Error(COPY.deposit.errors.appVersionUnsupported.body);
+      expect(formatPayoutSignatureError(err)).toEqual({
+        title: COPY.deposit.errors.appVersionUnsupported.title,
+        message: COPY.deposit.errors.appVersionUnsupported.body,
+      });
+    });
+
+    it("attaches raw diagnostics to the generic Error fallback without leaking them into the message", () => {
+      const err = new Error("sibling batch disagrees on fee rate: 3 vs 5");
+      const result = formatPayoutSignatureError(err);
+      expect(result.title).toBe(
+        COPY.deposit.payoutSignatureErrors.unexpected.title,
+      );
+      expect(result.message).toBe(
+        COPY.deposit.payoutSignatureErrors.unexpected.message,
+      );
+      expect(result.diagnostics).toContain("sibling batch disagrees");
     });
 
     it("keeps the VP mapping when a JsonRpcError carries an unrelated unsupported-method cause", () => {

--- a/services/vault/src/utils/errors/__tests__/formatting.test.ts
+++ b/services/vault/src/utils/errors/__tests__/formatting.test.ts
@@ -2,8 +2,10 @@
  * Tests for error formatting utilities
  */
 
+import { DepositTermsRejectedError } from "@babylonlabs-io/ts-sdk/tbv/core";
 import {
   JsonRpcError,
+  OnChainBtcVaultStatus,
   RpcErrorCode,
 } from "@babylonlabs-io/ts-sdk/tbv/core/clients";
 import { readFileSync } from "fs";
@@ -27,6 +29,7 @@ import {
   mapVpRpcError,
   sanitizeErrorMessage,
 } from "../formatting";
+import { VaultLifecycleStateError } from "../vaultLifecycleStateError";
 
 class FakeWalletError extends Error {
   constructor(
@@ -745,6 +748,150 @@ describe("Error Formatting", () => {
       );
       expect(formatPayoutSignatureError(rejection).title).toBe(
         "Signing rejected",
+      );
+    });
+
+    // Same drift guard for the second inlined wallet-connector code (see the
+    // CONNECTION_REJECTED note above): a rename upstream must fail here
+    // instead of silently degrading the unsupported-wallet branch.
+    it("inlined WALLET_METHOD_NOT_SUPPORTED code matches wallet-connector source", () => {
+      const codesPath = resolve(
+        __dirname,
+        "../../../../../../packages/babylon-wallet-connector/src/error/codes.ts",
+      );
+      const source = readFileSync(codesPath, "utf8");
+      const match = source.match(/WALLET_METHOD_NOT_SUPPORTED:\s*"([^"]+)"/);
+
+      expect(match).not.toBeNull();
+      expect(match?.[1]).toBe("WALLET_METHOD_NOT_SUPPORTED");
+
+      const unsupported = new FakeWalletError(
+        match![1],
+        "SomeWallet does not support deriveContextHash",
+      );
+      expect(formatPayoutSignatureError(unsupported).title).toBe(
+        COPY.deposit.errors.walletMethodNotSupported.title,
+      );
+    });
+
+    it("maps a DepositTermsRejectedError instance to the terms-rejected copy", () => {
+      const result = formatPayoutSignatureError(
+        new DepositTermsRejectedError("terms outside device envelope"),
+      );
+      expect(result).toEqual({
+        title: COPY.deposit.errors.depositTermsRejected.title,
+        message: COPY.deposit.errors.depositTermsRejected.body,
+      });
+    });
+
+    it("maps the documented structural rejection shape to the terms-rejected copy", () => {
+      const result = formatPayoutSignatureError({
+        name: "DepositTermsRejectedError",
+        reason: "device-envelope",
+        message: "terms outside device envelope",
+      });
+      expect(result.title).toBe(COPY.deposit.errors.depositTermsRejected.title);
+    });
+
+    it("lets a name-only rejection shape (no reason) fall through to the fallback", () => {
+      const result = formatPayoutSignatureError({
+        name: "DepositTermsRejectedError",
+        message: "no reason field",
+      });
+      expect(result.title).not.toBe(
+        COPY.deposit.errors.depositTermsRejected.title,
+      );
+      expect(result.title).toBe(
+        COPY.deposit.payoutSignatureErrors.fallback.title,
+      );
+    });
+
+    it("maps a presign ack-window-elapsed refusal to the timed-out refund copy", () => {
+      // The service reports the ACTUAL status (still PENDING) — the reason
+      // field alone selects the timed-out copy.
+      const err = new VaultLifecycleStateError("ack window elapsed", {
+        reason: "ack-window-elapsed",
+        stage: "presign",
+        role: "target",
+        status: OnChainBtcVaultStatus.PENDING,
+        vaultId: "0xabc",
+      });
+      expect(formatPayoutSignatureError(err)).toEqual(
+        COPY.deposit.payoutSignatureErrors.ackWindowElapsed,
+      );
+    });
+
+    it("maps a presign EXPIRED-target refusal to the timed-out refund copy", () => {
+      const err = new VaultLifecycleStateError("target expired", {
+        reason: "invalid-status",
+        stage: "presign",
+        role: "target",
+        status: OnChainBtcVaultStatus.EXPIRED,
+        vaultId: "0xabc",
+      });
+      expect(formatPayoutSignatureError(err)).toEqual(
+        COPY.deposit.payoutSignatureErrors.ackWindowElapsed,
+      );
+    });
+
+    it("maps other presign invalid-status refusals to the no-signatures-needed copy", () => {
+      const err = new VaultLifecycleStateError("target verified", {
+        reason: "invalid-status",
+        stage: "presign",
+        role: "target",
+        status: OnChainBtcVaultStatus.VERIFIED,
+        vaultId: "0xabc",
+      });
+      expect(formatPayoutSignatureError(err)).toEqual(
+        COPY.deposit.payoutSignatureErrors.signaturesNoLongerNeeded,
+      );
+    });
+
+    it("does not claim a broadcast-stage refusal is a presign outcome", () => {
+      // Broadcast-stage refusals belong to mapDepositError; here they take
+      // the generic payout-signing fallback instead of refund copy.
+      const err = new VaultLifecycleStateError("resume refused", {
+        reason: "invalid-status",
+        stage: "broadcast",
+        role: "sibling",
+        status: OnChainBtcVaultStatus.EXPIRED,
+        vaultId: "0xabc",
+      });
+      expect(formatPayoutSignatureError(err)).toEqual(
+        COPY.deposit.payoutSignatureErrors.unexpected,
+      );
+    });
+
+    it("maps a top-level WALLET_METHOD_NOT_SUPPORTED code to the unsupported-wallet copy", () => {
+      const err = new FakeWalletError(
+        "WALLET_METHOD_NOT_SUPPORTED",
+        "SomeWallet does not support deriveContextHash",
+      );
+      expect(formatPayoutSignatureError(err)).toEqual({
+        title: COPY.deposit.errors.walletMethodNotSupported.title,
+        message: COPY.deposit.errors.walletMethodNotSupported.body,
+      });
+    });
+
+    it("finds WALLET_METHOD_NOT_SUPPORTED nested in a wrapper's cause chain", () => {
+      const inner = new FakeWalletError(
+        "WALLET_METHOD_NOT_SUPPORTED",
+        "SomeWallet does not support deriveContextHash",
+      );
+      const wrapped = new Error("payout signing failed", { cause: inner });
+      expect(formatPayoutSignatureError(wrapped).title).toBe(
+        COPY.deposit.errors.walletMethodNotSupported.title,
+      );
+    });
+
+    it("keeps the VP mapping when a JsonRpcError carries an unrelated unsupported-method cause", () => {
+      // Precedence: typed classifications run before the cause walk.
+      const err = Object.assign(
+        new JsonRpcError(RpcErrorCode.PEGIN_NOT_FOUND, "PegIn not found"),
+        { cause: { code: "WALLET_METHOD_NOT_SUPPORTED" } },
+      );
+      expect(formatPayoutSignatureError(err).title).toBe(
+        "Vault provider syncing",
       );
     });
   });

--- a/services/vault/src/utils/errors/depositErrors.ts
+++ b/services/vault/src/utils/errors/depositErrors.ts
@@ -16,6 +16,12 @@
  *  - Registered-version mismatch — protocol params rotated mid-deposit.
  *  - Ethereum registration finality — the registration never reached the
  *    required confirmation depth, or disappeared from chain state entirely.
+ *  - Deposit-terms rejection — the signing device's envelope refused the
+ *    terms before approval (typed SDK error; can be terminal).
+ *  - Lifecycle refusal — the DepositTerms rebuild's typed status gate
+ *    (broadcast stage keeps its historical broadcast-bucket copy).
+ *  - Wallet method not supported — the connected wallet lacks a required
+ *    method (coded, cause-walking; runs after every typed bucket above).
  *  - Wallet not connected / wallet client missing.
  *  - Wallet account changed mid-flow (the WOTS-vs-PoP key guard).
  *  - Wrong wallet connected on resume (WOTS hash mismatch).
@@ -30,6 +36,7 @@
  */
 
 import {
+  isDepositTermsRejectedError,
   isParticipantKeyDriftError,
   isPeginRegistrationMissingError,
   isPeginRegistrationNotFinalError,
@@ -47,7 +54,9 @@ import {
   sanitizeErrorMessage,
 } from "./formatting";
 import { isUserCancellation, isWalletRejectionError } from "./userCancellation";
+import { isVaultLifecycleStateError } from "./vaultLifecycleStateError";
 import { isVaultRecordEmptyError } from "./vaultRecordEmpty";
+import { isWalletMethodNotSupported } from "./walletMethodNotSupported";
 
 export interface DepositErrorContent {
   title: string;
@@ -140,6 +149,26 @@ export function mapDepositError(err: unknown): DepositErrorContent {
     return ERRORS.ethRegistrationMissing;
   }
 
+  // 3d. Device-envelope rejection of the deposit terms. Can be terminal for
+  // this deposit, so the copy points at support instead of a retry.
+  if (isDepositTermsRejectedError(err)) {
+    return ERRORS.depositTermsRejected;
+  }
+
+  // 3e. Typed lifecycle refusal from the DepositTerms rebuild. The broadcast
+  // stage keeps the copy its generic-message predecessor landed on (the old
+  // message contained "broadcast", so it hit the broadcast bucket below).
+  if (isVaultLifecycleStateError(err) && err.stage === "broadcast") {
+    return ERRORS.broadcastFailed;
+  }
+
+  // 3f. Wallet lacks a required method. Cause-walking, so it must run AFTER
+  // every typed bucket above — an inner unsupported-method code must never
+  // override a meaningful outer wallet/VP/contract error.
+  if (isWalletMethodNotSupported(err)) {
+    return ERRORS.walletMethodNotSupported;
+  }
+
   const msg = lowerMessage(err);
 
   // 4. Wallet account changed mid-flow (WOTS-vs-PoP key guard).
@@ -211,10 +240,11 @@ export function mapDepositError(err: unknown): DepositErrorContent {
     return { title: COPY.wallet.liveness.errorTitle, body: livenessBody };
   }
 
-  // 6. Wallet signing rejection. The coded path (step 1) misses rejections that
-  // happen inside the broadcast step, because that catch re-wraps them in a
-  // fresh Error (losing the code). Checked before the broadcast bucket so
-  // "Failed to broadcast ...: user rejected" reads as a rejection.
+  // 6. Wallet signing rejection. The coded path (step 1) checks only the
+  // top-level code, so it misses rejections the broadcast step re-wrapped;
+  // this cause-walking check catches them by wording or by the coded inner
+  // frame the wrapper now preserves as `cause`. Checked before the broadcast
+  // bucket so "Failed to broadcast ...: user rejected" reads as a rejection.
   //
   // Shares its vocabulary with the Sentry-side drop rather than keeping a local
   // wording list: a cancellation that telemetry correctly suppressed used to

--- a/services/vault/src/utils/errors/depositErrors.ts
+++ b/services/vault/src/utils/errors/depositErrors.ts
@@ -9,10 +9,13 @@
  * an error reaches the view it is already a friendly { title, body }.
  *
  * Enumerated error sources (the map's spec):
- *  - Wallet rejection — user declines a signing prompt (CONNECTION_REJECTED, or
- *    "user rejected" / "denied" in the message).
  *  - Vault-provider RPC — JsonRpcError from the VP (syncing, timeout, network,
- *    proxy timeout/unavailable, generic). Delegated to `mapVpRpcError`.
+ *    proxy timeout/unavailable, generic). Delegated to `mapVpRpcError`. Runs
+ *    first: the VP's PEGIN_NOT_FOUND is numeric 4001, same as EIP-1193's
+ *    userRejectedRequest.
+ *  - Wallet rejection — user declines a signing prompt (typed top frame:
+ *    EIP-1193 4001 / viem UserRejectedRequestError / CONNECTION_REJECTED; or,
+ *    later and cause-walking, "user rejected" / "denied" wording).
  *  - Registered-version mismatch — protocol params rotated mid-deposit.
  *  - Ethereum registration finality — the registration never reached the
  *    required confirmation depth, or disappeared from chain state entirely.
@@ -20,6 +23,8 @@
  *    terms before approval (typed SDK error; can be terminal).
  *  - Lifecycle refusal — the DepositTerms rebuild's typed status gate
  *    (broadcast stage keeps its historical broadcast-bucket copy).
+ *  - Depositor wallet mismatch — the DepositTerms rebuild's typed refusal when
+ *    the connected Ethereum account is not the vault's depositor.
  *  - Wallet method not supported — the connected wallet lacks a required
  *    method (coded, cause-walking; runs after every typed bucket above).
  *  - Wallet not connected / wallet client missing.
@@ -47,13 +52,17 @@ import { type ReactNode } from "react";
 
 import { COPY } from "@/copy";
 
+import { isDepositorWalletMismatchError } from "./depositorWalletMismatch";
 import {
   classifyError,
   formatErrorDiagnostics,
   mapVpRpcError,
   sanitizeErrorMessage,
 } from "./formatting";
-import { isUserCancellation, isWalletRejectionError } from "./userCancellation";
+import {
+  isTypedUserRejectionFrame,
+  isUserCancellation,
+} from "./userCancellation";
 import { isVaultLifecycleStateError } from "./vaultLifecycleStateError";
 import { isVaultRecordEmptyError } from "./vaultRecordEmpty";
 import { isWalletMethodNotSupported } from "./walletMethodNotSupported";
@@ -115,15 +124,19 @@ function lowerMessage(err: unknown): string {
  * Pure: no side effects, safe to unit-test directly.
  */
 export function mapDepositError(err: unknown): DepositErrorContent {
-  // 1. Wallet rejection (coded) — most specific signal.
-  if (isWalletRejectionError(err)) {
-    return ERRORS.signingRejected;
-  }
-
-  // 2. Vault-provider JSON-RPC errors — reuse the shared VP mapping.
+  // 1. Vault-provider JSON-RPC errors — reuse the shared VP mapping. Must
+  // run before the typed-rejection check: the VP's PEGIN_NOT_FOUND is the
+  // numeric code 4001, which EIP-1193 also uses for userRejectedRequest.
   if (err instanceof JsonRpcError) {
     const { title, message } = mapVpRpcError(err);
     return { title, body: message };
+  }
+
+  // 2. Typed top-frame user rejection (EIP-1193 4001, viem, wallet-connector
+  // code) — most specific wallet signal. Top frame only; the cause-walking
+  // wording check is step 6, deliberately below the typed buckets.
+  if (isTypedUserRejectionFrame(err)) {
+    return ERRORS.signingRejected;
   }
 
   // 3. Protocol-parameter version mismatch (registered vault drifted).
@@ -162,9 +175,15 @@ export function mapDepositError(err: unknown): DepositErrorContent {
     return ERRORS.broadcastFailed;
   }
 
-  // 3f. Wallet lacks a required method. Cause-walking, so it must run AFTER
+  // 3f. Typed depositor-wallet refusal from the DepositTerms rebuild.
+  if (isDepositorWalletMismatchError(err)) {
+    return ERRORS.wrongDepositorWallet;
+  }
+
+  // 3g. Wallet lacks a required method. Cause-walking, so it must run AFTER
   // every typed bucket above — an inner unsupported-method code must never
-  // override a meaningful outer wallet/VP/contract error.
+  // override a meaningful outer wallet/VP/contract error (step 2 already
+  // claimed any typed top-frame rejection).
   if (isWalletMethodNotSupported(err)) {
     return ERRORS.walletMethodNotSupported;
   }
@@ -240,8 +259,8 @@ export function mapDepositError(err: unknown): DepositErrorContent {
     return { title: COPY.wallet.liveness.errorTitle, body: livenessBody };
   }
 
-  // 6. Wallet signing rejection. The coded path (step 1) checks only the
-  // top-level code, so it misses rejections the broadcast step re-wrapped;
+  // 6. Wallet signing rejection. The typed path (step 2) checks only the
+  // top-level frame, so it misses rejections the broadcast step re-wrapped;
   // this cause-walking check catches them by wording or by the coded inner
   // frame the wrapper now preserves as `cause`. Checked before the broadcast
   // bucket so "Failed to broadcast ...: user rejected" reads as a rejection.

--- a/services/vault/src/utils/errors/depositorWalletMismatch.ts
+++ b/services/vault/src/utils/errors/depositorWalletMismatch.ts
@@ -1,0 +1,36 @@
+import type { Address, Hex } from "viem";
+
+/**
+ * Typed refusal from the DepositTerms rebuild when the connected Ethereum
+ * wallet is not the vault's depositor. The most user-fixable thing the rebuild
+ * can throw, so both mappers branch on the class (not the message) and render
+ * "connect the depositor wallet" instead of the generic fallback.
+ */
+export class DepositorWalletMismatchError extends Error {
+  readonly vaultId: Hex;
+  readonly expectedDepositor: Address;
+  readonly connectedDepositor: Address;
+
+  constructor(fields: {
+    vaultId: Hex;
+    expectedDepositor: Address;
+    connectedDepositor: Address;
+  }) {
+    super(
+      `Vault ${fields.vaultId} is owned by ${fields.expectedDepositor}, but the ` +
+        `connected wallet is ${fields.connectedDepositor}. Connect with the ` +
+        `depositor wallet to resume.`,
+    );
+    this.name = "DepositorWalletMismatchError";
+    this.vaultId = fields.vaultId;
+    this.expectedDepositor = fields.expectedDepositor;
+    this.connectedDepositor = fields.connectedDepositor;
+  }
+}
+
+/** True when `err` is the rebuild's typed depositor-wallet refusal. */
+export function isDepositorWalletMismatchError(
+  err: unknown,
+): err is DepositorWalletMismatchError {
+  return err instanceof DepositorWalletMismatchError;
+}

--- a/services/vault/src/utils/errors/formatting.ts
+++ b/services/vault/src/utils/errors/formatting.ts
@@ -3,9 +3,11 @@
  * Transform errors to user-friendly messages
  */
 
+import { isDepositTermsRejectedError } from "@babylonlabs-io/ts-sdk/tbv/core";
 import {
   JSON_RPC_ERROR_CODES,
   JsonRpcError,
+  OnChainBtcVaultStatus,
   RpcErrorCode,
 } from "@babylonlabs-io/ts-sdk/tbv/core/clients";
 
@@ -15,7 +17,9 @@ import {
   isUserCancellationFrame,
   isWalletRejectionError,
 } from "./userCancellation";
+import { isVaultLifecycleStateError } from "./vaultLifecycleStateError";
 import { isVaultRecordEmptyError } from "./vaultRecordEmpty";
+import { isWalletMethodNotSupported } from "./walletMethodNotSupported";
 
 /** EIP-1193 provider error codes used by the classifier below. */
 const EIP1193 = {
@@ -473,37 +477,61 @@ export function formatErrorMessage(error: unknown): string {
 }
 
 /**
- * Format payout signature errors with user-friendly messages
+ * Format payout signature errors with user-friendly messages. Typed
+ * classifications run first (VP RPC, wallet rejection, deposit-terms
+ * rejection, lifecycle refusal), then the cause-walking method-not-supported
+ * check, then message-level matching — mirroring `mapDepositError`'s
+ * precedence so the two mappers cannot disagree on the same error.
  */
 export function formatPayoutSignatureError(error: unknown): {
   title: string;
   message: string;
 } {
+  const PSE = COPY.deposit.payoutSignatureErrors;
+
   if (error instanceof JsonRpcError) {
     return mapVpRpcError(error);
   }
 
   if (isWalletRejectionError(error)) {
+    return PSE.signingRejected;
+  }
+
+  // Device-envelope rejection of the deposit terms. Can be terminal for this
+  // deposit, so the copy points at support instead of a retry.
+  if (isDepositTermsRejectedError(error)) {
     return {
-      title: "Signing rejected",
-      message:
-        "You rejected the signing request in your wallet. Approve the request to continue, or click Retry to try again.",
+      title: COPY.deposit.errors.depositTermsRejected.title,
+      message: COPY.deposit.errors.depositTermsRejected.body,
+    };
+  }
+
+  // Typed lifecycle refusal from the presign-terms rebuild. An elapsed ack
+  // window — or an already-EXPIRED target — is routine for a stalled deposit,
+  // so it gets refund copy; any other status means signing is simply over.
+  if (isVaultLifecycleStateError(error) && error.stage === "presign") {
+    const timedOut =
+      error.reason === "ack-window-elapsed" ||
+      (error.reason === "invalid-status" &&
+        error.status === OnChainBtcVaultStatus.EXPIRED);
+    return timedOut ? PSE.ackWindowElapsed : PSE.signaturesNoLongerNeeded;
+  }
+
+  // Cause-walking, so it must run AFTER every typed bucket above — an inner
+  // unsupported-method code must never override a meaningful outer error.
+  if (isWalletMethodNotSupported(error)) {
+    return {
+      title: COPY.deposit.errors.walletMethodNotSupported.title,
+      message: COPY.deposit.errors.walletMethodNotSupported.body,
     };
   }
 
   if (error instanceof Error) {
     if (error.message.includes("Vault provider not found")) {
-      return {
-        title: "Vault provider not found",
-        message:
-          "The vault provider for this deposit could not be found. Please contact support.",
-      };
+      return PSE.providerNotFound;
     }
     if (error.message.includes("BTC wallet not connected")) {
-      return {
-        title: "Wallet not connected",
-        message: "Please reconnect your Bitcoin wallet to continue.",
-      };
+      return PSE.walletNotConnected;
     }
     // Empty vault record from the registry reader. Usually a lagging RPC
     // node rather than a missing deposit, so the copy points at waiting
@@ -518,18 +546,10 @@ export function formatPayoutSignatureError(error: unknown): {
     }
     // Contract call errors (viem) — surface a meaningful message instead of swallowing
     if (error.message.includes("reverted")) {
-      return {
-        title: "Contract call failed",
-        message:
-          "A contract call failed during payout signing. The on-chain BTC Vault data may be unavailable. Please try again or contact support.",
-      };
+      return PSE.contractCallFailed;
     }
 
-    return {
-      title: "Payout signing error",
-      message:
-        "An unexpected error occurred while signing payouts. Please try again or contact support.",
-    };
+    return PSE.unexpected;
   }
 
   // WASM panics and some wallet providers throw strings or plain objects.
@@ -547,10 +567,7 @@ export function formatPayoutSignatureError(error: unknown): {
     msg = (error as { message: string }).message;
   }
   return {
-    title: "Payout signing error",
-    message:
-      msg && msg !== "[object Object]"
-        ? msg
-        : "An unexpected error occurred while signing payouts.",
+    title: PSE.fallback.title,
+    message: msg && msg !== "[object Object]" ? msg : PSE.fallback.message,
   };
 }

--- a/services/vault/src/utils/errors/formatting.ts
+++ b/services/vault/src/utils/errors/formatting.ts
@@ -13,9 +13,10 @@ import {
 
 import { COPY } from "@/copy";
 
+import { isDepositorWalletMismatchError } from "./depositorWalletMismatch";
 import {
+  isTypedUserRejectionFrame,
   isUserCancellationFrame,
-  isWalletRejectionError,
 } from "./userCancellation";
 import { isVaultLifecycleStateError } from "./vaultLifecycleStateError";
 import { isVaultRecordEmptyError } from "./vaultRecordEmpty";
@@ -478,14 +479,20 @@ export function formatErrorMessage(error: unknown): string {
 
 /**
  * Format payout signature errors with user-friendly messages. Typed
- * classifications run first (VP RPC, wallet rejection, deposit-terms
- * rejection, lifecycle refusal), then the cause-walking method-not-supported
- * check, then message-level matching — mirroring `mapDepositError`'s
- * precedence so the two mappers cannot disagree on the same error.
+ * classifications run first (VP RPC, top-frame typed user rejection,
+ * deposit-terms rejection, lifecycle refusal, depositor mismatch), then the
+ * cause-walking method-not-supported check, then message-level matching.
+ *
+ * Same typed-bucket ORDER as `mapDepositError`, not identical behaviour: the
+ * deposit mapper additionally walks `cause` for cancellation wording (its
+ * broadcast step re-wraps wallet errors); this mapper is deliberately
+ * code-only for rejections (#1484) because nothing on the presign path
+ * re-wraps, and a wording match would misread other wallet codes.
  */
 export function formatPayoutSignatureError(error: unknown): {
   title: string;
   message: string;
+  diagnostics?: string;
 } {
   const PSE = COPY.deposit.payoutSignatureErrors;
 
@@ -493,7 +500,10 @@ export function formatPayoutSignatureError(error: unknown): {
     return mapVpRpcError(error);
   }
 
-  if (isWalletRejectionError(error)) {
+  // Typed top-frame rejection (EIP-1193 4001, viem, wallet-connector code).
+  // Runs before the cause-walking unsupported-method bucket below so an outer
+  // rejection wrapping an inner unsupported-method cause reads as a rejection.
+  if (isTypedUserRejectionFrame(error)) {
     return PSE.signingRejected;
   }
 
@@ -517,13 +527,17 @@ export function formatPayoutSignatureError(error: unknown): {
     return timedOut ? PSE.ackWindowElapsed : PSE.signaturesNoLongerNeeded;
   }
 
+  // Typed depositor-wallet refusal from the terms rebuild — the most
+  // user-fixable error the rebuild can throw, so it never hits the fallback.
+  if (isDepositorWalletMismatchError(error)) {
+    return PSE.wrongDepositorWallet;
+  }
+
   // Cause-walking, so it must run AFTER every typed bucket above — an inner
   // unsupported-method code must never override a meaningful outer error.
+  // Resume-specific copy: an in-flight deposit cannot switch wallets.
   if (isWalletMethodNotSupported(error)) {
-    return {
-      title: COPY.deposit.errors.walletMethodNotSupported.title,
-      message: COPY.deposit.errors.walletMethodNotSupported.body,
-    };
+    return PSE.walletMethodNotSupported;
   }
 
   if (error instanceof Error) {
@@ -532,6 +546,14 @@ export function formatPayoutSignatureError(error: unknown): {
     }
     if (error.message.includes("BTC wallet not connected")) {
       return PSE.walletNotConnected;
+    }
+    // assertVaultCoreVersionSupported throws the user-facing body verbatim
+    // (same match as mapDepositError 4c') — the rebuild runs it on presign.
+    if (error.message === COPY.deposit.errors.appVersionUnsupported.body) {
+      return {
+        title: COPY.deposit.errors.appVersionUnsupported.title,
+        message: COPY.deposit.errors.appVersionUnsupported.body,
+      };
     }
     // Empty vault record from the registry reader. Usually a lagging RPC
     // node rather than a missing deposit, so the copy points at waiting
@@ -549,7 +571,10 @@ export function formatPayoutSignatureError(error: unknown): {
       return PSE.contractCallFailed;
     }
 
-    return PSE.unexpected;
+    // Generic title/body stay generic (raw `Error.message` is never shown,
+    // #1290); the raw error rides along as `diagnostics` for a bug report,
+    // mirroring `mapDepositError`'s fallback bucket.
+    return { ...PSE.unexpected, diagnostics: formatErrorDiagnostics(error) };
   }
 
   // WASM panics and some wallet providers throw strings or plain objects.

--- a/services/vault/src/utils/errors/index.ts
+++ b/services/vault/src/utils/errors/index.ts
@@ -2,4 +2,5 @@ export * from "./contract";
 export * from "./depositErrors";
 export * from "./formatting";
 export * from "./types";
+export * from "./vaultLifecycleStateError";
 export * from "./vaultRecordEmpty";

--- a/services/vault/src/utils/errors/index.ts
+++ b/services/vault/src/utils/errors/index.ts
@@ -1,5 +1,6 @@
 export * from "./contract";
 export * from "./depositErrors";
+export * from "./depositorWalletMismatch";
 export * from "./formatting";
 export * from "./types";
 export * from "./vaultLifecycleStateError";

--- a/services/vault/src/utils/errors/userCancellation.ts
+++ b/services/vault/src/utils/errors/userCancellation.ts
@@ -68,23 +68,25 @@ const USER_CANCELLATION_PATTERN =
 const MAX_CAUSE_DEPTH = 10;
 
 /**
- * True when `error` carries the wallet-connector `CONNECTION_REJECTED` code.
- *
- * Lives here rather than in `formatting.ts` so the code constant and the
- * predicate that reads it stay in the same dependency-free module.
+ * True when this single error frame carries a TYPED user-rejection signal:
+ * EIP-1193 4001, viem's `UserRejectedRequestError`, or the wallet-connector
+ * `CONNECTION_REJECTED` code. No wording match and no `cause` walk, so a
+ * mapper can run it ahead of cause-walking buckets without letting an inner
+ * frame or incidental wording override a more specific outer error.
  */
-export function isWalletRejectionError(error: unknown): boolean {
+export function isTypedUserRejectionFrame(frame: unknown): boolean {
+  if (!frame || typeof frame !== "object") return false;
+  const { code, name } = frame as { code?: unknown; name?: unknown };
   return (
-    error instanceof Error &&
-    "code" in error &&
-    (error as { code: unknown }).code === WALLET_CONNECTION_REJECTED_CODE
+    code === EIP1193_USER_REJECTED ||
+    code === WALLET_CONNECTION_REJECTED_CODE ||
+    name === "UserRejectedRequestError"
   );
 }
 
 /**
  * True when this single error frame is a user cancellation - typed signals
- * (EIP-1193 4001, viem's `UserRejectedRequestError`, the wallet-connector
- * `CONNECTION_REJECTED` code) first, then wording.
+ * ({@link isTypedUserRejectionFrame}) first, then wording.
  *
  * Deliberately does NOT walk `cause`. Callers that classify per frame need to
  * decide precedence across frames themselves: `classifyError` is depth-first
@@ -94,17 +96,9 @@ export function isWalletRejectionError(error: unknown): boolean {
  */
 export function isUserCancellationFrame(frame: unknown): boolean {
   if (typeof frame === "string") return USER_CANCELLATION_PATTERN.test(frame);
+  if (isTypedUserRejectionFrame(frame)) return true;
   if (!frame || typeof frame !== "object") return false;
-
-  const { code, name, message } = frame as {
-    code?: unknown;
-    name?: unknown;
-    message?: unknown;
-  };
-
-  if (code === EIP1193_USER_REJECTED) return true;
-  if (code === WALLET_CONNECTION_REJECTED_CODE) return true;
-  if (name === "UserRejectedRequestError") return true;
+  const { message } = frame as { message?: unknown };
   return typeof message === "string" && USER_CANCELLATION_PATTERN.test(message);
 }
 

--- a/services/vault/src/utils/errors/vaultLifecycleStateError.ts
+++ b/services/vault/src/utils/errors/vaultLifecycleStateError.ts
@@ -1,0 +1,57 @@
+import { OnChainBtcVaultStatus } from "@babylonlabs-io/ts-sdk/tbv/core/clients";
+import type { Hex } from "viem";
+
+/** Why the lifecycle gate refused the batch member. */
+export type VaultLifecycleFailureReason =
+  | "invalid-status"
+  | "ack-window-elapsed";
+
+/** Which resume flow ran the gate — the two flows accept different statuses. */
+export type VaultLifecycleStage = "broadcast" | "presign";
+
+/** Whether the refused vault is the resumed vault or a discovered sibling. */
+export type VaultLifecycleRole = "target" | "sibling";
+
+/**
+ * Typed refusal from the DepositTerms rebuild's lifecycle gate.
+ *
+ * Thrown instead of a bare `Error` so the UI mappers can branch on the
+ * machine-readable fields rather than the message: a presign-stage EXPIRED
+ * target needs refund-path copy, while the broadcast-stage refusal keeps its
+ * existing mapping. `status` always carries the ACTUAL on-chain status — an
+ * ack-window refusal reports `reason: "ack-window-elapsed"` with the still-
+ * PENDING status, never a fabricated EXPIRED.
+ */
+export class VaultLifecycleStateError extends Error {
+  readonly reason: VaultLifecycleFailureReason;
+  readonly stage: VaultLifecycleStage;
+  readonly role: VaultLifecycleRole;
+  readonly status: OnChainBtcVaultStatus;
+  readonly vaultId: Hex;
+
+  constructor(
+    message: string,
+    fields: {
+      reason: VaultLifecycleFailureReason;
+      stage: VaultLifecycleStage;
+      role: VaultLifecycleRole;
+      status: OnChainBtcVaultStatus;
+      vaultId: Hex;
+    },
+  ) {
+    super(message);
+    this.name = "VaultLifecycleStateError";
+    this.reason = fields.reason;
+    this.stage = fields.stage;
+    this.role = fields.role;
+    this.status = fields.status;
+    this.vaultId = fields.vaultId;
+  }
+}
+
+/** True when `err` is the rebuild's typed lifecycle refusal. */
+export function isVaultLifecycleStateError(
+  err: unknown,
+): err is VaultLifecycleStateError {
+  return err instanceof VaultLifecycleStateError;
+}

--- a/services/vault/src/utils/errors/walletMethodNotSupported.ts
+++ b/services/vault/src/utils/errors/walletMethodNotSupported.ts
@@ -1,0 +1,44 @@
+/**
+ * Detection of the wallet-connector "method not supported" code.
+ *
+ * The single definition of "the connected wallet cannot perform a required
+ * method", shared by `mapDepositError` and `formatPayoutSignatureError` so the
+ * two mappers cannot drift apart. Deliberately dependency-free, mirroring
+ * `userCancellation.ts`: the code constant is inlined rather than imported
+ * from `@babylonlabs-io/wallet-connector` to keep that bundle out of this
+ * module (and its test transform).
+ */
+
+/**
+ * Wallet-connector error code thrown when a wallet does not implement a
+ * required method (e.g. `deriveContextHash`). Mirrors
+ * `ERROR_CODES.WALLET_METHOD_NOT_SUPPORTED`; if it ever changes upstream,
+ * this string must change too (a drift-guard test in formatting.test.ts
+ * reads the upstream codes.ts source to enforce that).
+ */
+const WALLET_METHOD_NOT_SUPPORTED_CODE = "WALLET_METHOD_NOT_SUPPORTED";
+
+/** How far to walk a `cause` chain before giving up (mirrors isUserCancellation). */
+const MAX_CAUSE_DEPTH = 10;
+
+/**
+ * True when the error — or anything in its `cause` chain — carries the
+ * wallet-connector WALLET_METHOD_NOT_SUPPORTED code. Walks `cause` because
+ * the deposit flow's broadcast catches re-wrap wallet errors (attaching the
+ * original as `cause`) before the mappers see them.
+ */
+export function isWalletMethodNotSupported(error: unknown): boolean {
+  let cur: unknown = error;
+
+  for (let depth = 0; depth <= MAX_CAUSE_DEPTH && cur != null; depth++) {
+    if (typeof cur !== "object") return false;
+
+    if ((cur as { code?: unknown }).code === WALLET_METHOD_NOT_SUPPORTED_CODE) {
+      return true;
+    }
+
+    cur = (cur as { cause?: unknown }).cause;
+  }
+
+  return false;
+}


### PR DESCRIPTION
Approval wallets resuming at payout signing now rebuild the terms from
chain state through the shared rebuildDepositTerms (new required
lifecycle param: presign mode tolerates advanced siblings and refuses
ack-expired targets before the device ceremony). Deposit-terms
rejections, unsupported wallet methods, and lifecycle refusals map to
dedicated copy on both error surfaces.

Review follow-ups: the approval-wallet presign path now runs the target
status/ack-window gates before the mempool fee read (a stalled deposit's
refund copy wins over a transient read error; the rebuild still re-checks);
terminal refusals hide Retry and stay out of funnel telemetry; typed
wrong-depositor error; resume-specific unsupported-method copy. The
unsupported-method mapping is forward-plumbing for #2219 — this branch
predates #2269, so on main the Ledger provider's payout `signPsbt` is
already wired and the copy only fires for wallets that genuinely lack a
method.
