### PR TITLE
feat(vault): chart the live position on the embedded liquidation preview

### DIFF
--- a/services/vault/.env.example
+++ b/services/vault/.env.example
@@ -59,9 +59,6 @@ NEXT_PUBLIC_REOWN_PROJECT_ID=your-reown-project-id-here
 # Kill-switch for the vault supply-cap UI (dashboard section + deposit-form validation).
 # When enabled, the CapPolicy contract is never read. Vault cap is on by default.
 # NEXT_PUBLIC_FF_DISABLE_VAULT_CAP=true
-# Shows the seizure-map chart in the overview's Liquidation Analysis card. Off
-# until the cascade is wired to live position data.
-# NEXT_PUBLIC_FF_LIQUIDATION_ANALYSIS_CHART=true
 # Shows the Explore section — the /explore page and its sidebar entry. Off until
 # the partner list is backed by the contributor registry; with it off the route
 # redirects to the overview.

--- a/services/vault/playwright.visual.config.ts
+++ b/services/vault/playwright.visual.config.ts
@@ -78,7 +78,6 @@ const VISUAL_ENV_VARS = {
   NEXT_PUBLIC_SENTRY_DSN: "",
   NEXT_PUBLIC_SENTRY_TUNNEL_URL: "",
   NEXT_PUBLIC_FF_ENABLE_EXPLORE: "true",
-  NEXT_PUBLIC_FF_LIQUIDATION_ANALYSIS_CHART: "true",
   // Dev-only panel; would overlay every screen it mounts on.
   NEXT_PUBLIC_FF_GOD_MODE_PANEL: "false",
 };

--- a/services/vault/src/__tests__/router.test.tsx
+++ b/services/vault/src/__tests__/router.test.tsx
@@ -31,7 +31,6 @@ import { Router } from "../router";
 import { getReserveDetailRoute } from "../routes";
 
 const featureFlagsState = vi.hoisted(() => ({
-  isLiquidationAnalysisChartEnabled: true,
   isExploreEnabled: true,
 }));
 
