### PR TITLE
fix(vault): let the risk price rail shrink with the card

### DIFF
--- a/services/vault/src/components/simple/RiskSection/RiskSection.tsx
+++ b/services/vault/src/components/simple/RiskSection/RiskSection.tsx
@@ -172,7 +172,7 @@ export function RiskSection({
             </div>
           </div>
 
-          <div className="w-full shrink-0 xl:w-[460px]">
+          <div className="w-full xl:w-[460px]">
             <RiskPriceRail
               state={state}
               currentPriceUsd={btcPriceUsd}


### PR DESCRIPTION
## Problem

The risk price rail ran past the right edge of the Risk card and out of frame.

The rail column was pinned with `shrink-0` at `xl:w-[460px]`, and the stat labels
(`whitespace-nowrap`) give the left column a min-content floor of ~470px. Neither
column could give way, so the row overflowed its card.

The `xl:` breakpoint measures the **viewport**, but the 242px sidebar plus the
40px page gutters and 24px card padding leave the card ~370px narrower than the
viewport. The result is a band where the two-column layout is on but the card is
too narrow for it:

```
card inner = viewport - 242 (sidebar) - 80 (mx-10) - 48 (p-6)
overflow when card inner < 470 + 24 (gap) + 460 = 954
             -> viewport roughly 1280px to 1330px
```

## Fix

Drop `shrink-0` from the rail column so it absorbs the shortfall. The rail
itself was already width-driven - `w-full` plus the `ResizeObserver` in
`useRailWidth` - so ticks, markers, labels and the gap arrow re-layout at
whatever width it gets.

## Verification

Headless Chromium repro of the two columns, container pinned at 910px
(the card inner width at a 1280px viewport):

| | left | rail column | overflow past card |
|---|---|---|---|
| `shrink-0` (before) | 461 | 460 | 35px |
| shrinkable (after) | 461 | 425 | 0 |

`nx lint` 0 errors, `nx test` 3302 passed, `nx build` green.

## Not in scope

The rail still caps at 460px on wide screens. Letting it grow with the card as
well would be `xl:w-[460px]` -> `xl:flex-1 xl:max-w-[...]`, which is a design
call rather than a bug fix.