@@ -220,7 +219,6 @@ function renderAt(path: string): RenderResult {
 
 afterEach(() => {
   vi.restoreAllMocks();
-  featureFlagsState.isLiquidationAnalysisChartEnabled = true;
   featureFlagsState.isExploreEnabled = true;
 });
 
@@ -284,26 +282,6 @@ describe("Router — / and /activity keep their original components", () => {
 describe("Router — section routes", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-  });
-
-  it("redirects /liquidations to / when the liquidation-analysis flag is off", async () => {
-    featureFlagsState.isLiquidationAnalysisChartEnabled = false;
-    renderAt("/liquidations");
-
-    await waitFor(() => {
-      expect(screen.getByTestId(DASHBOARD_TESTID)).toBeInTheDocument();
-    });
-    expect(screen.queryByTestId(LIQUIDATIONS_TESTID)).not.toBeInTheDocument();
-  });
-
-  it("redirects a deep link under /liquidations when its flag is off", async () => {
-    featureFlagsState.isLiquidationAnalysisChartEnabled = false;
-    renderAt("/liquidations/some-deep-link");
-
-    await waitFor(() => {
-      expect(screen.getByTestId(DASHBOARD_TESTID)).toBeInTheDocument();
-    });
-    expect(screen.queryByTestId("not-found")).not.toBeInTheDocument();
   });
 
   it("renders the market detail page at /markets/:reserveId", async () => {

--- a/services/vault/src/applications/aave/hooks/__tests__/usePositionNotifications.test.tsx
+++ b/services/vault/src/applications/aave/hooks/__tests__/usePositionNotifications.test.tsx
@@ -167,4 +167,40 @@ describe("usePositionNotifications — live-HF urgency guardrail", () => {
       result.current.result?.warnings.some((w) => w.type === "urgent"),
     ).toBe(false);
   });
+
+  // Optimistic activating rows are collateral the contract has not seen yet.
+  // Counting them inflates the collateral the cascade thinks is seizable, which
+  // pushes every liquidation price DOWN — the position reads safer than it is.
+  it("excludes optimistic activating vaults from the calculator inputs", () => {
+    const activating: CollateralVaultEntry = {
+      ...makeVault(VAULT_B, 5, Number.MAX_SAFE_INTEGER),
+      isActivating: true,
+    };
+    setDashboardState({
+      collateralVaults: [makeVault(VAULT_A, 0.5, 0), activating],
+      debtValueUsd: 30_000,
+    });
+
+    const { result } = renderHook(() => usePositionNotifications(USER));
+
+    expect(result.current.status).toBe("ready");
+    expect(result.current.params?.vaults.map((v) => v.id)).toEqual([VAULT_A]);
+    // The sentinel index would otherwise surface as "Vault 9007199254740992".
+    expect(result.current.params?.vaults.map((v) => v.name)).toEqual([
+      "Vault 1",
+    ]);
+  });
+
+  it("reports no vaults when every collateral row is still activating", () => {
+    setDashboardState({
+      collateralVaults: [{ ...makeVault(VAULT_A, 0.5, 0), isActivating: true }],
+      debtValueUsd: 30_000,
+    });
+
+    const { result } = renderHook(() => usePositionNotifications(USER));
+
+    expect(result.current.status).toBe("no-vaults");
+    expect(result.current.result).toBeNull();
+    expect(result.current.params).toBeNull();
+  });
 });

--- a/services/vault/src/applications/aave/hooks/usePositionNotifications.ts
+++ b/services/vault/src/applications/aave/hooks/usePositionNotifications.ts
@@ -116,7 +116,15 @@ export function usePositionNotifications(
         reorderVerificationContext: null,
         params: null,
       };
-    if (collateralVaults.length === 0)
+    // Optimistic activating rows carry collateral the contract has not seen
+    // yet, and a sentinel `liquidationIndex`. Including them would inflate
+    // `totalBtc`, pushing every liquidation price DOWN — understating the
+    // risk — and label a band "Vault 9007199254740992". The cascade models
+    // what the protocol would seize, so it sees indexed vaults only.
+    const indexedVaults = collateralVaults.filter(
+      (entry) => !entry.isActivating,
+    );
+    if (indexedVaults.length === 0)
       return {
         result: null,
         status: "no-vaults",
@@ -124,7 +132,7 @@ export function usePositionNotifications(
         params: null,
       };
 
-    const vaults: Vault[] = collateralVaults.map((entry) => ({
+    const vaults: Vault[] = indexedVaults.map((entry) => ({
       id: entry.vaultId,
       btc: entry.amountBtc,
       name: `Vault ${entry.liquidationIndex + 1}`,

--- a/services/vault/src/components/shared/__tests__/AppSidebar.test.tsx
+++ b/services/vault/src/components/shared/__tests__/AppSidebar.test.tsx
@@ -5,7 +5,6 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { AppSidebar } from "../AppSidebar";
 
 const featureFlagsMock = vi.hoisted(() => ({
-  isLiquidationAnalysisChartEnabled: true,
   isExploreEnabled: true,
 }));
 
@@ -13,7 +12,6 @@ vi.mock("@/config/featureFlags", () => ({ default: featureFlagsMock }));
 
 describe("AppSidebar", () => {
   beforeEach(() => {
-    featureFlagsMock.isLiquidationAnalysisChartEnabled = true;
     featureFlagsMock.isExploreEnabled = true;
   });
 
@@ -30,27 +28,6 @@ describe("AppSidebar", () => {
       "Loans",
       "Activity",
       "Liquidations",
-      "Explore",
-    ]) {
-      expect(screen.getByText(label)).toBeInTheDocument();
-    }
-  });
-
-  it("hides only Liquidations when the liquidation-analysis flag is off, keeping Explore", () => {
-    featureFlagsMock.isLiquidationAnalysisChartEnabled = false;
-
-    render(
-      <MemoryRouter initialEntries={["/"]}>
-        <AppSidebar />
-      </MemoryRouter>,
-    );
-
-    expect(screen.queryByText("Liquidations")).not.toBeInTheDocument();
-    for (const label of [
-      "Overview",
-      "Vaults",
-      "Loans",
-      "Activity",
       "Explore",
     ]) {
       expect(screen.getByText(label)).toBeInTheDocument();
@@ -74,23 +51,6 @@ describe("AppSidebar", () => {
       "Activity",
       "Liquidations",
     ]) {
-      expect(screen.getByText(label)).toBeInTheDocument();
-    }
-  });
-
-  it("renders only the first nav group when both section flags are off", () => {
-    featureFlagsMock.isLiquidationAnalysisChartEnabled = false;
-    featureFlagsMock.isExploreEnabled = false;
-
-    render(
-      <MemoryRouter initialEntries={["/"]}>
-        <AppSidebar />
-      </MemoryRouter>,
-    );
-
-    expect(screen.queryByText("Liquidations")).not.toBeInTheDocument();
-    expect(screen.queryByText("Explore")).not.toBeInTheDocument();
-    for (const label of ["Overview", "Vaults", "Loans", "Activity"]) {
       expect(screen.getByText(label)).toBeInTheDocument();
     }
   });

--- a/services/vault/src/components/simple/DashboardPage.tsx
+++ b/services/vault/src/components/simple/DashboardPage.tsx
@@ -68,20 +68,15 @@ export function DashboardPage() {
   // live position cascade. A status-only override (stale price) carries no
   // cascade, so it falls through to live. Null when neither has a result: the
   // section shows its empty states rather than charting placeholder numbers.
-  const liquidationCascade = useMemo(() => {
-    const cascade = cascadeOverride?.result
-      ? { result: cascadeOverride.result, params: cascadeOverride.params }
-      : positionNotifications && positionParams
-        ? { result: positionNotifications, params: positionParams }
-        : null;
-    if (!cascade) return null;
-    return {
-      result: cascade.result,
-      btcPrice: cascade.params.btcPrice,
-      collateralFactor: cascade.params.CF,
-      vaultsTotal: cascade.params.vaults.length,
-    };
-  }, [cascadeOverride, positionNotifications, positionParams]);
+  const liquidationCascade = useMemo(
+    () =>
+      cascadeOverride?.result
+        ? { result: cascadeOverride.result, params: cascadeOverride.params }
+        : positionNotifications && positionParams
+          ? { result: positionNotifications, params: positionParams }
+          : null,
+    [cascadeOverride, positionNotifications, positionParams],
+  );
   const {
     collateralBtc,
     collateralValueUsd,

--- a/services/vault/src/components/simple/DashboardPage.tsx
+++ b/services/vault/src/components/simple/DashboardPage.tsx
@@ -62,21 +62,27 @@ export function DashboardPage() {
   // change.
   const cascadeOverride = usePositionCascadeOverride();
   const liquidationCardOverride = useLiquidationCardOverride();
-  // No live source yet: the chart renders only from the god-mode cascade,
-  // behind its own flag. Elsewhere it stays absent rather than charting a real
-  // position from placeholder numbers.
-  const liquidationCascade = useMemo(
-    () =>
-      featureFlags.isLiquidationAnalysisChartEnabled && cascadeOverride?.result
-        ? {
-            result: cascadeOverride.result,
-            btcPrice: cascadeOverride.params.btcPrice,
-            collateralFactor: cascadeOverride.params.CF,
-            vaultsTotal: cascadeOverride.params.vaults.length,
-          }
-        : null,
-    [cascadeOverride],
-  );
+  const { result: positionNotifications, params: positionParams } =
+    usePositionNotifications(isConnected ? address : undefined);
+  // The chart takes the god-mode cascade when the panel publishes one, else the
+  // live position cascade. A status-only override (stale price) carries no
+  // cascade, so it falls through to live. Null when neither has a result: the
+  // section shows its empty states rather than charting placeholder numbers.
+  const liquidationCascade = useMemo(() => {
+    if (!featureFlags.isLiquidationAnalysisChartEnabled) return null;
+    const cascade = cascadeOverride?.result
+      ? { result: cascadeOverride.result, params: cascadeOverride.params }
+      : positionNotifications && positionParams
+        ? { result: positionNotifications, params: positionParams }
+        : null;
+    if (!cascade) return null;
+    return {
+      result: cascade.result,
+      btcPrice: cascade.params.btcPrice,
+      collateralFactor: cascade.params.CF,
+      vaultsTotal: cascade.params.vaults.length,
+    };
+  }, [cascadeOverride, positionNotifications, positionParams]);
   const {
     collateralBtc,
     collateralValueUsd,
@@ -103,9 +109,6 @@ export function DashboardPage() {
     isConnected ? address : undefined,
   );
 
-  const { result: positionNotifications } = usePositionNotifications(
-    isConnected ? address : undefined,
-  );
   const { prices, metadata } = usePrices();
 
   const liquidationNotificationsEnabled =

--- a/services/vault/src/components/simple/DashboardPage.tsx
+++ b/services/vault/src/components/simple/DashboardPage.tsx
@@ -69,7 +69,6 @@ export function DashboardPage() {
   // cascade, so it falls through to live. Null when neither has a result: the
   // section shows its empty states rather than charting placeholder numbers.
   const liquidationCascade = useMemo(() => {
-    if (!featureFlags.isLiquidationAnalysisChartEnabled) return null;
     const cascade = cascadeOverride?.result
       ? { result: cascadeOverride.result, params: cascadeOverride.params }
       : positionNotifications && positionParams

--- a/services/vault/src/components/simple/LiquidationAnalysisSection.tsx
+++ b/services/vault/src/components/simple/LiquidationAnalysisSection.tsx
@@ -1,9 +1,13 @@
 import { Heading, SeizureMap, Slider } from "@babylonlabs-io/core-ui";
-import { useMemo, useState } from "react";
+import { useDeferredValue, useMemo, useState } from "react";
 import { useNavigate } from "react-router";
 import { twJoin } from "tailwind-merge";
 
-import type { CalculatorResult } from "@/applications/aave/positionNotifications/types";
+import { calculate } from "@/applications/aave/positionNotifications";
+import type {
+  CalculatorParams,
+  CalculatorResult,
+} from "@/applications/aave/positionNotifications/types";
 import { LiquidationEventCards } from "@/components/pages/Liquidations/LiquidationEventCards";
 import {
   buildLiquidationChartData,
@@ -17,17 +21,16 @@ import { COPY } from "@/copy";
 import { ROUTES } from "@/routes";
 import { formatPriceUsd } from "@/utils/formatting";
 
-/** The cascade the chart renders. Absent = nothing to chart yet. */
+/** The cascade the chart renders. Absent = nothing to chart yet.
+ *
+ *  Carries the params `result` was computed from, not values derived from
+ *  them: the price simulator has to re-run `calculate()` at the simulated
+ *  price, and `params.vaults` is the only source for the "x/y vaults" count
+ *  (`calculate()` stops emitting groups once the debt clears, so a vault it
+ *  never consumed has no group). */
 export interface LiquidationCascade {
   result: CalculatorResult;
-  btcPrice: number;
-  collateralFactor: number;
-  /**
-   * Vaults in the position. Not derivable from `result`: `calculate()` stops
-   * emitting groups once the debt clears, so a vault it never consumed has no
-   * group and would otherwise vanish from the "x/y vaults" count.
-   */
-  vaultsTotal: number;
+  params: CalculatorParams;
 }
 
 interface LiquidationAnalysisSectionProps {
@@ -88,29 +91,36 @@ function EmptyState({
 }
 
 function LiquidationChartPanel({
-  cascade,
-  effectivePrice,
+  params,
+  projectedResult,
+  projectedPrice,
+  sliderPrice,
   simulating,
   onSimulate,
   onReset,
   onExplore,
 }: {
-  cascade: LiquidationCascade;
-  effectivePrice: number;
+  params: CalculatorParams;
+  projectedResult: CalculatorResult;
+  projectedPrice: number;
+  sliderPrice: number;
   simulating: boolean;
   onSimulate: (price: number) => void;
   onReset: () => void;
   onExplore: () => void;
 }) {
+  // Built from `projectedPrice`, the price `projectedResult` was calculated
+  // at, so the bands and the price line can never disagree while the deferred
+  // cascade is catching up with the thumb.
   const { bands, priceAxis, shareAxisTicks, cards } = useMemo(
     () =>
-      buildLiquidationChartData(cascade.result, {
-        btcPrice: effectivePrice,
-        collateralFactor: cascade.collateralFactor,
-        livePrice: cascade.btcPrice,
-        vaultsTotal: cascade.vaultsTotal,
+      buildLiquidationChartData(projectedResult, {
+        btcPrice: projectedPrice,
+        collateralFactor: params.CF,
+        livePrice: params.btcPrice,
+        vaultsTotal: params.vaults.length,
       }),
-    [cascade, effectivePrice],
+    [projectedResult, projectedPrice, params],
   );
 
   // Cards and bands share keys, so the chart's liquidated state is the
@@ -146,9 +156,9 @@ function LiquidationChartPanel({
       <div className="flex items-center gap-4">
         <div className="flex-1">
           <Slider
-            value={effectivePrice}
+            value={sliderPrice}
             min={0}
-            max={cascade.btcPrice}
+            max={params.btcPrice}
             step={SIM_PRICE_STEP_USD}
             steps={[]}
             onChange={onSimulate}
@@ -157,7 +167,7 @@ function LiquidationChartPanel({
           />
         </div>
         <span className="min-w-[92px] rounded-md border border-secondary-strokeLight px-3 py-1.5 text-center text-sm font-medium tabular-nums text-accent-primary">
-          {formatPriceUsd(effectivePrice)}
+          {formatPriceUsd(sliderPrice)}
         </span>
         <button
           type="button"
@@ -173,8 +183,8 @@ function LiquidationChartPanel({
 
       <SeizureMap
         bands={bands}
-        currentPrice={effectivePrice}
-        currentPriceLabel={formatPriceUsd(effectivePrice)}
+        currentPrice={projectedPrice}
+        currentPriceLabel={formatPriceUsd(projectedPrice)}
         priceLineCaption={COPY.liquidations.bitcoinPriceCaption}
         priceAxis={priceAxis}
         shareAxisTicks={shareAxisTicks}
@@ -212,23 +222,45 @@ export function LiquidationAnalysisSection({
   const navigate = useNavigate();
   const [simulatedPrice, setSimulatedPrice] = useState<number | null>(null);
 
-  const showChart = hasCollateral && hasLoans && Boolean(cascade);
-  const livePrice = cascade?.btcPrice ?? 0;
+  const livePrice = cascade?.params.btcPrice ?? 0;
   // Downward-only: a live-price move below a stale simulated value re-clamps.
-  const effectivePrice =
+  const sliderPrice =
     simulatedPrice === null ? livePrice : Math.min(simulatedPrice, livePrice);
-  const simulating = showChart && effectivePrice < livePrice;
+  // `calculate()` runs an O(3^n) bitmask DP over the vault set, so dragging
+  // the slider would otherwise fire it once per step synchronously. Deferring
+  // only the price the CASCADE reads keeps the drag responsive: the slider and
+  // its readout still track `sliderPrice` directly, so the thumb never lags.
+  const projectedPrice = useDeferredValue(sliderPrice);
+
+  // The what-if path: re-run the pure calculator at the simulated price rather
+  // than re-projecting the live-price result, so the preview and /liquidations
+  // answer the same question with the same numbers.
+  const projectedResult = useMemo(() => {
+    if (!cascade) return null;
+    if (projectedPrice === cascade.params.btcPrice) return cascade.result;
+    return calculate({ ...cascade.params, btcPrice: projectedPrice });
+  }, [cascade, projectedPrice]);
+
+  // Invalid governance params leave `groups` empty with debt still present
+  // (calculate.ts skips the prefix walk when `seizedFraction` clamps). Charting
+  // that renders zero bands and a "Seized 0% / 0.00000000 BTC remaining"
+  // summary beside a real position, so treat it as nothing to chart — the same
+  // guard the /liquidations page applies.
+  const chartable =
+    projectedResult !== null && projectedResult.groups.length > 0;
+  const showChart = hasCollateral && hasLoans && chartable;
+  const simulating = showChart && projectedPrice < livePrice;
 
   const summary = useMemo(
     () =>
-      showChart && cascade
+      showChart && cascade && projectedResult
         ? buildSimulationSummary(
-            cascade.result,
-            effectivePrice,
-            cascade.vaultsTotal,
+            projectedResult,
+            projectedPrice,
+            cascade.params.vaults.length,
           )
         : null,
-    [showChart, cascade, effectivePrice],
+    [showChart, cascade, projectedResult, projectedPrice],
   );
 
   let body;
@@ -251,11 +283,13 @@ export function LiquidationAnalysisSection({
         onAction={onBorrow}
       />
     );
-  } else if (cascade) {
+  } else if (cascade && projectedResult && chartable) {
     body = (
       <LiquidationChartPanel
-        cascade={cascade}
-        effectivePrice={effectivePrice}
+        params={cascade.params}
+        projectedResult={projectedResult}
+        projectedPrice={projectedPrice}
+        sliderPrice={sliderPrice}
         simulating={simulating}
         onSimulate={setSimulatedPrice}
         onReset={() => setSimulatedPrice(null)}

--- a/services/vault/src/components/simple/__tests__/DashboardPage.test.tsx
+++ b/services/vault/src/components/simple/__tests__/DashboardPage.test.tsx
@@ -16,7 +16,6 @@ const featureFlagsMock = vi.hoisted(() => ({
   isLiquidationNotificationsEnabled: false,
   isGodModePanelEnabled: false,
   isPositionDebugPanelEnabled: false,
-  isLiquidationAnalysisChartEnabled: false,
 }));
 
 vi.mock("@/config/featureFlags", () => ({ default: featureFlagsMock }));
@@ -136,7 +135,6 @@ beforeEach(() => {
   vi.clearAllMocks();
   featureFlagsMock.isLiquidationNotificationsEnabled = false;
   featureFlagsMock.isGodModePanelEnabled = false;
-  featureFlagsMock.isLiquidationAnalysisChartEnabled = false;
   positionNotificationsMock.result = null;
   positionNotificationsMock.params = null;
   setPositionCascadeOverride(null);
@@ -225,10 +223,6 @@ const OVERRIDE_PARAMS: CalculatorParams = {
 const OVERRIDE_RESULT = calculate(OVERRIDE_PARAMS);
 
 describe("DashboardPage embedded liquidation preview", () => {
-  beforeEach(() => {
-    featureFlagsMock.isLiquidationAnalysisChartEnabled = true;
-  });
-
   it("charts the live position cascade built from the live calculator params", () => {
     positionNotificationsMock.result = LIVE_RESULT;
     positionNotificationsMock.params = LIVE_PARAMS;
@@ -279,19 +273,6 @@ describe("DashboardPage embedded liquidation preview", () => {
   });
 
   it("charts nothing when neither the override nor the live position has a result", () => {
-    render(<DashboardPage />);
-
-    expect(screen.getByTestId("liquidation-analysis")).toHaveAttribute(
-      "data-cascade",
-      "no",
-    );
-  });
-
-  it("charts nothing with the flag off, even with a live cascade", () => {
-    featureFlagsMock.isLiquidationAnalysisChartEnabled = false;
-    positionNotificationsMock.result = LIVE_RESULT;
-    positionNotificationsMock.params = LIVE_PARAMS;
-
     render(<DashboardPage />);
 
     expect(screen.getByTestId("liquidation-analysis")).toHaveAttribute(

--- a/services/vault/src/components/simple/__tests__/DashboardPage.test.tsx
+++ b/services/vault/src/components/simple/__tests__/DashboardPage.test.tsx
@@ -108,6 +108,17 @@ vi.mock("../CriticalLiquidationTopBanner", () => ({
 vi.mock("../DisconnectedOverview", () => ({
   DisconnectedOverview: () => null,
 }));
+// Captures the raw cascade prop so tests can assert on the *identity* of the
+// CalculatorResult that reached the section, not just values re-derived from
+// it — a regression that pairs an override's params with the live result
+// (or vice versa) would otherwise slip past scalar-only assertions.
+const receivedCascade = vi.hoisted(() => ({
+  current: null as {
+    result: CalculatorResult;
+    params: CalculatorParams;
+  } | null,
+}));
+
 vi.mock("../LiquidationAnalysisSection", () => ({
   LiquidationAnalysisSection: ({
     cascade,
@@ -116,16 +127,19 @@ vi.mock("../LiquidationAnalysisSection", () => ({
       result: CalculatorResult;
       params: CalculatorParams;
     } | null;
-  }) => (
-    <div
-      data-testid="liquidation-analysis"
-      data-cascade={cascade ? "yes" : "no"}
-      data-btc-price={cascade?.params.btcPrice ?? ""}
-      data-collateral-factor={cascade?.params.CF ?? ""}
-      data-vaults-total={cascade?.params.vaults.length ?? ""}
-      data-current-hf={cascade?.result.currentHF ?? ""}
-    />
-  ),
+  }) => {
+    receivedCascade.current = cascade ?? null;
+    return (
+      <div
+        data-testid="liquidation-analysis"
+        data-cascade={cascade ? "yes" : "no"}
+        data-btc-price={cascade?.params.btcPrice ?? ""}
+        data-collateral-factor={cascade?.params.CF ?? ""}
+        data-vaults-total={cascade?.params.vaults.length ?? ""}
+        data-current-hf={cascade?.result.currentHF ?? ""}
+      />
+    );
+  },
 }));
 vi.mock("@/components/shared", () => ({
   HeartIcon: () => null,
@@ -141,6 +155,7 @@ beforeEach(() => {
   pricesMock.prices = {};
   pricesMock.metadata = {};
   setHealthFactorOverride(null);
+  receivedCascade.current = null;
 });
 
 describe("DashboardPage composition", () => {
@@ -238,6 +253,9 @@ describe("DashboardPage embedded liquidation preview", () => {
       "data-current-hf",
       String(LIVE_RESULT.currentHF),
     );
+    // Identity, not just value — catches a regression that recomputes a
+    // result matching LIVE_RESULT's numbers from the wrong params.
+    expect(receivedCascade.current?.result).toBe(LIVE_RESULT);
   });
 
   it("prefers the god-mode cascade over the live one", () => {
@@ -261,6 +279,9 @@ describe("DashboardPage embedded liquidation preview", () => {
       "data-current-hf",
       String(OVERRIDE_RESULT.currentHF),
     );
+    // The override's params must never pair with the live result.
+    expect(receivedCascade.current?.result).toBe(OVERRIDE_RESULT);
+    expect(receivedCascade.current?.result).not.toBe(LIVE_RESULT);
   });
 
   it("falls through to the live cascade for a status-only override", () => {
@@ -282,6 +303,10 @@ describe("DashboardPage embedded liquidation preview", () => {
       "data-current-hf",
       String(LIVE_RESULT.currentHF),
     );
+    // A status-only override carries no result — the section must still get
+    // the live result, never the override's (unset) one.
+    expect(receivedCascade.current?.result).toBe(LIVE_RESULT);
+    expect(receivedCascade.current?.result).not.toBe(OVERRIDE_RESULT);
   });
 
   it("charts nothing when neither the override nor the live position has a result", () => {

--- a/services/vault/src/components/simple/__tests__/DashboardPage.test.tsx
+++ b/services/vault/src/components/simple/__tests__/DashboardPage.test.tsx
@@ -113,17 +113,17 @@ vi.mock("../LiquidationAnalysisSection", () => ({
     cascade,
   }: {
     cascade?: {
-      btcPrice: number;
-      collateralFactor: number;
-      vaultsTotal: number;
+      result: CalculatorResult;
+      params: CalculatorParams;
     } | null;
   }) => (
     <div
       data-testid="liquidation-analysis"
       data-cascade={cascade ? "yes" : "no"}
-      data-btc-price={cascade?.btcPrice ?? ""}
-      data-collateral-factor={cascade?.collateralFactor ?? ""}
-      data-vaults-total={cascade?.vaultsTotal ?? ""}
+      data-btc-price={cascade?.params.btcPrice ?? ""}
+      data-collateral-factor={cascade?.params.CF ?? ""}
+      data-vaults-total={cascade?.params.vaults.length ?? ""}
+      data-current-hf={cascade?.result.currentHF ?? ""}
     />
   ),
 }));
@@ -234,6 +234,10 @@ describe("DashboardPage embedded liquidation preview", () => {
     expect(section).toHaveAttribute("data-btc-price", "61722.5");
     expect(section).toHaveAttribute("data-collateral-factor", "0.75");
     expect(section).toHaveAttribute("data-vaults-total", "2");
+    expect(section).toHaveAttribute(
+      "data-current-hf",
+      String(LIVE_RESULT.currentHF),
+    );
   });
 
   it("prefers the god-mode cascade over the live one", () => {
@@ -253,6 +257,10 @@ describe("DashboardPage embedded liquidation preview", () => {
     const section = screen.getByTestId("liquidation-analysis");
     expect(section).toHaveAttribute("data-btc-price", "88400");
     expect(section).toHaveAttribute("data-vaults-total", "1");
+    expect(section).toHaveAttribute(
+      "data-current-hf",
+      String(OVERRIDE_RESULT.currentHF),
+    );
   });
 
   it("falls through to the live cascade for a status-only override", () => {
@@ -270,6 +278,10 @@ describe("DashboardPage embedded liquidation preview", () => {
     const section = screen.getByTestId("liquidation-analysis");
     expect(section).toHaveAttribute("data-btc-price", "61722.5");
     expect(section).toHaveAttribute("data-vaults-total", "2");
+    expect(section).toHaveAttribute(
+      "data-current-hf",
+      String(LIVE_RESULT.currentHF),
+    );
   });
 
   it("charts nothing when neither the override nor the live position has a result", () => {

--- a/services/vault/src/components/simple/__tests__/DashboardPage.test.tsx
+++ b/services/vault/src/components/simple/__tests__/DashboardPage.test.tsx
@@ -1,8 +1,14 @@
 import { render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import { calculate } from "@/applications/aave/positionNotifications";
+import type {
+  CalculatorParams,
+  CalculatorResult,
+} from "@/applications/aave/positionNotifications/types";
 import { COPY } from "@/copy";
 import { setHealthFactorOverride } from "@/overrides/borrowCapacity";
+import { setPositionCascadeOverride } from "@/overrides/position";
 
 import { DashboardPage } from "../DashboardPage";
 
@@ -10,6 +16,7 @@ const featureFlagsMock = vi.hoisted(() => ({
   isLiquidationNotificationsEnabled: false,
   isGodModePanelEnabled: false,
   isPositionDebugPanelEnabled: false,
+  isLiquidationAnalysisChartEnabled: false,
 }));
 
 vi.mock("@/config/featureFlags", () => ({ default: featureFlagsMock }));
@@ -78,8 +85,13 @@ vi.mock("@/applications/aave/hooks", () => ({
   useAaveVaults: () => ({ vaults: [], redeemedVaults: [] }),
 }));
 
+const positionNotificationsMock = vi.hoisted(() => ({
+  result: null as CalculatorResult | null,
+  params: null as CalculatorParams | null,
+}));
+
 vi.mock("@/applications/aave/hooks/usePositionNotifications", () => ({
-  usePositionNotifications: () => ({ result: null }),
+  usePositionNotifications: () => positionNotificationsMock,
 }));
 
 vi.mock("../OverviewSection", () => ({
@@ -97,6 +109,25 @@ vi.mock("../CriticalLiquidationTopBanner", () => ({
 vi.mock("../DisconnectedOverview", () => ({
   DisconnectedOverview: () => null,
 }));
+vi.mock("../LiquidationAnalysisSection", () => ({
+  LiquidationAnalysisSection: ({
+    cascade,
+  }: {
+    cascade?: {
+      btcPrice: number;
+      collateralFactor: number;
+      vaultsTotal: number;
+    } | null;
+  }) => (
+    <div
+      data-testid="liquidation-analysis"
+      data-cascade={cascade ? "yes" : "no"}
+      data-btc-price={cascade?.btcPrice ?? ""}
+      data-collateral-factor={cascade?.collateralFactor ?? ""}
+      data-vaults-total={cascade?.vaultsTotal ?? ""}
+    />
+  ),
+}));
 vi.mock("@/components/shared", () => ({
   HeartIcon: () => null,
 }));
@@ -105,6 +136,10 @@ beforeEach(() => {
   vi.clearAllMocks();
   featureFlagsMock.isLiquidationNotificationsEnabled = false;
   featureFlagsMock.isGodModePanelEnabled = false;
+  featureFlagsMock.isLiquidationAnalysisChartEnabled = false;
+  positionNotificationsMock.result = null;
+  positionNotificationsMock.params = null;
+  setPositionCascadeOverride(null);
   pricesMock.prices = {};
   pricesMock.metadata = {};
   setHealthFactorOverride(null);
@@ -161,5 +196,107 @@ describe("DashboardPage risk card under a forced health factor", () => {
       screen.getAllByText(COPY.common.emptyValue).length,
     ).toBeGreaterThanOrEqual(2);
     expect(screen.queryByText("58.3%")).not.toBeInTheDocument();
+  });
+});
+
+// A real 2-vault position and a deliberately differently-shaped 1-vault
+// god-mode cascade, so which one reached the chart is unambiguous.
+const LIVE_PARAMS: CalculatorParams = {
+  btcPrice: 61_722.5,
+  totalDebtUsd: 44_287.72,
+  vaults: [
+    { id: "vault-1", name: "Vault 1", btc: 0.65 },
+    { id: "vault-2", name: "Vault 2", btc: 0.35 },
+  ],
+  CF: 0.75,
+  THF: 1.1,
+  maxLB: 1.05,
+};
+const LIVE_RESULT = calculate(LIVE_PARAMS);
+
+const OVERRIDE_PARAMS: CalculatorParams = {
+  btcPrice: 88_400,
+  totalDebtUsd: 28_383,
+  vaults: [{ id: "gm-1", name: "Vault 1", btc: 0.6 }],
+  CF: 0.5,
+  THF: 1.1,
+  maxLB: 1.05,
+};
+const OVERRIDE_RESULT = calculate(OVERRIDE_PARAMS);
+
+describe("DashboardPage embedded liquidation preview", () => {
+  beforeEach(() => {
+    featureFlagsMock.isLiquidationAnalysisChartEnabled = true;
+  });
+
+  it("charts the live position cascade built from the live calculator params", () => {
+    positionNotificationsMock.result = LIVE_RESULT;
+    positionNotificationsMock.params = LIVE_PARAMS;
+
+    render(<DashboardPage />);
+
+    const section = screen.getByTestId("liquidation-analysis");
+    expect(section).toHaveAttribute("data-cascade", "yes");
+    expect(section).toHaveAttribute("data-btc-price", "61722.5");
+    expect(section).toHaveAttribute("data-collateral-factor", "0.75");
+    expect(section).toHaveAttribute("data-vaults-total", "2");
+  });
+
+  it("prefers the god-mode cascade over the live one", () => {
+    // The override store reads through the god-mode gate, so the panel flag
+    // has to be on for a published override to be visible at all.
+    featureFlagsMock.isGodModePanelEnabled = true;
+    positionNotificationsMock.result = LIVE_RESULT;
+    positionNotificationsMock.params = LIVE_PARAMS;
+    setPositionCascadeOverride({
+      result: OVERRIDE_RESULT,
+      status: null,
+      params: OVERRIDE_PARAMS,
+    });
+
+    render(<DashboardPage />);
+
+    const section = screen.getByTestId("liquidation-analysis");
+    expect(section).toHaveAttribute("data-btc-price", "88400");
+    expect(section).toHaveAttribute("data-vaults-total", "1");
+  });
+
+  it("falls through to the live cascade for a status-only override", () => {
+    featureFlagsMock.isGodModePanelEnabled = true;
+    positionNotificationsMock.result = LIVE_RESULT;
+    positionNotificationsMock.params = LIVE_PARAMS;
+    setPositionCascadeOverride({
+      result: null,
+      status: "stale-price",
+      params: OVERRIDE_PARAMS,
+    });
+
+    render(<DashboardPage />);
+
+    const section = screen.getByTestId("liquidation-analysis");
+    expect(section).toHaveAttribute("data-btc-price", "61722.5");
+    expect(section).toHaveAttribute("data-vaults-total", "2");
+  });
+
+  it("charts nothing when neither the override nor the live position has a result", () => {
+    render(<DashboardPage />);
+
+    expect(screen.getByTestId("liquidation-analysis")).toHaveAttribute(
+      "data-cascade",
+      "no",
+    );
+  });
+
+  it("charts nothing with the flag off, even with a live cascade", () => {
+    featureFlagsMock.isLiquidationAnalysisChartEnabled = false;
+    positionNotificationsMock.result = LIVE_RESULT;
+    positionNotificationsMock.params = LIVE_PARAMS;
+
+    render(<DashboardPage />);
+
+    expect(screen.getByTestId("liquidation-analysis")).toHaveAttribute(
+      "data-cascade",
+      "no",
+    );
   });
 });

--- a/services/vault/src/components/simple/__tests__/LiquidationAnalysisSection.test.tsx
+++ b/services/vault/src/components/simple/__tests__/LiquidationAnalysisSection.test.tsx
@@ -2,7 +2,8 @@ import { fireEvent, render, screen, within } from "@testing-library/react";
 import { MemoryRouter } from "react-router";
 import { describe, expect, it, vi } from "vitest";
 
-import type { CalculatorResult } from "@/applications/aave/positionNotifications/types";
+import { calculate } from "@/applications/aave/positionNotifications";
+import type { CalculatorParams } from "@/applications/aave/positionNotifications/types";
 import { COPY } from "@/copy";
 
 import {
@@ -10,38 +11,32 @@ import {
   type LiquidationCascade,
 } from "../LiquidationAnalysisSection";
 
-const CASCADE: LiquidationCascade = {
+/**
+ * A real single-vault position: 0.6 BTC at $88,400 against $22,000 of debt,
+ * CF 0.5. `calculate()` puts its one liquidation trigger at $73,333, so the
+ * position opens healthy and a drag below that trigger liquidates it. The
+ * result is real calculator output, never hand-built, so the fixture cannot
+ * drift from the maths the component re-runs.
+ */
+const PARAMS: CalculatorParams = {
   btcPrice: 88_400,
-  collateralFactor: 0.5,
-  vaultsTotal: 1,
-  result: {
-    groups: [
-      {
-        // calculate() emits 1-based indices; the projection must not key off it.
-        index: 1,
-        vaults: [{ id: "v-1", name: "Vault 1", btc: 0.6 }],
-        combinedBtc: 0.6,
-        liquidationPrice: 77_682,
-        distancePct: -12.1,
-        targetSeizureBtc: 0.58,
-        overSeizureBtc: 0.02,
-        isFullLiquidation: true,
-        debtToRepay: 28_383,
-        liquidatorProfitUsd: 1_419,
-        debtRepaid: 28_383,
-        fairnessDebtRepay: 0,
-        fairnessPaymentUsd: 798,
-        debtRemainingAfter: 0,
-        btcRemainingAfter: 0,
-      },
-    ],
-    currentHF: 1.1,
-    collateralValue: 53_040,
-    targetSeizureBtc: 0.58,
-    warnings: [],
-    optimalVaultOrder: null,
-    suggestedNewVaultBtc: null,
-  } satisfies CalculatorResult,
+  totalDebtUsd: 22_000,
+  vaults: [{ id: "v-1", name: "Vault 1", btc: 0.6 }],
+  CF: 0.5,
+  THF: 1.1,
+  maxLB: 1.05,
+};
+const CASCADE: LiquidationCascade = {
+  result: calculate(PARAMS),
+  params: PARAMS,
+};
+
+/** Governance params whose seizure fraction clamps out of range: `calculate()`
+ *  returns no groups while the debt is still there. */
+const INVALID_PARAMS: CalculatorParams = { ...PARAMS, CF: 0.92 };
+const INVALID_CASCADE: LiquidationCascade = {
+  result: calculate(INVALID_PARAMS),
+  params: INVALID_PARAMS,
 };
 
 function renderSection(props: {
@@ -104,8 +99,8 @@ describe("LiquidationAnalysisSection", () => {
     const slider = screen.getByRole("slider", {
       name: COPY.liquidations.simulateLabel,
     });
-    expect(slider).toHaveValue(String(CASCADE.btcPrice));
-    expect(slider).toHaveAttribute("max", String(CASCADE.btcPrice));
+    expect(slider).toHaveValue(String(PARAMS.btcPrice));
+    expect(slider).toHaveAttribute("max", String(PARAMS.btcPrice));
     expect(slider).toHaveAttribute("min", "0");
     // Step 1: a coarser grid cannot land back on the float live price, which
     // would leave the simulator stuck in "simulating" after a full drag right.
@@ -148,7 +143,7 @@ describe("LiquidationAnalysisSection", () => {
       screen.getByRole("button", { name: COPY.liquidations.reset }),
     );
 
-    expect(slider).toHaveValue(String(CASCADE.btcPrice));
+    expect(slider).toHaveValue(String(PARAMS.btcPrice));
     expect(screen.queryByText(COPY.liquidations.simulationChip)).toBeNull();
     expect(
       screen.queryByText(COPY.liquidations.events.liquidatedInSimulation),
@@ -224,5 +219,37 @@ describe("LiquidationAnalysisSection", () => {
     );
 
     expect(onBorrow).toHaveBeenCalledWith();
+  });
+
+  // The distance a liquidation event reports is measured from the price the
+  // cascade was calculated at. Re-projecting the live-price cascade onto a
+  // dragged price keeps the live distance (-17.0% here) while the band already
+  // reads as liquidated; re-running `calculate()` at the dragged price reports
+  // the price as 22.2% PAST the trigger. Only the recomputed figure is
+  // consistent with the band beside it.
+  it("recalculates the cascade at the simulated price rather than reprojecting the live one", () => {
+    renderSection({ hasCollateral: true, hasLoans: true, cascade: CASCADE });
+
+    fireEvent.change(
+      screen.getByRole("slider", { name: COPY.liquidations.simulateLabel }),
+      { target: { value: "60000" } },
+    );
+
+    const cards = within(screen.getByTestId("liq-event-cards"));
+    expect(cards.getByText("+22.2%")).toBeInTheDocument();
+    expect(cards.queryByText("-17.0%")).toBeNull();
+  });
+
+  it("charts nothing when the cascade has no groups to seize", () => {
+    renderSection({
+      hasCollateral: true,
+      hasLoans: true,
+      cascade: INVALID_CASCADE,
+    });
+
+    expect(INVALID_CASCADE.result.groups).toHaveLength(0);
+    expect(screen.queryByText(COPY.liquidations.simulateLabel)).toBeNull();
+    expect(screen.queryByTestId("liq-event-cards")).toBeNull();
+    expect(screen.queryByTestId("liq-seized-pct")).toBeNull();
   });
 });

--- a/services/vault/src/config/__tests__/v3Navigation.test.ts
+++ b/services/vault/src/config/__tests__/v3Navigation.test.ts
@@ -14,24 +14,22 @@ import {
 } from "../v3Navigation";
 
 const featureFlagsMock = vi.hoisted(() => ({
-  isLiquidationAnalysisChartEnabled: true,
   isExploreEnabled: true,
 }));
 
 vi.mock("@/config/featureFlags", () => ({ default: featureFlagsMock }));
 
 beforeEach(() => {
-  featureFlagsMock.isLiquidationAnalysisChartEnabled = true;
   featureFlagsMock.isExploreEnabled = true;
 });
 
 describe("isV3SectionEnabled", () => {
   it("returns true for a section with no flag of its own", () => {
-    featureFlagsMock.isLiquidationAnalysisChartEnabled = false;
     featureFlagsMock.isExploreEnabled = false;
 
     expect(isV3SectionEnabled("vaults")).toBe(true);
     expect(isV3SectionEnabled("overview")).toBe(true);
+    expect(isV3SectionEnabled("liquidations")).toBe(true);
   });
 
   it("follows the explore flag for the explore section", () => {
@@ -40,14 +38,6 @@ describe("isV3SectionEnabled", () => {
     featureFlagsMock.isExploreEnabled = false;
 
     expect(isV3SectionEnabled("explore")).toBe(false);
-  });
-
-  it("follows the liquidation-analysis flag for the liquidations section", () => {
-    expect(isV3SectionEnabled("liquidations")).toBe(true);
-
-    featureFlagsMock.isLiquidationAnalysisChartEnabled = false;
-
-    expect(isV3SectionEnabled("liquidations")).toBe(false);
   });
 });
 
@@ -71,21 +61,6 @@ describe("getVisibleV3NavGroups", () => {
       ["liquidations"],
     ]);
   });
-
-  it("drops a group its flags emptied instead of leaving an empty one", () => {
-    featureFlagsMock.isLiquidationAnalysisChartEnabled = false;
-    featureFlagsMock.isExploreEnabled = false;
-
-    const groups = getVisibleV3NavGroups();
-
-    expect(groups).toHaveLength(1);
-    expect(groups[0].map((item) => item.id)).toEqual([
-      "overview",
-      "vaults",
-      "loans",
-      "activity",
-    ]);
-  });
 });
 
 describe("getFlagDisabledV3SectionPaths", () => {
@@ -97,15 +72,5 @@ describe("getFlagDisabledV3SectionPaths", () => {
     featureFlagsMock.isExploreEnabled = false;
 
     expect(getFlagDisabledV3SectionPaths()).toEqual(["explore"]);
-  });
-
-  it("returns every flag-disabled section", () => {
-    featureFlagsMock.isLiquidationAnalysisChartEnabled = false;
-    featureFlagsMock.isExploreEnabled = false;
-
-    expect(getFlagDisabledV3SectionPaths()).toEqual([
-      "liquidations",
-      "explore",
-    ]);
   });
 });

--- a/services/vault/src/config/featureFlags.ts
+++ b/services/vault/src/config/featureFlags.ts
@@ -158,23 +158,6 @@ export default {
     return process.env.NEXT_PUBLIC_FF_ENABLE_SIGNING_NOTIFICATIONS === "true";
   },
 
-  /**
-   * LIQUIDATION_ANALYSIS_CHART feature flag
-   *
-   * Purpose: Gates the liquidation-analysis feature — the seizure-map chart
-   * inside the overview's Liquidation Analysis card, plus the sidebar's
-   * Liquidations section and the /liquidations Liquidation Dashboard. The
-   * overview card's empty states read the live position and are not gated by
-   * this.
-   * Why needed: the /liquidations page charts the live
-   * `usePositionNotifications` cascade, but the overview card's cascade is
-   * still god-mode-only, and rendering that beside a real position would
-   * present fabricated liquidation prices as the user's own.
-   * Default: false (no chart unless explicitly set to "true")
-   */
-  get isLiquidationAnalysisChartEnabled() {
-    return process.env.NEXT_PUBLIC_FF_LIQUIDATION_ANALYSIS_CHART === "true";
-  },
 
   /**
    * ENABLE_EXPLORE feature flag

--- a/services/vault/src/config/featureFlags.ts
+++ b/services/vault/src/config/featureFlags.ts
@@ -158,7 +158,6 @@ export default {
     return process.env.NEXT_PUBLIC_FF_ENABLE_SIGNING_NOTIFICATIONS === "true";
   },
 
-
   /**
    * ENABLE_EXPLORE feature flag
    *

--- a/services/vault/src/config/v3Navigation.ts
+++ b/services/vault/src/config/v3Navigation.ts
@@ -62,7 +62,6 @@ export const V3_NAV_ITEMS: readonly V3NavItem[] = V3_NAV_GROUPS.flat();
  * takes effect. Inlining them as values would freeze every flag at import.
  */
 const V3_SECTION_FLAG_GATES: Partial<Record<V3NavItemId, () => boolean>> = {
-  liquidations: () => featureFlags.isLiquidationAnalysisChartEnabled,
   explore: () => featureFlags.isExploreEnabled,
 };
 


### PR DESCRIPTION
Closes #2038.

Three commits: wire the embedded preview to the live position cascade, retire `NEXT_PUBLIC_FF_LIQUIDATION_ANALYSIS_CHART` now that nothing is left to gate, then fix three review findings on the charted cascade. Rebased onto `795b4dcf`.

## What changed

The Overview page's embedded Liquidation Analysis card now charts the user's real position. Until now it rendered only from the god-mode cascade override, which nothing populates outside the debug panel — so a depositor with a live position saw an empty card.

`DashboardPage.tsx` destructures `params` from the `usePositionNotifications` call it already makes, and feeds the section the same `{ result, params }` pair the full `/liquidations` dashboard charts. Same calculator, same params, so the compact preview and the full dashboard cannot disagree.

`LiquidationCascade` is now `{ result, params }` — the params the result was computed from, not values derived from them — so `LiquidationAnalysisSection` can re-run the calculator for the price simulator and derive `btcPrice`/`CF`/`vaultsTotal` itself. That removed the mapping in `DashboardPage` entirely, and the preview and `/liquidations` are now structurally identical. `components/pages/Liquidations/` and `src/overrides/` are untouched.

## Precedence ladder

1. **Override** — the god-mode cascade wins when the panel publishes one (`cascadeOverride?.result`, dev-only; the store is never written in production).
2. **Live** — otherwise the live position cascade, when `result` and `params` are both present.
3. **null** — neither has a result: no chart, and the section renders its own empty states rather than charting placeholder numbers.

Guarding on `cascadeOverride?.result` rather than `cascadeOverride` is what makes a status-only override (e.g. a simulated stale price, which carries no cascade) fall through to live instead of blanking the chart — matching `useLiquidationsPageState`.

`usePositionNotifications` returns `result: null, params: null` for every non-`ready` status (`loading`, `no-wallet`, `no-vaults`, `no-price`, `stale-price`), and non-null only together at `ready`. So the disconnected and no-position states chart nothing by construction, not by an extra guard.

## Flag retirement

The flag existed because the overview card's cascade was god-mode-only, and charting that beside a real position would present fabricated liquidation prices as the user's own. The first commit removes that reason, so the second commit removes the flag:

| File | Change |
| --- | --- |
| `config/featureFlags.ts` | delete the `isLiquidationAnalysisChartEnabled` getter and its doc block |
| `config/v3Navigation.ts` | drop `liquidations` from `V3_SECTION_FLAG_GATES` — the sidebar section and the `/liquidations` route are now unconditional |
| `components/simple/DashboardPage.tsx` | drop the early return from the cascade memo |
| `playwright.visual.config.ts`, `.env.example` | remove the entries |
| 4 test files | remove the flag mocks and the flag-off cases that are no longer reachable |

The section-gate mechanism itself stays — Explore still uses it. One consequence worth naming: with `liquidations` ungated, the second nav group always has at least one visible item, so the `filter(group => group.length > 0)` branch in `getVisibleV3NavGroups` is no longer reachable and its test is gone. The line is kept deliberately: it is part of the generic gate mechanism and would be needed again the moment another section in that group gets a flag.

**Deployment note:** this feature has run in no environment. Removing the flag means production is its first exposure, with no kill switch. Requested deliberately; calling it out for the reviewer rather than burying it.

## Review findings fixed

Three defects on the charted cascade, all confirmed against the code before changing anything:

**1. Optimistic activating vaults inflated the cascade.** `useDashboardState.collateralVaults` appends optimistic rows for vaults whose activation tx has landed but which the indexer has not seen, with a sentinel `liquidationIndex: Number.MAX_SAFE_INTEGER`. `usePositionNotifications` fed all of them to `calculate()`, so activating a vault while holding a loan inflated `totalBtc` with collateral the contract cannot seize — pushing every liquidation price DOWN, i.e. reading safer than reality — and labelled a band "Vault 9007199254740992".

Fixed in `usePositionNotifications`, not at the call site: the hook is shared, so `/liquidations`, the cascade banner and the critical top banner all had the same defect. The cascade now sees indexed vaults only, matching how `useVaultsPageData` already filters `isActivating`. A position whose every row is still activating reports `no-vaults` → null result → empty states, which is correct: debt cannot exist against collateral the contract has not registered.

Because that hook also feeds the reorder CTA, I traced the signing path. `ReorderVerificationContext` carries only scalars (CF, THF, maxLB, btcPrice, totalDebtUsd) — no vault list — and both guards re-derive the vault set from chain: `assertReorderMembership` refuses unless the submitted multiset equals `getPosition(user).vaultIds`, and `assertOptimalOrderMatchesOnChain` re-runs `calculate()` against `getBtcVaultBasicInfo` amounts. So this change cannot alter what gets signed; it can only make the guard refuse. The one behavioural consequence: while the indexer lags an already-confirmed activation, the "apply optimal order" CTA now fails closed on a membership mismatch instead of submitting an order derived from inflated collateral. Failing closed is the correct direction for a signing path, and the previous suggestion was computed from collateral the trusted recompute would have rejected anyway.

**2. An empty cascade charted a real position as zeroes.** `calculate()` returns `groups: []` with debt still present when the seizure fraction clamps out of range — reachable with plain governance values (CF 0.92, LB 1.05, THF 1.1 gives a raw fraction of ~1.14, and any THF ≤ LB·CF gives Infinity). The preview charted zero bands and a "Seized 0% / 0.00000000 BTC remaining" summary beside real collateral. Now guarded in the section, which is also where a mid-drag recompute can newly empty the groups; `/liquidations` guards the same condition at `index.tsx:129`. The section already renders nothing for a real position with no cascade, so no new empty state was needed.

**3. The price simulator never re-ran the calculator.** The preview re-projected the live-price result onto the dragged price, while `/liquidations` recomputes (`index.tsx:113-117`). Observable divergence: dragging a $88,400 position with a $73,333 trigger down to $60,000 reported the event as `-17.0%` away (the distance from the live price) while the band beside it already read as liquidated; recomputing reports `+22.2%`, i.e. past the trigger. The section now re-runs `calculate()` at the simulated price behind `useDeferredValue`, copying the `/liquidations` drag mechanics — `calculate()` is an O(3^n) bitmask DP, so the slider and its readout track the undeferred price while only the cascade defers.

## Tests

Extended `components/simple/__tests__/DashboardPage.test.tsx` in place, mocking only `usePositionNotifications` and the cascade override store:

- live result → cascade built from the live params (btcPrice, CF, vault count)
- override set → override wins over a live result
- status-only override + live result → live wins
- no result anywhere → null

The mock exposes a result-derived value alongside the params, so a regression pairing one side's params with the other side's result fails instead of passing.

`usePositionNotifications.test.tsx`: an activating row never reaches the calculator inputs and its sentinel name never escapes; an all-activating position reports `no-vaults`.

`LiquidationAnalysisSection.test.tsx`: its fixture is now real `calculate()` output rather than a hand-built result, so it cannot drift from the maths the component re-runs. Two new cases — the drag recomputes rather than re-projects, and a no-groups cascade charts nothing. Both were confirmed to fail against the pre-fix code before being kept.

Every live fixture is real `calculate()` output, so params and result cannot drift apart.

Verified locally on Node 24 after all three commits: full vault suite 3388 passed / 6 skipped (294 files), `tsc --noEmit -p tsconfig.lib.json` clean, eslint and prettier clean.
