### PR TITLE
Feat/ledger pop wallet policy

### DIFF
--- a/packages/babylon-ledger-vault-signer/src/__tests__/derivation.test.ts
+++ b/packages/babylon-ledger-vault-signer/src/__tests__/derivation.test.ts
@@ -10,7 +10,7 @@
 import { HDKey } from "@scure/bip32";
 import { describe, expect, it } from "vitest";
 
-import { getXOnlyPublicKeyHex } from "../derivation";
+import { getExtendedPublicKey, getMasterFingerprintHex, getXOnlyPublicKeyHex } from "../derivation";
 
 /** BIP-86 test vectors (mnemonic "abandon ... about"), published in the BIP. */
 const BIP86_ACCOUNT_XPUB =
@@ -22,6 +22,7 @@ const TESTNET_VERSIONS = { public: 0x043587cf, private: 0x04358394 };
 
 const HARDENED = 0x80000000;
 const MAINNET_LEAF_PATH = [86 + HARDENED, 0 + HARDENED, 0 + HARDENED, 0, 0];
+const MAINNET_ACCOUNT_PATH = [86 + HARDENED, 0 + HARDENED, 0 + HARDENED];
 
 /** A sender that records the APDU and answers with a fixed payload. */
 function fakeSender(responseBytes: Uint8Array) {
@@ -87,5 +88,50 @@ describe("getXOnlyPublicKeyHex", () => {
     const { send } = fakeSender(new TextEncoder().encode("not-an-extended-key"));
 
     await expect(getXOnlyPublicKeyHex(send, MAINNET_LEAF_PATH, MAINNET_VERSIONS)).rejects.toThrow();
+  });
+});
+
+describe("getMasterFingerprintHex", () => {
+  it("sends GET_MASTER_FINGERPRINT (INS 0x05, empty data) and returns the 4 bytes as lowercase hex", async () => {
+    const { send, sent } = fakeSender(new Uint8Array([0xf5, 0xac, 0xc2, 0xfd]));
+
+    const fingerprint = await getMasterFingerprintHex(send);
+
+    expect(fingerprint).toBe("f5acc2fd");
+    expect(sent).toHaveLength(1);
+    expect([sent[0].cla, sent[0].ins, sent[0].p1, sent[0].p2]).toEqual([0xe1, 0x05, 0x00, 0x01]);
+    expect(sent[0].data).toHaveLength(0);
+  });
+
+  it("rejects a response that is not exactly 4 bytes", async () => {
+    const { send } = fakeSender(new Uint8Array([0xf5, 0xac, 0xc2]));
+    await expect(getMasterFingerprintHex(send)).rejects.toThrow(/4-byte master fingerprint/);
+  });
+});
+
+describe("getExtendedPublicKey", () => {
+  it("returns the device's extended key string verbatim for a 3-level account path", async () => {
+    const { send, sent } = fakeSender(new TextEncoder().encode(BIP86_ACCOUNT_XPUB));
+
+    const xpub = await getExtendedPublicKey(send, MAINNET_ACCOUNT_PATH, MAINNET_VERSIONS);
+
+    expect(xpub).toBe(BIP86_ACCOUNT_XPUB);
+    expect([sent[0].cla, sent[0].ins, sent[0].p1, sent[0].p2]).toEqual([0xe1, 0x00, 0x00, 0x01]);
+    // display=0 (silent) ‖ n=3 ‖ three u32BE levels
+    expect(Buffer.from(sent[0].data).toString("hex")).toBe("00" + "03" + "80000056" + "80000000" + "80000000");
+  });
+
+  it("rejects an extended key that does not decode under the requested version bytes", async () => {
+    // A mainnet xpub read under testnet versions: the device build and the host
+    // network disagree — surface it here, before the string is embedded in a policy.
+    const { send } = fakeSender(new TextEncoder().encode(BIP86_ACCOUNT_XPUB));
+    await expect(getExtendedPublicKey(send, MAINNET_ACCOUNT_PATH, TESTNET_VERSIONS)).rejects.toThrow();
+  });
+
+  it("rejects an empty response", async () => {
+    const { send } = fakeSender(new Uint8Array(0));
+    await expect(getExtendedPublicKey(send, MAINNET_ACCOUNT_PATH, MAINNET_VERSIONS)).rejects.toThrow(
+      /empty extended key/,
+    );
   });
 });

--- a/packages/babylon-ledger-vault-signer/src/__tests__/e2e/peginFixture.ts
+++ b/packages/babylon-ledger-vault-signer/src/__tests__/e2e/peginFixture.ts
@@ -123,11 +123,13 @@ function encodeScriptNum(n: number): Buffer {
   return Buffer.from([bytes.length, ...bytes]);
 }
 
-/** N-of-N multisig fragment (test_sign_psbt_validate.py:142). */
+/**
+ * N-of-N multisig fragment. No single-key special case: `encode_multisig_group`
+ * (fw `src/vault_script.c:204-231` @ e2d0c45b) emits the counted form for N>=1,
+ * so a `<key> OP_CHECKSIG` shortcut would build a leaf 4 bytes short of the one
+ * the device rebuilds and compares.
+ */
 function multisigGroup(keys: readonly Buffer[], isFinal: boolean): Buffer {
-  if (keys.length === 1) {
-    return Buffer.concat([Buffer.from([PUSH_32]), keys[0], Buffer.from([isFinal ? OP_CHECKSIG : OP_CHECKSIGVERIFY])]);
-  }
   const parts: Buffer[] = [Buffer.concat([Buffer.from([PUSH_32]), keys[0], Buffer.from([OP_CHECKSIG])])];
   for (const key of keys.slice(1)) {
     parts.push(Buffer.concat([Buffer.from([PUSH_32]), key, Buffer.from([OP_CHECKSIGADD])]));
@@ -343,6 +345,13 @@ export function termsToIntent(terms: DepositTerms): IntentFixture {
 const PREPEGIN_INPUT_COUNT = 2;
 /** Distinct but otherwise arbitrary prevout hashes — the device never fetches them. */
 const PREPEGIN_PREVOUT_HASH_BASE = 0x40;
+/**
+ * `_validate_prepegin` (fw `sign_psbt_validate.c:334-545` @ e2d0c45b) does not
+ * constrain the sequence — it only hashes it into the txid it compares against
+ * the intent (`:283-292`). So this must match what the toolkit's funding path
+ * emits: bitcoinjs' DEFAULT_SEQUENCE (fundPeginTransaction.ts:148).
+ */
+const PREPEGIN_SEQUENCE_FINAL = 0xffffffff;
 
 export interface PrePeginPsbtFixture {
   /** v0, NOT augmented — the test augments it the way the provider does. */
@@ -378,10 +387,7 @@ export function buildPrePeginPsbt(hashlock: Buffer, changeXOnlyHex: string): Pre
     psbt.addInput({
       hash: Buffer.alloc(32, PREPEGIN_PREVOUT_HASH_BASE + i),
       index: i,
-      // SEQUENCE_FINAL: the fw (fix/audit-findings > e2d0c45b) requires Pre-PegIn
-      // inputs present AND final (no RBF/CSV) — and the toolkit's funding path
-      // emits bitcoinjs' default 0xffffffff (fundPeginTransaction.ts:148).
-      sequence: 0xffffffff,
+      sequence: PREPEGIN_SEQUENCE_FINAL,
       witnessUtxo: { script: depositorSpk, value: PREPEGIN_INPUT_VALUE_SATS },
       tapInternalKey: depositor,
     });
@@ -405,10 +411,13 @@ export interface PeginPsbtFixture {
   readonly controlBlock: Buffer;
 }
 
+/** RBF-signalling, per the fw builder. */
+const PEGIN_SEQUENCE = 0xfffffffe;
+
 /**
  * PegIn PSBTv0: input 0 spends the HTLC at (prepegin_txid, vout 0) via
  * Leaf 0; outputs are Vault, Depositor Claim, and the P2A anchor. Tx v3
- * (TRUC), locktime 0, sequence 0xFFFFFFFE — all per the fw builder.
+ * (TRUC), locktime 0, sequence {@link PEGIN_SEQUENCE} — all per the fw builder.
  */
 export function buildPeginPsbt(hashlock: Buffer, prepeginTxidInternal: Buffer): PeginPsbtFixture {
   const depositor = hexToBuffer(DEPOSITOR_XONLY_HEX);
@@ -435,7 +444,7 @@ export function buildPeginPsbt(hashlock: Buffer, prepeginTxidInternal: Buffer): 
   psbt.addInput({
     hash: prepeginTxidInternal, // Buffer form: used as-is (internal order)
     index: HTLC_VOUT,
-    sequence: 0xfffffffe,
+    sequence: PEGIN_SEQUENCE,
     witnessUtxo: { script: htlcScriptPubKey, value: HTLC_VALUE_SATS },
     tapInternalKey: NUMS_XONLY,
     tapMerkleRoot: merkleRoot,

--- a/packages/babylon-ledger-vault-signer/src/__tests__/e2e/peginFixture.ts
+++ b/packages/babylon-ledger-vault-signer/src/__tests__/e2e/peginFixture.ts
@@ -378,7 +378,10 @@ export function buildPrePeginPsbt(hashlock: Buffer, changeXOnlyHex: string): Pre
     psbt.addInput({
       hash: Buffer.alloc(32, PREPEGIN_PREVOUT_HASH_BASE + i),
       index: i,
-      sequence: 0xfffffffd,
+      // SEQUENCE_FINAL: the fw (fix/audit-findings > e2d0c45b) requires Pre-PegIn
+      // inputs present AND final (no RBF/CSV) — and the toolkit's funding path
+      // emits bitcoinjs' default 0xffffffff (fundPeginTransaction.ts:148).
+      sequence: 0xffffffff,
       witnessUtxo: { script: depositorSpk, value: PREPEGIN_INPUT_VALUE_SATS },
       tapInternalKey: depositor,
     });

--- a/packages/babylon-ledger-vault-signer/src/__tests__/e2e/peginFixture.ts
+++ b/packages/babylon-ledger-vault-signer/src/__tests__/e2e/peginFixture.ts
@@ -1,5 +1,10 @@
 /**
- * Signable PegIn fixture for the Speculos e2e suite.
+ * Signable Pre-PegIn and PegIn fixtures for the Speculos e2e suite.
+ *
+ * The Pre-PegIn is built FIRST and its txid feeds both the intent
+ * (`prepeginTxid`) and the PegIn input, because `_validate_prepegin` compares
+ * SHA256d(unsigned tx) against the intent's `prepegin_txid`
+ * (fw `sign_psbt_validate.c:529-537` @ 4decf822).
  *
  * The committed SIGN_PSBT vectors were generated from foreign seeds, so this
  * builder replicates the firmware's own signable test path byte-for-byte:
@@ -12,13 +17,16 @@
  */
 
 import * as ecc from "@bitcoin-js/tiny-secp256k1-asmjs";
-import { crypto as bcrypto, Psbt, Transaction } from "bitcoinjs-lib";
+import { crypto as bcrypto, initEccLib, payments, Psbt, Transaction } from "bitcoinjs-lib";
 import { Buffer } from "buffer";
 import { createHash, createHmac } from "node:crypto";
 
 import type { IntentScalars, IntentVaultGroup } from "../../intentTlv";
 import { tapLeafHash } from "../../tapLeafHash";
 import type { DepositTerms } from "../../types";
+
+// `payments.p2tr` tweaks the internal key, which needs the ecc backend.
+initEccLib(ecc);
 
 /** BIP-341 tapscript leaf version — the only one the vault graph uses. */
 const TAPSCRIPT_LEAF_VERSION = 0xc0;
@@ -59,8 +67,14 @@ export const PREPEGIN_MAX_FEE_SATS = 500_000;
  */
 export const HTLC_VALUE_SATS = VAULT_AMOUNT_SATS + DEPOSITOR_CLAIM_VALUE_SATS + PEGIN_ANCHOR_VALUE_SATS + 234_567;
 
-/** _PREPEGIN_TXID = bytes(range(32)) (test_sign_psbt_validate.py:135), INTERNAL order. */
-export const PREPEGIN_TXID_INTERNAL = Buffer.from(Array.from({ length: 32 }, (_, i) => i));
+/** Value of each Pre-PegIn funding input — two of them cover HTLC + anchor + change + fee. */
+export const PREPEGIN_INPUT_VALUE_SATS = 20_000_000;
+/** ≤ PREPEGIN_MAX_FEE_SATS, and far above 1 sat/vB for a ~254 vB transaction. */
+const PREPEGIN_FEE_SATS = 50_000;
+/** VAULT_DUST_LIMIT — the exact CPFP anchor value the device demands (fw vault_constants.h:64). */
+const CPFP_ANCHOR_VALUE_SATS = 546;
+/** Testnet BIP-32 version bytes — the signet build answers tpub/tprv. */
+export const TESTNET_VERSIONS = { public: 0x043587cf, private: 0x04358394 };
 
 /** _DERIVE_CONTEXT = bytes(range(72)) (test_sign_psbt_validate.py:591). */
 export const DERIVE_CONTEXT = Uint8Array.from(Array.from({ length: 72 }, (_, i) => i));
@@ -249,21 +263,22 @@ export function vaultHashlock(root: Uint8Array, htlcVout: number): Buffer {
 // ---------------------------------------------------------------------------
 
 /**
- * The e2e deposit terms, matching the fw test intent (`_setup_s2_state` with
- * `_PREPEGIN_TXID`). `prepeginTxid` is DISPLAY order — the seam converts
- * display → internal exactly like wallet-connector's provider, and the wire
- * carries the internal-order bytes the firmware compares against the PSBT.
- * `vaultCoreVersion` is 2: the device-supported tx-graph version gate — the
- * TLV's structure/version constants (both 1) are pinned inside the encoder.
+ * The e2e deposit terms, bound to the Pre-PegIn the suite actually signs —
+ * pass {@link PrePeginPsbtFixture.txidInternal}. `prepeginTxid` is DISPLAY
+ * order: the seam converts display → internal exactly like wallet-connector's
+ * provider, and the wire carries the internal-order bytes the firmware compares
+ * against the PSBT. `vaultCoreVersion` is 2: the device-supported tx-graph
+ * version gate — the TLV's structure/version constants (both 1) are pinned
+ * inside the encoder.
  */
-export function buildDepositTerms(): DepositTerms {
+export function buildDepositTerms(prepeginTxidInternal: Buffer): DepositTerms {
   return {
     vaultCoreVersion: 2,
     protocolFeeRate: BigInt(BASE_FEE_RATE),
     timelockPegin: PEGIN_CSV_TIMELOCK,
     timelockAssert: PAYOUT_TIMELOCK,
     timelockRefund: HTLC_REFUND_TIMELOCK,
-    prepeginTxid: Buffer.from(PREPEGIN_TXID_INTERNAL).reverse().toString("hex"),
+    prepeginTxid: Buffer.from(prepeginTxidInternal).reverse().toString("hex"),
     prepeginMaxFee: BigInt(PREPEGIN_MAX_FEE_SATS),
     vaultKeeperBtcPubkeys: [KEEPER_KEY_HEX],
     universalChallengerBtcPubkeys: [CHALLENGER_KEY_HEX],
@@ -321,6 +336,61 @@ export function termsToIntent(terms: DepositTerms): IntentFixture {
 }
 
 // ---------------------------------------------------------------------------
+// Pre-PegIn PSBT — the transaction the intent binds to
+// (`_validate_prepegin`, fw sign_psbt_validate.c:334-545 @ 4decf822)
+// ---------------------------------------------------------------------------
+
+const PREPEGIN_INPUT_COUNT = 2;
+/** Distinct but otherwise arbitrary prevout hashes — the device never fetches them. */
+const PREPEGIN_PREVOUT_HASH_BASE = 0x40;
+
+export interface PrePeginPsbtFixture {
+  /** v0, NOT augmented — the test augments it the way the provider does. */
+  readonly psbtHex: string;
+  /** Raw SHA256d of the unsigned tx (PSBT/internal order) — the intent's prepegin_txid and the PegIn prevout. */
+  readonly txidInternal: Buffer;
+  readonly htlcScriptPubKey: Buffer;
+}
+
+/**
+ * Toolkit-shaped Pre-PegIn: two depositor key-path inputs → [HTLC, CPFP anchor
+ * 546 P2TR(depositor), change P2TR(changeKey)]. No OP_RETURN (optional on-device).
+ * Layout matches btc-vault `[HTLC×n, OP_RETURN?, anchor, change*]`.
+ */
+export function buildPrePeginPsbt(hashlock: Buffer, changeXOnlyHex: string): PrePeginPsbtFixture {
+  const depositor = hexToBuffer(DEPOSITOR_XONLY_HEX);
+  const vp = hexToBuffer(VP_KEY_HEX);
+  const keepers = [hexToBuffer(KEEPER_KEY_HEX)];
+  const challengers = [hexToBuffer(CHALLENGER_KEY_HEX)];
+  const leaf0 = htlcLeaf0(depositor, vp, keepers, challengers, hashlock);
+  const leaf1 = htlcLeaf1(depositor, HTLC_REFUND_TIMELOCK);
+  const merkleRoot = tapBranch(tapLeafHash(TAPSCRIPT_LEAF_VERSION, leaf0), tapLeafHash(TAPSCRIPT_LEAF_VERSION, leaf1));
+  const htlcScriptPubKey = Buffer.concat([Buffer.from([0x51, PUSH_32]), tweakNums(merkleRoot).xOnly]);
+  const depositorSpk = payments.p2tr({ internalPubkey: depositor }).output!;
+  const changeSpk = payments.p2tr({ internalPubkey: hexToBuffer(changeXOnlyHex) }).output!;
+  const changeValue =
+    PREPEGIN_INPUT_COUNT * PREPEGIN_INPUT_VALUE_SATS - HTLC_VALUE_SATS - CPFP_ANCHOR_VALUE_SATS - PREPEGIN_FEE_SATS;
+
+  const psbt = new Psbt();
+  psbt.setVersion(2); // fw requires tx_version >= 2
+  psbt.setLocktime(0);
+  for (let i = 0; i < PREPEGIN_INPUT_COUNT; i++) {
+    psbt.addInput({
+      hash: Buffer.alloc(32, PREPEGIN_PREVOUT_HASH_BASE + i),
+      index: i,
+      sequence: 0xfffffffd,
+      witnessUtxo: { script: depositorSpk, value: PREPEGIN_INPUT_VALUE_SATS },
+      tapInternalKey: depositor,
+    });
+  }
+  psbt.addOutput({ script: htlcScriptPubKey, value: HTLC_VALUE_SATS });
+  psbt.addOutput({ script: depositorSpk, value: CPFP_ANCHOR_VALUE_SATS });
+  psbt.addOutput({ script: changeSpk, value: changeValue });
+  const tx = Transaction.fromBuffer(psbt.data.globalMap.unsignedTx.toBuffer());
+  return { psbtHex: psbt.toHex(), txidInternal: tx.getHash(), htlcScriptPubKey };
+}
+
+// ---------------------------------------------------------------------------
 // PegIn PSBT (test_sign_psbt_validate.py:309 `_build_pegin_psbt`)
 // ---------------------------------------------------------------------------
 
@@ -337,7 +407,7 @@ export interface PeginPsbtFixture {
  * Leaf 0; outputs are Vault, Depositor Claim, and the P2A anchor. Tx v3
  * (TRUC), locktime 0, sequence 0xFFFFFFFE — all per the fw builder.
  */
-export function buildPeginPsbt(hashlock: Buffer): PeginPsbtFixture {
+export function buildPeginPsbt(hashlock: Buffer, prepeginTxidInternal: Buffer): PeginPsbtFixture {
   const depositor = hexToBuffer(DEPOSITOR_XONLY_HEX);
   const vp = hexToBuffer(VP_KEY_HEX);
   const keepers = [hexToBuffer(KEEPER_KEY_HEX)];
@@ -360,7 +430,7 @@ export function buildPeginPsbt(hashlock: Buffer): PeginPsbtFixture {
   psbt.setVersion(3); // TRUC (BIP-431)
   psbt.setLocktime(0);
   psbt.addInput({
-    hash: PREPEGIN_TXID_INTERNAL, // Buffer form: used as-is (internal order)
+    hash: prepeginTxidInternal, // Buffer form: used as-is (internal order)
     index: HTLC_VOUT,
     sequence: 0xfffffffe,
     witnessUtxo: { script: htlcScriptPubKey, value: HTLC_VALUE_SATS },

--- a/packages/babylon-ledger-vault-signer/src/__tests__/e2e/speculos.e2e.test.ts
+++ b/packages/babylon-ledger-vault-signer/src/__tests__/e2e/speculos.e2e.test.ts
@@ -100,13 +100,15 @@ const POP_MESSAGE =
 const ACCOUNT_PATH_LEVELS = 3;
 const POLICY_COIN_TYPE = 1;
 const POLICY_ACCOUNT_INDEX = 0;
-/** Change lives at `account/1/0` — BIP-86 change branch, first address. */
-const BIP86_CHANGE_BRANCH = 1;
+/** Change lives at `account/1/0` — the policy derives the branch, we pick the index. */
 const CHANGE_ADDRESS_INDEX = 0;
 
 /**
- * BIP-322 to_sign shape, restated rather than imported from `popPsbt.ts` so the
- * verification below is independent of the builder under test.
+ * BIP-322 to_sign framing, restated. The to_spend txid still comes from
+ * `bip322ToSpendTxid` (the builder under test), but the device is the
+ * independent oracle for it: the firmware rebuilds to_spend from the message
+ * and its own BIP-86 key and rejects a PSBT_IN_PREVIOUS_TXID mismatch before
+ * signing (`sign_psbt_validate.c:2751-2802` @ 4decf822).
  */
 const TO_SIGN_VERSION = 0;
 const TO_SIGN_LOCKTIME = 0;
@@ -178,6 +180,7 @@ describe.skipIf(SPECULOS_URL === "")("Speculos end-to-end vault signing", () => 
         coinType: POLICY_COIN_TYPE,
         accountIndex: POLICY_ACCOUNT_INDEX,
         accountXpub,
+        bip32Versions: TESTNET_VERSIONS,
       });
       changeXOnly = deriveChangeXOnlyHex(accountXpub, TESTNET_VERSIONS, CHANGE_ADDRESS_INDEX);
       prePegin = buildPrePeginPsbt(vaultHashlock(contextRoot as Uint8Array, HTLC_VOUT), changeXOnly);
@@ -219,7 +222,7 @@ describe.skipIf(SPECULOS_URL === "")("Speculos end-to-end vault signing", () => 
       const unmarkedChange = augmentPsbtForWalletPolicy({
         psbtHex: (prePegin as PrePeginPsbtFixture).psbtHex,
         depositorXOnlyHex: DEPOSITOR_XONLY_HEX,
-        masterFingerprintHex: masterFingerprintHex as string,
+        walletPolicy: policy as DefaultTaprootWalletPolicy,
         depositorPath: DEPOSITOR_PATH,
         // no `change` → the change output is external on-device → `_validate_prepegin`
         // catch-all reject (`sign_psbt_validate.c:507-510`), before the txid/cap checks.
@@ -254,12 +257,9 @@ describe.skipIf(SPECULOS_URL === "")("Speculos end-to-end vault signing", () => 
       const augmented = augmentPsbtForWalletPolicy({
         psbtHex: psbtFixture.psbtHex,
         depositorXOnlyHex: DEPOSITOR_XONLY_HEX,
-        masterFingerprintHex: masterFingerprintHex as string,
+        walletPolicy: policy as DefaultTaprootWalletPolicy,
         depositorPath: DEPOSITOR_PATH,
-        change: {
-          xOnlyHex: changeXOnly as string,
-          path: [...DEPOSITOR_PATH.slice(0, ACCOUNT_PATH_LEVELS), BIP86_CHANGE_BRANCH, CHANGE_ADDRESS_INDEX],
-        },
+        change: { addressIndex: CHANGE_ADDRESS_INDEX },
       });
       const prepared = prepareSignPsbt({
         psbtHex: augmented,
@@ -398,6 +398,7 @@ describe.skipIf(SPECULOS_URL === "")("Speculos end-to-end vault signing", () => 
           coinType: POLICY_COIN_TYPE,
           accountIndex: POLICY_ACCOUNT_INDEX,
           accountXpub,
+          bip32Versions: TESTNET_VERSIONS,
         });
         const psbtHex = buildPopPsbtHex({
           message: POP_MESSAGE,

--- a/packages/babylon-ledger-vault-signer/src/__tests__/e2e/speculos.e2e.test.ts
+++ b/packages/babylon-ledger-vault-signer/src/__tests__/e2e/speculos.e2e.test.ts
@@ -1,9 +1,22 @@
 /**
- * Speculos end-to-end signing test (#2219 B2, #2221 PoP): the full production
- * path — envelope gate → DERIVE_CONTEXT_HASH → APPROVE_VAULT_INTENT →
- * signVaultPsbt → BIP-322 PoP under the default wallet policy — against the
- * real vault app in a Speculos container, ending in cryptographic verification
- * of the device's Schnorr signatures.
+ * Speculos end-to-end signing test (#2219 B2, #2221 PoP, #2222 Pre-PegIn): the
+ * full production path against the real vault app in a Speculos container,
+ * ending in cryptographic verification of the device's Schnorr signatures.
+ *
+ * Stages, in order — each one arms the device state the next consumes:
+ *   1. app identity
+ *   2. DERIVE_CONTEXT_HASH → context root (the HTLC hashlock's source)
+ *   3. policy context (fingerprint, account xpub, change key) + Pre-PegIn build
+ *   4. APPROVE_VAULT_INTENT over terms bound to that Pre-PegIn's txid
+ *   5. Pre-PegIn with an UNMARKED change output → device rejection, intent intact
+ *   6. Pre-PegIn under the default wallet policy → one key-path yield per input
+ *   7-9. PegIn (spends the real Pre-PegIn txid), sighash check, finalize
+ *   10. BIP-322 PoP, last, so it signs while the intent is still loaded — the
+ *       path that exercises the firmware's intent-key check
+ *       (`sign_psbt_validate.c:2764-2769`).
+ *
+ * Stage 5 MUST precede stage 6: a successful Pre-PegIn sign arms the one-shot
+ * cap and the next one answers SW_CAP_EXCEEDED (`sign_psbt_validate.c:539-543`).
  *
  * Requires a running container with the vault app (nanosp, testnet build,
  * firmware-test mnemonic) built from ELF commit `e2d0c45b`. Skipped unless
@@ -11,11 +24,8 @@
  *
  *   SPECULOS_URL=http://127.0.0.1:5055 pnpm exec vitest run src/__tests__/e2e/
  *
- * The suite is stateful and ordered: the ceremony arms the device state the
- * signing stage consumes, and the PoP stage runs last so it signs while the
- * intent is still loaded — the path that exercises the firmware's intent-key
- * check (`sign_psbt_validate.c:2764-2769`). Each run re-runs the full ceremony,
- * so the container does not need restarting between runs.
+ * Each run re-runs the full ceremony, so the container does not need restarting
+ * between runs.
  */
 
 import { Psbt, Transaction } from "bitcoinjs-lib";
@@ -24,26 +34,31 @@ import { describe, expect, it } from "vitest";
 
 import { getExtendedPublicKey, getMasterFingerprintHex } from "../../derivation";
 import { assertDepositTermsDeviceCompatible } from "../../envelope";
+import { isLedgerDeviceError } from "../../errors";
 import { bip86OutputScript } from "../../expectedSignatures";
+import { augmentPsbtForWalletPolicy, deriveChangeXOnlyHex } from "../../policyPsbt";
 import { bip322ToSpendTxid, buildPopPsbtHex } from "../../popPsbt";
 import { signPreparedVaultPsbt, signVaultPsbt, type SignVaultPsbtResult } from "../../signPsbt";
 import { prepareSignPsbt } from "../../signPsbtPrepare";
 import { approveVaultIntent, deriveContextHash } from "../../vaultCommands";
-import { buildDefaultTaprootPolicy } from "../../walletPolicy";
+import { buildDefaultTaprootPolicy, type DefaultTaprootWalletPolicy } from "../../walletPolicy";
 import {
   buildDepositTerms,
   buildPeginPsbt,
+  buildPrePeginPsbt,
   computePeginSighash,
   DEPOSITOR_PATH,
   DEPOSITOR_XONLY_HEX,
   DERIVE_CONTEXT,
   HTLC_VOUT,
-  PREPEGIN_TXID_INTERNAL,
+  PREPEGIN_INPUT_VALUE_SATS,
   termsToIntent,
+  TESTNET_VERSIONS,
   VAULT_APP_NAME,
   vaultHashlock,
   verifySchnorrSignature,
   type PeginPsbtFixture,
+  type PrePeginPsbtFixture,
 } from "./peginFixture";
 import {
   approveOnScreen,
@@ -75,15 +90,19 @@ const SIGNING_ABORT_MS = SIGNING_TIMEOUT_MS - 10_000;
 
 const SCHNORR_SIG_BYTES = 64;
 
+/** SW_INCORRECT_DATA — `_validate_prepegin`'s catch-all output reject (`sign_psbt_validate.c:507-510`). */
+const SW_INCORRECT_DATA = 0x6a80;
+
 /** `<eth>:<chainId>:pegin:<registry>` — grammar is the device's boundary, not ours. */
 const POP_MESSAGE =
   "0xabcdef1234567890abcdef1234567890abcdef12:11155111:pegin:0x1234567890abcdef1234567890abcdef12345678";
-/** Testnet BIP-32 version bytes — the signet build answers tpub/tprv. */
-const TESTNET_VERSIONS = { public: 0x043587cf, private: 0x04358394 };
 /** The policy's key origin is DEPOSITOR_PATH's account prefix, m/86'/1'/0'. */
 const ACCOUNT_PATH_LEVELS = 3;
 const POLICY_COIN_TYPE = 1;
 const POLICY_ACCOUNT_INDEX = 0;
+/** Change lives at `account/1/0` — BIP-86 change branch, first address. */
+const BIP86_CHANGE_BRANCH = 1;
+const CHANGE_ADDRESS_INDEX = 0;
 
 /**
  * BIP-322 to_sign shape, restated rather than imported from `popPsbt.ts` so the
@@ -105,6 +124,10 @@ describe.skipIf(SPECULOS_URL === "")("Speculos end-to-end vault signing", () => 
   // Ordered stages share state; a later stage failing on `undefined` means an
   // earlier stage failed first — read its failure, not this one.
   let contextRoot: Uint8Array | undefined;
+  let policy: DefaultTaprootWalletPolicy | undefined;
+  let masterFingerprintHex: string | undefined;
+  let changeXOnly: string | undefined;
+  let prePegin: PrePeginPsbtFixture | undefined;
   let fixture: PeginPsbtFixture | undefined;
   let signResult: SignVaultPsbtResult | undefined;
 
@@ -120,16 +143,8 @@ describe.skipIf(SPECULOS_URL === "")("Speculos end-to-end vault signing", () => 
   );
 
   it(
-    "(2) ceremony: envelope gate, DERIVE_CONTEXT_HASH, APPROVE_VAULT_INTENT via the production encoders",
+    "(2) DERIVE_CONTEXT_HASH returns the vault context root",
     async () => {
-      const terms = buildDepositTerms();
-      // The envelope gate must accept these terms with zero device I/O.
-      assertDepositTermsDeviceCompatible(terms);
-      const intent = termsToIntent(terms);
-      // Byte-order seam: display-order terms txid maps to the internal-order
-      // prevout the PSBT carries and the firmware compares against.
-      expect(Buffer.from(intent.scalars.prepeginTxidInternal).equals(PREPEGIN_TXID_INTERNAL)).toBe(true);
-
       // The final DERIVE APDU blocks on the review screen — drive it concurrently.
       const rootPending = deriveContextHash(send, {
         appName: VAULT_APP_NAME,
@@ -144,9 +159,49 @@ describe.skipIf(SPECULOS_URL === "")("Speculos end-to-end vault signing", () => 
       // ("never log payload bytes") is unconditional here, and this suite can
       // be pointed at a real device. Assertions below pin the values instead.
       console.log(`[speculos-e2e] derive screens: ${deriveScreens.join(" || ")}`);
+    },
+    CEREMONY_TIMEOUT_MS,
+  );
+
+  it(
+    "(3) reads the policy context and builds the Pre-PegIn the intent will bind to",
+    async () => {
+      expect(contextRoot, "derive stage must have produced a root").toBeDefined();
+      masterFingerprintHex = await getMasterFingerprintHex(send);
+      const accountXpub = await getExtendedPublicKey(
+        send,
+        DEPOSITOR_PATH.slice(0, ACCOUNT_PATH_LEVELS),
+        TESTNET_VERSIONS,
+      );
+      policy = buildDefaultTaprootPolicy({
+        masterFingerprintHex,
+        coinType: POLICY_COIN_TYPE,
+        accountIndex: POLICY_ACCOUNT_INDEX,
+        accountXpub,
+      });
+      changeXOnly = deriveChangeXOnlyHex(accountXpub, TESTNET_VERSIONS, CHANGE_ADDRESS_INDEX);
+      prePegin = buildPrePeginPsbt(vaultHashlock(contextRoot as Uint8Array, HTLC_VOUT), changeXOnly);
+      expect(prePegin.txidInternal).toHaveLength(32);
+    },
+    SANITY_TIMEOUT_MS,
+  );
+
+  it(
+    "(4) APPROVE_VAULT_INTENT accepts terms bound to that Pre-PegIn txid",
+    async () => {
+      expect(prePegin, "policy-context stage must have built the Pre-PegIn").toBeDefined();
+      const terms = buildDepositTerms((prePegin as PrePeginPsbtFixture).txidInternal);
+      // The envelope gate must accept these terms with zero device I/O.
+      assertDepositTermsDeviceCompatible(terms);
+      const intent = termsToIntent(terms);
+      // Byte-order seam: display-order terms txid maps to the internal-order
+      // prevout the PSBT carries and the firmware compares against.
+      expect(
+        Buffer.from(intent.scalars.prepeginTxidInternal).equals((prePegin as PrePeginPsbtFixture).txidInternal),
+      ).toBe(true);
 
       // Scalars and group APDUs answer immediately; the final key batch blocks
-      // on the intent review screen — drive it concurrently too.
+      // on the intent review screen — drive it concurrently.
       await waitForIdleScreen();
       const approvePending = approveVaultIntent(send, intent);
       approvePending.catch(() => undefined); // handled at the await below
@@ -158,11 +213,98 @@ describe.skipIf(SPECULOS_URL === "")("Speculos end-to-end vault signing", () => 
   );
 
   it(
-    "(3) signVaultPsbt signs the PegIn PSBT on the device",
+    "(5) rejects a Pre-PegIn whose change output carries no derivation (not internal) without dropping the intent",
     async () => {
-      expect(contextRoot, "ceremony stage must have produced a root").toBeDefined();
+      expect(prePegin, "policy-context stage must have built the Pre-PegIn").toBeDefined();
+      const unmarkedChange = augmentPsbtForWalletPolicy({
+        psbtHex: (prePegin as PrePeginPsbtFixture).psbtHex,
+        depositorXOnlyHex: DEPOSITOR_XONLY_HEX,
+        masterFingerprintHex: masterFingerprintHex as string,
+        depositorPath: DEPOSITOR_PATH,
+        // no `change` → the change output is external on-device → `_validate_prepegin`
+        // catch-all reject (`sign_psbt_validate.c:507-510`), before the txid/cap checks.
+      });
+      const prepared = prepareSignPsbt({
+        psbtHex: unmarkedChange,
+        depositorXOnlyHex: DEPOSITOR_XONLY_HEX,
+        walletPolicy: policy as DefaultTaprootWalletPolicy,
+      });
+      const failure = await signPreparedVaultPsbt(sendRaw, prepared, {
+        signal: AbortSignal.timeout(SIGNING_ABORT_MS),
+      }).then(
+        () => null,
+        (error: unknown) => error,
+      );
+      // A terminal status word from the loop is classified into LedgerDeviceError
+      // (`rawApdu.ts classifyStatusWord`, `signPsbtLoop.ts:159-171`).
+      expect(isLedgerDeviceError(failure)).toBe(true);
+      expect((failure as { statusWord: number }).statusWord).toBe(SW_INCORRECT_DATA);
+      // Session and intent survive a validation failure: the next stage signs
+      // the same Pre-PegIn under the same intent.
+      expect(await getMasterFingerprintHex(send)).toBe(masterFingerprintHex);
+    },
+    SIGNING_TIMEOUT_MS,
+  );
+
+  it(
+    "(6) signs the toolkit-shaped Pre-PegIn under the default policy — one key-path yield per input, each verifiable",
+    async () => {
+      expect(prePegin, "policy-context stage must have built the Pre-PegIn").toBeDefined();
+      const psbtFixture = prePegin as PrePeginPsbtFixture;
+      const augmented = augmentPsbtForWalletPolicy({
+        psbtHex: psbtFixture.psbtHex,
+        depositorXOnlyHex: DEPOSITOR_XONLY_HEX,
+        masterFingerprintHex: masterFingerprintHex as string,
+        depositorPath: DEPOSITOR_PATH,
+        change: {
+          xOnlyHex: changeXOnly as string,
+          path: [...DEPOSITOR_PATH.slice(0, ACCOUNT_PATH_LEVELS), BIP86_CHANGE_BRANCH, CHANGE_ADDRESS_INDEX],
+        },
+      });
+      const prepared = prepareSignPsbt({
+        psbtHex: augmented,
+        depositorXOnlyHex: DEPOSITOR_XONLY_HEX,
+        walletPolicy: policy as DefaultTaprootWalletPolicy,
+      });
+      expect(prepared.table.expectedYieldCount).toBe(2);
+      // Pre-PegIn is silent on-device (no review screen) — no approveOnScreen here.
+      const result = await signPreparedVaultPsbt(sendRaw, prepared, {
+        signal: AbortSignal.timeout(SIGNING_ABORT_MS),
+      });
+      expect(result.yields).toHaveLength(2);
+
+      const depositorSpk = bip86OutputScript(DEPOSITOR_XONLY_HEX);
+      const tx = Transaction.fromBuffer(Psbt.fromHex(psbtFixture.psbtHex).data.globalMap.unsignedTx.toBuffer());
+      for (const y of result.yields) {
+        expect(y.kind).toBe("taproot-keypath");
+        expect(y.signature).toHaveLength(SCHNORR_SIG_BYTES);
+        const sighash = tx.hashForWitnessV1(
+          y.inputIndex,
+          [depositorSpk, depositorSpk],
+          [PREPEGIN_INPUT_VALUE_SATS, PREPEGIN_INPUT_VALUE_SATS],
+          Transaction.SIGHASH_DEFAULT,
+        );
+        expect(
+          verifySchnorrSignature(
+            sighash,
+            depositorSpk.subarray(P2TR_WITNESS_PROGRAM_OFFSET).toString("hex"),
+            y.signature,
+          ),
+        ).toBe(true);
+      }
+    },
+    SIGNING_TIMEOUT_MS,
+  );
+
+  it(
+    "(7) signVaultPsbt signs the PegIn PSBT on the device",
+    async () => {
+      expect(contextRoot, "derive stage must have produced a root").toBeDefined();
+      expect(prePegin, "policy-context stage must have built the Pre-PegIn").toBeDefined();
       const hashlock = vaultHashlock(contextRoot as Uint8Array, HTLC_VOUT);
-      fixture = buildPeginPsbt(hashlock);
+      fixture = buildPeginPsbt(hashlock, (prePegin as PrePeginPsbtFixture).txidInternal);
+      // The PegIn spends the Pre-PegIn's HTLC output — same script, same txid.
+      expect(fixture.htlcScriptPubKey.equals((prePegin as PrePeginPsbtFixture).htlcScriptPubKey)).toBe(true);
 
       // PegIn signing is silent (fw test_sign_psbt_validate.py header) — the
       // approved intent authorizes it, so no screen driving here.
@@ -185,13 +327,13 @@ describe.skipIf(SPECULOS_URL === "")("Speculos end-to-end vault signing", () => 
   );
 
   it(
-    "(4) the device signature verifies against the BIP-341 script-path sighash",
+    "(8) the device signature verifies against the BIP-341 script-path sighash",
     () => {
       expect(fixture, "signing stage must have built the fixture").toBeDefined();
       expect(signResult, "signing stage must have produced yields").toBeDefined();
       const psbtFixture = fixture as PeginPsbtFixture;
       const yielded = (signResult as SignVaultPsbtResult).yields[0];
-      if (yielded.kind !== "tapscript") throw new Error("stage (3) asserted tapscript");
+      if (yielded.kind !== "tapscript") throw new Error("stage (7) asserted tapscript");
 
       const sighash = computePeginSighash(psbtFixture.psbtHex, psbtFixture);
       const valid = verifySchnorrSignature(sighash, DEPOSITOR_XONLY_HEX, yielded.signature);
@@ -207,7 +349,7 @@ describe.skipIf(SPECULOS_URL === "")("Speculos end-to-end vault signing", () => 
   );
 
   it(
-    "(5) the merged PSBT carries the tapScriptSig and finalizes",
+    "(9) the merged PSBT carries the tapScriptSig and finalizes",
     () => {
       expect(fixture, "signing stage must have built the fixture").toBeDefined();
       expect(signResult, "signing stage must have produced a merged PSBT").toBeDefined();
@@ -241,18 +383,18 @@ describe.skipIf(SPECULOS_URL === "")("Speculos end-to-end vault signing", () => 
     SANITY_TIMEOUT_MS,
   );
 
-  describe("(6) PoP (BIP-322) under the default policy", () => {
+  describe("(10) PoP (BIP-322) under the default policy", () => {
     it(
       "signs a PoP while the intent is loaded and the signature verifies over the BIP-322 to_sign sighash",
       async () => {
-        const masterFingerprintHex = await getMasterFingerprintHex(send);
+        const popFingerprintHex = await getMasterFingerprintHex(send);
         const accountXpub = await getExtendedPublicKey(
           send,
           DEPOSITOR_PATH.slice(0, ACCOUNT_PATH_LEVELS),
           TESTNET_VERSIONS,
         );
-        const policy = buildDefaultTaprootPolicy({
-          masterFingerprintHex,
+        const popPolicy = buildDefaultTaprootPolicy({
+          masterFingerprintHex: popFingerprintHex,
           coinType: POLICY_COIN_TYPE,
           accountIndex: POLICY_ACCOUNT_INDEX,
           accountXpub,
@@ -260,10 +402,10 @@ describe.skipIf(SPECULOS_URL === "")("Speculos end-to-end vault signing", () => 
         const psbtHex = buildPopPsbtHex({
           message: POP_MESSAGE,
           depositorXOnlyHex: DEPOSITOR_XONLY_HEX,
-          masterFingerprintHex,
+          masterFingerprintHex: popFingerprintHex,
           depositorPath: DEPOSITOR_PATH,
         });
-        const prepared = prepareSignPsbt({ psbtHex, depositorXOnlyHex: DEPOSITOR_XONLY_HEX, walletPolicy: policy });
+        const prepared = prepareSignPsbt({ psbtHex, depositorXOnlyHex: DEPOSITOR_XONLY_HEX, walletPolicy: popPolicy });
 
         // PoP is the one signing flow with a review screen — drive it concurrently.
         const approval = approveOnScreen(SPECULOS_URL, POP_APPROVAL_TEXT);

--- a/packages/babylon-ledger-vault-signer/src/__tests__/e2e/speculos.e2e.test.ts
+++ b/packages/babylon-ledger-vault-signer/src/__tests__/e2e/speculos.e2e.test.ts
@@ -1,26 +1,35 @@
 /**
- * Speculos end-to-end signing test (#2219 B2): the full production path —
- * envelope gate → DERIVE_CONTEXT_HASH → APPROVE_VAULT_INTENT → signVaultPsbt —
- * against the real vault app in a Speculos container, ending in cryptographic
- * verification of the device's Schnorr signature.
+ * Speculos end-to-end signing test (#2219 B2, #2221 PoP): the full production
+ * path — envelope gate → DERIVE_CONTEXT_HASH → APPROVE_VAULT_INTENT →
+ * signVaultPsbt → BIP-322 PoP under the default wallet policy — against the
+ * real vault app in a Speculos container, ending in cryptographic verification
+ * of the device's Schnorr signatures.
  *
  * Requires a running container with the vault app (nanosp, testnet build,
- * firmware-test mnemonic). Skipped unless SPECULOS_URL is set:
+ * firmware-test mnemonic) built from ELF commit `e2d0c45b`. Skipped unless
+ * SPECULOS_URL is set:
  *
  *   SPECULOS_URL=http://127.0.0.1:5055 pnpm exec vitest run src/__tests__/e2e/
  *
  * The suite is stateful and ordered: the ceremony arms the device state the
- * signing stage consumes. Each run re-runs the full ceremony, so the container
- * does not need restarting between runs.
+ * signing stage consumes, and the PoP stage runs last so it signs while the
+ * intent is still loaded — the path that exercises the firmware's intent-key
+ * check (`sign_psbt_validate.c:2764-2769`). Each run re-runs the full ceremony,
+ * so the container does not need restarting between runs.
  */
 
-import { Psbt } from "bitcoinjs-lib";
+import { Psbt, Transaction } from "bitcoinjs-lib";
 import { Buffer } from "buffer";
 import { describe, expect, it } from "vitest";
 
+import { getExtendedPublicKey, getMasterFingerprintHex } from "../../derivation";
 import { assertDepositTermsDeviceCompatible } from "../../envelope";
-import { signVaultPsbt, type SignVaultPsbtResult } from "../../signPsbt";
+import { bip86OutputScript } from "../../expectedSignatures";
+import { bip322ToSpendTxid, buildPopPsbtHex } from "../../popPsbt";
+import { signPreparedVaultPsbt, signVaultPsbt, type SignVaultPsbtResult } from "../../signPsbt";
+import { prepareSignPsbt } from "../../signPsbtPrepare";
 import { approveVaultIntent, deriveContextHash } from "../../vaultCommands";
+import { buildDefaultTaprootPolicy } from "../../walletPolicy";
 import {
   buildDepositTerms,
   buildPeginPsbt,
@@ -50,13 +59,44 @@ const SPECULOS_URL = process.env.SPECULOS_URL ?? "";
 /** Live-verified nanosp review-screen texts (reference driver `lsk_ceremony2.py`). */
 const DERIVE_APPROVAL_TEXT = "Allow derivation";
 const INTENT_APPROVAL_TEXT = "Approve intent";
+/**
+ * The PoP finish page is "Register ETH\naddress?" (`display.c:336-342`); the
+ * intro page is the same title WITHOUT the question mark, and `approveOnScreen`
+ * presses both on the FIRST match — so target the "?", unique to the finish page.
+ */
+const POP_APPROVAL_TEXT = "address?";
 
 /** Ceremony = APDUs + human-speed screen navigation; signing = ~40 APDU rounds. */
 const CEREMONY_TIMEOUT_MS = 120_000;
 const SIGNING_TIMEOUT_MS = 60_000;
 const SANITY_TIMEOUT_MS = 30_000;
+/** Shorter than the test timeout so the typed abort surfaces first. */
+const SIGNING_ABORT_MS = SIGNING_TIMEOUT_MS - 10_000;
 
 const SCHNORR_SIG_BYTES = 64;
+
+/** `<eth>:<chainId>:pegin:<registry>` — grammar is the device's boundary, not ours. */
+const POP_MESSAGE =
+  "0xabcdef1234567890abcdef1234567890abcdef12:11155111:pegin:0x1234567890abcdef1234567890abcdef12345678";
+/** Testnet BIP-32 version bytes — the signet build answers tpub/tprv. */
+const TESTNET_VERSIONS = { public: 0x043587cf, private: 0x04358394 };
+/** The policy's key origin is DEPOSITOR_PATH's account prefix, m/86'/1'/0'. */
+const ACCOUNT_PATH_LEVELS = 3;
+const POLICY_COIN_TYPE = 1;
+const POLICY_ACCOUNT_INDEX = 0;
+
+/**
+ * BIP-322 to_sign shape, restated rather than imported from `popPsbt.ts` so the
+ * verification below is independent of the builder under test.
+ */
+const TO_SIGN_VERSION = 0;
+const TO_SIGN_LOCKTIME = 0;
+const TO_SIGN_SEQUENCE = 0;
+const TO_SPEND_VOUT = 0;
+const OP_RETURN_SCRIPT = Buffer.from([0x6a]);
+const ZERO_SATS = 0;
+/** P2TR scriptPubKey = `OP_1 ‖ push-32 ‖ output key`; the key starts here. */
+const P2TR_WITNESS_PROGRAM_OFFSET = 2;
 
 describe.skipIf(SPECULOS_URL === "")("Speculos end-to-end vault signing", () => {
   const sendRaw = createSpeculosRawApduSender(SPECULOS_URL);
@@ -126,11 +166,10 @@ describe.skipIf(SPECULOS_URL === "")("Speculos end-to-end vault signing", () => 
 
       // PegIn signing is silent (fw test_sign_psbt_validate.py header) — the
       // approved intent authorizes it, so no screen driving here.
-      // Shorter than the test timeout so the typed abort surfaces first.
       signResult = await signVaultPsbt(sendRaw, {
         psbtHex: fixture.psbtHex,
         depositorXOnlyHex: DEPOSITOR_XONLY_HEX,
-        signal: AbortSignal.timeout(SIGNING_TIMEOUT_MS - 10_000),
+        signal: AbortSignal.timeout(SIGNING_ABORT_MS),
       });
 
       expect(signResult.yields).toHaveLength(1);
@@ -202,7 +241,64 @@ describe.skipIf(SPECULOS_URL === "")("Speculos end-to-end vault signing", () => 
     SANITY_TIMEOUT_MS,
   );
 
-  /** Best-effort settle back to the dashboard between the two approval flows. */
+  describe("(6) PoP (BIP-322) under the default policy", () => {
+    it(
+      "signs a PoP while the intent is loaded and the signature verifies over the BIP-322 to_sign sighash",
+      async () => {
+        const masterFingerprintHex = await getMasterFingerprintHex(send);
+        const accountXpub = await getExtendedPublicKey(
+          send,
+          DEPOSITOR_PATH.slice(0, ACCOUNT_PATH_LEVELS),
+          TESTNET_VERSIONS,
+        );
+        const policy = buildDefaultTaprootPolicy({
+          masterFingerprintHex,
+          coinType: POLICY_COIN_TYPE,
+          accountIndex: POLICY_ACCOUNT_INDEX,
+          accountXpub,
+        });
+        const psbtHex = buildPopPsbtHex({
+          message: POP_MESSAGE,
+          depositorXOnlyHex: DEPOSITOR_XONLY_HEX,
+          masterFingerprintHex,
+          depositorPath: DEPOSITOR_PATH,
+        });
+        const prepared = prepareSignPsbt({ psbtHex, depositorXOnlyHex: DEPOSITOR_XONLY_HEX, walletPolicy: policy });
+
+        // PoP is the one signing flow with a review screen — drive it concurrently.
+        const approval = approveOnScreen(SPECULOS_URL, POP_APPROVAL_TEXT);
+        approval.catch(() => undefined); // handled at the await below
+        const result = await signPreparedVaultPsbt(sendRaw, prepared, {
+          signal: AbortSignal.timeout(SIGNING_ABORT_MS),
+        });
+        const popScreens = await approval;
+        console.log(`[speculos-e2e] pop screens: ${popScreens.join(" || ")}`);
+
+        expect(result.yields).toHaveLength(1);
+        const yielded = result.yields[0];
+        expect(yielded.kind).toBe("taproot-keypath");
+        expect(yielded.signature).toHaveLength(SCHNORR_SIG_BYTES);
+
+        // Independent verification: BIP-341 key-path sighash of to_sign, checked
+        // against the BIP-86 tweaked output key.
+        const spk = bip86OutputScript(DEPOSITOR_XONLY_HEX);
+        const tweakedKey = spk.subarray(P2TR_WITNESS_PROGRAM_OFFSET);
+        const toSign = new Transaction();
+        toSign.version = TO_SIGN_VERSION;
+        toSign.locktime = TO_SIGN_LOCKTIME;
+        const toSpendTxid = bip322ToSpendTxid(new TextEncoder().encode(POP_MESSAGE), tweakedKey);
+        toSign.addInput(Buffer.from(toSpendTxid), TO_SPEND_VOUT, TO_SIGN_SEQUENCE);
+        toSign.addOutput(OP_RETURN_SCRIPT, ZERO_SATS);
+        const sighash = toSign.hashForWitnessV1(0, [spk], [ZERO_SATS], Transaction.SIGHASH_DEFAULT);
+        // Key-path: the device signs under the TWEAKED key, and
+        // verifySchnorrSignature verifies against the key as passed (no tweak).
+        expect(verifySchnorrSignature(sighash, tweakedKey.toString("hex"), yielded.signature)).toBe(true);
+      },
+      SIGNING_TIMEOUT_MS,
+    );
+  });
+
+  /** Best-effort settle back to the dashboard between the ceremony's two approval flows. */
   async function waitForIdleScreen(): Promise<void> {
     const deadline = Date.now() + 5_000;
     while (Date.now() < deadline) {

--- a/packages/babylon-ledger-vault-signer/src/__tests__/policyPsbt.test.ts
+++ b/packages/babylon-ledger-vault-signer/src/__tests__/policyPsbt.test.ts
@@ -1,0 +1,218 @@
+/**
+ * Policy-mode PSBT shaping. The base app marks inputs/outputs internal only from
+ * TAP_BIP32_DERIVATION (`preprocess_inputs.c`, `process_in_outs.c:114-117` @ e400d8d8),
+ * and `_validate_prepegin` needs every input internal and change internal
+ * (`sign_psbt_validate.c:334-545` @ 4decf822). Vectors: BIP-86 published test vectors.
+ */
+
+import { Psbt } from "bitcoinjs-lib";
+import { Buffer } from "buffer";
+import { describe, expect, it } from "vitest";
+
+import { bip86OutputScript } from "../expectedSignatures";
+import { augmentPsbtForWalletPolicy, deriveChangeXOnlyHex, psbtPaysChangeScript } from "../policyPsbt";
+import { prepareSignPsbt } from "../signPsbtPrepare";
+import { buildDefaultTaprootPolicy } from "../walletPolicy";
+
+const MAINNET_VERSIONS = { public: 0x0488b21e, private: 0x0488ade4 };
+/** BIP-86 published vectors ("abandon … about"). */
+const ACCOUNT_XPUB =
+  "xpub6BgBgsespWvERF3LHQu6CnqdvfEvtMcQjYrcRzx53QJjSxarj2afYWcLteoGVky7D3UKDP9QyrLprQ3VCECoY49yfdDEHGCtMMj92pReUsQ";
+const RECEIVE0_XONLY = "cc8a4bc64d897bddc5fbc2f670f7a8ba0b386779106cf1223c6fc5d7cd6fc115"; // m/86'/0'/0'/0/0
+const CHANGE0_XONLY = "399f1b2f4393f29a18c937859c5dd8a77350103157eb880f02e8c08214277cef"; // m/86'/0'/0'/1/0
+const FINGERPRINT = "73c5da0a";
+const H = 0x80000000;
+const DEPOSITOR_PATH = [86 + H, 0 + H, 0 + H, 0, 0];
+const CHANGE_PATH = [86 + H, 0 + H, 0 + H, 1, 0];
+
+describe("deriveChangeXOnlyHex", () => {
+  it("derives the BIP-86 first change key from the account xpub", () => {
+    expect(deriveChangeXOnlyHex(ACCOUNT_XPUB, MAINNET_VERSIONS, 0)).toBe(CHANGE0_XONLY);
+  });
+
+  it("rejects a non-integer, negative or hardened address index", () => {
+    expect(() => deriveChangeXOnlyHex(ACCOUNT_XPUB, MAINNET_VERSIONS, -1)).toThrow(/addressIndex/);
+    expect(() => deriveChangeXOnlyHex(ACCOUNT_XPUB, MAINNET_VERSIONS, 1.5)).toThrow(/addressIndex/);
+    expect(() => deriveChangeXOnlyHex(ACCOUNT_XPUB, MAINNET_VERSIONS, H)).toThrow(/addressIndex/);
+  });
+});
+
+function prePeginLikePsbt(): string {
+  // Two depositor key-path inputs, one HTLC-ish P2TR output, one change output to the change key.
+  const psbt = new Psbt();
+  const depositorSpk = bip86OutputScript(RECEIVE0_XONLY);
+  for (let i = 0; i < 2; i++) {
+    psbt.addInput({
+      hash: Buffer.alloc(32, i + 1),
+      index: 0,
+      witnessUtxo: { script: depositorSpk, value: 100_000 },
+      tapInternalKey: Buffer.from(RECEIVE0_XONLY, "hex"),
+    });
+  }
+  psbt.addOutput({
+    script: Buffer.concat([Buffer.from([0x51, 0x20]), Buffer.alloc(32, 0xaa)]),
+    value: 150_000,
+  });
+  psbt.addOutput({ script: bip86OutputScript(CHANGE0_XONLY), value: 49_000 });
+  return psbt.toHex();
+}
+
+describe("psbtPaysChangeScript", () => {
+  it("is true when an output pays the BIP-86 P2TR of the change key", () => {
+    expect(psbtPaysChangeScript(prePeginLikePsbt(), CHANGE0_XONLY)).toBe(true);
+  });
+
+  it("is false for a change-less PSBT — the Max-sweep and dust-revert shape", () => {
+    const psbt = new Psbt();
+    psbt.addInput({
+      hash: Buffer.alloc(32, 1),
+      index: 0,
+      witnessUtxo: { script: bip86OutputScript(RECEIVE0_XONLY), value: 100_000 },
+      tapInternalKey: Buffer.from(RECEIVE0_XONLY, "hex"),
+    });
+    psbt.addOutput({ script: Buffer.concat([Buffer.from([0x51, 0x20]), Buffer.alloc(32, 0xaa)]), value: 99_000 });
+
+    expect(psbtPaysChangeScript(psbt.toHex(), CHANGE0_XONLY)).toBe(false);
+  });
+});
+
+describe("augmentPsbtForWalletPolicy", () => {
+  const out = augmentPsbtForWalletPolicy({
+    psbtHex: prePeginLikePsbt(),
+    depositorXOnlyHex: RECEIVE0_XONLY,
+    masterFingerprintHex: FINGERPRINT,
+    depositorPath: DEPOSITOR_PATH,
+    change: { xOnlyHex: CHANGE0_XONLY, path: CHANGE_PATH },
+  });
+  const psbt = Psbt.fromHex(out);
+
+  it("adds TAP_BIP32_DERIVATION (fingerprint + depositor path, no leaf hashes) to every depositor key-path input", () => {
+    for (const input of psbt.data.inputs) {
+      const [d] = input.tapBip32Derivation!;
+      expect(Buffer.from(d.pubkey).toString("hex")).toBe(RECEIVE0_XONLY);
+      expect(Buffer.from(d.masterFingerprint).toString("hex")).toBe(FINGERPRINT);
+      expect(d.path).toBe("m/86'/0'/0'/0/0");
+      expect(d.leafHashes).toHaveLength(0);
+    }
+  });
+
+  it("marks the change output with tapInternalKey + derivation on the change branch, and leaves other outputs untouched", () => {
+    expect(psbt.data.outputs[0].tapBip32Derivation).toBeUndefined();
+    expect(psbt.data.outputs[0].tapInternalKey).toBeUndefined();
+    const change = psbt.data.outputs[1];
+    expect(Buffer.from(change.tapInternalKey!).toString("hex")).toBe(CHANGE0_XONLY);
+    const [d] = change.tapBip32Derivation!;
+    expect(Buffer.from(d.pubkey).toString("hex")).toBe(CHANGE0_XONLY);
+    expect(d.path).toBe("m/86'/0'/0'/1/0");
+  });
+
+  it("does not change the unsigned transaction", () => {
+    const before = Psbt.fromHex(prePeginLikePsbt()).data.globalMap.unsignedTx.toBuffer();
+    expect(psbt.data.globalMap.unsignedTx.toBuffer().equals(before)).toBe(true);
+  });
+
+  it("leaves inputs whose internal key is not the depositor's alone", () => {
+    const p = new Psbt();
+    p.addInput({
+      hash: Buffer.alloc(32, 9),
+      index: 0,
+      witnessUtxo: { script: bip86OutputScript(CHANGE0_XONLY), value: 1 },
+      tapInternalKey: Buffer.from(CHANGE0_XONLY, "hex"),
+    });
+    p.addOutput({ script: Buffer.from([0x6a]), value: 0 });
+    const res = Psbt.fromHex(
+      augmentPsbtForWalletPolicy({
+        psbtHex: p.toHex(),
+        depositorXOnlyHex: RECEIVE0_XONLY,
+        masterFingerprintHex: FINGERPRINT,
+        depositorPath: DEPOSITOR_PATH,
+      }),
+    );
+    expect(res.data.inputs[0].tapBip32Derivation).toBeUndefined();
+  });
+
+  it("rejects paths that are not 5 levels, carry non-u32 levels, or break the receive/change/account pairing", () => {
+    const base = {
+      psbtHex: prePeginLikePsbt(),
+      depositorXOnlyHex: RECEIVE0_XONLY,
+      masterFingerprintHex: FINGERPRINT,
+    };
+    expect(() => augmentPsbtForWalletPolicy({ ...base, depositorPath: [86 + H, 0, 0] })).toThrow(/depositorPath/);
+    expect(() => augmentPsbtForWalletPolicy({ ...base, depositorPath: [86 + H, 0 + H, 0 + H, 0, 2 ** 32] })).toThrow(
+      /depositorPath/,
+    );
+    // depositor on the change branch
+    expect(() => augmentPsbtForWalletPolicy({ ...base, depositorPath: [86 + H, 0 + H, 0 + H, 1, 0] })).toThrow(
+      /receive branch 0/,
+    );
+    // change on the receive branch
+    expect(() =>
+      augmentPsbtForWalletPolicy({
+        ...base,
+        depositorPath: DEPOSITOR_PATH,
+        change: { xOnlyHex: CHANGE0_XONLY, path: [86 + H, 0 + H, 0 + H, 0, 0] },
+      }),
+    ).toThrow(/change branch 1/);
+    // change under a different account
+    expect(() =>
+      augmentPsbtForWalletPolicy({
+        ...base,
+        depositorPath: DEPOSITOR_PATH,
+        change: { xOnlyHex: CHANGE0_XONLY, path: [86 + H, 0 + H, 1 + H, 1, 0] },
+      }),
+    ).toThrow(/same purpose/);
+    expect(() =>
+      augmentPsbtForWalletPolicy({
+        ...base,
+        depositorPath: DEPOSITOR_PATH,
+        change: { xOnlyHex: CHANGE0_XONLY, path: [1, 0] },
+      }),
+    ).toThrow(/change.path/);
+  });
+
+  it("rejects a change key no output pays", () => {
+    // m/86'/0'/0'/1/1 — a real point on the change branch, but not this PSBT's change output.
+    const unusedChangeKey = deriveChangeXOnlyHex(ACCOUNT_XPUB, MAINNET_VERSIONS, 1);
+    expect(() =>
+      augmentPsbtForWalletPolicy({
+        psbtHex: prePeginLikePsbt(),
+        depositorXOnlyHex: RECEIVE0_XONLY,
+        masterFingerprintHex: FINGERPRINT,
+        depositorPath: DEPOSITOR_PATH,
+        change: { xOnlyHex: unusedChangeKey, path: [86 + H, 0 + H, 0 + H, 1, 1] },
+      }),
+    ).toThrow(/matches no output/);
+  });
+
+  it("rejects a hardened address index or an unhardened account level", () => {
+    const base = {
+      psbtHex: prePeginLikePsbt(),
+      depositorXOnlyHex: RECEIVE0_XONLY,
+      masterFingerprintHex: FINGERPRINT,
+    };
+    expect(() => augmentPsbtForWalletPolicy({ ...base, depositorPath: [86 + H, 0 + H, 0 + H, 0, 0 + H] })).toThrow(
+      /depositorPath must harden/,
+    );
+    expect(() =>
+      augmentPsbtForWalletPolicy({
+        ...base,
+        depositorPath: DEPOSITOR_PATH,
+        change: { xOnlyHex: CHANGE0_XONLY, path: [86 + H, 0 + H, 0, 1, 0] },
+      }),
+    ).toThrow(/change.path must harden/);
+  });
+
+  it("is accepted by prepareSignPsbt in policy mode as an all-key-path table (one yield per input)", () => {
+    const policy = buildDefaultTaprootPolicy({
+      masterFingerprintHex: FINGERPRINT,
+      coinType: 0,
+      accountIndex: 0,
+      accountXpub: ACCOUNT_XPUB,
+    });
+    const prepared = prepareSignPsbt({ psbtHex: out, depositorXOnlyHex: RECEIVE0_XONLY, walletPolicy: policy });
+    expect(prepared.table.expectedYieldCount).toBe(2);
+    for (const expectation of prepared.table.byInput.values()) {
+      expect(expectation.kind).toBe("taproot-keypath");
+    }
+  });
+});

--- a/packages/babylon-ledger-vault-signer/src/__tests__/policyPsbt.test.ts
+++ b/packages/babylon-ledger-vault-signer/src/__tests__/policyPsbt.test.ts
@@ -23,7 +23,6 @@ const CHANGE0_XONLY = "399f1b2f4393f29a18c937859c5dd8a77350103157eb880f02e8c0821
 const FINGERPRINT = "73c5da0a";
 const H = 0x80000000;
 const DEPOSITOR_PATH = [86 + H, 0 + H, 0 + H, 0, 0];
-const CHANGE_PATH = [86 + H, 0 + H, 0 + H, 1, 0];
 
 describe("deriveChangeXOnlyHex", () => {
   it("derives the BIP-86 first change key from the account xpub", () => {
@@ -57,6 +56,24 @@ function prePeginLikePsbt(): string {
   return psbt.toHex();
 }
 
+/** Same shape as {@link prePeginLikePsbt} but paying the change key at `addressIndex`. */
+function psbtPayingChangeIndex(addressIndex: number): string {
+  const psbt = new Psbt();
+  const depositorSpk = bip86OutputScript(RECEIVE0_XONLY);
+  psbt.addInput({
+    hash: Buffer.alloc(32, 1),
+    index: 0,
+    witnessUtxo: { script: depositorSpk, value: 100_000 },
+    tapInternalKey: Buffer.from(RECEIVE0_XONLY, "hex"),
+  });
+  psbt.addOutput({ script: Buffer.concat([Buffer.from([0x51, 0x20]), Buffer.alloc(32, 0xaa)]), value: 50_000 });
+  psbt.addOutput({
+    script: bip86OutputScript(deriveChangeXOnlyHex(ACCOUNT_XPUB, MAINNET_VERSIONS, addressIndex)),
+    value: 49_000,
+  });
+  return psbt.toHex();
+}
+
 describe("psbtPaysChangeScript", () => {
   it("is true when an output pays the BIP-86 P2TR of the change key", () => {
     expect(psbtPaysChangeScript(prePeginLikePsbt(), CHANGE0_XONLY)).toBe(true);
@@ -77,12 +94,22 @@ describe("psbtPaysChangeScript", () => {
 });
 
 describe("augmentPsbtForWalletPolicy", () => {
-  const out = augmentPsbtForWalletPolicy({
+  const POLICY = buildDefaultTaprootPolicy({
+    masterFingerprintHex: FINGERPRINT,
+    coinType: 0,
+    accountIndex: 0,
+    accountXpub: ACCOUNT_XPUB,
+    bip32Versions: MAINNET_VERSIONS,
+  });
+  const base = {
     psbtHex: prePeginLikePsbt(),
     depositorXOnlyHex: RECEIVE0_XONLY,
-    masterFingerprintHex: FINGERPRINT,
+    walletPolicy: POLICY,
+  };
+  const out = augmentPsbtForWalletPolicy({
+    ...base,
     depositorPath: DEPOSITOR_PATH,
-    change: { xOnlyHex: CHANGE0_XONLY, path: CHANGE_PATH },
+    change: { addressIndex: 0 },
   });
   const psbt = Psbt.fromHex(out);
 
@@ -106,12 +133,30 @@ describe("augmentPsbtForWalletPolicy", () => {
     expect(d.path).toBe("m/86'/0'/0'/1/0");
   });
 
+  it("derives the change key and its path from the same account index, so they cannot disagree", () => {
+    // The caller supplies only the index; a key/path pair that described
+    // different children used to be accepted here and die on-device.
+    const atIndex1 = Psbt.fromHex(
+      augmentPsbtForWalletPolicy({
+        ...base,
+        psbtHex: psbtPayingChangeIndex(1),
+        depositorPath: DEPOSITOR_PATH,
+        change: { addressIndex: 1 },
+      }),
+    );
+    const change = atIndex1.data.outputs[1];
+    expect(Buffer.from(change.tapInternalKey!).toString("hex")).toBe(deriveChangeXOnlyHex(ACCOUNT_XPUB, MAINNET_VERSIONS, 1));
+    expect(change.tapBip32Derivation![0].path).toBe("m/86'/0'/0'/1/1");
+  });
+
   it("does not change the unsigned transaction", () => {
     const before = Psbt.fromHex(prePeginLikePsbt()).data.globalMap.unsignedTx.toBuffer();
     expect(psbt.data.globalMap.unsignedTx.toBuffer().equals(before)).toBe(true);
   });
 
-  it("leaves inputs whose internal key is not the depositor's alone", () => {
+  it("rejects a PSBT with an input the depositor key does not own", () => {
+    // _validate_prepegin needs EVERY input internal; an unmarked one reaches
+    // the device and dies mid-ceremony, after the approval screens.
     const p = new Psbt();
     p.addInput({
       hash: Buffer.alloc(32, 9),
@@ -120,96 +165,54 @@ describe("augmentPsbtForWalletPolicy", () => {
       tapInternalKey: Buffer.from(CHANGE0_XONLY, "hex"),
     });
     p.addOutput({ script: Buffer.from([0x6a]), value: 0 });
-    const res = Psbt.fromHex(
-      augmentPsbtForWalletPolicy({
-        psbtHex: p.toHex(),
-        depositorXOnlyHex: RECEIVE0_XONLY,
-        masterFingerprintHex: FINGERPRINT,
-        depositorPath: DEPOSITOR_PATH,
-      }),
-    );
-    expect(res.data.inputs[0].tapBip32Derivation).toBeUndefined();
+
+    expect(() =>
+      augmentPsbtForWalletPolicy({ ...base, psbtHex: p.toHex(), depositorPath: DEPOSITOR_PATH }),
+    ).toThrow(/1 of 1 inputs do not carry the depositor key/);
   });
 
-  it("rejects paths that are not 5 levels, carry non-u32 levels, or break the receive/change/account pairing", () => {
-    const base = {
-      psbtHex: prePeginLikePsbt(),
-      depositorXOnlyHex: RECEIVE0_XONLY,
-      masterFingerprintHex: FINGERPRINT,
-    };
+  it("rejects paths that are not 5 levels, carry non-u32 levels, or sit on the change branch", () => {
     expect(() => augmentPsbtForWalletPolicy({ ...base, depositorPath: [86 + H, 0, 0] })).toThrow(/depositorPath/);
     expect(() => augmentPsbtForWalletPolicy({ ...base, depositorPath: [86 + H, 0 + H, 0 + H, 0, 2 ** 32] })).toThrow(
       /depositorPath/,
     );
-    // depositor on the change branch
     expect(() => augmentPsbtForWalletPolicy({ ...base, depositorPath: [86 + H, 0 + H, 0 + H, 1, 0] })).toThrow(
       /receive branch 0/,
     );
-    // change on the receive branch
-    expect(() =>
-      augmentPsbtForWalletPolicy({
-        ...base,
-        depositorPath: DEPOSITOR_PATH,
-        change: { xOnlyHex: CHANGE0_XONLY, path: [86 + H, 0 + H, 0 + H, 0, 0] },
-      }),
-    ).toThrow(/change branch 1/);
-    // change under a different account
-    expect(() =>
-      augmentPsbtForWalletPolicy({
-        ...base,
-        depositorPath: DEPOSITOR_PATH,
-        change: { xOnlyHex: CHANGE0_XONLY, path: [86 + H, 0 + H, 1 + H, 1, 0] },
-      }),
-    ).toThrow(/same purpose/);
-    expect(() =>
-      augmentPsbtForWalletPolicy({
-        ...base,
-        depositorPath: DEPOSITOR_PATH,
-        change: { xOnlyHex: CHANGE0_XONLY, path: [1, 0] },
-      }),
-    ).toThrow(/change.path/);
   });
 
-  it("rejects a change key no output pays", () => {
+  it("rejects a depositorPath that is not under the policy's key origin", () => {
+    // The policy is built over m/86'/0'/0'; a path under another purpose,
+    // coin or account can never be matched against `@0/<0;1>/*` on-device.
+    expect(() => augmentPsbtForWalletPolicy({ ...base, depositorPath: [84 + H, 0 + H, 0 + H, 0, 0] })).toThrow(
+      /BIP-86 purpose/,
+    );
+    expect(() => augmentPsbtForWalletPolicy({ ...base, depositorPath: [86 + H, 1 + H, 0 + H, 0, 0] })).toThrow(
+      /key origin/,
+    );
+    expect(() => augmentPsbtForWalletPolicy({ ...base, depositorPath: [86 + H, 0 + H, 1 + H, 0, 0] })).toThrow(
+      /key origin/,
+    );
+  });
+
+  it("rejects a change index no output pays", () => {
     // m/86'/0'/0'/1/1 — a real point on the change branch, but not this PSBT's change output.
-    const unusedChangeKey = deriveChangeXOnlyHex(ACCOUNT_XPUB, MAINNET_VERSIONS, 1);
     expect(() =>
-      augmentPsbtForWalletPolicy({
-        psbtHex: prePeginLikePsbt(),
-        depositorXOnlyHex: RECEIVE0_XONLY,
-        masterFingerprintHex: FINGERPRINT,
-        depositorPath: DEPOSITOR_PATH,
-        change: { xOnlyHex: unusedChangeKey, path: [86 + H, 0 + H, 0 + H, 1, 1] },
-      }),
+      augmentPsbtForWalletPolicy({ ...base, depositorPath: DEPOSITOR_PATH, change: { addressIndex: 1 } }),
     ).toThrow(/matches no output/);
   });
 
   it("rejects a hardened address index or an unhardened account level", () => {
-    const base = {
-      psbtHex: prePeginLikePsbt(),
-      depositorXOnlyHex: RECEIVE0_XONLY,
-      masterFingerprintHex: FINGERPRINT,
-    };
     expect(() => augmentPsbtForWalletPolicy({ ...base, depositorPath: [86 + H, 0 + H, 0 + H, 0, 0 + H] })).toThrow(
       /depositorPath must harden/,
     );
-    expect(() =>
-      augmentPsbtForWalletPolicy({
-        ...base,
-        depositorPath: DEPOSITOR_PATH,
-        change: { xOnlyHex: CHANGE0_XONLY, path: [86 + H, 0 + H, 0, 1, 0] },
-      }),
-    ).toThrow(/change.path must harden/);
+    expect(() => augmentPsbtForWalletPolicy({ ...base, depositorPath: [86 + H, 0 + H, 0, 0, 0] })).toThrow(
+      /depositorPath must harden/,
+    );
   });
 
   it("is accepted by prepareSignPsbt in policy mode as an all-key-path table (one yield per input)", () => {
-    const policy = buildDefaultTaprootPolicy({
-      masterFingerprintHex: FINGERPRINT,
-      coinType: 0,
-      accountIndex: 0,
-      accountXpub: ACCOUNT_XPUB,
-    });
-    const prepared = prepareSignPsbt({ psbtHex: out, depositorXOnlyHex: RECEIVE0_XONLY, walletPolicy: policy });
+    const prepared = prepareSignPsbt({ psbtHex: out, depositorXOnlyHex: RECEIVE0_XONLY, walletPolicy: POLICY });
     expect(prepared.table.expectedYieldCount).toBe(2);
     for (const expectation of prepared.table.byInput.values()) {
       expect(expectation.kind).toBe("taproot-keypath");

--- a/packages/babylon-ledger-vault-signer/src/__tests__/popPsbt.test.ts
+++ b/packages/babylon-ledger-vault-signer/src/__tests__/popPsbt.test.ts
@@ -10,7 +10,7 @@ import { Buffer } from "buffer";
 import { describe, expect, it } from "vitest";
 
 import { bip86OutputScript } from "../expectedSignatures";
-import { bip322ToSpendTxid, buildPopPsbtHex, POP_MESSAGE_PROPRIETARY_KEY } from "../popPsbt";
+import { bip322ToSpendTxid, buildPopPsbtHex } from "../popPsbt";
 import { prepareSignPsbt } from "../signPsbtPrepare";
 import { PsbtV2 } from "../vendor/ledger-bitcoin/psbtv2";
 
@@ -81,7 +81,6 @@ describe("buildPopPsbtHex", () => {
     const unknown = psbt.data.globalMap.unknownKeyVals!;
     expect(unknown).toHaveLength(1);
     expect(Buffer.from(unknown[0].key).toString("hex")).toBe("fc06627661756c7400");
-    expect(Buffer.from(unknown[0].key).equals(Buffer.from(POP_MESSAGE_PROPRIETARY_KEY))).toBe(true);
     expect(Buffer.from(unknown[0].value).toString("ascii")).toBe(MESSAGE);
   });
 

--- a/packages/babylon-ledger-vault-signer/src/__tests__/popPsbt.test.ts
+++ b/packages/babylon-ledger-vault-signer/src/__tests__/popPsbt.test.ts
@@ -1,0 +1,131 @@
+/**
+ * PoP PSBT golden tests. The to_spend txid vector is the Babylon canonical one
+ * the firmware pins (`tests/test_screen7_pop.py:115-117`); every PSBT field is
+ * asserted against `_validate_display_pop` (`sign_psbt_validate.c:2591-2869`
+ * @ 4decf822) — see the device-contract block in the plan.
+ */
+
+import { Psbt } from "bitcoinjs-lib";
+import { Buffer } from "buffer";
+import { describe, expect, it } from "vitest";
+
+import { bip86OutputScript } from "../expectedSignatures";
+import { bip322ToSpendTxid, buildPopPsbtHex, POP_MESSAGE_PROPRIETARY_KEY } from "../popPsbt";
+import { prepareSignPsbt } from "../signPsbtPrepare";
+import { PsbtV2 } from "../vendor/ledger-bitcoin/psbtv2";
+
+const CANONICAL_MESSAGE =
+  "0xcabdce2a2010a9a88c75506a86dba669716d47fa:11155111:pegin:0xb331467c4db13dccc77fa66c2d185b74ed57ab80";
+const CANONICAL_TWEAKED_KEY = "3ba1d14c8716be7930aebf51cd0866ac56af9b85078df5fc31756a094ba55c6f";
+const CANONICAL_TO_SPEND_TXID = "e54c4ffe9be74e12ca2e9461da9f5c49626ce5b2c600abaf5320c25124fc129c";
+
+/** BIP-86 published vector: first receive key of the "abandon … about" seed. */
+const DEPOSITOR_XONLY = "cc8a4bc64d897bddc5fbc2f670f7a8ba0b386779106cf1223c6fc5d7cd6fc115";
+const MASTER_FINGERPRINT = "73c5da0a";
+const HARDENED = 0x80000000;
+const DEPOSITOR_PATH = [86 + HARDENED, 0 + HARDENED, 0 + HARDENED, 0, 0];
+const MESSAGE = "0xabcdef1234567890abcdef1234567890abcdef12:11155111:pegin:0x1234567890abcdef1234567890abcdef12345678";
+
+describe("bip322ToSpendTxid", () => {
+  it("matches the Babylon canonical vector (raw SHA256d, not display-reversed)", () => {
+    const txid = bip322ToSpendTxid(
+      new TextEncoder().encode(CANONICAL_MESSAGE),
+      Buffer.from(CANONICAL_TWEAKED_KEY, "hex"),
+    );
+    expect(Buffer.from(txid).toString("hex")).toBe(CANONICAL_TO_SPEND_TXID);
+  });
+});
+
+describe("buildPopPsbtHex", () => {
+  const hex = buildPopPsbtHex({
+    message: MESSAGE,
+    depositorXOnlyHex: DEPOSITOR_XONLY,
+    masterFingerprintHex: MASTER_FINGERPRINT,
+    depositorPath: DEPOSITOR_PATH,
+  });
+  const psbt = Psbt.fromHex(hex);
+
+  it("is a v0 PSBT whose unsigned tx has version 0, locktime 0, one input with sequence 0 and one OP_RETURN output of value 0", () => {
+    // Public bitcoinjs getters (psbt.d.ts:68-70, txInputs/txOutputs) — never the private __CACHE.
+    expect(psbt.version).toBe(0);
+    expect(psbt.locktime).toBe(0);
+    expect(psbt.txInputs).toHaveLength(1);
+    expect(psbt.txInputs[0].sequence).toBe(0);
+    expect(psbt.txInputs[0].index).toBe(0);
+    expect(psbt.txOutputs).toHaveLength(1);
+    expect(psbt.txOutputs[0].value).toBe(0);
+    expect(Buffer.from(psbt.txOutputs[0].script).toString("hex")).toBe("6a");
+  });
+
+  it("spends the BIP-322 to_spend output of the depositor's BIP-86 key, txid in raw wire order", () => {
+    const spk = bip86OutputScript(DEPOSITOR_XONLY);
+    const expectedTxid = bip322ToSpendTxid(new TextEncoder().encode(MESSAGE), spk.subarray(2));
+    expect(Buffer.from(psbt.txInputs[0].hash).toString("hex")).toBe(Buffer.from(expectedTxid).toString("hex"));
+    const input = psbt.data.inputs[0];
+    expect(input.witnessUtxo?.value).toBe(0);
+    expect(Buffer.from(input.witnessUtxo!.script).toString("hex")).toBe(spk.toString("hex"));
+    expect(Buffer.from(input.tapInternalKey!).toString("hex")).toBe(DEPOSITOR_XONLY);
+    expect(input.tapMerkleRoot).toBeUndefined();
+    expect(input.sighashType).toBeUndefined();
+  });
+
+  it("carries TAP_BIP32_DERIVATION keyed by the internal key with the master fingerprint and the 5-level BIP-86 path", () => {
+    const [derivation] = psbt.data.inputs[0].tapBip32Derivation!;
+    expect(Buffer.from(derivation.pubkey).toString("hex")).toBe(DEPOSITOR_XONLY);
+    expect(Buffer.from(derivation.masterFingerprint).toString("hex")).toBe(MASTER_FINGERPRINT);
+    expect(derivation.path).toBe("m/86'/0'/0'/0/0");
+    expect(derivation.leafHashes).toHaveLength(0);
+  });
+
+  it("carries the message in the FC 06 'bvault' 00 global proprietary key", () => {
+    const unknown = psbt.data.globalMap.unknownKeyVals!;
+    expect(unknown).toHaveLength(1);
+    expect(Buffer.from(unknown[0].key).toString("hex")).toBe("fc06627661756c7400");
+    expect(Buffer.from(unknown[0].key).equals(Buffer.from(POP_MESSAGE_PROPRIETARY_KEY))).toBe(true);
+    expect(Buffer.from(unknown[0].value).toString("ascii")).toBe(MESSAGE);
+  });
+
+  it("normalizes to a v2 PSBT where OUTPUT_INDEX and SEQUENCE are physically present and zero", () => {
+    // The device demands both keys on the wire (`:2806-2831`); the vendored
+    // v0→v2 converter is what `prepareSignPsbt` runs, so assert on its output.
+    const v2 = new PsbtV2();
+    v2.deserialize(Buffer.from(hex, "hex"));
+    expect(v2.getInputOutputIndex(0)).toBe(0);
+    expect(v2.getInputSequence(0)).toBe(0);
+    expect(v2.getGlobalInputCount()).toBe(1);
+    expect(v2.getGlobalOutputCount()).toBe(1);
+  });
+
+  it("validates only the hex/shape inputs — message grammar and length are the device's to enforce", () => {
+    expect(() =>
+      buildPopPsbtHex({
+        message: MESSAGE,
+        depositorXOnlyHex: "zz",
+        masterFingerprintHex: MASTER_FINGERPRINT,
+        depositorPath: DEPOSITOR_PATH,
+      }),
+    ).toThrow(/depositorXOnlyHex/);
+    expect(() =>
+      buildPopPsbtHex({
+        message: MESSAGE,
+        depositorXOnlyHex: DEPOSITOR_XONLY,
+        masterFingerprintHex: "73c5",
+        depositorPath: DEPOSITOR_PATH,
+      }),
+    ).toThrow(/masterFingerprintHex/);
+    expect(() =>
+      buildPopPsbtHex({
+        message: MESSAGE,
+        depositorXOnlyHex: DEPOSITOR_XONLY,
+        masterFingerprintHex: MASTER_FINGERPRINT,
+        depositorPath: [1, 2],
+      }),
+    ).toThrow(/depositorPath/);
+  });
+
+  it("is accepted by prepareSignPsbt as a single key-path expectation", () => {
+    const prepared = prepareSignPsbt({ psbtHex: hex, depositorXOnlyHex: DEPOSITOR_XONLY });
+    expect(prepared.table.expectedYieldCount).toBe(1);
+    expect(prepared.table.byInput.get(0)?.kind).toBe("taproot-keypath");
+  });
+});

--- a/packages/babylon-ledger-vault-signer/src/__tests__/signPsbt.test.ts
+++ b/packages/babylon-ledger-vault-signer/src/__tests__/signPsbt.test.ts
@@ -255,6 +255,23 @@ describe("signVaultPsbt", () => {
     expect(sent()).toBe(0);
   });
 
+  it("rejects a key-path PSBT prepared without a walletPolicy, with zero device I/O", async () => {
+    // No policy means the base app skips sign_internal_inputs and answers
+    // SW_OK with no yield — the collector would only notice after the user
+    // has approved the ceremony on-device.
+    const prePegin = JSON.parse(
+      readFileSync(join(VECTORS_DIR, "generated__deposit-flow__pre_pegin__0.json"), "utf8"),
+    ) as { psbt_hex: string; input_maps: [string, string][][] };
+    const depositorXOnlyHex = prePegin.input_maps[0].find(([key]) => key === "17")![1];
+    const prepared = prepareSignPsbt({ psbtHex: prePegin.psbt_hex, depositorXOnlyHex });
+
+    const { send, sent } = createScriptedSender([]);
+    await expect(signPreparedVaultPsbt(send, prepared, { signal: new AbortController().signal })).rejects.toThrow(
+      /walletPolicy/,
+    );
+    expect(sent()).toBe(0);
+  });
+
   it("rejects reuse of a prepared signing state after an abort", async () => {
     const prepared = prepareSignPsbt({ psbtHex: vector.psbt_hex, depositorXOnlyHex: TEST_DEPOSITOR_KEY_HEX });
     const aborted = new AbortController();

--- a/packages/babylon-ledger-vault-signer/src/__tests__/signPsbtLoop.test.ts
+++ b/packages/babylon-ledger-vault-signer/src/__tests__/signPsbtLoop.test.ts
@@ -226,7 +226,13 @@ describe("happy-path trace replay through the loop (T1, T11, T12)", () => {
     interpreter.addKnownList(elements);
     const prepared = makePreparedSignPsbt(
       { table, unsignedTxid: "00".repeat(32) },
-      { cdata: Uint8Array.from(Buffer.alloc(4, 0x11)), interpreter, collector, originalPsbtHex: "" },
+      {
+        cdata: Uint8Array.from(Buffer.alloc(4, 0x11)),
+        interpreter,
+        collector,
+        originalPsbtHex: "",
+        signsUnderWalletPolicy: false,
+      },
     );
 
     const traces = [

--- a/packages/babylon-ledger-vault-signer/src/__tests__/signPsbtPrepare.test.ts
+++ b/packages/babylon-ledger-vault-signer/src/__tests__/signPsbtPrepare.test.ts
@@ -17,8 +17,10 @@ import { isLedgerSignPsbtProtocolError } from "../errors";
 import { buildSignPsbtApdu, getPreparedSignPsbtState, prepareSignPsbt } from "../signPsbtPrepare";
 import { MerkelizedPsbt } from "../vendor/ledger-bitcoin/merkelizedPsbt";
 import { hashLeaf, Merkle } from "../vendor/ledger-bitcoin/merkle";
+import { DefaultWalletPolicy } from "../vendor/ledger-bitcoin/policy";
 import { PsbtV2 } from "../vendor/ledger-bitcoin/psbtv2";
 import { createVarint, parseVarint, sanitizeBigintToNumber } from "../vendor/ledger-bitcoin/varint";
+import { buildDefaultTaprootPolicy } from "../walletPolicy";
 
 const VECTORS_DIR = join(__dirname, "..", "vendor", "ledger-bitcoin", "__tests__", "vectors", "signpsbt");
 
@@ -408,5 +410,79 @@ describe("already-signed inputs are rejected before any device I/O", () => {
     psbt.updateInput(0, { tapKeySig: Buffer.alloc(64, 0x22) });
 
     expectPrepareRejects(psbt.toHex(), depositorKeyFor(KEYPATH_VECTOR, vector), /input 0 already carries a tapKeySig/);
+  });
+});
+
+const KEYPATH_VECTOR_NAME = "generated__deposit-flow__pre_pegin__0";
+const KEYPATH_VECTOR = loadVector(KEYPATH_VECTOR_NAME);
+const KEYPATH_FIXTURE_HEX = KEYPATH_VECTOR.psbt_hex;
+const KEYPATH_DEPOSITOR_XONLY = depositorKeyFor(KEYPATH_VECTOR_NAME, KEYPATH_VECTOR);
+
+const POLICY = buildDefaultTaprootPolicy({
+  masterFingerprintHex: "f5acc2fd",
+  coinType: 1,
+  accountIndex: 0,
+  accountXpub:
+    "tpubDDKYE6BREvDsSWMazgHoyQWiJwYaDDYPbCFjYxN3HFXJP5fokeiK4hwK5tTLBNEDBwrDXn8cQ4v9b2xdW62Xr5yxoQdMu1v6c7UDXYVH27U",
+});
+
+describe("prepareSignPsbt — wallet-policy mode", () => {
+  it("puts the policy id in the wallet_id slot and keeps the hmac all-zero", () => {
+    const prepared = prepareSignPsbt({
+      psbtHex: KEYPATH_FIXTURE_HEX,
+      depositorXOnlyHex: KEYPATH_DEPOSITOR_XONLY,
+      walletPolicy: POLICY,
+    });
+    const cdata = Buffer.from(getPreparedSignPsbtState(prepared).cdata);
+    expect(cdata.subarray(cdata.length - 64, cdata.length - 32).toString("hex")).toBe(POLICY.walletIdHex);
+    expect(cdata.subarray(cdata.length - 32).toString("hex")).toBe("00".repeat(32));
+  });
+
+  it("leaves the no-policy cdata byte-identical (wallet_id and hmac both zero)", () => {
+    const prepared = prepareSignPsbt({ psbtHex: KEYPATH_FIXTURE_HEX, depositorXOnlyHex: KEYPATH_DEPOSITOR_XONLY });
+    const cdata = Buffer.from(getPreparedSignPsbtState(prepared).cdata);
+    expect(cdata.subarray(cdata.length - 64).toString("hex")).toBe("00".repeat(64));
+  });
+
+  it("answers GET_PREIMAGE for the policy serialization, its template and its key info", () => {
+    const prepared = prepareSignPsbt({
+      psbtHex: KEYPATH_FIXTURE_HEX,
+      depositorXOnlyHex: KEYPATH_DEPOSITOR_XONLY,
+      walletPolicy: POLICY,
+    });
+    const { interpreter } = getPreparedSignPsbtState(prepared);
+    const vendor = new DefaultWalletPolicy(POLICY.descriptorTemplate, POLICY.keyInfo);
+    // GET_PREIMAGE request: 0x40 ‖ 0x00 ‖ sha256(preimage) (vendored clientCommands.ts GetPreimageCommand).
+    const ask = (preimage: Buffer) =>
+      interpreter.execute(Buffer.concat([Buffer.from([0x40, 0x00]), bcrypto.sha256(preimage)]));
+    // Response: varint(len) ‖ b ‖ preimage[0:b] — for short preimages b == len, so the tail is the preimage.
+    expect(ask(vendor.serialize()).subarray(-vendor.serialize().length).equals(vendor.serialize())).toBe(true);
+    const template = Buffer.from(POLICY.descriptorTemplate);
+    expect(ask(template).subarray(-template.length).equals(template)).toBe(true);
+    // Key-info leaves are hashed as 0x00 ‖ leaf (addKnownList).
+    const keyLeaf = Buffer.concat([Buffer.from([0]), Buffer.from(POLICY.keyInfo, "ascii")]);
+    expect(ask(keyLeaf).subarray(-keyLeaf.length).equals(keyLeaf)).toBe(true);
+  });
+
+  it("rejects a policy whose wallet id is not 64 hex chars before any device I/O", () => {
+    expect(() =>
+      prepareSignPsbt({
+        psbtHex: KEYPATH_FIXTURE_HEX,
+        depositorXOnlyHex: KEYPATH_DEPOSITOR_XONLY,
+        walletPolicy: { ...POLICY, walletIdHex: "abc" },
+      }),
+    ).toThrow(/walletIdHex/);
+  });
+
+  it("rejects a well-formed wallet id that is not the hash of the policy it ships with", () => {
+    // The header carries walletIdHex while the interpreter seeds preimages keyed
+    // on template+keyInfo — a mismatch would otherwise die untyped mid-loop.
+    expect(() =>
+      prepareSignPsbt({
+        psbtHex: KEYPATH_FIXTURE_HEX,
+        depositorXOnlyHex: KEYPATH_DEPOSITOR_XONLY,
+        walletPolicy: { ...POLICY, walletIdHex: "ab".repeat(32) },
+      }),
+    ).toThrow(/walletIdHex does not match/);
   });
 });

--- a/packages/babylon-ledger-vault-signer/src/__tests__/signPsbtPrepare.test.ts
+++ b/packages/babylon-ledger-vault-signer/src/__tests__/signPsbtPrepare.test.ts
@@ -424,6 +424,7 @@ const POLICY = buildDefaultTaprootPolicy({
   accountIndex: 0,
   accountXpub:
     "tpubDDKYE6BREvDsSWMazgHoyQWiJwYaDDYPbCFjYxN3HFXJP5fokeiK4hwK5tTLBNEDBwrDXn8cQ4v9b2xdW62Xr5yxoQdMu1v6c7UDXYVH27U",
+  bip32Versions: { public: 0x043587cf, private: 0x04358394 },
 });
 
 describe("prepareSignPsbt — wallet-policy mode", () => {

--- a/packages/babylon-ledger-vault-signer/src/__tests__/walletPolicy.test.ts
+++ b/packages/babylon-ledger-vault-signer/src/__tests__/walletPolicy.test.ts
@@ -60,6 +60,27 @@ describe("buildDefaultTaprootPolicy", () => {
     ).toThrow(/non-negative integers/);
   });
 
+  it("accepts the largest index a hardened path component can hold", () => {
+    const policy = buildDefaultTaprootPolicy({
+      masterFingerprintHex: FINGERPRINT,
+      coinType: 0x7fffffff,
+      accountIndex: 0x7fffffff,
+      accountXpub: TPUB,
+    });
+    expect(policy.keyInfo).toBe(`[f5acc2fd/86'/2147483647'/2147483647']${TPUB}`);
+  });
+
+  it("rejects an index that would overflow hardened derivation", () => {
+    expect(() =>
+      buildDefaultTaprootPolicy({
+        masterFingerprintHex: FINGERPRINT,
+        coinType: 1,
+        accountIndex: 0x80000000,
+        accountXpub: TPUB,
+      }),
+    ).toThrow(/coinType and accountIndex/);
+  });
+
   it("rejects an empty xpub", () => {
     expect(() =>
       buildDefaultTaprootPolicy({ masterFingerprintHex: FINGERPRINT, coinType: 1, accountIndex: 0, accountXpub: "" }),

--- a/packages/babylon-ledger-vault-signer/src/__tests__/walletPolicy.test.ts
+++ b/packages/babylon-ledger-vault-signer/src/__tests__/walletPolicy.test.ts
@@ -81,6 +81,17 @@ describe("buildDefaultTaprootPolicy", () => {
     ).toThrow(/coinType and accountIndex/);
   });
 
+  it("rejects a coin type that would overflow hardened derivation", () => {
+    expect(() =>
+      buildDefaultTaprootPolicy({
+        masterFingerprintHex: FINGERPRINT,
+        coinType: 0x80000000,
+        accountIndex: 0,
+        accountXpub: TPUB,
+      }),
+    ).toThrow(/coinType and accountIndex/);
+  });
+
   it("rejects an empty xpub", () => {
     expect(() =>
       buildDefaultTaprootPolicy({ masterFingerprintHex: FINGERPRINT, coinType: 1, accountIndex: 0, accountXpub: "" }),

--- a/packages/babylon-ledger-vault-signer/src/__tests__/walletPolicy.test.ts
+++ b/packages/babylon-ledger-vault-signer/src/__tests__/walletPolicy.test.ts
@@ -1,0 +1,68 @@
+/**
+ * The default wallet policy is the routing switch that makes the device sign
+ * key-path inputs at all (base `sign_psbt.c:142-148`). Its id becomes the
+ * SIGN_PSBT header's wallet_id, so the serialization must match the Python
+ * client the firmware tests drive (`ledger-bitcoin==0.4.0`). Oracle values are
+ * the same ones the vendored `policy.golden.test.ts` pins.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { DefaultWalletPolicy } from "../vendor/ledger-bitcoin/policy";
+import { buildDefaultTaprootPolicy } from "../walletPolicy";
+
+// [f5acc2fd/86'/1'/0']tpub… — the base app's standard BIP-86 testnet key info.
+const FINGERPRINT = "f5acc2fd";
+const TPUB =
+  "tpubDDKYE6BREvDsSWMazgHoyQWiJwYaDDYPbCFjYxN3HFXJP5fokeiK4hwK5tTLBNEDBwrDXn8cQ4v9b2xdW62Xr5yxoQdMu1v6c7UDXYVH27U";
+const ORACLE_ID_HEX = "627535418bc03eeee2b62b3a0254dc0624881f8bc6fc20c4d3b2c1c4fc929893";
+
+describe("buildDefaultTaprootPolicy", () => {
+  it("formats the key info as [fingerprint/86'/coin'/account']xpub", () => {
+    const policy = buildDefaultTaprootPolicy({
+      masterFingerprintHex: FINGERPRINT,
+      coinType: 1,
+      accountIndex: 0,
+      accountXpub: TPUB,
+    });
+    expect(policy.descriptorTemplate).toBe("tr(@0/**)");
+    expect(policy.keyInfo).toBe(`[f5acc2fd/86'/1'/0']${TPUB}`);
+  });
+
+  it("derives the oracle wallet id for the standard testnet key", () => {
+    const policy = buildDefaultTaprootPolicy({
+      masterFingerprintHex: FINGERPRINT,
+      coinType: 1,
+      accountIndex: 0,
+      accountXpub: TPUB,
+    });
+    expect(policy.walletIdHex).toBe(ORACLE_ID_HEX);
+    // Same id the vendored class (the only serializer) produces for these inputs.
+    const vendor = new DefaultWalletPolicy(policy.descriptorTemplate, policy.keyInfo);
+    expect(vendor.getId().toString("hex")).toBe(ORACLE_ID_HEX);
+    expect(vendor.name).toBe("");
+  });
+
+  it("rejects a fingerprint that is not 8 lowercase hex chars", () => {
+    expect(() =>
+      buildDefaultTaprootPolicy({ masterFingerprintHex: "F5ACC2FD", coinType: 1, accountIndex: 0, accountXpub: TPUB }),
+    ).toThrow(/masterFingerprintHex/);
+  });
+
+  it("rejects a negative account index", () => {
+    expect(() =>
+      buildDefaultTaprootPolicy({
+        masterFingerprintHex: FINGERPRINT,
+        coinType: 1,
+        accountIndex: -1,
+        accountXpub: TPUB,
+      }),
+    ).toThrow(/non-negative integers/);
+  });
+
+  it("rejects an empty xpub", () => {
+    expect(() =>
+      buildDefaultTaprootPolicy({ masterFingerprintHex: FINGERPRINT, coinType: 1, accountIndex: 0, accountXpub: "" }),
+    ).toThrow(/accountXpub/);
+  });
+});

--- a/packages/babylon-ledger-vault-signer/src/__tests__/walletPolicy.test.ts
+++ b/packages/babylon-ledger-vault-signer/src/__tests__/walletPolicy.test.ts
@@ -8,7 +8,6 @@
 
 import { describe, expect, it } from "vitest";
 
-import { DefaultWalletPolicy } from "../vendor/ledger-bitcoin/policy";
 import { buildDefaultTaprootPolicy } from "../walletPolicy";
 
 // [f5acc2fd/86'/1'/0']tpub… — the base app's standard BIP-86 testnet key info.
@@ -16,6 +15,8 @@ const FINGERPRINT = "f5acc2fd";
 const TPUB =
   "tpubDDKYE6BREvDsSWMazgHoyQWiJwYaDDYPbCFjYxN3HFXJP5fokeiK4hwK5tTLBNEDBwrDXn8cQ4v9b2xdW62Xr5yxoQdMu1v6c7UDXYVH27U";
 const ORACLE_ID_HEX = "627535418bc03eeee2b62b3a0254dc0624881f8bc6fc20c4d3b2c1c4fc929893";
+/** Testnet BIP-32 version bytes — the network the TPUB above belongs to. */
+const TESTNET_VERSIONS = { public: 0x043587cf, private: 0x04358394 };
 
 describe("buildDefaultTaprootPolicy", () => {
   it("formats the key info as [fingerprint/86'/coin'/account']xpub", () => {
@@ -24,6 +25,7 @@ describe("buildDefaultTaprootPolicy", () => {
       coinType: 1,
       accountIndex: 0,
       accountXpub: TPUB,
+      bip32Versions: TESTNET_VERSIONS,
     });
     expect(policy.descriptorTemplate).toBe("tr(@0/**)");
     expect(policy.keyInfo).toBe(`[f5acc2fd/86'/1'/0']${TPUB}`);
@@ -35,17 +37,17 @@ describe("buildDefaultTaprootPolicy", () => {
       coinType: 1,
       accountIndex: 0,
       accountXpub: TPUB,
+      bip32Versions: TESTNET_VERSIONS,
     });
+    // The pinned oracle is the whole check: re-deriving the id through
+    // DefaultWalletPolicy here would just re-run what the function already
+    // called, and prove nothing.
     expect(policy.walletIdHex).toBe(ORACLE_ID_HEX);
-    // Same id the vendored class (the only serializer) produces for these inputs.
-    const vendor = new DefaultWalletPolicy(policy.descriptorTemplate, policy.keyInfo);
-    expect(vendor.getId().toString("hex")).toBe(ORACLE_ID_HEX);
-    expect(vendor.name).toBe("");
   });
 
   it("rejects a fingerprint that is not 8 lowercase hex chars", () => {
     expect(() =>
-      buildDefaultTaprootPolicy({ masterFingerprintHex: "F5ACC2FD", coinType: 1, accountIndex: 0, accountXpub: TPUB }),
+      buildDefaultTaprootPolicy({ masterFingerprintHex: "F5ACC2FD", coinType: 1, accountIndex: 0, accountXpub: TPUB, bip32Versions: TESTNET_VERSIONS }),
     ).toThrow(/masterFingerprintHex/);
   });
 
@@ -56,6 +58,7 @@ describe("buildDefaultTaprootPolicy", () => {
         coinType: 1,
         accountIndex: -1,
         accountXpub: TPUB,
+      bip32Versions: TESTNET_VERSIONS,
       }),
     ).toThrow(/non-negative integers/);
   });
@@ -66,6 +69,7 @@ describe("buildDefaultTaprootPolicy", () => {
       coinType: 0x7fffffff,
       accountIndex: 0x7fffffff,
       accountXpub: TPUB,
+      bip32Versions: TESTNET_VERSIONS,
     });
     expect(policy.keyInfo).toBe(`[f5acc2fd/86'/2147483647'/2147483647']${TPUB}`);
   });
@@ -77,6 +81,7 @@ describe("buildDefaultTaprootPolicy", () => {
         coinType: 1,
         accountIndex: 0x80000000,
         accountXpub: TPUB,
+      bip32Versions: TESTNET_VERSIONS,
       }),
     ).toThrow(/coinType and accountIndex/);
   });
@@ -88,13 +93,60 @@ describe("buildDefaultTaprootPolicy", () => {
         coinType: 0x80000000,
         accountIndex: 0,
         accountXpub: TPUB,
+      bip32Versions: TESTNET_VERSIONS,
       }),
     ).toThrow(/coinType and accountIndex/);
   });
 
   it("rejects an empty xpub", () => {
     expect(() =>
-      buildDefaultTaprootPolicy({ masterFingerprintHex: FINGERPRINT, coinType: 1, accountIndex: 0, accountXpub: "" }),
+      buildDefaultTaprootPolicy({
+        masterFingerprintHex: FINGERPRINT,
+        coinType: 1,
+        accountIndex: 0,
+        accountXpub: "",
+        bip32Versions: TESTNET_VERSIONS,
+      }),
     ).toThrow(/accountXpub/);
+  });
+
+  it("rejects an xpub that is not a decodable extended key", () => {
+    // Key info is serialized with Buffer.from(k, "ascii"), so garbage still
+    // yields a well-formed wallet id the device can never match a preimage to.
+    expect(() =>
+      buildDefaultTaprootPolicy({
+        masterFingerprintHex: FINGERPRINT,
+        coinType: 1,
+        accountIndex: 0,
+        accountXpub: "tpubNOTAREALEXTENDEDKEY",
+        bip32Versions: TESTNET_VERSIONS,
+      }),
+    ).toThrow(/accountXpub/);
+  });
+
+  it("rejects an xpub whose version bytes belong to another network", () => {
+    const MAINNET_VERSIONS = { public: 0x0488b21e, private: 0x0488ade4 };
+    expect(() =>
+      buildDefaultTaprootPolicy({
+        masterFingerprintHex: FINGERPRINT,
+        coinType: 0,
+        accountIndex: 0,
+        accountXpub: TPUB,
+        bip32Versions: MAINNET_VERSIONS,
+      }),
+    ).toThrow(/accountXpub/);
+  });
+
+  it("exposes the key origin the derivation fields must sit under", () => {
+    const policy = buildDefaultTaprootPolicy({
+      masterFingerprintHex: FINGERPRINT,
+      coinType: 1,
+      accountIndex: 0,
+      accountXpub: TPUB,
+      bip32Versions: TESTNET_VERSIONS,
+    });
+    expect(policy.keyOriginPath).toEqual([0x80000000 + 86, 0x80000000 + 1, 0x80000000]);
+    expect(policy.accountXpub).toBe(TPUB);
+    expect(policy.masterFingerprintHex).toBe(FINGERPRINT);
   });
 });

--- a/packages/babylon-ledger-vault-signer/src/bip86Path.ts
+++ b/packages/babylon-ledger-vault-signer/src/bip86Path.ts
@@ -1,0 +1,51 @@
+/**
+ * Shared BIP-86 derivation-path validation and rendering.
+ *
+ * Both key-path builders send a path to the device: `policyPsbt` writes it into
+ * TAP_BIP32_DERIVATION, `popPsbt` into the PoP input's. A path the device
+ * cannot match against the policy key expression `@0/<0;1>/*` dies mid-ceremony,
+ * after the user has already reached an approval screen — so both validate
+ * here, identically, before any device I/O.
+ *
+ * @module ledger-vault-signer/bip86Path
+ */
+
+export const HARDENED = 0x80000000;
+export const U32_MAX = 0xffffffff;
+export const BIP86_PURPOSE = 86;
+export const BIP86_RECEIVE_BRANCH = 0;
+export const BIP86_CHANGE_BRANCH = 1;
+export const BIP86_PATH_LEVELS = 5;
+/** purpose'/coin'/account' — the key-info origin prefix. */
+export const PATH_ACCOUNT_LEVELS = 3;
+export const PATH_BRANCH_INDEX = 3;
+export const PATH_ADDRESS_INDEX = 4;
+
+/**
+ * A 5-level BIP-86 path with hardened purpose'/coin'/account' and an
+ * unhardened address index. `>>> 0` and `& HARDENED` coerce silently, so the
+ * range check must run before any rendering.
+ */
+export function assertBip86Path(name: string, levels: readonly number[]): void {
+  if (levels.length !== BIP86_PATH_LEVELS) {
+    throw new Error(`${name} must have exactly ${BIP86_PATH_LEVELS} levels, got ${levels.length}`);
+  }
+  for (const level of levels) {
+    if (!Number.isInteger(level) || level < 0 || level > U32_MAX) {
+      throw new Error(`${name} levels must be integers in 0..0xffffffff`);
+    }
+  }
+  // Any other hardening shape is unmatchable against the policy expression
+  // `@0/<0;1>/*`, so the device could never mark the input/output internal.
+  const accountHardened = levels.slice(0, PATH_ACCOUNT_LEVELS).every((level) => (level & HARDENED) !== 0);
+  if (!accountHardened || (levels[PATH_ADDRESS_INDEX] & HARDENED) !== 0) {
+    throw new Error(`${name} must harden purpose'/coin'/account' and leave the address index unhardened`);
+  }
+  if (levels[0] !== (HARDENED | BIP86_PURPOSE) >>> 0) {
+    throw new Error(`${name} must use BIP-86 purpose ${BIP86_PURPOSE}'`);
+  }
+}
+
+export function bip86PathToString(levels: readonly number[]): string {
+  return "m/" + levels.map((l) => ((l & HARDENED) !== 0 ? `${(l & ~HARDENED) >>> 0}'` : `${l >>> 0}`)).join("/");
+}

--- a/packages/babylon-ledger-vault-signer/src/derivation.ts
+++ b/packages/babylon-ledger-vault-signer/src/derivation.ts
@@ -1,9 +1,10 @@
 /**
- * Read-only key derivation over raw APDUs (the Bitcoin signer kit cannot
- * express the vault's no-policy flows). Byte layout per the base app's
- * `get_extended_pubkey.c`; the response is the extended key as ASCII, and
- * `display = 0` is silent for allowlisted BIP-86 paths. The taproot ADDRESS
- * is never read from the device — the provider derives it locally.
+ * Read-only key derivation and the master-fingerprint read over raw APDUs (the
+ * Bitcoin signer kit cannot express the vault's no-policy flows). Byte layout
+ * per the base app's `get_extended_pubkey.c`; the response is the extended key
+ * as ASCII, and `display = 0` is silent for allowlisted BIP-86 paths. The
+ * taproot ADDRESS is never read from the device — the provider derives it
+ * locally.
  *
  * @module ledger-vault-signer/derivation
  */
@@ -31,15 +32,42 @@ const COMPRESSED_PUBKEY_BYTES = 33;
 const MAX_BIP32_PATH_STEPS = 10;
 
 /**
- * Read the x-only public key at the given BIP-32 path.
- *
- * @param send - APDU sender bound to the live device session
- * @param path - Full BIP-32 path as raw u32 levels (hardened bits included)
- * @param bip32Versions - Version bytes for the decode: the signet build
- *   returns a tpub, and `@scure/bip32` throws "Version mismatch" on its
- *   mainnet defaults without them.
+ * `GET_MASTER_FINGERPRINT` (base `commands.h:11`): no payload, answers the 4-byte
+ * fingerprint (`get_master_fingerprint.c:38`). P2 = protocol version 1, as both
+ * reference clients send (`bitcoin_client/ledger_bitcoin/command_builder.py:57`
+ * default `p2 = CURRENT_PROTOCOL_VERSION`; `bitcoin_client_rs/src/apdu.rs:131`).
  */
-export async function getXOnlyPublicKeyHex(
+const INS_GET_MASTER_FINGERPRINT = 0x05;
+const MASTER_FINGERPRINT_BYTES = 4;
+
+/**
+ * Read the device's BIP-32 master key fingerprint. Both the default wallet
+ * policy's key origin and the PoP input's TAP_BIP32_DERIVATION must carry it —
+ * the device compares against `crypto_get_master_key_fingerprint()`
+ * (`sign_psbt_validate.c:2732` @ 4decf822).
+ */
+export async function getMasterFingerprintHex(send: ApduSender): Promise<string> {
+  const response = await send({
+    cla: CLA_APP,
+    ins: INS_GET_MASTER_FINGERPRINT,
+    p1: P1_NONE,
+    p2: P2_PROTOCOL_VERSION,
+    data: new Uint8Array(0),
+  });
+  if (response.length !== MASTER_FINGERPRINT_BYTES) {
+    throw new Error(`Ledger returned a ${response.length}-byte response instead of the 4-byte master fingerprint`);
+  }
+  return toHex(response);
+}
+
+/**
+ * Read the extended public key at `path` and return the device's serialized
+ * string VERBATIM. A wallet policy's key info embeds this string and the device
+ * byte-compares it against its own re-derivation (base `policy.c:1447-1511`),
+ * so the host must never re-serialize it. The decode is only a sanity check
+ * that the key parses under the expected network's version bytes.
+ */
+export async function getExtendedPublicKey(
   send: ApduSender,
   path: readonly number[],
   bip32Versions: { private: number; public: number },
@@ -54,8 +82,30 @@ export async function getXOnlyPublicKeyHex(
     p2: P2_PROTOCOL_VERSION,
     data: encodeGetExtendedPubkeyData(path),
   });
-
   const extendedKey = new TextDecoder().decode(response);
+  if (extendedKey.length === 0) {
+    throw new Error("Ledger returned an empty extended key");
+  }
+  // Throws "Version mismatch"/checksum errors for a wrong-network or corrupt key.
+  HDKey.fromExtendedKey(extendedKey, bip32Versions);
+  return extendedKey;
+}
+
+/**
+ * Read the x-only public key at the given BIP-32 path.
+ *
+ * @param send - APDU sender bound to the live device session
+ * @param path - Full BIP-32 path as raw u32 levels (hardened bits included)
+ * @param bip32Versions - Version bytes for the decode: the signet build
+ *   returns a tpub, and `@scure/bip32` throws "Version mismatch" on its
+ *   mainnet defaults without them.
+ */
+export async function getXOnlyPublicKeyHex(
+  send: ApduSender,
+  path: readonly number[],
+  bip32Versions: { private: number; public: number },
+): Promise<string> {
+  const extendedKey = await getExtendedPublicKey(send, path, bip32Versions);
   const node = HDKey.fromExtendedKey(extendedKey, bip32Versions);
   if (!node.publicKey || node.publicKey.length !== COMPRESSED_PUBKEY_BYTES) {
     throw new Error(`Ledger returned an extended key without a ${COMPRESSED_PUBKEY_BYTES}-byte public key`);

--- a/packages/babylon-ledger-vault-signer/src/expectedSignatures.ts
+++ b/packages/babylon-ledger-vault-signer/src/expectedSignatures.ts
@@ -128,8 +128,11 @@ export interface BuildExpectedSignatureTableParams {
   readonly depositorXOnlyHex: string;
 }
 
-/** BIP-86/BIP-341 keypath-only P2TR scriptPubKey of an x-only internal key. */
-function bip86OutputScript(xOnlyKeyHex: string): Buffer {
+/**
+ * BIP-86/BIP-341 keypath-only P2TR scriptPubKey of an x-only internal key.
+ * Exported for popPsbt.ts — package-internal.
+ */
+export function bip86OutputScript(xOnlyKeyHex: string): Buffer {
   // Not memoized: bitcoinjs re-verifies only when handed a DIFFERENT instance
   // (`bitcoinjs-lib@6.1.7 src/ecc_lib.js:13-23`), so a "done" flag would
   // silently skip that check once another instance reached the same copy.

--- a/packages/babylon-ledger-vault-signer/src/expectedSignatures.ts
+++ b/packages/babylon-ledger-vault-signer/src/expectedSignatures.ts
@@ -130,7 +130,7 @@ export interface BuildExpectedSignatureTableParams {
 
 /**
  * BIP-86/BIP-341 keypath-only P2TR scriptPubKey of an x-only internal key.
- * Exported for popPsbt.ts — package-internal.
+ * Package-internal: shared by the PoP and wallet-policy builders.
  */
 export function bip86OutputScript(xOnlyKeyHex: string): Buffer {
   // Not memoized: bitcoinjs re-verifies only when handed a DIFFERENT instance

--- a/packages/babylon-ledger-vault-signer/src/index.ts
+++ b/packages/babylon-ledger-vault-signer/src/index.ts
@@ -2,15 +2,16 @@
  * Host-side client for the Ledger Babylon Vault app: DMK session lifecycle,
  * raw APDU framing over the {@link ApduSender} seam, the silent key read,
  * the device envelope gate, the DERIVE_CONTEXT_HASH / APPROVE_VAULT_INTENT
- * ceremony, and the SIGN_PSBT interrupt/continue signing loop
- * ({@link signVaultPsbt}). Wallet-connector's LedgerVaultProvider is the
+ * ceremony, the SIGN_PSBT interrupt/continue signing loop
+ * ({@link signVaultPsbt}), and the wallet-policy plumbing and the PoP PSBT
+ * builder (#2221). Wallet-connector's LedgerVaultProvider is the
  * consuming adapter; this package holds everything device-protocol-shaped and
  * nothing wallet-taxonomy-shaped.
  *
  * @module ledger-vault-signer
  */
 
-export { getXOnlyPublicKeyHex } from "./derivation";
+export { getExtendedPublicKey, getMasterFingerprintHex, getXOnlyPublicKeyHex } from "./derivation";
 export { createDmkApduSender, createDmkRawApduSender } from "./dmkApduSender";
 export { closeDmk, connectDmkSession, disconnectDmkSession, isSessionAlive, type DmkSessionHandle } from "./dmkSession";
 export { assertDepositTermsDeviceCompatible } from "./envelope";
@@ -47,6 +48,7 @@ export {
   type IntentScalars,
   type IntentVaultGroup,
 } from "./intentTlv";
+export { POP_MESSAGE_PROPRIETARY_KEY, buildPopPsbtHex, type BuildPopPsbtParams } from "./popPsbt";
 export {
   SW_BAD_STATE,
   SW_CAP_EXCEEDED,
@@ -64,7 +66,7 @@ export {
   type SignVaultPsbtParams,
   type SignVaultPsbtResult,
 } from "./signPsbt";
-export { prepareSignPsbt, type PreparedSignPsbt } from "./signPsbtPrepare";
+export { prepareSignPsbt, type PrepareSignPsbtParams, type PreparedSignPsbt } from "./signPsbtPrepare";
 export {
   DEPOSIT_TERMS_REJECTED_ERROR_NAME,
   DepositTermsRejectedError,
@@ -79,3 +81,8 @@ export {
   type ApproveVaultIntentParams,
   type DeriveContextHashParams,
 } from "./vaultCommands";
+export {
+  buildDefaultTaprootPolicy,
+  type BuildDefaultTaprootPolicyParams,
+  type DefaultTaprootWalletPolicy,
+} from "./walletPolicy";

--- a/packages/babylon-ledger-vault-signer/src/index.ts
+++ b/packages/babylon-ledger-vault-signer/src/index.ts
@@ -54,7 +54,7 @@ export {
   psbtPaysChangeScript,
   type AugmentPsbtForWalletPolicyParams,
 } from "./policyPsbt";
-export { POP_MESSAGE_PROPRIETARY_KEY, buildPopPsbtHex, type BuildPopPsbtParams } from "./popPsbt";
+export { buildPopPsbtHex, type BuildPopPsbtParams } from "./popPsbt";
 export {
   SW_BAD_STATE,
   SW_CAP_EXCEEDED,

--- a/packages/babylon-ledger-vault-signer/src/index.ts
+++ b/packages/babylon-ledger-vault-signer/src/index.ts
@@ -48,6 +48,12 @@ export {
   type IntentScalars,
   type IntentVaultGroup,
 } from "./intentTlv";
+export {
+  augmentPsbtForWalletPolicy,
+  deriveChangeXOnlyHex,
+  psbtPaysChangeScript,
+  type AugmentPsbtForWalletPolicyParams,
+} from "./policyPsbt";
 export { POP_MESSAGE_PROPRIETARY_KEY, buildPopPsbtHex, type BuildPopPsbtParams } from "./popPsbt";
 export {
   SW_BAD_STATE,

--- a/packages/babylon-ledger-vault-signer/src/index.ts
+++ b/packages/babylon-ledger-vault-signer/src/index.ts
@@ -51,6 +51,7 @@ export {
 export {
   augmentPsbtForWalletPolicy,
   deriveChangeXOnlyHex,
+  deriveReceiveXOnlyHex,
   psbtPaysChangeScript,
   type AugmentPsbtForWalletPolicyParams,
 } from "./policyPsbt";

--- a/packages/babylon-ledger-vault-signer/src/policyPsbt.ts
+++ b/packages/babylon-ledger-vault-signer/src/policyPsbt.ts
@@ -52,20 +52,36 @@ function assertDepositorPathUnderPolicy(depositorPath: readonly number[], keyOri
   }
 }
 
+function deriveBranchXOnlyHex(
+  accountXpub: string,
+  bip32Versions: Bip32Versions,
+  branch: number,
+  addressIndex: number,
+): string {
+  if (!Number.isInteger(addressIndex) || addressIndex < 0 || addressIndex >= HARDENED) {
+    throw new Error("addressIndex must be a non-hardened integer in 0..2^31-1");
+  }
+  const node = HDKey.fromExtendedKey(accountXpub, bip32Versions).deriveChild(branch).deriveChild(addressIndex);
+  if (!node.publicKey) throw new Error(`account xpub derived no public key at ${branch}/${addressIndex}`);
+  return Buffer.from(node.publicKey.subarray(1)).toString("hex");
+}
+
 /** x-only key at `account/1/addressIndex` from the device's verbatim account xpub. */
 export function deriveChangeXOnlyHex(
   accountXpub: string,
   bip32Versions: Bip32Versions,
   addressIndex: number,
 ): string {
-  if (!Number.isInteger(addressIndex) || addressIndex < 0 || addressIndex >= HARDENED) {
-    throw new Error("addressIndex must be a non-hardened integer in 0..2^31-1");
-  }
-  const node = HDKey.fromExtendedKey(accountXpub, bip32Versions)
-    .deriveChild(BIP86_CHANGE_BRANCH)
-    .deriveChild(addressIndex);
-  if (!node.publicKey) throw new Error("account xpub derived no public key for the change address");
-  return Buffer.from(node.publicKey.subarray(1)).toString("hex");
+  return deriveBranchXOnlyHex(accountXpub, bip32Versions, BIP86_CHANGE_BRANCH, addressIndex);
+}
+
+/** x-only key at `account/0/addressIndex` — the depositor branch. */
+export function deriveReceiveXOnlyHex(
+  accountXpub: string,
+  bip32Versions: Bip32Versions,
+  addressIndex: number,
+): string {
+  return deriveBranchXOnlyHex(accountXpub, bip32Versions, BIP86_RECEIVE_BRANCH, addressIndex);
 }
 
 /** Output indices paying the BIP-86 P2TR of `changeXOnlyHex` — the ONE change-match site. */

--- a/packages/babylon-ledger-vault-signer/src/policyPsbt.ts
+++ b/packages/babylon-ledger-vault-signer/src/policyPsbt.ts
@@ -1,0 +1,159 @@
+/**
+ * Wallet-policy PSBT shaping for the vault app's key-path flows (Pre-PegIn).
+ *
+ * The base app marks an input internal when its TAP_BIP32_DERIVATION matches a
+ * policy key expression at (change, index) and the script equals the policy
+ * script there (`bitcoin_app_base/src/handler/sign_psbt/preprocess_inputs.c`
+ * @ e400d8d8); outputs are internal ONLY on the change branch
+ * (`process_in_outs.c:114-117`, `preprocess_outputs.c:74-79`). `_validate_prepegin`
+ * requires every input internal and accepts change only when internal
+ * (`sign_psbt_validate.c:334-545` @ 4decf822). This module adds exactly those
+ * fields; it never touches the unsigned transaction.
+ *
+ * @module ledger-vault-signer/policyPsbt
+ */
+import { HDKey } from "@scure/bip32";
+import { Psbt } from "bitcoinjs-lib";
+import { Buffer } from "buffer";
+
+import { bip86OutputScript } from "./expectedSignatures";
+
+const HARDENED = 0x80000000;
+const U32_MAX = 0xffffffff;
+const BIP86_CHANGE_BRANCH = 1;
+const BIP86_PATH_LEVELS = 5;
+const X_ONLY_HEX_RE = /^[0-9a-f]{64}$/;
+const FINGERPRINT_HEX_RE = /^[0-9a-f]{8}$/;
+
+const BIP86_RECEIVE_BRANCH = 0;
+const PATH_ACCOUNT_LEVELS = 3; // purpose'/coin'/account'
+const PATH_BRANCH_INDEX = 3;
+const PATH_ADDRESS_INDEX = 4;
+
+function assertBip86Path(name: string, levels: readonly number[]): void {
+  if (levels.length !== BIP86_PATH_LEVELS) {
+    throw new Error(`${name} must have exactly ${BIP86_PATH_LEVELS} levels, got ${levels.length}`);
+  }
+  for (const level of levels) {
+    if (!Number.isInteger(level) || level < 0 || level > U32_MAX) {
+      throw new Error(`${name} levels must be integers in 0..0xffffffff`);
+    }
+  }
+  // Any other hardening shape is unmatchable against the policy expression
+  // `@0/<0;1>/*`, so the device could never mark the input/output internal.
+  const accountHardened = levels.slice(0, PATH_ACCOUNT_LEVELS).every((level) => (level & HARDENED) !== 0);
+  if (!accountHardened || (levels[PATH_ADDRESS_INDEX] & HARDENED) !== 0) {
+    throw new Error(`${name} must harden purpose'/coin'/account' and leave the address index unhardened`);
+  }
+}
+
+/**
+ * The device matches derivations against the policy key expression
+ * `@0/<0;1>/*`: depositor inputs live on branch 0, change on branch 1, both
+ * under the SAME account as the policy key — anything else cannot be internal.
+ */
+function assertPolicyPathPair(depositorPath: readonly number[], changePath?: readonly number[]): void {
+  assertBip86Path("depositorPath", depositorPath);
+  if (depositorPath[PATH_BRANCH_INDEX] !== BIP86_RECEIVE_BRANCH) {
+    throw new Error("depositorPath must use BIP-86 receive branch 0");
+  }
+  if (!changePath) return;
+  assertBip86Path("change.path", changePath);
+  for (let i = 0; i < PATH_ACCOUNT_LEVELS; i++) {
+    if (changePath[i] !== depositorPath[i]) {
+      throw new Error("change.path must use the same purpose'/coin'/account' as depositorPath");
+    }
+  }
+  if (changePath[PATH_BRANCH_INDEX] !== BIP86_CHANGE_BRANCH) {
+    throw new Error("change.path must use BIP-86 change branch 1");
+  }
+}
+
+function pathToString(levels: readonly number[]): string {
+  return "m/" + levels.map((l) => ((l & HARDENED) !== 0 ? `${(l & ~HARDENED) >>> 0}'` : `${l >>> 0}`)).join("/");
+}
+
+/** x-only key at `account/1/addressIndex` from the device's verbatim account xpub. */
+export function deriveChangeXOnlyHex(
+  accountXpub: string,
+  bip32Versions: { private: number; public: number },
+  addressIndex: number,
+): string {
+  if (!Number.isInteger(addressIndex) || addressIndex < 0 || addressIndex >= HARDENED) {
+    throw new Error("addressIndex must be a non-hardened integer in 0..2^31-1");
+  }
+  const node = HDKey.fromExtendedKey(accountXpub, bip32Versions)
+    .deriveChild(BIP86_CHANGE_BRANCH)
+    .deriveChild(addressIndex);
+  if (!node.publicKey) throw new Error("account xpub derived no public key for the change address");
+  return Buffer.from(node.publicKey.subarray(1)).toString("hex");
+}
+
+/** Output indices paying the BIP-86 P2TR of `changeXOnlyHex` — the ONE change-match site. */
+function changeOutputIndices(psbt: Psbt, changeXOnlyHex: string): number[] {
+  const changeScript = bip86OutputScript(changeXOnlyHex);
+  return psbt.txOutputs.flatMap((out, index) => (Buffer.from(out.script).equals(changeScript) ? [index] : []));
+}
+
+/**
+ * Does this PSBT pay the wallet's change address? A Pre-PegIn legitimately has
+ * no change (dust-revert, and the Max sweep by design), so callers pass
+ * `change` to {@link augmentPsbtForWalletPolicy} only when this is true —
+ * passing it otherwise is the "matches no output" throw.
+ */
+export function psbtPaysChangeScript(psbtHex: string, changeXOnlyHex: string): boolean {
+  if (!X_ONLY_HEX_RE.test(changeXOnlyHex)) throw new Error("changeXOnlyHex must be 64 lowercase hex characters");
+  return changeOutputIndices(Psbt.fromHex(psbtHex), changeXOnlyHex).length > 0;
+}
+
+export interface AugmentPsbtForWalletPolicyParams {
+  readonly psbtHex: string;
+  readonly depositorXOnlyHex: string;
+  readonly masterFingerprintHex: string;
+  readonly depositorPath: readonly number[];
+  /** The change output's key and path; omit when the PSBT carries no change. */
+  readonly change?: { readonly xOnlyHex: string; readonly path: readonly number[] };
+}
+
+export function augmentPsbtForWalletPolicy(params: AugmentPsbtForWalletPolicyParams): string {
+  const { psbtHex, depositorXOnlyHex, masterFingerprintHex, depositorPath, change } = params;
+  if (!X_ONLY_HEX_RE.test(depositorXOnlyHex)) throw new Error("depositorXOnlyHex must be 64 lowercase hex characters");
+  if (!FINGERPRINT_HEX_RE.test(masterFingerprintHex)) {
+    throw new Error("masterFingerprintHex must be 8 lowercase hex characters");
+  }
+  if (change && !X_ONLY_HEX_RE.test(change.xOnlyHex)) {
+    throw new Error("change.xOnlyHex must be 64 lowercase hex characters");
+  }
+  assertPolicyPathPair(depositorPath, change?.path);
+  const psbt = Psbt.fromHex(psbtHex);
+  const fingerprint = Buffer.from(masterFingerprintHex, "hex");
+  const depositorKey = Buffer.from(depositorXOnlyHex, "hex");
+  psbt.data.inputs.forEach((input, i) => {
+    if (input.tapInternalKey && Buffer.from(input.tapInternalKey).equals(depositorKey)) {
+      psbt.updateInput(i, {
+        tapBip32Derivation: [
+          { masterFingerprint: fingerprint, pubkey: depositorKey, path: pathToString(depositorPath), leafHashes: [] },
+        ],
+      });
+    }
+  });
+  if (change) {
+    const changeKey = Buffer.from(change.xOnlyHex, "hex");
+    const matched = changeOutputIndices(psbt, change.xOnlyHex);
+    // Marking nothing passes every host gate and dies mid-ceremony on-device
+    // (`sign_psbt_validate.c:507-510`); omit `change` for a change-less PSBT
+    // ({@link psbtPaysChangeScript} is the caller-side test).
+    if (matched.length === 0) {
+      throw new Error("change script matches no output — the PSBT does not pay the wallet's change address");
+    }
+    for (const index of matched) {
+      psbt.updateOutput(index, {
+        tapInternalKey: changeKey,
+        tapBip32Derivation: [
+          { masterFingerprint: fingerprint, pubkey: changeKey, path: pathToString(change.path), leafHashes: [] },
+        ],
+      });
+    }
+  }
+  return psbt.toHex();
+}

--- a/packages/babylon-ledger-vault-signer/src/policyPsbt.ts
+++ b/packages/babylon-ledger-vault-signer/src/policyPsbt.ts
@@ -16,67 +16,46 @@ import { HDKey } from "@scure/bip32";
 import { Psbt } from "bitcoinjs-lib";
 import { Buffer } from "buffer";
 
+import {
+  assertBip86Path,
+  BIP86_CHANGE_BRANCH,
+  BIP86_RECEIVE_BRANCH,
+  bip86PathToString,
+  HARDENED,
+  PATH_ACCOUNT_LEVELS,
+  PATH_BRANCH_INDEX,
+} from "./bip86Path";
 import { bip86OutputScript } from "./expectedSignatures";
+import type { Bip32Versions, DefaultTaprootWalletPolicy } from "./walletPolicy";
 
-const HARDENED = 0x80000000;
-const U32_MAX = 0xffffffff;
-const BIP86_CHANGE_BRANCH = 1;
-const BIP86_PATH_LEVELS = 5;
 const X_ONLY_HEX_RE = /^[0-9a-f]{64}$/;
-const FINGERPRINT_HEX_RE = /^[0-9a-f]{8}$/;
-
-const BIP86_RECEIVE_BRANCH = 0;
-const PATH_ACCOUNT_LEVELS = 3; // purpose'/coin'/account'
-const PATH_BRANCH_INDEX = 3;
-const PATH_ADDRESS_INDEX = 4;
-
-function assertBip86Path(name: string, levels: readonly number[]): void {
-  if (levels.length !== BIP86_PATH_LEVELS) {
-    throw new Error(`${name} must have exactly ${BIP86_PATH_LEVELS} levels, got ${levels.length}`);
-  }
-  for (const level of levels) {
-    if (!Number.isInteger(level) || level < 0 || level > U32_MAX) {
-      throw new Error(`${name} levels must be integers in 0..0xffffffff`);
-    }
-  }
-  // Any other hardening shape is unmatchable against the policy expression
-  // `@0/<0;1>/*`, so the device could never mark the input/output internal.
-  const accountHardened = levels.slice(0, PATH_ACCOUNT_LEVELS).every((level) => (level & HARDENED) !== 0);
-  if (!accountHardened || (levels[PATH_ADDRESS_INDEX] & HARDENED) !== 0) {
-    throw new Error(`${name} must harden purpose'/coin'/account' and leave the address index unhardened`);
-  }
-}
 
 /**
  * The device matches derivations against the policy key expression
  * `@0/<0;1>/*`: depositor inputs live on branch 0, change on branch 1, both
  * under the SAME account as the policy key — anything else cannot be internal.
+ * The account prefix is checked against the POLICY's own key origin, not
+ * against a second caller-supplied path.
  */
-function assertPolicyPathPair(depositorPath: readonly number[], changePath?: readonly number[]): void {
+function assertDepositorPathUnderPolicy(depositorPath: readonly number[], keyOriginPath: readonly number[]): void {
   assertBip86Path("depositorPath", depositorPath);
   if (depositorPath[PATH_BRANCH_INDEX] !== BIP86_RECEIVE_BRANCH) {
     throw new Error("depositorPath must use BIP-86 receive branch 0");
   }
-  if (!changePath) return;
-  assertBip86Path("change.path", changePath);
   for (let i = 0; i < PATH_ACCOUNT_LEVELS; i++) {
-    if (changePath[i] !== depositorPath[i]) {
-      throw new Error("change.path must use the same purpose'/coin'/account' as depositorPath");
+    if (depositorPath[i] !== keyOriginPath[i]) {
+      throw new Error(
+        `depositorPath ${bip86PathToString(depositorPath)} is not under the wallet policy's key origin ` +
+          `${bip86PathToString(keyOriginPath)} — the device could never mark the input internal`,
+      );
     }
   }
-  if (changePath[PATH_BRANCH_INDEX] !== BIP86_CHANGE_BRANCH) {
-    throw new Error("change.path must use BIP-86 change branch 1");
-  }
-}
-
-function pathToString(levels: readonly number[]): string {
-  return "m/" + levels.map((l) => ((l & HARDENED) !== 0 ? `${(l & ~HARDENED) >>> 0}'` : `${l >>> 0}`)).join("/");
 }
 
 /** x-only key at `account/1/addressIndex` from the device's verbatim account xpub. */
 export function deriveChangeXOnlyHex(
   accountXpub: string,
-  bip32Versions: { private: number; public: number },
+  bip32Versions: Bip32Versions,
   addressIndex: number,
 ): string {
   if (!Number.isInteger(addressIndex) || addressIndex < 0 || addressIndex >= HARDENED) {
@@ -109,37 +88,59 @@ export function psbtPaysChangeScript(psbtHex: string, changeXOnlyHex: string): b
 export interface AugmentPsbtForWalletPolicyParams {
   readonly psbtHex: string;
   readonly depositorXOnlyHex: string;
-  readonly masterFingerprintHex: string;
+  /** The policy the PSBT signs under — supplies the fingerprint, account origin and xpub. */
+  readonly walletPolicy: DefaultTaprootWalletPolicy;
   readonly depositorPath: readonly number[];
-  /** The change output's key and path; omit when the PSBT carries no change. */
-  readonly change?: { readonly xOnlyHex: string; readonly path: readonly number[] };
+  /**
+   * Index on the policy's change branch. The key and path are BOTH derived
+   * from it and the policy, so they cannot disagree; omit when the PSBT
+   * carries no change.
+   */
+  readonly change?: { readonly addressIndex: number };
 }
 
 export function augmentPsbtForWalletPolicy(params: AugmentPsbtForWalletPolicyParams): string {
-  const { psbtHex, depositorXOnlyHex, masterFingerprintHex, depositorPath, change } = params;
+  const { psbtHex, depositorXOnlyHex, walletPolicy, depositorPath, change } = params;
   if (!X_ONLY_HEX_RE.test(depositorXOnlyHex)) throw new Error("depositorXOnlyHex must be 64 lowercase hex characters");
-  if (!FINGERPRINT_HEX_RE.test(masterFingerprintHex)) {
-    throw new Error("masterFingerprintHex must be 8 lowercase hex characters");
-  }
-  if (change && !X_ONLY_HEX_RE.test(change.xOnlyHex)) {
-    throw new Error("change.xOnlyHex must be 64 lowercase hex characters");
-  }
-  assertPolicyPathPair(depositorPath, change?.path);
+  assertDepositorPathUnderPolicy(depositorPath, walletPolicy.keyOriginPath);
   const psbt = Psbt.fromHex(psbtHex);
-  const fingerprint = Buffer.from(masterFingerprintHex, "hex");
+  const fingerprint = Buffer.from(walletPolicy.masterFingerprintHex, "hex");
   const depositorKey = Buffer.from(depositorXOnlyHex, "hex");
+  let markedInputs = 0;
   psbt.data.inputs.forEach((input, i) => {
     if (input.tapInternalKey && Buffer.from(input.tapInternalKey).equals(depositorKey)) {
+      markedInputs++;
       psbt.updateInput(i, {
         tapBip32Derivation: [
-          { masterFingerprint: fingerprint, pubkey: depositorKey, path: pathToString(depositorPath), leafHashes: [] },
+          {
+            masterFingerprint: fingerprint,
+            pubkey: depositorKey,
+            path: bip86PathToString(depositorPath),
+            leafHashes: [],
+          },
         ],
       });
     }
   });
+  // `_validate_prepegin` requires EVERY input internal (`sign_psbt_validate.c:334-545`),
+  // and an unmarked input is also skipped by the expected-signature table — so it
+  // would reach the device and die mid-ceremony, after the approval screens.
+  // Fail here, at zero device I/O, exactly like the change branch below.
+  if (markedInputs !== psbt.data.inputs.length) {
+    throw new Error(
+      `${psbt.data.inputs.length - markedInputs} of ${psbt.data.inputs.length} inputs do not carry the ` +
+        `depositor key as TAP_INTERNAL_KEY — every Pre-PegIn input must be internal`,
+    );
+  }
   if (change) {
-    const changeKey = Buffer.from(change.xOnlyHex, "hex");
-    const matched = changeOutputIndices(psbt, change.xOnlyHex);
+    const changeXOnlyHex = deriveChangeXOnlyHex(
+      walletPolicy.accountXpub,
+      walletPolicy.bip32Versions,
+      change.addressIndex,
+    );
+    const changePath = [...depositorPath.slice(0, PATH_ACCOUNT_LEVELS), BIP86_CHANGE_BRANCH, change.addressIndex];
+    const changeKey = Buffer.from(changeXOnlyHex, "hex");
+    const matched = changeOutputIndices(psbt, changeXOnlyHex);
     // Marking nothing passes every host gate and dies mid-ceremony on-device
     // (`sign_psbt_validate.c:507-510`); omit `change` for a change-less PSBT
     // ({@link psbtPaysChangeScript} is the caller-side test).
@@ -150,7 +151,7 @@ export function augmentPsbtForWalletPolicy(params: AugmentPsbtForWalletPolicyPar
       psbt.updateOutput(index, {
         tapInternalKey: changeKey,
         tapBip32Derivation: [
-          { masterFingerprint: fingerprint, pubkey: changeKey, path: pathToString(change.path), leafHashes: [] },
+          { masterFingerprint: fingerprint, pubkey: changeKey, path: bip86PathToString(changePath), leafHashes: [] },
         ],
       });
     }

--- a/packages/babylon-ledger-vault-signer/src/popPsbt.ts
+++ b/packages/babylon-ledger-vault-signer/src/popPsbt.ts
@@ -1,0 +1,124 @@
+/**
+ * BIP-322 "simple" proof-of-possession PSBT for the vault app's Screen 7.
+ *
+ * The device signs PoP as a SIGN_PSBT whose unsigned tx has `version == 0`
+ * (`sign_psbt_validate.c:3213` @ 4decf822). The PSBT is the BIP-322 to_sign
+ * transaction: one input spending to_spend:0 (sequence 0), one OP_RETURN
+ * output of value 0, locktime 0, with the message in the global proprietary
+ * key `FC 06 "bvault" 00` (`bip322.h:24-38`). The firmware rebuilds to_spend
+ * from the message and the BIP-86 tweaked key and compares its raw SHA256d
+ * against PSBT_IN_PREVIOUS_TXID (`bip322.c:203-213`, `:2794-2802`). Built as a
+ * PSBTv0: the vendored v0→v2 conversion in prepareSignPsbt emits the
+ * OUTPUT_INDEX/SEQUENCE keys the device requires physically present
+ * (`:2806-2831`). Message grammar is NOT validated here — the device is the boundary.
+ *
+ * @module ledger-vault-signer/popPsbt
+ */
+
+import { crypto as bcrypto, Psbt, Transaction } from "bitcoinjs-lib";
+import { Buffer } from "buffer";
+
+import { bip86OutputScript } from "./expectedSignatures";
+
+const BIP322_TAG = "BIP0322-signed-message";
+/** `0xFC ‖ 0x06 ‖ "bvault" ‖ 0x00` — `BIP322_PSBT_PROP_POP_MSG_KEY` (`bip322.c:10-11`; doc `bip322.h:22-29,37-38`). */
+export const POP_MESSAGE_PROPRIETARY_KEY = new Uint8Array([0xfc, 0x06, 0x62, 0x76, 0x61, 0x75, 0x6c, 0x74, 0x00]);
+
+const POP_TX_VERSION = 0;
+const POP_LOCKTIME = 0;
+const POP_SEQUENCE = 0;
+const TO_SPEND_VOUT = 0;
+const ZERO_SATS = 0;
+const OP_RETURN_SCRIPT = Buffer.from([0x6a]);
+const X_ONLY_HEX_RE = /^[0-9a-f]{64}$/;
+const FINGERPRINT_HEX_RE = /^[0-9a-f]{8}$/;
+const BIP86_PATH_LEVELS = 5;
+const HARDENED = 0x80000000;
+/** BIP-322 to_spend prevout: all-zero txid, vout 0xFFFFFFFF. */
+const TO_SPEND_PREVOUT_TXID = Buffer.alloc(32, 0);
+const TO_SPEND_PREVOUT_VOUT = 0xffffffff;
+/** `OP_0 ‖ PUSHBYTES_32` — scriptSig prefix of the to_spend input. */
+const TO_SPEND_SCRIPTSIG_PREFIX = Buffer.from([0x00, 0x20]);
+/** `OP_1 ‖ PUSHBYTES_32` — P2TR scriptPubKey prefix (BIP-341). */
+const P2TR_SCRIPT_PREFIX = Buffer.from([0x51, 0x20]);
+/** P2TR scriptPubKey = prefix(2) ‖ witness program(32); the program starts here. */
+const P2TR_WITNESS_PROGRAM_OFFSET = 2;
+
+/** BIP-340 tagged hash; hand-rolled because BIP-322's tag is not in bitcoinjs' prefix table. */
+function taggedHash(tag: string, data: Uint8Array): Buffer {
+  const tagHash = bcrypto.sha256(Buffer.from(tag, "utf8"));
+  return bcrypto.sha256(Buffer.concat([tagHash, tagHash, Buffer.from(data)]));
+}
+
+/**
+ * BIP-322 to_spend txid: SHA256d of the legacy serialization, returned in
+ * wire byte order (raw digest) — exactly what the firmware stores in
+ * PSBT_IN_PREVIOUS_TXID (`bip322.c:103,203-213`).
+ */
+export function bip322ToSpendTxid(messageBytes: Uint8Array, tweakedXOnlyKey: Uint8Array): Uint8Array {
+  const toSpend = new Transaction();
+  toSpend.version = POP_TX_VERSION;
+  toSpend.locktime = POP_LOCKTIME;
+  // scriptSig = OP_0 PUSHBYTES_32 tagged_hash("BIP0322-signed-message", message)
+  const scriptSig = Buffer.concat([TO_SPEND_SCRIPTSIG_PREFIX, taggedHash(BIP322_TAG, messageBytes)]);
+  toSpend.addInput(TO_SPEND_PREVOUT_TXID, TO_SPEND_PREVOUT_VOUT, POP_SEQUENCE, scriptSig);
+  toSpend.addOutput(Buffer.concat([P2TR_SCRIPT_PREFIX, Buffer.from(tweakedXOnlyKey)]), ZERO_SATS);
+  // getHash(false) = SHA256d of the legacy (no-witness) serialization, raw order.
+  return Uint8Array.from(toSpend.getHash(false));
+}
+
+export interface BuildPopPsbtParams {
+  /** `<eth>:<chainId>:pegin:<registry>` exactly as the SDK built it (already lowercase). */
+  readonly message: string;
+  /** 64 lowercase hex — the device key at `depositorPath`. */
+  readonly depositorXOnlyHex: string;
+  /** 8 lowercase hex from `getMasterFingerprintHex`. */
+  readonly masterFingerprintHex: string;
+  /** 5-level BIP-86 path, raw u32 levels (hardened bits included). */
+  readonly depositorPath: readonly number[];
+}
+
+function pathToString(levels: readonly number[]): string {
+  return "m/" + levels.map((l) => ((l & HARDENED) !== 0 ? `${(l & ~HARDENED) >>> 0}'` : `${l >>> 0}`)).join("/");
+}
+
+/** Build the PoP to_sign PSBT (v0 hex) for `prepareSignPsbt` in wallet-policy mode. */
+export function buildPopPsbtHex(params: BuildPopPsbtParams): string {
+  const { message, depositorXOnlyHex, masterFingerprintHex, depositorPath } = params;
+  if (!X_ONLY_HEX_RE.test(depositorXOnlyHex)) {
+    throw new Error("depositorXOnlyHex must be 64 lowercase hex characters");
+  }
+  if (!FINGERPRINT_HEX_RE.test(masterFingerprintHex)) {
+    throw new Error("masterFingerprintHex must be 8 lowercase hex characters");
+  }
+  if (depositorPath.length !== BIP86_PATH_LEVELS) {
+    throw new Error(`depositorPath must have exactly ${BIP86_PATH_LEVELS} levels, got ${depositorPath.length}`);
+  }
+  const messageBytes = new TextEncoder().encode(message);
+  const depositorKey = Buffer.from(depositorXOnlyHex, "hex");
+  const toSpendScript = bip86OutputScript(depositorXOnlyHex); // 51 20 <tweaked>
+  const toSpendTxid = bip322ToSpendTxid(messageBytes, toSpendScript.subarray(P2TR_WITNESS_PROGRAM_OFFSET));
+
+  const psbt = new Psbt();
+  psbt.setVersion(POP_TX_VERSION);
+  psbt.setLocktime(POP_LOCKTIME);
+  psbt.addInput({
+    // A Buffer hash is used as-is (internal/wire order) — no reversal.
+    hash: Buffer.from(toSpendTxid),
+    index: TO_SPEND_VOUT,
+    sequence: POP_SEQUENCE,
+    witnessUtxo: { script: toSpendScript, value: ZERO_SATS },
+    tapInternalKey: depositorKey,
+    tapBip32Derivation: [
+      {
+        masterFingerprint: Buffer.from(masterFingerprintHex, "hex"),
+        pubkey: depositorKey,
+        path: pathToString(depositorPath),
+        leafHashes: [],
+      },
+    ],
+  });
+  psbt.addOutput({ script: OP_RETURN_SCRIPT, value: ZERO_SATS });
+  psbt.addUnknownKeyValToGlobal({ key: Buffer.from(POP_MESSAGE_PROPRIETARY_KEY), value: Buffer.from(messageBytes) });
+  return psbt.toHex();
+}

--- a/packages/babylon-ledger-vault-signer/src/popPsbt.ts
+++ b/packages/babylon-ledger-vault-signer/src/popPsbt.ts
@@ -18,11 +18,12 @@
 import { crypto as bcrypto, Psbt, Transaction } from "bitcoinjs-lib";
 import { Buffer } from "buffer";
 
+import { assertBip86Path, bip86PathToString } from "./bip86Path";
 import { bip86OutputScript } from "./expectedSignatures";
 
 const BIP322_TAG = "BIP0322-signed-message";
 /** `0xFC ‖ 0x06 ‖ "bvault" ‖ 0x00` — `BIP322_PSBT_PROP_POP_MSG_KEY` (`bip322.c:10-11`; doc `bip322.h:22-29,37-38`). */
-export const POP_MESSAGE_PROPRIETARY_KEY = new Uint8Array([0xfc, 0x06, 0x62, 0x76, 0x61, 0x75, 0x6c, 0x74, 0x00]);
+const POP_MESSAGE_PROPRIETARY_KEY = new Uint8Array([0xfc, 0x06, 0x62, 0x76, 0x61, 0x75, 0x6c, 0x74, 0x00]);
 
 const POP_TX_VERSION = 0;
 const POP_LOCKTIME = 0;
@@ -32,8 +33,6 @@ const ZERO_SATS = 0;
 const OP_RETURN_SCRIPT = Buffer.from([0x6a]);
 const X_ONLY_HEX_RE = /^[0-9a-f]{64}$/;
 const FINGERPRINT_HEX_RE = /^[0-9a-f]{8}$/;
-const BIP86_PATH_LEVELS = 5;
-const HARDENED = 0x80000000;
 /** BIP-322 to_spend prevout: all-zero txid, vout 0xFFFFFFFF. */
 const TO_SPEND_PREVOUT_TXID = Buffer.alloc(32, 0);
 const TO_SPEND_PREVOUT_VOUT = 0xffffffff;
@@ -78,10 +77,6 @@ export interface BuildPopPsbtParams {
   readonly depositorPath: readonly number[];
 }
 
-function pathToString(levels: readonly number[]): string {
-  return "m/" + levels.map((l) => ((l & HARDENED) !== 0 ? `${(l & ~HARDENED) >>> 0}'` : `${l >>> 0}`)).join("/");
-}
-
 /** Build the PoP to_sign PSBT (v0 hex) for `prepareSignPsbt` in wallet-policy mode. */
 export function buildPopPsbtHex(params: BuildPopPsbtParams): string {
   const { message, depositorXOnlyHex, masterFingerprintHex, depositorPath } = params;
@@ -91,9 +86,10 @@ export function buildPopPsbtHex(params: BuildPopPsbtParams): string {
   if (!FINGERPRINT_HEX_RE.test(masterFingerprintHex)) {
     throw new Error("masterFingerprintHex must be 8 lowercase hex characters");
   }
-  if (depositorPath.length !== BIP86_PATH_LEVELS) {
-    throw new Error(`depositorPath must have exactly ${BIP86_PATH_LEVELS} levels, got ${depositorPath.length}`);
-  }
+  // Same 5-level BIP-86 shape policyPsbt enforces: an unhardened or
+  // out-of-range level renders to a DIFFERENT path than the caller asked for
+  // and only dies on-device, after the approval screen.
+  assertBip86Path("depositorPath", depositorPath);
   const messageBytes = new TextEncoder().encode(message);
   const depositorKey = Buffer.from(depositorXOnlyHex, "hex");
   const toSpendScript = bip86OutputScript(depositorXOnlyHex); // 51 20 <tweaked>
@@ -113,7 +109,7 @@ export function buildPopPsbtHex(params: BuildPopPsbtParams): string {
       {
         masterFingerprint: Buffer.from(masterFingerprintHex, "hex"),
         pubkey: depositorKey,
-        path: pathToString(depositorPath),
+        path: bip86PathToString(depositorPath),
         leafHashes: [],
       },
     ],

--- a/packages/babylon-ledger-vault-signer/src/signPsbt.ts
+++ b/packages/babylon-ledger-vault-signer/src/signPsbt.ts
@@ -87,10 +87,19 @@ export async function signPreparedVaultPsbt(
   // Resolve first so a forged handle dies as "unrecognised", then claim —
   // synchronously BEFORE the first await, so success, abort, and concurrent
   // reuse are all rejected with zero device I/O.
-  const { originalPsbtHex } = getPreparedSignPsbtState(prepared);
+  const { originalPsbtHex, signsUnderWalletPolicy } = getPreparedSignPsbtState(prepared);
   if (consumedPrepared.has(prepared)) {
     throw new LedgerSignPsbtProtocolError(
       "prepared signing state was already used — call prepareSignPsbt again for a retry",
+    );
+  }
+  // Without a policy the base app skips sign_internal_inputs (`base:sign_psbt.c:142-148`)
+  // and answers SW_OK with no yield — a failure the collector would only catch
+  // after the user has approved on-device. Reject here, at zero device I/O.
+  const needsWalletPolicy = [...prepared.table.byInput.values()].some((e) => e.kind === "taproot-keypath");
+  if (needsWalletPolicy && !signsUnderWalletPolicy) {
+    throw new LedgerSignPsbtProtocolError(
+      "PSBT signs a key-path input but was prepared without a walletPolicy — the device would answer SW_OK with no signature",
     );
   }
   consumedPrepared.add(prepared);

--- a/packages/babylon-ledger-vault-signer/src/signPsbtPrepare.ts
+++ b/packages/babylon-ledger-vault-signer/src/signPsbtPrepare.ts
@@ -196,7 +196,8 @@ export interface PrepareSignPsbtParams {
    * (PoP, Pre-PegIn): without a policy the base app skips `sign_internal_inputs`
    * (`base:sign_psbt.c:142-148`) and the device answers SW_OK with no yield
    * (`app-babylon-vault/src/sign_custom_inputs.c:101-107` @ 4decf822). Omit for
-   * the no-policy tapscript flows.
+   * the no-policy tapscript flows; `signPreparedVaultPsbt` enforces the
+   * requirement before any device I/O.
    */
   readonly walletPolicy?: DefaultTaprootWalletPolicy;
 }
@@ -224,6 +225,8 @@ interface PreparedSignPsbtState {
   readonly collector: YieldCollector;
   /** Merge target — the v0 bytes, untouched. */
   readonly originalPsbtHex: string;
+  /** Whether a policy was supplied — key-path signing needs one. */
+  readonly signsUnderWalletPolicy: boolean;
 }
 
 const preparedStates = new WeakMap<PreparedSignPsbt, PreparedSignPsbtState>();
@@ -343,6 +346,12 @@ export function prepareSignPsbt(params: PrepareSignPsbtParams): PreparedSignPsbt
   // The brand is type-only; forged objects miss the WeakMap and die typed.
   return makePreparedSignPsbt(
     { table, unsignedTxid: BitcoinjsTransaction.fromBuffer(mergeTarget.data.globalMap.unsignedTx.toBuffer()).getId() },
-    { cdata: buildSignPsbtCdata(merkelized, walletId), interpreter, collector, originalPsbtHex: psbtHex },
+    {
+      cdata: buildSignPsbtCdata(merkelized, walletId),
+      interpreter,
+      collector,
+      originalPsbtHex: psbtHex,
+      signsUnderWalletPolicy: walletPolicy !== undefined,
+    },
   );
 }

--- a/packages/babylon-ledger-vault-signer/src/signPsbtPrepare.ts
+++ b/packages/babylon-ledger-vault-signer/src/signPsbtPrepare.ts
@@ -29,8 +29,10 @@ import { CLA_APP } from "./vaultCommands";
 import { ClientCommandInterpreter } from "./vendor/ledger-bitcoin/clientCommands";
 import { MerkelizedPsbt } from "./vendor/ledger-bitcoin/merkelizedPsbt";
 import { hashLeaf, Merkle } from "./vendor/ledger-bitcoin/merkle";
+import { DefaultWalletPolicy } from "./vendor/ledger-bitcoin/policy";
 import { PsbtV2 } from "./vendor/ledger-bitcoin/psbtv2";
 import { createVarint } from "./vendor/ledger-bitcoin/varint";
+import type { DefaultTaprootWalletPolicy } from "./walletPolicy";
 
 /** Base app SIGN_PSBT instruction (`base:commands.h`). */
 const INS_SIGN_PSBT = 0x04;
@@ -48,8 +50,9 @@ const WALLET_FIELD_BYTES = 32;
  * (`has_no_wallet_policy`, `base:init_global_state.c:192-198`), which treat
  * every input/output as external — nothing is marked internal because both
  * preprocess passes return early on that flag (`base:preprocess_inputs.c:66-68`,
- * `base:preprocess_outputs.c:54-56`). A non-zero id would make the device fetch a
- * serialized policy this module never seeds — a mid-loop "unknown preimage".
+ * `base:preprocess_outputs.c:54-56`). A non-zero id without the policy preimages
+ * seeded would make the device ask for an unknown preimage mid-loop — policy
+ * mode seeds them.
  */
 const NO_WALLET_POLICY_ID = new Uint8Array(WALLET_FIELD_BYTES);
 /**
@@ -63,6 +66,7 @@ const NO_WALLET_POLICY_HMAC = new Uint8Array(WALLET_FIELD_BYTES);
 
 const DEPOSITOR_X_ONLY_HEX_RE = /^[0-9a-f]{64}$/;
 const PSBT_HEX_RE = /^(?:[0-9a-fA-F]{2})+$/;
+const WALLET_ID_HEX_RE = /^[0-9a-f]{64}$/;
 
 /**
  * The commitment surface of the vendored `MerkelizedPsbt` the header builder
@@ -93,7 +97,7 @@ export interface SignPsbtInterpreter {
  * outputsRoot(32) ‖ walletId(32) ‖ walletHmac(32)`.
  * Built from parts — never assert a fixed length (varints grow past 252).
  */
-function buildSignPsbtCdata(merkelized: SignPsbtCommitments): Uint8Array {
+function buildSignPsbtCdata(merkelized: SignPsbtCommitments, walletId: Uint8Array): Uint8Array {
   // Outer trees hash each per-map COMMITMENT as a 0x00-prefixed leaf
   // (`js:appClient.ts:317-325`; consumed at `base:get_merkleized_map.c:20-39`).
   const inputsRoot = new Merkle(merkelized.inputMapCommitments.map((commitment) => hashLeaf(commitment))).getRoot();
@@ -105,7 +109,9 @@ function buildSignPsbtCdata(merkelized: SignPsbtCommitments): Uint8Array {
       inputsRoot,
       createVarint(merkelized.getGlobalOutputCount()),
       outputsRoot,
-      Buffer.from(NO_WALLET_POLICY_ID),
+      Buffer.from(walletId),
+      // Derived apps have no registered policies: the hmac is all-zero for the
+      // default policy too (`base:init_global_state.c:184-187`).
       Buffer.from(NO_WALLET_POLICY_HMAC),
     ]),
   );
@@ -184,6 +190,15 @@ export interface PrepareSignPsbtParams {
   readonly psbtHex: string;
   /** Cached GET_EXTENDED_PUBKEY read (64 lowercase hex) — pins the table. */
   readonly depositorXOnlyHex: string;
+  /**
+   * Wallet-policy mode: the SIGN_PSBT wallet_id becomes the policy id and the
+   * interpreter serves the policy preimages. Required for key-path signing
+   * (PoP, Pre-PegIn): without a policy the base app skips `sign_internal_inputs`
+   * (`base:sign_psbt.c:142-148`) and the device answers SW_OK with no yield
+   * (`app-babylon-vault/src/sign_custom_inputs.c:101-107` @ 4decf822). Omit for
+   * the no-policy tapscript flows.
+   */
+  readonly walletPolicy?: DefaultTaprootWalletPolicy;
 }
 
 declare const preparedSignPsbtBrand: unique symbol;
@@ -239,9 +254,22 @@ export function getPreparedSignPsbtState(prepared: PreparedSignPsbt): PreparedSi
  * device I/O.
  */
 export function prepareSignPsbt(params: PrepareSignPsbtParams): PreparedSignPsbt {
-  const { psbtHex, depositorXOnlyHex } = params;
+  const { psbtHex, depositorXOnlyHex, walletPolicy } = params;
   if (!DEPOSITOR_X_ONLY_HEX_RE.test(depositorXOnlyHex)) {
     throw new LedgerSignPsbtProtocolError("depositorXOnlyHex must be 64 lowercase hex characters");
+  }
+  // Value import only — the vendored type never appears in an exported signature.
+  let vendorPolicy: DefaultWalletPolicy | undefined;
+  if (walletPolicy !== undefined) {
+    if (!WALLET_ID_HEX_RE.test(walletPolicy.walletIdHex)) {
+      throw new LedgerSignPsbtProtocolError("walletPolicy.walletIdHex must be 64 lowercase hex characters");
+    }
+    vendorPolicy = new DefaultWalletPolicy(walletPolicy.descriptorTemplate, walletPolicy.keyInfo);
+    // The header ships walletIdHex but the interpreter seeds preimages keyed on
+    // template+keyInfo, so a mismatch dies untyped mid-loop, after device I/O.
+    if (vendorPolicy.getId().toString("hex") !== walletPolicy.walletIdHex) {
+      throw new LedgerSignPsbtProtocolError("walletPolicy.walletIdHex does not match sha256 of the serialized policy");
+    }
   }
   // Buffer.from(hex) silently truncates at the first invalid character.
   if (!PSBT_HEX_RE.test(psbtHex)) {
@@ -291,8 +319,8 @@ export function prepareSignPsbt(params: PrepareSignPsbtParams): PreparedSignPsbt
 
   // ONE yield mechanism: the onYield seam — the loop never parses YIELDs.
   const interpreter = new ClientCommandInterpreter(undefined, (payload) => collector.assertAndRecord(payload));
-  // Reference composition: the stock client's signPsbt seeding. NO policy
-  // registration — B1 is no-policy mode only (wallet_id = 32×00).
+  // Reference composition: the stock client's signPsbt seeding — the map/list
+  // preimages both modes need; the policy preimages are seeded below.
   interpreter.addKnownMapping(merkelized.globalMerkleMap);
   for (const inputMap of merkelized.inputMerkleMaps) {
     interpreter.addKnownMapping(inputMap);
@@ -303,9 +331,18 @@ export function prepareSignPsbt(params: PrepareSignPsbtParams): PreparedSignPsbt
   interpreter.addKnownList(merkelized.inputMapCommitments);
   interpreter.addKnownList(merkelized.outputMapCommitments);
 
+  // Policy mode: the device fetches the policy serialization, then walks the
+  // key-info tree and the template (`base:sign_psbt.c` wallet header checks)
+  // before signing internal inputs. Seed all three preimages (vendored
+  // `addKnownWalletPolicy`); no-policy mode seeds nothing and keeps wallet_id zero.
+  const walletId = walletPolicy ? Buffer.from(walletPolicy.walletIdHex, "hex") : NO_WALLET_POLICY_ID;
+  if (vendorPolicy) {
+    interpreter.addKnownWalletPolicy(vendorPolicy);
+  }
+
   // The brand is type-only; forged objects miss the WeakMap and die typed.
   return makePreparedSignPsbt(
     { table, unsignedTxid: BitcoinjsTransaction.fromBuffer(mergeTarget.data.globalMap.unsignedTx.toBuffer()).getId() },
-    { cdata: buildSignPsbtCdata(merkelized), interpreter, collector, originalPsbtHex: psbtHex },
+    { cdata: buildSignPsbtCdata(merkelized, walletId), interpreter, collector, originalPsbtHex: psbtHex },
   );
 }

--- a/packages/babylon-ledger-vault-signer/src/walletPolicy.ts
+++ b/packages/babylon-ledger-vault-signer/src/walletPolicy.ts
@@ -20,6 +20,8 @@ import { DefaultWalletPolicy } from "./vendor/ledger-bitcoin/policy";
 
 export const DEFAULT_TAPROOT_DESCRIPTOR_TEMPLATE = "tr(@0/**)";
 const BIP86_PURPOSE = 86;
+// Hardened derivation adds 0x80000000, so the component itself must fit in 31 bits.
+const MAX_HARDENED_CHILD_INDEX = 0x7fffffff;
 const FINGERPRINT_HEX_RE = /^[0-9a-f]{8}$/;
 
 export interface DefaultTaprootWalletPolicy {
@@ -45,8 +47,15 @@ export function buildDefaultTaprootPolicy(params: BuildDefaultTaprootPolicyParam
   if (!FINGERPRINT_HEX_RE.test(masterFingerprintHex)) {
     throw new Error("masterFingerprintHex must be 8 lowercase hex characters");
   }
-  if (!Number.isInteger(coinType) || coinType < 0 || !Number.isInteger(accountIndex) || accountIndex < 0) {
-    throw new Error("coinType and accountIndex must be non-negative integers");
+  if (
+    !Number.isInteger(coinType) ||
+    coinType < 0 ||
+    coinType > MAX_HARDENED_CHILD_INDEX ||
+    !Number.isInteger(accountIndex) ||
+    accountIndex < 0 ||
+    accountIndex > MAX_HARDENED_CHILD_INDEX
+  ) {
+    throw new Error("coinType and accountIndex must be non-negative integers in 0..0x7fffffff");
   }
   if (accountXpub.length === 0) {
     throw new Error("accountXpub must be the device's extended key string");

--- a/packages/babylon-ledger-vault-signer/src/walletPolicy.ts
+++ b/packages/babylon-ledger-vault-signer/src/walletPolicy.ts
@@ -1,0 +1,57 @@
+/**
+ * The default BIP-86 wallet policy the vault app signs key-path inputs under.
+ *
+ * The base app signs internal (key-path) inputs only when a wallet policy is
+ * present (`bitcoin_app_base/src/handler/sign_psbt.c:142-148` @ e400d8d8);
+ * without one a PoP returns SW_OK with no signature
+ * (`app-babylon-vault/src/sign_custom_inputs.c:101-107` @ 4decf822). A default
+ * policy needs no registration: empty name (`init_global_state.c:238-242`),
+ * template `tr(@0/**)`, one key info `[fpr/86'/coin'/account']xpub`
+ * (`tests/test_screen7_pop.py:135-142`), hmac 32×00. The id is
+ * `sha256(serialize())` and becomes the SIGN_PSBT header's wallet_id.
+ *
+ * The public shape is structural so the vendored class never reaches the
+ * emitted declarations (`scripts/check-dist-types.cjs`).
+ *
+ * @module ledger-vault-signer/walletPolicy
+ */
+
+import { DefaultWalletPolicy } from "./vendor/ledger-bitcoin/policy";
+
+export const DEFAULT_TAPROOT_DESCRIPTOR_TEMPLATE = "tr(@0/**)";
+const BIP86_PURPOSE = 86;
+const FINGERPRINT_HEX_RE = /^[0-9a-f]{8}$/;
+
+export interface DefaultTaprootWalletPolicy {
+  readonly descriptorTemplate: typeof DEFAULT_TAPROOT_DESCRIPTOR_TEMPLATE;
+  /** `[fingerprint/86'/coin'/account']xpub` — the device's xpub string verbatim. */
+  readonly keyInfo: string;
+  /** `sha256(serialized policy)`, 64 lowercase hex — the SIGN_PSBT wallet_id. */
+  readonly walletIdHex: string;
+}
+
+export interface BuildDefaultTaprootPolicyParams {
+  /** 8 lowercase hex chars from `getMasterFingerprintHex`. */
+  readonly masterFingerprintHex: string;
+  /** SLIP-44 coin type of the device build (0 mainnet, 1 testnet/signet). */
+  readonly coinType: number;
+  readonly accountIndex: number;
+  /** Base58 extended key at `m/86'/coin'/account'` from `getExtendedPublicKey`, verbatim. */
+  readonly accountXpub: string;
+}
+
+export function buildDefaultTaprootPolicy(params: BuildDefaultTaprootPolicyParams): DefaultTaprootWalletPolicy {
+  const { masterFingerprintHex, coinType, accountIndex, accountXpub } = params;
+  if (!FINGERPRINT_HEX_RE.test(masterFingerprintHex)) {
+    throw new Error("masterFingerprintHex must be 8 lowercase hex characters");
+  }
+  if (!Number.isInteger(coinType) || coinType < 0 || !Number.isInteger(accountIndex) || accountIndex < 0) {
+    throw new Error("coinType and accountIndex must be non-negative integers");
+  }
+  if (accountXpub.length === 0) {
+    throw new Error("accountXpub must be the device's extended key string");
+  }
+  const keyInfo = `[${masterFingerprintHex}/${BIP86_PURPOSE}'/${coinType}'/${accountIndex}']${accountXpub}`;
+  const walletIdHex = new DefaultWalletPolicy(DEFAULT_TAPROOT_DESCRIPTOR_TEMPLATE, keyInfo).getId().toString("hex");
+  return { descriptorTemplate: DEFAULT_TAPROOT_DESCRIPTOR_TEMPLATE, keyInfo, walletIdHex };
+}

--- a/packages/babylon-ledger-vault-signer/src/walletPolicy.ts
+++ b/packages/babylon-ledger-vault-signer/src/walletPolicy.ts
@@ -16,13 +16,20 @@
  * @module ledger-vault-signer/walletPolicy
  */
 
+import { HDKey } from "@scure/bip32";
+
+import { BIP86_PURPOSE, HARDENED } from "./bip86Path";
 import { DefaultWalletPolicy } from "./vendor/ledger-bitcoin/policy";
 
 export const DEFAULT_TAPROOT_DESCRIPTOR_TEMPLATE = "tr(@0/**)";
-const BIP86_PURPOSE = 86;
 // Hardened derivation adds 0x80000000, so the component itself must fit in 31 bits.
 const MAX_HARDENED_CHILD_INDEX = 0x7fffffff;
 const FINGERPRINT_HEX_RE = /^[0-9a-f]{8}$/;
+
+export interface Bip32Versions {
+  readonly private: number;
+  readonly public: number;
+}
 
 export interface DefaultTaprootWalletPolicy {
   readonly descriptorTemplate: typeof DEFAULT_TAPROOT_DESCRIPTOR_TEMPLATE;
@@ -30,6 +37,12 @@ export interface DefaultTaprootWalletPolicy {
   readonly keyInfo: string;
   /** `sha256(serialized policy)`, 64 lowercase hex — the SIGN_PSBT wallet_id. */
   readonly walletIdHex: string;
+  /** The account key this policy is built over, verbatim from the device. */
+  readonly accountXpub: string;
+  readonly bip32Versions: Bip32Versions;
+  /** `m/86'/coin'/account'` as path levels — the key-info origin. */
+  readonly keyOriginPath: readonly number[];
+  readonly masterFingerprintHex: string;
 }
 
 export interface BuildDefaultTaprootPolicyParams {
@@ -40,10 +53,12 @@ export interface BuildDefaultTaprootPolicyParams {
   readonly accountIndex: number;
   /** Base58 extended key at `m/86'/coin'/account'` from `getExtendedPublicKey`, verbatim. */
   readonly accountXpub: string;
+  /** Version bytes of the device build, to decode `accountXpub`. */
+  readonly bip32Versions: Bip32Versions;
 }
 
 export function buildDefaultTaprootPolicy(params: BuildDefaultTaprootPolicyParams): DefaultTaprootWalletPolicy {
-  const { masterFingerprintHex, coinType, accountIndex, accountXpub } = params;
+  const { masterFingerprintHex, coinType, accountIndex, accountXpub, bip32Versions } = params;
   if (!FINGERPRINT_HEX_RE.test(masterFingerprintHex)) {
     throw new Error("masterFingerprintHex must be 8 lowercase hex characters");
   }
@@ -57,10 +72,25 @@ export function buildDefaultTaprootPolicy(params: BuildDefaultTaprootPolicyParam
   ) {
     throw new Error("coinType and accountIndex must be non-negative integers in 0..0x7fffffff");
   }
-  if (accountXpub.length === 0) {
-    throw new Error("accountXpub must be the device's extended key string");
+  // `WalletPolicy.serialize()` encodes key info with Buffer.from(k, "ascii"),
+  // which masks anything above 0x7F — a garbage xpub would still yield a
+  // well-formed wallet id the device can never be served a preimage for.
+  try {
+    HDKey.fromExtendedKey(accountXpub, bip32Versions);
+  } catch (error) {
+    throw new Error(
+      `accountXpub is not a valid extended key for this network: ${error instanceof Error ? error.message : String(error)}`,
+    );
   }
   const keyInfo = `[${masterFingerprintHex}/${BIP86_PURPOSE}'/${coinType}'/${accountIndex}']${accountXpub}`;
   const walletIdHex = new DefaultWalletPolicy(DEFAULT_TAPROOT_DESCRIPTOR_TEMPLATE, keyInfo).getId().toString("hex");
-  return { descriptorTemplate: DEFAULT_TAPROOT_DESCRIPTOR_TEMPLATE, keyInfo, walletIdHex };
+  return {
+    descriptorTemplate: DEFAULT_TAPROOT_DESCRIPTOR_TEMPLATE,
+    keyInfo,
+    walletIdHex,
+    accountXpub,
+    bip32Versions,
+    keyOriginPath: [(HARDENED | BIP86_PURPOSE) >>> 0, (HARDENED | coinType) >>> 0, (HARDENED | accountIndex) >>> 0],
+    masterFingerprintHex,
+  };
 }

--- a/packages/babylon-ts-sdk/docs/api/deposit-terms.md
+++ b/packages/babylon-ts-sdk/docs/api/deposit-terms.md
@@ -818,9 +818,10 @@ function supportsDepositApproval(wallet): wallet is BitcoinWallet & DepositTerms
 
 Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts)
 
-True when the wallet implements [DepositTermsApprover.approveDepositTerms](#approvedepositterms).
-Narrows to the whole interface: a provider with one method and not the other
-is a provider bug, not a shape this seam supports.
+Probes [DepositTermsApprover.approveDepositTerms](#approvedepositterms) alone but narrows to
+the whole interface: a conforming approval wallet implements all of
+[DepositTermsApprover](#deposittermsapprover), `getChangeAddress` included, so a provider with
+one method and not the other is a provider bug, not a shape this seam supports.
 
 #### Parameters
 

--- a/packages/babylon-ts-sdk/docs/api/deposit-terms.md
+++ b/packages/babylon-ts-sdk/docs/api/deposit-terms.md
@@ -319,17 +319,12 @@ optional holdsApprovedDepositTerms(terms): Promise<boolean>;
 
 Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts)
 
-OPTIONAL fast-path probe: does the current device connection still hold
-an approval for exactly these terms that the NEXT terms-bound signature
-can proceed under without a new ceremony? "Held but consumed" (anything
-already signed under a one-shot intent) MUST report false — a true that
-cannot sign again strands the caller with no recovery path.
-Implementations MUST answer from host-side state without device I/O,
-MUST return false on any doubt (including a dropped connection or terms
-that fail to encode), and MUST never throw. The SDK uses a true answer
-only to skip an otherwise redundant re-derive + re-approve ceremony; a
-stale true fails closed at the next signature, so this probe is a UX
-optimization, never an authorization.
+OPTIONAL fast-path probe: can the Pre-PegIn signature for exactly these
+terms proceed under the connection's held approval without a new
+ceremony? MUST report false once that Pre-PegIn was signed (one-shot),
+MUST answer from host state without device I/O, MUST return false on any
+doubt, and MUST never throw. A stale true fails closed at the next
+signature — this is a UX optimization, never an authorization.
 
 ###### Parameters
 
@@ -495,7 +490,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/prePeginApproval
 
 Minimal structural wallet for the Pre-PegIn ceremony. Mirrors
 `DeriveContextHashCapableWallet` so an app-side wrapper object qualifies
-without implementing all of `BitcoinWallet`. Both methods are optional so
+without implementing all of `BitcoinWallet`. All methods are optional so
 the capability probe below can run on any wallet.
 
 #### Methods
@@ -946,18 +941,14 @@ Run the derive → approve ceremony (or a no-op) before a Pre-PegIn signature.
 - Approval-capable wallets: require terms, assert they match this tx's txid,
   derive the vault root over the tx's funding outpoints, then approve.
 
-Skip fast-path: when the wallet reports (via `holdsApprovedDepositTerms`, a
-host-side mirror read) that these byte-equal terms are still approved on the
-live connection, the ceremony is skipped entirely — the intent approved at
-`preparePegin` survives everything the flow does in between (PoP signing is
-state-independent and no base-app APDU touches the vault context;
-app-babylon-vault `sign_psbt_validate.c` PoP dispatch comment @ 73a57c50).
-A stale "true" fails closed: the device rejects the signature with a state
-error, the provider drops its mirror, and the retry runs the full ceremony.
+Skip fast-path: when `holdsApprovedDepositTerms` reports the byte-equal
+intent still live, the ceremony is skipped — it survives everything the
+flow does in between (PoP/PegIn signing spend separate device state;
+app-babylon-vault `sign_psbt_validate.c` @ 73a57c50). A stale true fails
+closed at the signature; the retry then re-runs the full ceremony.
 
-Otherwise always derives first: the host cannot read device state, and the
-one-shot Pre-PegIn cap means every retry needs the full ceremony — so this
-path never approves-only.
+Otherwise always derives first — the host cannot read device state, so
+this path never approves-only.
 
 #### Parameters
 

--- a/packages/babylon-ts-sdk/docs/api/deposit-terms.md
+++ b/packages/babylon-ts-sdk/docs/api/deposit-terms.md
@@ -336,6 +336,26 @@ signature — this is a UX optimization, never an authorization.
 
 `Promise`\<`boolean`\>
 
+***
+
+### PrePeginChangeSource
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts)
+
+Where Pre-PegIn change must pay. Approval (policy) wallets sign key-path
+under a wallet policy whose change branch the device alone can derive and
+mark internal — the receive address is NOT acceptable change
+(`process_in_outs.c:114-117` @ e400d8d8).
+
+Separate from [DepositTermsApprover](#deposittermsapprover) because only the Pre-PegIn build
+needs it: the presign/payout ceremonies approve terms without ever creating
+change, so they must not require a wallet to implement this.
+
+MUST be stable across a deposit flow: the app reads it to build the tx and
+`preparePegin` re-reads it to verify, so mid-flow rotation fails that gate.
+
+#### Methods
+
 ##### getChangeAddress()
 
 ```ts
@@ -343,14 +363,6 @@ getChangeAddress(): Promise<string>;
 ```
 
 Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts)
-
-The address Pre-PegIn change must pay to. Approval (policy) wallets sign
-key-path under a wallet policy whose change branch the device alone can
-derive and mark internal — the receive address is NOT acceptable change
-(`process_in_outs.c:114-117` @ e400d8d8).
-
-MUST be stable across a deposit flow: the app reads it to build the tx and
-`preparePegin` re-reads it to verify, so mid-flow rotation fails that gate.
 
 ###### Returns
 
@@ -862,10 +874,7 @@ function supportsDepositApproval(wallet): wallet is BitcoinWallet & DepositTerms
 
 Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts)
 
-Probes [DepositTermsApprover.approveDepositTerms](#approvedepositterms) alone but narrows to
-the whole interface: a conforming approval wallet implements all of
-[DepositTermsApprover](#deposittermsapprover), `getChangeAddress` included, so a provider with
-one method and not the other is a provider bug, not a shape this seam supports.
+Probes [DepositTermsApprover.approveDepositTerms](#approvedepositterms).
 
 #### Parameters
 
@@ -879,10 +888,41 @@ one method and not the other is a provider bug, not a shape this seam supports.
 
 ***
 
+### requireChangeAddress()
+
+```ts
+function requireChangeAddress(wallet): Promise<string>;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts)
+
+The wallet's change address, for the one caller that needs it.
+
+Narrowing on `approveDepositTerms` alone cannot promise this method, so
+calling it off the narrowed value would die on `is not a function` in the
+middle of `preparePegin`, after the pubkey read. Ask here instead and fail
+with something a provider author can act on.
+
+#### Parameters
+
+##### wallet
+
+[`BitcoinWallet`](managers.md#bitcoinwallet)
+
+#### Returns
+
+`Promise`\<`string`\>
+
+#### Throws
+
+If the wallet cannot report a change address.
+
+***
+
 ### forwardDepositApproval()
 
 ```ts
-function forwardDepositApproval(wallet): Partial<DepositTermsApprover>;
+function forwardDepositApproval(wallet): Partial<DepositTermsApprover & PrePeginChangeSource>;
 ```
 
 Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts)
@@ -899,7 +939,7 @@ must re-attach the capability explicitly: `...forwardDepositApproval(wallet)`.
 
 #### Returns
 
-`Partial`\<[`DepositTermsApprover`](#deposittermsapprover)\>
+`Partial`\<[`DepositTermsApprover`](#deposittermsapprover) & [`PrePeginChangeSource`](#prepeginchangesource)\>
 
 ***
 

--- a/packages/babylon-ts-sdk/docs/api/deposit-terms.md
+++ b/packages/babylon-ts-sdk/docs/api/deposit-terms.md
@@ -288,7 +288,8 @@ Seam invariant: any derive invalidates a prior approval, so the SDK
 re-approves after every derive and before the next terms-bound signature.
 The re-approval sites are `PeginManager.preparePegin`,
 `runDepositorPresignFlow`, and `signAndBroadcast` (the Pre-PegIn broadcast,
-which derives immediately before approving — see `ensurePrePeginTermsApproval`).
+which re-derives before approving unless `holdsApprovedDepositTerms`
+reports the byte-equal intent still live — see `ensurePrePeginTermsApproval`).
 
 #### Methods
 
@@ -309,6 +310,36 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts]
 ###### Returns
 
 `Promise`\<`void`\>
+
+##### holdsApprovedDepositTerms()?
+
+```ts
+optional holdsApprovedDepositTerms(terms): Promise<boolean>;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts)
+
+OPTIONAL fast-path probe: does the current device connection still hold
+an approval for exactly these terms that the NEXT terms-bound signature
+can proceed under without a new ceremony? "Held but consumed" (anything
+already signed under a one-shot intent) MUST report false — a true that
+cannot sign again strands the caller with no recovery path.
+Implementations MUST answer from host-side state without device I/O,
+MUST return false on any doubt (including a dropped connection or terms
+that fail to encode), and MUST never throw. The SDK uses a true answer
+only to skip an otherwise redundant re-derive + re-approve ceremony; a
+stale true fails closed at the next signature, so this probe is a UX
+optimization, never an authorization.
+
+###### Parameters
+
+###### terms
+
+[`DepositTerms`](#depositterms)
+
+###### Returns
+
+`Promise`\<`boolean`\>
 
 ##### getChangeAddress()
 
@@ -508,6 +539,24 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/prePeginApproval
 ###### Returns
 
 `Promise`\<`void`\>
+
+##### holdsApprovedDepositTerms()?
+
+```ts
+optional holdsApprovedDepositTerms(terms): Promise<boolean>;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/prePeginApproval.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/prePeginApproval.ts)
+
+###### Parameters
+
+###### terms
+
+[`DepositTerms`](#depositterms)
+
+###### Returns
+
+`Promise`\<`boolean`\>
 
 ***
 
@@ -897,10 +946,18 @@ Run the derive → approve ceremony (or a no-op) before a Pre-PegIn signature.
 - Approval-capable wallets: require terms, assert they match this tx's txid,
   derive the vault root over the tx's funding outpoints, then approve.
 
-Always derives first: the host cannot read device state, a one-shot cap means
-every retry needs the full ceremony, and whether interleaved signing
-nullifies a loaded intent is unresolved — so the broadcast path never
-approves-only.
+Skip fast-path: when the wallet reports (via `holdsApprovedDepositTerms`, a
+host-side mirror read) that these byte-equal terms are still approved on the
+live connection, the ceremony is skipped entirely — the intent approved at
+`preparePegin` survives everything the flow does in between (PoP signing is
+state-independent and no base-app APDU touches the vault context;
+app-babylon-vault `sign_psbt_validate.c` PoP dispatch comment @ 73a57c50).
+A stale "true" fails closed: the device rejects the signature with a state
+error, the provider drops its mirror, and the retry runs the full ceremony.
+
+Otherwise always derives first: the host cannot read device state, and the
+one-shot Pre-PegIn cap means every retry needs the full ceremony — so this
+path never approves-only.
 
 #### Parameters
 

--- a/packages/babylon-ts-sdk/docs/api/deposit-terms.md
+++ b/packages/babylon-ts-sdk/docs/api/deposit-terms.md
@@ -310,6 +310,26 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts]
 
 `Promise`\<`void`\>
 
+##### getChangeAddress()
+
+```ts
+getChangeAddress(): Promise<string>;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts)
+
+The address Pre-PegIn change must pay to. Approval (policy) wallets sign
+key-path under a wallet policy whose change branch the device alone can
+derive and mark internal — the receive address is NOT acceptable change
+(`process_in_outs.c:114-117` @ e400d8d8).
+
+MUST be stable across a deposit flow: the app reads it to build the tx and
+`preparePegin` re-reads it to verify, so mid-flow rotation fails that gate.
+
+###### Returns
+
+`Promise`\<`string`\>
+
 ***
 
 ### BuildDepositTermsInputs
@@ -799,6 +819,8 @@ function supportsDepositApproval(wallet): wallet is BitcoinWallet & DepositTerms
 Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts)
 
 True when the wallet implements [DepositTermsApprover.approveDepositTerms](#approvedepositterms).
+Narrows to the whole interface: a provider with one method and not the other
+is a provider bug, not a shape this seam supports.
 
 #### Parameters
 
@@ -820,7 +842,7 @@ function forwardDepositApproval(wallet): Partial<DepositTermsApprover>;
 
 Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts)
 
-Spreadable forward of `approveDepositTerms` for wallet-wrapper objects.
+Spreadable forward of the approval capability for wallet-wrapper objects.
 Object spread drops prototype methods, so every `{...wallet}` wrapper site
 must re-attach the capability explicitly: `...forwardDepositApproval(wallet)`.
 

--- a/packages/babylon-ts-sdk/docs/api/managers.md
+++ b/packages/babylon-ts-sdk/docs/api/managers.md
@@ -1022,20 +1022,38 @@ Forwarded to [buildPayoutPsbt](primitives.md#buildpayoutpsbt) for the fee band.
 SignPayoutBaseParams.protocolFeeRate
 ```
 
-##### councilSize
+##### councilMembers
 
 ```ts
-councilSize: number;
+councilMembers: string[];
 ```
 
 Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts)
 
-Security council member count; forwarded to the fee floor (see PayoutParams).
+Security council member x-only pubkeys (hex); forwarded to
+[buildPayoutPsbt](primitives.md#buildpayoutpsbt) to rebuild the Assert:0 payout leaf and to size the
+fee floor (see PayoutParams).
 
 ###### Inherited from
 
 ```ts
-SignPayoutBaseParams.councilSize
+SignPayoutBaseParams.councilMembers
+```
+
+##### councilQuorum
+
+```ts
+councilQuorum: number;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts)
+
+M-of-N council quorum; shapes the Assert:0 council leaf (see PayoutParams).
+
+###### Inherited from
+
+```ts
+SignPayoutBaseParams.councilQuorum
 ```
 
 ##### vkClaimerPayoutScriptPubKeys

--- a/packages/babylon-ts-sdk/docs/api/managers.md
+++ b/packages/babylon-ts-sdk/docs/api/managers.md
@@ -382,9 +382,18 @@ wallet to the connected ETH account for this chain and vault
 registry. The returned [PopSignature](#popsignature) can be reused across
 every register call in the same session.
 
+A one-item (P2TR) witness is verified against the depositor key before
+it is returned — see verifyPopWitness. Two-item (P2WPKH)
+witnesses are not yet verified host-side.
+
 ###### Returns
 
 `Promise`\<[`PopSignature`](#popsignature)\>
+
+###### Throws
+
+If the wallet returns a malformed witness or a P2TR signature
+        that does not verify.
 
 ##### getNetwork()
 

--- a/packages/babylon-ts-sdk/docs/api/primitives.md
+++ b/packages/babylon-ts-sdk/docs/api/primitives.md
@@ -683,19 +683,32 @@ Tx-graph fee rate (sat/vB) the graph was built with — the version-locked
 `offchainParams.feeRate` at the vault's stamped `offchainParamsVersion`,
 NOT a live read. Anchors both ends of the fee band.
 
-##### councilSize
+##### councilMembers
 
 ```ts
-councilSize: number;
+councilMembers: string[];
 ```
 
 Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts)
 
-Security council member count from the locked offchain params version.
-Mirrors the upstream estimator's signature; at the current model pins the
-council occupies a single taptree leaf regardless of size, so the floor
-is council-size-invariant — passed for forward compatibility with future
-pinned models.
+Security council member x-only public keys (hex) from the locked offchain
+params version — `getOffchainParamsByVersion(...).securityCouncilKeys`.
+The council occupies the last leaf of the Assert:0 taptree
+(btc-vault `crates/vault/src/connectors/assert_payout_nopayout_council.rs`),
+so the keys are needed to rebuild input 1's payout leaf, and the count
+feeds the fee-band domain.
+
+##### councilQuorum
+
+```ts
+councilQuorum: number;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts)
+
+M-of-N council quorum from the locked offchain params version —
+`getOffchainParamsByVersion(...).councilQuorum`. Shapes the council leaf's
+multisig script, and with it the Assert:0 taptree root.
 
 ##### vkClaimerPayoutScriptPubKeys
 
@@ -2093,6 +2106,9 @@ Payout transactions have the following structure:
 - Input 0: from PeginTx output0 (signed by depositor)
 - Input 1: from Assert output0 (NOT signed by depositor)
 
+Both inputs carry their taproot script-path leaf. Input 1's is not signed
+here — it is what a hardware signer reads to display the payout terms.
+
 #### Parameters
 
 ##### params
@@ -2135,7 +2151,7 @@ If the implicit fee (inputs − outputs) is outside the fee band —
 
 #### Throws
 
-If `protocolFeeRate`, a participant count, or `councilSize` is
+If `protocolFeeRate`, a participant count, or the council size is
   outside the accepted input domain (see assertPayoutFeeBandDomain)
 
 #### Throws
@@ -2155,6 +2171,11 @@ If payout output count, outs[0] script, outs[last] anchor value, or
 #### Throws
 
 If `commissionBps` is not a non-negative integer below 10_000
+
+#### Throws
+
+If the locally rebuilt Assert:0 payout leaf does not bind to the
+  Assert output input 1 spends
 
 ***
 

--- a/packages/babylon-ts-sdk/docs/api/primitives.md
+++ b/packages/babylon-ts-sdk/docs/api/primitives.md
@@ -1349,6 +1349,72 @@ PSBT hex ready for depositor signing
 
 ***
 
+### AssertKeyPathSchnorrSignatureParams
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/verifyKeyPathSchnorrSignature.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/verifyKeyPathSchnorrSignature.ts)
+
+#### Properties
+
+##### requestedPsbtHex
+
+```ts
+requestedPsbtHex: string;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/verifyKeyPathSchnorrSignature.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/verifyKeyPathSchnorrSignature.ts)
+
+Hex of the PSBT we built and sent (trusted prevout scripts/values). NOT the wallet's.
+
+##### signatureHex
+
+```ts
+signatureHex: string;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/verifyKeyPathSchnorrSignature.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/verifyKeyPathSchnorrSignature.ts)
+
+64- or 65-byte signature, hex.
+
+##### inputIndex
+
+```ts
+inputIndex: number;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/verifyKeyPathSchnorrSignature.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/verifyKeyPathSchnorrSignature.ts)
+
+Index of the input the signature is for.
+
+***
+
+### AssertReturnedKeyPathSignaturesParams
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/verifyKeyPathSchnorrSignature.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/verifyKeyPathSchnorrSignature.ts)
+
+#### Properties
+
+##### requestedPsbtHex
+
+```ts
+requestedPsbtHex: string;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/verifyKeyPathSchnorrSignature.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/verifyKeyPathSchnorrSignature.ts)
+
+PSBT we built locally and asked the wallet to sign.
+
+##### returnedPsbtHex
+
+```ts
+returnedPsbtHex: string;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/verifyKeyPathSchnorrSignature.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/verifyKeyPathSchnorrSignature.ts)
+
+PSBT the wallet returned after signing.
+
+***
+
 ### VerifyScriptPathSchnorrSignatureParams
 
 Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/verifyScriptPathSchnorrSignature.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/verifyScriptPathSchnorrSignature.ts)
@@ -2377,6 +2443,67 @@ If the HTLC output at htlcVout is not found
 #### Throws
 
 If the refund transaction does not have exactly 1 input
+
+***
+
+### assertKeyPathSchnorrSignature()
+
+```ts
+function assertKeyPathSchnorrSignature(params): void;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/verifyKeyPathSchnorrSignature.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/verifyKeyPathSchnorrSignature.ts)
+
+Assert that `signatureHex` is a valid BIP-340 Schnorr signature over the
+Taproot key-path sighash of `requestedPsbtHex` input `inputIndex`, under the
+tweaked output key taken from that input's prevout scriptPubKey.
+
+#### Parameters
+
+##### params
+
+[`AssertKeyPathSchnorrSignatureParams`](#assertkeypathschnorrsignatureparams)
+
+#### Returns
+
+`void`
+
+#### Throws
+
+If the input is not a key-path P2TR spend, the requested PSBT lacks
+        the prevout data needed to recompute the sighash, or the signature
+        does not verify.
+
+***
+
+### assertReturnedKeyPathSignatures()
+
+```ts
+function assertReturnedKeyPathSignatures(params): void;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/verifyKeyPathSchnorrSignature.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/verifyKeyPathSchnorrSignature.ts)
+
+Verify every key-path-eligible input of the REQUESTED PSBT against what the
+wallet RETURNED: `tapKeySig`, or the single finalized witness item for wallets
+that auto-finalize — and when both are present they must be the same bytes.
+Script-path inputs are skipped (they have their own check).
+
+#### Parameters
+
+##### params
+
+[`AssertReturnedKeyPathSignaturesParams`](#assertreturnedkeypathsignaturesparams)
+
+#### Returns
+
+`void`
+
+#### Throws
+
+If the input counts differ, an eligible input carries no signature, a
+        finalized witness disagrees with its `tapKeySig`, or any signature
+        does not verify.
 
 ***
 

--- a/packages/babylon-ts-sdk/docs/api/primitives.md
+++ b/packages/babylon-ts-sdk/docs/api/primitives.md
@@ -2500,7 +2500,7 @@ If the input is not a key-path P2TR spend, the requested PSBT lacks
 ### assertReturnedKeyPathSignatures()
 
 ```ts
-function assertReturnedKeyPathSignatures(params): void;
+function assertReturnedKeyPathSignatures(params): number;
 ```
 
 Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/verifyKeyPathSchnorrSignature.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/verifyKeyPathSchnorrSignature.ts)
@@ -2518,7 +2518,12 @@ Script-path inputs are skipped (they have their own check).
 
 #### Returns
 
-`void`
+`number`
+
+How many inputs were actually verified. 0 means NO input was
+         key-path eligible — a caller that knows every input is taproot
+         key-path must assert this equals its input count, or a P2WPKH
+         depositor would read "nothing verified" as "all verified".
 
 #### Throws
 

--- a/packages/babylon-ts-sdk/docs/api/services.md
+++ b/packages/babylon-ts-sdk/docs/api/services.md
@@ -1029,7 +1029,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorP
 Security council member x-only public keys (hex, no prefix).
 Source: ProtocolParams contract via
 `getOffchainParamsByVersion(...).securityCouncilKeys`.
-Required for the depositor-graph NoPayout local rebuild.
+Required to rebuild every Assert:0 leaf (payout and NoPayout) locally.
 
 ##### councilQuorum
 
@@ -1042,7 +1042,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorP
 M-of-N council quorum threshold.
 Source: ProtocolParams contract via
 `getOffchainParamsByVersion(...).councilQuorum`.
-Required for the depositor-graph NoPayout local rebuild.
+Required to rebuild every Assert:0 leaf (payout and NoPayout) locally.
 
 ##### network
 

--- a/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/__tests__/bip322Verify.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/__tests__/bip322Verify.test.ts
@@ -114,4 +114,22 @@ describe("verifyBip322Simple — end-to-end via encodeServerIdentityPayload", ()
 
     expect(verifyBip322Simple(payload, signingKey, signature)).toBe(true);
   });
+
+  it("refuses sighash types a BIP-322 witness may not carry", () => {
+    // SIGHASH_NONE/SINGLE and the ANYONECANPAY variants are rejected
+    // downstream, so verifying them here would report a false positive.
+    const payload = encodeServerIdentityPayload(
+      new TextEncoder().encode("btc-auth.server-identity.v1"),
+      fromHex(GOLDEN_EPHEMERAL_PUBKEY_COMPRESSED),
+      GOLDEN_EXPIRES_AT,
+    );
+    const signingKey = fromHex(GOLDEN_SIGNING_KEY_XONLY);
+    const signature = fromHex(GOLDEN_SIGNATURE_HEX);
+
+    for (const hashType of [0x02, 0x03, 0x81, 0x82, 0x83]) {
+      expect(verifyBip322Simple(payload, signingKey, signature, hashType)).toBe(
+        false,
+      );
+    }
+  });
 });

--- a/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/bip322Verify.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/bip322Verify.ts
@@ -39,8 +39,8 @@
 import * as ecc from "@bitcoin-js/tiny-secp256k1-asmjs";
 import { payments, Transaction } from "bitcoinjs-lib";
 
-import { Buffer } from "buffer";
 import { sha256 } from "@noble/hashes/sha2.js";
+import { Buffer } from "buffer";
 
 /** BIP-322 message tag (BIP-340 tagged-hash style). */
 const BIP322_TAG = "BIP0322-signed-message";
@@ -86,9 +86,9 @@ function tweakXOnlyKey(xOnly: Uint8Array): Uint8Array | null {
  * Verify a BIP-322 "simple" P2TR key-path signature over an arbitrary
  * byte message.
  *
- * @internal Exposed only so the golden-vector test suite can pin the
- * verifier independently of `verifyServerIdentity`. Production callers
- * should use `verifyServerIdentity` from `./serverIdentity` instead.
+ * @internal Consumed by `verifyServerIdentity` (VP auth) and
+ * `verifyPopWitness` (PoP pre-registration check), and exposed so the
+ * golden-vector test suite can pin the verifier independently.
  *
  * @param messageBytes - The bytes that were signed (e.g. a CBOR-encoded
  *                       payload). Not pre-hashed; this function applies
@@ -150,8 +150,8 @@ export function verifyBip322Simple(
     ]);
     toSpend.addInput(
       Buffer.alloc(32, 0), // prev_txid = 0x0000...0000
-      0xffffffff,          // prev_vout = 0xFFFFFFFF
-      0,                   // sequence = 0
+      0xffffffff, // prev_vout = 0xFFFFFFFF
+      0, // sequence = 0
       scriptSig,
     );
     toSpend.addOutput(scriptPubKey, ZERO_SATS);

--- a/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/bip322Verify.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/bip322Verify.ts
@@ -20,8 +20,9 @@
  *   3. Build a "to_sign" transaction that spends to_spend[0] and has a
  *      single `OP_RETURN` output (value 0).
  *
- *   4. Compute the BIP-341 taproot sighash of to_sign input 0 with
- *      SIGHASH_DEFAULT (0x00).
+ *   4. Compute the BIP-341 taproot sighash of to_sign input 0 with the
+ *      caller's `hashType` (SIGHASH_DEFAULT 0x00 unless the witness item
+ *      carried a trailing SIGHASH_ALL 0x01 byte).
  *
  *   5. Verify the 64-byte Schnorr signature against the **tweaked**
  *      output key `Q = P + tap_tweak(P) * G`, where `tap_tweak(P) =
@@ -94,8 +95,12 @@ function tweakXOnlyKey(xOnly: Uint8Array): Uint8Array | null {
  *                       the BIP-322 tagged hash internally.
  * @param xOnlyPubkey  - 32-byte x-only pubkey of the signer (pre-tweak).
  * @param signature    - 64-byte raw Schnorr signature (BIP-340), as
- *                       emitted by a key-path witness with
- *                       SIGHASH_DEFAULT.
+ *                       emitted by a key-path witness. The trailing
+ *                       sighash byte of a 65-byte witness item is not
+ *                       part of it — pass it as `hashType` instead.
+ * @param hashType     - BIP-341 sighash type the signature commits to.
+ *                       `SIGHASH_DEFAULT` (0x00) for a 64-byte witness
+ *                       item, `SIGHASH_ALL` (0x01) for a 65-byte one.
  * @returns `true` if the signature verifies against the address
  *          derived from `xOnlyPubkey`; `false` otherwise.
  */
@@ -103,6 +108,7 @@ export function verifyBip322Simple(
   messageBytes: Uint8Array,
   xOnlyPubkey: Uint8Array,
   signature: Uint8Array,
+  hashType: number = Transaction.SIGHASH_DEFAULT,
 ): boolean {
   if (xOnlyPubkey.length !== X_ONLY_PUBKEY_SIZE) return false;
   if (signature.length !== SCHNORR_SIG_SIZE) return false;
@@ -159,12 +165,12 @@ export function verifyBip322Simple(
     toSign.addInput(toSpendTxid, 0, 0);
     toSign.addOutput(Buffer.from([0x6a]), ZERO_SATS); // OP_RETURN
 
-    // Step 5: taproot sighash for to_sign input 0 (SIGHASH_DEFAULT).
+    // Step 5: taproot sighash for to_sign input 0.
     const sighash = toSign.hashForWitnessV1(
       0,
       [scriptPubKey],
       [ZERO_SATS],
-      Transaction.SIGHASH_DEFAULT,
+      hashType,
     );
 
     // Step 6: tweak the x-only pubkey (no merkle root) and verify Schnorr.

--- a/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/bip322Verify.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/bip322Verify.ts
@@ -112,6 +112,14 @@ export function verifyBip322Simple(
 ): boolean {
   if (xOnlyPubkey.length !== X_ONLY_PUBKEY_SIZE) return false;
   if (signature.length !== SCHNORR_SIG_SIZE) return false;
+  // Only the two types a BIP-322 witness may carry. SIGHASH_NONE/SINGLE and the
+  // ANYONECANPAY variants would verify here but are rejected downstream.
+  if (
+    hashType !== Transaction.SIGHASH_DEFAULT &&
+    hashType !== Transaction.SIGHASH_ALL
+  ) {
+    return false;
+  }
 
   // Any exception from the underlying crypto libraries (e.g. the
   // `Expected Point` error `tiny-secp256k1` throws when the supplied

--- a/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/__tests__/buildDepositTerms.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/__tests__/buildDepositTerms.test.ts
@@ -158,6 +158,7 @@ describe("supportsDepositApproval", () => {
     const capable = {
       ...base,
       approveDepositTerms: async () => {},
+      getChangeAddress: async () => "tb1pchange",
     } as unknown as BitcoinWallet;
     expect(supportsDepositApproval(capable)).toBe(true);
   });

--- a/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/__tests__/depositTerms.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/__tests__/depositTerms.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import type { BitcoinWallet } from "../../../../shared";
 import {
   forwardDepositApproval,
+  requireChangeAddress,
   supportsDepositApproval,
 } from "../depositTerms";
 
@@ -24,6 +25,37 @@ describe("forwardDepositApproval", () => {
   it("forwards nothing for software wallets and keeps the probe on approveDepositTerms", () => {
     expect(forwardDepositApproval(base)).toEqual({});
     expect(supportsDepositApproval(base)).toBe(false);
+  });
+
+  it("still recognizes an approver that cannot report a change address", () => {
+    // The presign/payout ceremonies approve terms without ever creating
+    // change, so getChangeAddress is not part of being an approval wallet.
+    const approverOnly = Object.assign(Object.create({}), base, {
+      approveDepositTerms: vi.fn(async () => {}),
+    });
+
+    expect(supportsDepositApproval(approverOnly)).toBe(true);
+  });
+
+  it("fails with an actionable error when the Pre-PegIn build needs a change address the wallet lacks", async () => {
+    // Calling getChangeAddress off the narrowed value would instead die on
+    // `is not a function` in the middle of preparePegin.
+    const approverOnly = Object.assign(Object.create({}), base, {
+      approveDepositTerms: vi.fn(async () => {}),
+    });
+
+    await expect(requireChangeAddress(approverOnly)).rejects.toThrow(
+      /getChangeAddress/,
+    );
+  });
+
+  it("returns the wallet's change address when it has one", async () => {
+    const approver = Object.assign(Object.create({}), base, {
+      approveDepositTerms: vi.fn(async () => {}),
+      getChangeAddress: vi.fn(async () => "tb1pchange"),
+    });
+
+    await expect(requireChangeAddress(approver)).resolves.toBe("tb1pchange");
   });
 
   it("forwards holdsApprovedDepositTerms only when the wallet implements it", async () => {

--- a/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/__tests__/depositTerms.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/__tests__/depositTerms.test.ts
@@ -25,4 +25,23 @@ describe("forwardDepositApproval", () => {
     expect(forwardDepositApproval(base)).toEqual({});
     expect(supportsDepositApproval(base)).toBe(false);
   });
+
+  it("forwards holdsApprovedDepositTerms only when the wallet implements it", async () => {
+    const withoutProbe = Object.assign(Object.create({}), base, {
+      approveDepositTerms: vi.fn(async () => {}),
+      getChangeAddress: vi.fn(async () => "tb1pchange"),
+    });
+    expect(
+      forwardDepositApproval(withoutProbe).holdsApprovedDepositTerms,
+    ).toBeUndefined();
+
+    const withProbe = Object.assign(Object.create({}), withoutProbe, {
+      holdsApprovedDepositTerms: vi.fn(async () => true),
+    });
+    const fwd = forwardDepositApproval(withProbe);
+    await expect(fwd.holdsApprovedDepositTerms!({} as never)).resolves.toBe(
+      true,
+    );
+    expect(withProbe.holdsApprovedDepositTerms).toHaveBeenCalledOnce();
+  });
 });

--- a/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/__tests__/depositTerms.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/__tests__/depositTerms.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { BitcoinWallet } from "../../../../shared";
+import {
+  forwardDepositApproval,
+  supportsDepositApproval,
+} from "../depositTerms";
+
+const base = {} as BitcoinWallet;
+
+describe("forwardDepositApproval", () => {
+  it("forwards approveDepositTerms AND getChangeAddress for approval wallets", async () => {
+    const wallet = Object.assign(Object.create({}), base, {
+      approveDepositTerms: vi.fn(async () => {}),
+      getChangeAddress: vi.fn(async () => "tb1pchange"),
+    });
+    const fwd = forwardDepositApproval(wallet);
+    await fwd.approveDepositTerms!({} as never);
+    await expect(fwd.getChangeAddress!()).resolves.toBe("tb1pchange");
+    expect(wallet.approveDepositTerms).toHaveBeenCalledOnce();
+    expect(wallet.getChangeAddress).toHaveBeenCalledOnce();
+  });
+
+  it("forwards nothing for software wallets and keeps the probe on approveDepositTerms", () => {
+    expect(forwardDepositApproval(base)).toEqual({});
+    expect(supportsDepositApproval(base)).toBe(false);
+  });
+});

--- a/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/__tests__/prePeginApproval.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/__tests__/prePeginApproval.test.ts
@@ -208,4 +208,68 @@ describe("ensurePrePeginTermsApproval", () => {
     ).resolves.toBeUndefined();
     expect(wallet.approveDepositTerms).toHaveBeenCalledTimes(1);
   });
+
+  it("skips derive and approve when the wallet still holds the approved terms", async () => {
+    const { hex, txid } = makeFundedTx();
+    const wallet: PrePeginApprovalWallet = {
+      deriveContextHash: vi.fn(),
+      approveDepositTerms: vi.fn(),
+      holdsApprovedDepositTerms: vi.fn(async () => true),
+    };
+    const terms = makeTerms(txid);
+
+    await ensurePrePeginTermsApproval({
+      wallet,
+      depositTerms: terms,
+      fundedPrePeginTxHex: hex,
+      depositorBtcPubkey: DEPOSITOR_PUBKEY,
+    });
+
+    expect(wallet.holdsApprovedDepositTerms).toHaveBeenCalledWith(terms);
+    expect(wallet.deriveContextHash).not.toHaveBeenCalled();
+    expect(wallet.approveDepositTerms).not.toHaveBeenCalled();
+  });
+
+  it("runs the full ceremony when the wallet reports the terms not held", async () => {
+    const { hex, txid } = makeFundedTx();
+    const order: string[] = [];
+    const wallet: PrePeginApprovalWallet = {
+      deriveContextHash: vi.fn(async () => {
+        order.push("derive");
+        return "ab".repeat(32);
+      }),
+      approveDepositTerms: vi.fn(async () => {
+        order.push("approve");
+      }),
+      holdsApprovedDepositTerms: vi.fn(async () => false),
+    };
+
+    await ensurePrePeginTermsApproval({
+      wallet,
+      depositTerms: makeTerms(txid),
+      fundedPrePeginTxHex: hex,
+      depositorBtcPubkey: DEPOSITOR_PUBKEY,
+    });
+
+    expect(order).toEqual(["derive", "approve"]);
+  });
+
+  it("still rejects mismatched-txid terms even when the wallet holds an approval", async () => {
+    const { hex } = makeFundedTx();
+    const wallet: PrePeginApprovalWallet = {
+      deriveContextHash: vi.fn(),
+      approveDepositTerms: vi.fn(),
+      holdsApprovedDepositTerms: vi.fn(async () => true),
+    };
+
+    await expect(
+      ensurePrePeginTermsApproval({
+        wallet,
+        depositTerms: makeTerms("99".repeat(32)),
+        fundedPrePeginTxHex: hex,
+        depositorBtcPubkey: DEPOSITOR_PUBKEY,
+      }),
+    ).rejects.toThrow(/do not match the transaction/);
+    expect(wallet.holdsApprovedDepositTerms).not.toHaveBeenCalled();
+  });
 });

--- a/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/__tests__/prePeginApproval.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/__tests__/prePeginApproval.test.ts
@@ -254,6 +254,55 @@ describe("ensurePrePeginTermsApproval", () => {
     expect(order).toEqual(["derive", "approve"]);
   });
 
+  it("falls back to the full ceremony when the probe throws", async () => {
+    const { hex, txid } = makeFundedTx();
+    const order: string[] = [];
+    const wallet: PrePeginApprovalWallet = {
+      deriveContextHash: vi.fn(async () => {
+        order.push("derive");
+        return "ab".repeat(32);
+      }),
+      approveDepositTerms: vi.fn(async () => {
+        order.push("approve");
+      }),
+      holdsApprovedDepositTerms: vi.fn(async () => {
+        throw new Error("seam-violating probe");
+      }),
+    };
+
+    await ensurePrePeginTermsApproval({
+      wallet,
+      depositTerms: makeTerms(txid),
+      fundedPrePeginTxHex: hex,
+      depositorBtcPubkey: DEPOSITOR_PUBKEY,
+    });
+
+    expect(order).toEqual(["derive", "approve"]);
+  });
+
+  it("invokes approveDepositTerms with the wallet as `this`", async () => {
+    const { hex, txid } = makeFundedTx();
+    const calls: unknown[] = [];
+    const wallet: PrePeginApprovalWallet & { calls: unknown[] } = {
+      calls,
+      deriveContextHash: vi.fn(async () => "ab".repeat(32)),
+      // Prototype-style method: `this` must be the wallet, not undefined.
+      async approveDepositTerms(terms) {
+        this.calls.push(terms);
+      },
+    };
+    const terms = makeTerms(txid);
+
+    await ensurePrePeginTermsApproval({
+      wallet,
+      depositTerms: terms,
+      fundedPrePeginTxHex: hex,
+      depositorBtcPubkey: DEPOSITOR_PUBKEY,
+    });
+
+    expect(calls).toEqual([terms]);
+  });
+
   it("still rejects mismatched-txid terms even when the wallet holds an approval", async () => {
     const { hex } = makeFundedTx();
     const wallet: PrePeginApprovalWallet = {

--- a/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts
@@ -111,17 +111,12 @@ export interface DepositTerms {
 export interface DepositTermsApprover {
   approveDepositTerms(terms: DepositTerms): Promise<void>;
   /**
-   * OPTIONAL fast-path probe: does the current device connection still hold
-   * an approval for exactly these terms that the NEXT terms-bound signature
-   * can proceed under without a new ceremony? "Held but consumed" (anything
-   * already signed under a one-shot intent) MUST report false — a true that
-   * cannot sign again strands the caller with no recovery path.
-   * Implementations MUST answer from host-side state without device I/O,
-   * MUST return false on any doubt (including a dropped connection or terms
-   * that fail to encode), and MUST never throw. The SDK uses a true answer
-   * only to skip an otherwise redundant re-derive + re-approve ceremony; a
-   * stale true fails closed at the next signature, so this probe is a UX
-   * optimization, never an authorization.
+   * OPTIONAL fast-path probe: can the Pre-PegIn signature for exactly these
+   * terms proceed under the connection's held approval without a new
+   * ceremony? MUST report false once that Pre-PegIn was signed (one-shot),
+   * MUST answer from host state without device I/O, MUST return false on any
+   * doubt, and MUST never throw. A stale true fails closed at the next
+   * signature — this is a UX optimization, never an authorization.
    */
   holdsApprovedDepositTerms?(terms: DepositTerms): Promise<boolean>;
   /**

--- a/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts
@@ -119,24 +119,26 @@ export interface DepositTermsApprover {
    * signature — this is a UX optimization, never an authorization.
    */
   holdsApprovedDepositTerms?(terms: DepositTerms): Promise<boolean>;
-  /**
-   * The address Pre-PegIn change must pay to. Approval (policy) wallets sign
-   * key-path under a wallet policy whose change branch the device alone can
-   * derive and mark internal — the receive address is NOT acceptable change
-   * (`process_in_outs.c:114-117` @ e400d8d8).
-   *
-   * MUST be stable across a deposit flow: the app reads it to build the tx and
-   * `preparePegin` re-reads it to verify, so mid-flow rotation fails that gate.
-   */
-  getChangeAddress(): Promise<string>;
 }
 
 /**
- * Probes {@link DepositTermsApprover.approveDepositTerms} alone but narrows to
- * the whole interface: a conforming approval wallet implements all of
- * {@link DepositTermsApprover}, `getChangeAddress` included, so a provider with
- * one method and not the other is a provider bug, not a shape this seam supports.
+ * Where Pre-PegIn change must pay. Approval (policy) wallets sign key-path
+ * under a wallet policy whose change branch the device alone can derive and
+ * mark internal — the receive address is NOT acceptable change
+ * (`process_in_outs.c:114-117` @ e400d8d8).
+ *
+ * Separate from {@link DepositTermsApprover} because only the Pre-PegIn build
+ * needs it: the presign/payout ceremonies approve terms without ever creating
+ * change, so they must not require a wallet to implement this.
+ *
+ * MUST be stable across a deposit flow: the app reads it to build the tx and
+ * `preparePegin` re-reads it to verify, so mid-flow rotation fails that gate.
  */
+export interface PrePeginChangeSource {
+  getChangeAddress(): Promise<string>;
+}
+
+/** Probes {@link DepositTermsApprover.approveDepositTerms}. */
 export function supportsDepositApproval(
   wallet: BitcoinWallet,
 ): wallet is BitcoinWallet & DepositTermsApprover {
@@ -147,22 +149,49 @@ export function supportsDepositApproval(
 }
 
 /**
+ * The wallet's change address, for the one caller that needs it.
+ *
+ * Narrowing on `approveDepositTerms` alone cannot promise this method, so
+ * calling it off the narrowed value would die on `is not a function` in the
+ * middle of `preparePegin`, after the pubkey read. Ask here instead and fail
+ * with something a provider author can act on.
+ *
+ * @throws If the wallet cannot report a change address.
+ */
+export async function requireChangeAddress(
+  wallet: BitcoinWallet,
+): Promise<string> {
+  const changeSource = wallet as Partial<PrePeginChangeSource>;
+  if (typeof changeSource.getChangeAddress !== "function") {
+    throw new Error(
+      "Approval wallet does not implement getChangeAddress; it must expose its change branch, " +
+        "because the signing device accepts Pre-PegIn change only there.",
+    );
+  }
+  return changeSource.getChangeAddress();
+}
+
+/**
  * Spreadable forward of the approval capability for wallet-wrapper objects.
  * Object spread drops prototype methods, so every `{...wallet}` wrapper site
  * must re-attach the capability explicitly: `...forwardDepositApproval(wallet)`.
  */
 export function forwardDepositApproval(
   wallet: BitcoinWallet,
-): Partial<DepositTermsApprover> {
+): Partial<DepositTermsApprover & PrePeginChangeSource> {
   if (!supportsDepositApproval(wallet)) {
     return {};
   }
   const holdsApprovedDepositTerms = wallet.holdsApprovedDepositTerms;
+  const getChangeAddress = (wallet as Partial<PrePeginChangeSource>)
+    .getChangeAddress;
   return {
     approveDepositTerms: (terms) => wallet.approveDepositTerms(terms),
-    getChangeAddress: () => wallet.getChangeAddress(),
-    // Optional in the seam: forward only when the provider implements it, so
+    // Both optional in the seam: forward only what the provider implements, so
     // wrapper consumers can keep probing by typeof.
+    ...(typeof getChangeAddress === "function"
+      ? { getChangeAddress: () => getChangeAddress.call(wallet) }
+      : {}),
     ...(typeof holdsApprovedDepositTerms === "function"
       ? {
           holdsApprovedDepositTerms: (terms: DepositTerms) =>

--- a/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts
@@ -122,9 +122,10 @@ export interface DepositTermsApprover {
 }
 
 /**
- * True when the wallet implements {@link DepositTermsApprover.approveDepositTerms}.
- * Narrows to the whole interface: a provider with one method and not the other
- * is a provider bug, not a shape this seam supports.
+ * Probes {@link DepositTermsApprover.approveDepositTerms} alone but narrows to
+ * the whole interface: a conforming approval wallet implements all of
+ * {@link DepositTermsApprover}, `getChangeAddress` included, so a provider with
+ * one method and not the other is a provider bug, not a shape this seam supports.
  */
 export function supportsDepositApproval(
   wallet: BitcoinWallet,

--- a/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts
@@ -105,10 +105,25 @@ export interface DepositTerms {
  * re-approves after every derive and before the next terms-bound signature.
  * The re-approval sites are `PeginManager.preparePegin`,
  * `runDepositorPresignFlow`, and `signAndBroadcast` (the Pre-PegIn broadcast,
- * which derives immediately before approving — see `ensurePrePeginTermsApproval`).
+ * which re-derives before approving unless `holdsApprovedDepositTerms`
+ * reports the byte-equal intent still live — see `ensurePrePeginTermsApproval`).
  */
 export interface DepositTermsApprover {
   approveDepositTerms(terms: DepositTerms): Promise<void>;
+  /**
+   * OPTIONAL fast-path probe: does the current device connection still hold
+   * an approval for exactly these terms that the NEXT terms-bound signature
+   * can proceed under without a new ceremony? "Held but consumed" (anything
+   * already signed under a one-shot intent) MUST report false — a true that
+   * cannot sign again strands the caller with no recovery path.
+   * Implementations MUST answer from host-side state without device I/O,
+   * MUST return false on any doubt (including a dropped connection or terms
+   * that fail to encode), and MUST never throw. The SDK uses a true answer
+   * only to skip an otherwise redundant re-derive + re-approve ceremony; a
+   * stale true fails closed at the next signature, so this probe is a UX
+   * optimization, never an authorization.
+   */
+  holdsApprovedDepositTerms?(terms: DepositTerms): Promise<boolean>;
   /**
    * The address Pre-PegIn change must pay to. Approval (policy) wallets sign
    * key-path under a wallet policy whose change branch the device alone can
@@ -144,12 +159,22 @@ export function supportsDepositApproval(
 export function forwardDepositApproval(
   wallet: BitcoinWallet,
 ): Partial<DepositTermsApprover> {
-  return supportsDepositApproval(wallet)
-    ? {
-        approveDepositTerms: (terms) => wallet.approveDepositTerms(terms),
-        getChangeAddress: () => wallet.getChangeAddress(),
-      }
-    : {};
+  if (!supportsDepositApproval(wallet)) {
+    return {};
+  }
+  const holdsApprovedDepositTerms = wallet.holdsApprovedDepositTerms;
+  return {
+    approveDepositTerms: (terms) => wallet.approveDepositTerms(terms),
+    getChangeAddress: () => wallet.getChangeAddress(),
+    // Optional in the seam: forward only when the provider implements it, so
+    // wrapper consumers can keep probing by typeof.
+    ...(typeof holdsApprovedDepositTerms === "function"
+      ? {
+          holdsApprovedDepositTerms: (terms: DepositTerms) =>
+            holdsApprovedDepositTerms.call(wallet, terms),
+        }
+      : {}),
+  };
 }
 
 export interface BuildDepositTermsInputs {

--- a/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts
@@ -109,9 +109,23 @@ export interface DepositTerms {
  */
 export interface DepositTermsApprover {
   approveDepositTerms(terms: DepositTerms): Promise<void>;
+  /**
+   * The address Pre-PegIn change must pay to. Approval (policy) wallets sign
+   * key-path under a wallet policy whose change branch the device alone can
+   * derive and mark internal — the receive address is NOT acceptable change
+   * (`process_in_outs.c:114-117` @ e400d8d8).
+   *
+   * MUST be stable across a deposit flow: the app reads it to build the tx and
+   * `preparePegin` re-reads it to verify, so mid-flow rotation fails that gate.
+   */
+  getChangeAddress(): Promise<string>;
 }
 
-/** True when the wallet implements {@link DepositTermsApprover.approveDepositTerms}. */
+/**
+ * True when the wallet implements {@link DepositTermsApprover.approveDepositTerms}.
+ * Narrows to the whole interface: a provider with one method and not the other
+ * is a provider bug, not a shape this seam supports.
+ */
 export function supportsDepositApproval(
   wallet: BitcoinWallet,
 ): wallet is BitcoinWallet & DepositTermsApprover {
@@ -122,7 +136,7 @@ export function supportsDepositApproval(
 }
 
 /**
- * Spreadable forward of `approveDepositTerms` for wallet-wrapper objects.
+ * Spreadable forward of the approval capability for wallet-wrapper objects.
  * Object spread drops prototype methods, so every `{...wallet}` wrapper site
  * must re-attach the capability explicitly: `...forwardDepositApproval(wallet)`.
  */
@@ -130,7 +144,10 @@ export function forwardDepositApproval(
   wallet: BitcoinWallet,
 ): Partial<DepositTermsApprover> {
   return supportsDepositApproval(wallet)
-    ? { approveDepositTerms: (terms) => wallet.approveDepositTerms(terms) }
+    ? {
+        approveDepositTerms: (terms) => wallet.approveDepositTerms(terms),
+        getChangeAddress: () => wallet.getChangeAddress(),
+      }
     : {};
 }
 

--- a/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/prePeginApproval.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/prePeginApproval.ts
@@ -25,7 +25,7 @@ import type { DepositTerms } from "./depositTerms";
 /**
  * Minimal structural wallet for the Pre-PegIn ceremony. Mirrors
  * `DeriveContextHashCapableWallet` so an app-side wrapper object qualifies
- * without implementing all of `BitcoinWallet`. Both methods are optional so
+ * without implementing all of `BitcoinWallet`. All methods are optional so
  * the capability probe below can run on any wallet.
  */
 export interface PrePeginApprovalWallet {
@@ -51,18 +51,14 @@ export interface EnsurePrePeginTermsApprovalParams {
  * - Approval-capable wallets: require terms, assert they match this tx's txid,
  *   derive the vault root over the tx's funding outpoints, then approve.
  *
- * Skip fast-path: when the wallet reports (via `holdsApprovedDepositTerms`, a
- * host-side mirror read) that these byte-equal terms are still approved on the
- * live connection, the ceremony is skipped entirely — the intent approved at
- * `preparePegin` survives everything the flow does in between (PoP signing is
- * state-independent and no base-app APDU touches the vault context;
- * app-babylon-vault `sign_psbt_validate.c` PoP dispatch comment @ 73a57c50).
- * A stale "true" fails closed: the device rejects the signature with a state
- * error, the provider drops its mirror, and the retry runs the full ceremony.
+ * Skip fast-path: when `holdsApprovedDepositTerms` reports the byte-equal
+ * intent still live, the ceremony is skipped — it survives everything the
+ * flow does in between (PoP/PegIn signing spend separate device state;
+ * app-babylon-vault `sign_psbt_validate.c` @ 73a57c50). A stale true fails
+ * closed at the signature; the retry then re-runs the full ceremony.
  *
- * Otherwise always derives first: the host cannot read device state, and the
- * one-shot Pre-PegIn cap means every retry needs the full ceremony — so this
- * path never approves-only.
+ * Otherwise always derives first — the host cannot read device state, so
+ * this path never approves-only.
  *
  * @throws If approval-capable but no terms are provided, or the provided terms
  *   are for a different transaction.
@@ -122,15 +118,19 @@ export async function ensurePrePeginTermsApproval(
     );
   }
 
-  // Fast path: the intent approved at preparePegin is still live on this
-  // connection, so re-deriving (which would wipe it) buys nothing but a second
-  // device ceremony. A stale answer fails closed at the signature (see module
-  // doc), so a mirror read is sufficient here.
-  if (
-    typeof wallet.holdsApprovedDepositTerms === "function" &&
-    (await wallet.holdsApprovedDepositTerms(depositTerms))
-  ) {
-    return;
+  // Fast path: the preparePegin intent is still live — re-deriving would only
+  // wipe it and force a second ceremony. Stale answers fail closed at the sig.
+  if (typeof wallet.holdsApprovedDepositTerms === "function") {
+    let holdsApproval = false;
+    try {
+      holdsApproval = await wallet.holdsApprovedDepositTerms(depositTerms);
+    } catch {
+      // The seam forbids the probe to throw; a violating provider falls back
+      // to the full ceremony rather than aborting the broadcast.
+    }
+    if (holdsApproval) {
+      return;
+    }
   }
 
   // Same funding outpoints preparePegin derived over, via the shared
@@ -150,5 +150,7 @@ export async function ensurePrePeginTermsApproval(
   // secrets, so wipe the returned root immediately.
   root.fill(0);
 
-  await approveDepositTerms(depositTerms);
+  // .call keeps `this` for providers that implement the seam as a prototype
+  // method rather than a bound/arrow field.
+  await approveDepositTerms.call(wallet, depositTerms);
 }

--- a/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/prePeginApproval.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/prePeginApproval.ts
@@ -31,6 +31,7 @@ import type { DepositTerms } from "./depositTerms";
 export interface PrePeginApprovalWallet {
   deriveContextHash?(appName: string, context: string): Promise<string>;
   approveDepositTerms?(terms: DepositTerms): Promise<void>;
+  holdsApprovedDepositTerms?(terms: DepositTerms): Promise<boolean>;
 }
 
 export interface EnsurePrePeginTermsApprovalParams {
@@ -50,10 +51,18 @@ export interface EnsurePrePeginTermsApprovalParams {
  * - Approval-capable wallets: require terms, assert they match this tx's txid,
  *   derive the vault root over the tx's funding outpoints, then approve.
  *
- * Always derives first: the host cannot read device state, a one-shot cap means
- * every retry needs the full ceremony, and whether interleaved signing
- * nullifies a loaded intent is unresolved — so the broadcast path never
- * approves-only.
+ * Skip fast-path: when the wallet reports (via `holdsApprovedDepositTerms`, a
+ * host-side mirror read) that these byte-equal terms are still approved on the
+ * live connection, the ceremony is skipped entirely — the intent approved at
+ * `preparePegin` survives everything the flow does in between (PoP signing is
+ * state-independent and no base-app APDU touches the vault context;
+ * app-babylon-vault `sign_psbt_validate.c` PoP dispatch comment @ 73a57c50).
+ * A stale "true" fails closed: the device rejects the signature with a state
+ * error, the provider drops its mirror, and the retry runs the full ceremony.
+ *
+ * Otherwise always derives first: the host cannot read device state, and the
+ * one-shot Pre-PegIn cap means every retry needs the full ceremony — so this
+ * path never approves-only.
  *
  * @throws If approval-capable but no terms are provided, or the provided terms
  *   are for a different transaction.
@@ -111,6 +120,17 @@ export async function ensurePrePeginTermsApproval(
     throw new Error(
       "A deposit-approval wallet must also implement deriveContextHash, but this one does not.",
     );
+  }
+
+  // Fast path: the intent approved at preparePegin is still live on this
+  // connection, so re-deriving (which would wipe it) buys nothing but a second
+  // device ceremony. A stale answer fails closed at the signature (see module
+  // doc), so a mirror read is sufficient here.
+  if (
+    typeof wallet.holdsApprovedDepositTerms === "function" &&
+    (await wallet.holdsApprovedDepositTerms(depositTerms))
+  ) {
+    return;
   }
 
   // Same funding outpoints preparePegin derived over, via the shared

--- a/packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/PayoutManager.ts
@@ -117,8 +117,15 @@ interface SignPayoutBaseParams {
    */
   protocolFeeRate: bigint;
 
-  /** Security council member count; forwarded to the fee floor (see PayoutParams). */
-  councilSize: number;
+  /**
+   * Security council member x-only pubkeys (hex); forwarded to
+   * {@link buildPayoutPsbt} to rebuild the Assert:0 payout leaf and to size the
+   * fee floor (see PayoutParams).
+   */
+  councilMembers: string[];
+
+  /** M-of-N council quorum; shapes the Assert:0 council leaf (see PayoutParams). */
+  councilQuorum: number;
 
   /**
    * RFC-006 resolved payout destinations, keyed by lowercased x-only operation
@@ -249,7 +256,8 @@ export class PayoutManager {
       registeredPayoutScriptPubKey: params.registeredPayoutScriptPubKey,
       commissionBps: params.commissionBps,
       protocolFeeRate: params.protocolFeeRate,
-      councilSize: params.councilSize,
+      councilMembers: params.councilMembers,
+      councilQuorum: params.councilQuorum,
       vkClaimerPayoutScriptPubKeys: params.vkClaimerPayoutScriptPubKeys,
       vpCommissionScriptPubKey: params.vpCommissionScriptPubKey,
     });
@@ -355,7 +363,8 @@ export class PayoutManager {
         registeredPayoutScriptPubKey: tx.registeredPayoutScriptPubKey,
         commissionBps: tx.commissionBps,
         protocolFeeRate: tx.protocolFeeRate,
-        councilSize: tx.councilSize,
+        councilMembers: tx.councilMembers,
+        councilQuorum: tx.councilQuorum,
         vkClaimerPayoutScriptPubKeys: tx.vkClaimerPayoutScriptPubKeys,
         vpCommissionScriptPubKey: tx.vpCommissionScriptPubKey,
       });

--- a/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts
@@ -62,6 +62,7 @@ import {
 } from "../deposit-terms";
 import {
   assertPsbtUnsignedTxMatches,
+  assertReturnedKeyPathSignatures,
   assertScriptPathSchnorrSignature,
   buildPeginInputPsbt,
   buildPeginTxFromFundedPrePegin,
@@ -675,9 +676,23 @@ export class PeginManager {
     // whatever output the PSBT carries; nothing downstream proves the
     // change address belongs to the signing key, so a state-race / stale
     // FE / hostile adapter that puts an attacker-controlled address here
-    // would drain the change after signing. Bind once at entry using the
-    // pubkey snapshot above (no second wallet read).
-    if (
+    // would drain the change after signing. Bind once at entry — against the
+    // wallet's own change branch when it has one, else the pubkey snapshot.
+    if (supportsDepositApproval(this.config.btcWallet)) {
+      // Approval (policy) wallets own their change branch: the device accepts a
+      // change output only on `.../1/i`, which is not derivable from the receive
+      // key. Any other change address fails mid-ceremony on the device, so this
+      // gate closes that window before the first device I/O.
+      const walletChange = (
+        await this.config.btcWallet.getChangeAddress()
+      ).trim();
+      if (params.changeAddress.trim() !== walletChange) {
+        throw new Error(
+          `Pre-PegIn changeAddress "${params.changeAddress}" is not the approval wallet's change address ` +
+            `("${walletChange}"). Refusing to build a tx the signing device would reject.`,
+        );
+      }
+    } else if (
       !isAddressFromPublicKey(
         params.changeAddress,
         depositorBtcPubkeyRaw,
@@ -1188,6 +1203,14 @@ export class PeginManager {
       await this.config.btcWallet.signPsbt(requestedPsbtHex);
 
     assertPsbtUnsignedTxMatches({
+      requestedPsbtHex,
+      returnedPsbtHex: signedPsbtHex,
+    });
+
+    // Far-side check of the key-path signatures (CLAUDE.md §8: never trust the
+    // wallet's success/finalization) — Pre-PegIn inputs are the depositor's
+    // BIP-86 key-path spends.
+    assertReturnedKeyPathSignatures({
       requestedPsbtHex,
       returnedPsbtHex: signedPsbtHex,
     });

--- a/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts
@@ -39,6 +39,7 @@ import {
   normalizePopSignature,
   normalizeXOnlyPubkey,
   signPsbtsWithFallback,
+  verifyPopWitness,
 } from "./pegin";
 
 import type {
@@ -1747,6 +1748,13 @@ export class PeginManager {
    * wallet to the connected ETH account for this chain and vault
    * registry. The returned {@link PopSignature} can be reused across
    * every register call in the same session.
+   *
+   * A one-item (P2TR) witness is verified against the depositor key before
+   * it is returned — see {@link verifyPopWitness}. Two-item (P2WPKH)
+   * witnesses are not yet verified host-side.
+   *
+   * @throws If the wallet returns a malformed witness or a P2TR signature
+   *         that does not verify.
    */
   async signProofOfPossession(): Promise<PopSignature> {
     if (!this.config.ethWallet.account) {
@@ -1766,11 +1774,15 @@ export class PeginManager {
       "bip322-simple",
     );
 
-    return {
-      btcPopSignature: normalizePopSignature(raw),
-      depositorEthAddress,
+    const btcPopSignature = normalizePopSignature(raw);
+    // Fail before the Ethereum registration: vaultd rejects a bad PoP permanently.
+    verifyPopWitness(
+      new TextEncoder().encode(popMessage),
       depositorBtcPubkey,
-    };
+      btcPopSignature,
+    );
+
+    return { btcPopSignature, depositorEthAddress, depositorBtcPubkey };
   }
 
   /**

--- a/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts
@@ -57,6 +57,7 @@ import {
   COMMISSION_BPS_HEADROOM,
   ensurePrePeginTermsApproval,
   MAX_ACCEPTABLE_COMMISSION_BPS_CAP,
+  requireChangeAddress,
   supportsDepositApproval,
   type DepositTerms,
 } from "../deposit-terms";
@@ -682,9 +683,10 @@ export class PeginManager {
       // Approval (policy) wallets own their change branch: the device accepts a
       // change output only on `.../1/i`, which is not derivable from the receive
       // key. Any other change address fails mid-ceremony on the device, so this
-      // gate closes that window before the first device I/O.
+      // gate closes that window before any approval screen (the only device
+      // traffic it costs is the silent policy-context read).
       const walletChange = (
-        await this.config.btcWallet.getChangeAddress()
+        await requireChangeAddress(this.config.btcWallet)
       ).trim();
       if (params.changeAddress.trim() !== walletChange) {
         throw new Error(
@@ -1211,10 +1213,21 @@ export class PeginManager {
     // wallet's success/finalization). Covers taproot-funded inputs only —
     // P2WPKH/P2WSH funding (non-taproot software-wallet accounts) is skipped
     // by isKeyPathEligible and stays unverified here.
-    assertReturnedKeyPathSignatures({
+    const verifiedInputs = assertReturnedKeyPathSignatures({
       requestedPsbtHex,
       returnedPsbtHex: signedPsbtHex,
     });
+    // An approval wallet signs key-path under a wallet policy, so every input
+    // must have been verified; 0 would mean the check silently covered nothing.
+    if (
+      supportsDepositApproval(this.config.btcWallet) &&
+      verifiedInputs !== psbt.data.inputs.length
+    ) {
+      throw new Error(
+        `Key-path verification covered ${verifiedInputs} of ${psbt.data.inputs.length} Pre-PegIn ` +
+          `inputs; an approval wallet signs every input key-path, so the unverified ones must not be broadcast.`,
+      );
+    }
 
     const signedPsbt = Psbt.fromHex(signedPsbtHex);
 
@@ -1800,6 +1813,8 @@ export class PeginManager {
 
     const btcPopSignature = normalizePopSignature(raw);
     // Fail before the Ethereum registration: vaultd rejects a bad PoP permanently.
+    // The verdict is informational — a P2WPKH witness can only be pubkey-checked,
+    // and both outcomes are acceptable here; anything worse already threw.
     verifyPopWitness(
       new TextEncoder().encode(popMessage),
       depositorBtcPubkey,

--- a/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts
@@ -1208,8 +1208,9 @@ export class PeginManager {
     });
 
     // Far-side check of the key-path signatures (CLAUDE.md §8: never trust the
-    // wallet's success/finalization) — Pre-PegIn inputs are the depositor's
-    // BIP-86 key-path spends.
+    // wallet's success/finalization). Covers taproot-funded inputs only —
+    // P2WPKH/P2WSH funding (non-taproot software-wallet accounts) is skipped
+    // by isKeyPathEligible and stays unverified here.
     assertReturnedKeyPathSignatures({
       requestedPsbtHex,
       returnedPsbtHex: signedPsbtHex,

--- a/packages/babylon-ts-sdk/src/tbv/core/managers/__tests__/PayoutManager.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/__tests__/PayoutManager.test.ts
@@ -7,6 +7,7 @@
 
 import { Buffer } from "buffer";
 
+import { getAssertPayoutScriptInfo } from "@babylonlabs-io/babylon-tbv-rust-wasm";
 import { Psbt, Transaction } from "bitcoinjs-lib";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 
@@ -17,15 +18,23 @@ import {
   NULL_TXID,
   P2WPKH_PREFIX,
   SEQUENCE_MAX,
+  TAPSCRIPT_LEAF_VERSION,
   TEST_CLAIM_VALUE,
   TEST_COMBINED_VALUE,
   TEST_PEGIN_VALUE,
   createDummyP2TR,
   createDummyP2WPKH,
 } from "../../primitives/psbt/__tests__/constants";
-import { initializeWasmForTests } from "../../primitives/psbt/__tests__/helpers";
+import {
+  generateXOnlyKeys,
+  initializeWasmForTests,
+} from "../../primitives/psbt/__tests__/helpers";
 import { PAYOUT_ANCHOR_DUST_SATS } from "../../primitives/psbt/constants";
-import { deriveBip86ScriptPubKeyHex } from "../../primitives/utils/bitcoin";
+import {
+  deriveBip86ScriptPubKeyHex,
+  hexToUint8Array,
+} from "../../primitives/utils/bitcoin";
+import { computeTaprootScriptPubKey } from "../../primitives/utils/taproot";
 import { PayoutManager, type PayoutManagerConfig } from "../PayoutManager";
 
 // These tests inject synthetic signatures into otherwise-real payout PSBTs to
@@ -62,6 +71,41 @@ const TEST_VK_PAYOUT_SCRIPTS: Readonly<Record<string, string>> = {
     TEST_KEYS.VAULT_KEEPER_1,
   ),
 };
+
+/** Security council backing every fixture: 3 members, quorum 2. */
+const TEST_COUNCIL_MEMBERS = generateXOnlyKeys(3, 9_000);
+const TEST_COUNCIL_QUORUM = 2;
+
+/** Assert CSV timelock shared by every payout fixture below. */
+const TEST_TIMELOCK_ASSERT = 144;
+
+/**
+ * Creates the assert transaction the payout fixtures spend. Output 0 must be
+ * the real Assert:0 taproot output, or `buildPayoutPsbt` refuses to attach the
+ * payout leaf it rebuilds for input 1.
+ */
+async function createTestAssertTransaction(): Promise<string> {
+  const { payoutScript, payoutControlBlock } = await getAssertPayoutScriptInfo({
+    txGraphVersion: 1,
+    claimer: TEST_KEYS.VAULT_PROVIDER,
+    localChallengers: [TEST_KEYS.VAULT_KEEPER_1],
+    universalChallengers: [TEST_KEYS.UNIVERSAL_CHALLENGER_1],
+    timelockAssert: TEST_TIMELOCK_ASSERT,
+    councilMembers: TEST_COUNCIL_MEMBERS,
+    councilQuorum: TEST_COUNCIL_QUORUM,
+  });
+  const tx = new Transaction();
+  tx.addInput(DUMMY_TXID_1, 0xffffffff, SEQUENCE_MAX);
+  tx.addOutput(
+    computeTaprootScriptPubKey({
+      leafVersion: TAPSCRIPT_LEAF_VERSION,
+      script: hexToUint8Array(payoutScript),
+      controlBlock: hexToUint8Array(payoutControlBlock),
+    }),
+    Number(TEST_CLAIM_VALUE),
+  );
+  return tx.toHex();
+}
 
 describe("PayoutManager", () => {
   beforeAll(async () => {
@@ -143,16 +187,6 @@ describe("PayoutManager", () => {
 
   describe("signPayoutTransactionsBatch", () => {
     /**
-     * Creates a deterministic assert transaction used for payout inputs.
-     */
-    function createTestAssertTransaction(): string {
-      const tx = new Transaction();
-      tx.addInput(DUMMY_TXID_1, 0xffffffff, SEQUENCE_MAX);
-      tx.addOutput(createDummyP2WPKH("c"), Number(TEST_CLAIM_VALUE));
-      return tx.toHex();
-    }
-
-    /**
      * Creates a deterministic Payout transaction. Output shape follows the
      * VP-claimer canonical structure enforced by `buildPayoutPsbt`'s
      * per-role check:
@@ -190,7 +224,7 @@ describe("PayoutManager", () => {
 
     it("should batch sign multiple payout transactions", async () => {
       const peginTxHex = createTestPeginTransaction();
-      const assertTxHex = createTestAssertTransaction();
+      const assertTxHex = await createTestAssertTransaction();
       const payoutTxHex1 = createTestPayoutTransaction(peginTxHex, assertTxHex);
       const payoutTxHex2 = createTestPayoutTransaction(peginTxHex, assertTxHex);
 
@@ -253,7 +287,8 @@ describe("PayoutManager", () => {
           claimerBtcPubkey: TEST_KEYS.VAULT_PROVIDER,
           commissionBps: 500,
           protocolFeeRate: 10n,
-          councilSize: 3,
+          councilMembers: TEST_COUNCIL_MEMBERS,
+          councilQuorum: TEST_COUNCIL_QUORUM,
           vkClaimerPayoutScriptPubKeys: TEST_VK_PAYOUT_SCRIPTS,
           vpCommissionScriptPubKey: TEST_VP_COMMISSION_SCRIPT,
         },
@@ -272,7 +307,8 @@ describe("PayoutManager", () => {
           claimerBtcPubkey: TEST_KEYS.VAULT_PROVIDER,
           commissionBps: 500,
           protocolFeeRate: 10n,
-          councilSize: 3,
+          councilMembers: TEST_COUNCIL_MEMBERS,
+          councilQuorum: TEST_COUNCIL_QUORUM,
           vkClaimerPayoutScriptPubKeys: TEST_VK_PAYOUT_SCRIPTS,
           vpCommissionScriptPubKey: TEST_VP_COMMISSION_SCRIPT,
         },
@@ -326,7 +362,8 @@ describe("PayoutManager", () => {
             claimerBtcPubkey: TEST_KEYS.VAULT_PROVIDER,
             commissionBps: 500,
             protocolFeeRate: 10n,
-            councilSize: 3,
+            councilMembers: TEST_COUNCIL_MEMBERS,
+            councilQuorum: TEST_COUNCIL_QUORUM,
             vkClaimerPayoutScriptPubKeys: TEST_VK_PAYOUT_SCRIPTS,
             vpCommissionScriptPubKey: TEST_VP_COMMISSION_SCRIPT,
           },
@@ -377,7 +414,8 @@ describe("PayoutManager", () => {
             claimerBtcPubkey: TEST_KEYS.VAULT_PROVIDER,
             commissionBps: 500,
             protocolFeeRate: 10n,
-            councilSize: 3,
+            councilMembers: TEST_COUNCIL_MEMBERS,
+            councilQuorum: TEST_COUNCIL_QUORUM,
             vkClaimerPayoutScriptPubKeys: TEST_VK_PAYOUT_SCRIPTS,
             vpCommissionScriptPubKey: TEST_VP_COMMISSION_SCRIPT,
           },
@@ -387,7 +425,7 @@ describe("PayoutManager", () => {
 
     it("should throw error when wallet returns fewer PSBTs than expected", async () => {
       const peginTxHex = createTestPeginTransaction();
-      const assertTxHex = createTestAssertTransaction();
+      const assertTxHex = await createTestAssertTransaction();
 
       const getPublicKeyHex = vi
         .fn<() => Promise<string>>()
@@ -443,7 +481,8 @@ describe("PayoutManager", () => {
             claimerBtcPubkey: TEST_KEYS.VAULT_PROVIDER,
             commissionBps: 500,
             protocolFeeRate: 10n,
-            councilSize: 3,
+            councilMembers: TEST_COUNCIL_MEMBERS,
+            councilQuorum: TEST_COUNCIL_QUORUM,
             vkClaimerPayoutScriptPubKeys: TEST_VK_PAYOUT_SCRIPTS,
             vpCommissionScriptPubKey: TEST_VP_COMMISSION_SCRIPT,
           },
@@ -462,7 +501,8 @@ describe("PayoutManager", () => {
             claimerBtcPubkey: TEST_KEYS.VAULT_PROVIDER,
             commissionBps: 500,
             protocolFeeRate: 10n,
-            councilSize: 3,
+            councilMembers: TEST_COUNCIL_MEMBERS,
+            councilQuorum: TEST_COUNCIL_QUORUM,
             vkClaimerPayoutScriptPubKeys: TEST_VK_PAYOUT_SCRIPTS,
             vpCommissionScriptPubKey: TEST_VP_COMMISSION_SCRIPT,
           },
@@ -472,7 +512,7 @@ describe("PayoutManager", () => {
 
     it("should throw error when wallet returns more PSBTs than expected", async () => {
       const peginTxHex = createTestPeginTransaction();
-      const assertTxHex = createTestAssertTransaction();
+      const assertTxHex = await createTestAssertTransaction();
 
       const getPublicKeyHex = vi
         .fn<() => Promise<string>>()
@@ -530,7 +570,8 @@ describe("PayoutManager", () => {
             claimerBtcPubkey: TEST_KEYS.VAULT_PROVIDER,
             commissionBps: 500,
             protocolFeeRate: 10n,
-            councilSize: 3,
+            councilMembers: TEST_COUNCIL_MEMBERS,
+            councilQuorum: TEST_COUNCIL_QUORUM,
             vkClaimerPayoutScriptPubKeys: TEST_VK_PAYOUT_SCRIPTS,
             vpCommissionScriptPubKey: TEST_VP_COMMISSION_SCRIPT,
           },
@@ -549,7 +590,8 @@ describe("PayoutManager", () => {
             claimerBtcPubkey: TEST_KEYS.VAULT_PROVIDER,
             commissionBps: 500,
             protocolFeeRate: 10n,
-            councilSize: 3,
+            councilMembers: TEST_COUNCIL_MEMBERS,
+            councilQuorum: TEST_COUNCIL_QUORUM,
             vkClaimerPayoutScriptPubKeys: TEST_VK_PAYOUT_SCRIPTS,
             vpCommissionScriptPubKey: TEST_VP_COMMISSION_SCRIPT,
           },
@@ -559,16 +601,6 @@ describe("PayoutManager", () => {
   });
 
   describe("payout output address validation", () => {
-    /**
-     * Creates a deterministic assert transaction used for payout inputs.
-     */
-    function createTestAssertTransaction(): string {
-      const tx = new Transaction();
-      tx.addInput(DUMMY_TXID_1, 0xffffffff, SEQUENCE_MAX);
-      tx.addOutput(createDummyP2WPKH("c"), Number(TEST_CLAIM_VALUE));
-      return tx.toHex();
-    }
-
     /**
      * Creates a deterministic Payout transaction. Output shape follows the
      * VP-claimer canonical structure enforced by `buildPayoutPsbt`'s
@@ -607,7 +639,7 @@ describe("PayoutManager", () => {
 
     it("should throw when payout TX output 0 does not pay to registered address", async () => {
       const peginTxHex = createTestPeginTransaction();
-      const assertTxHex = createTestAssertTransaction();
+      const assertTxHex = await createTestAssertTransaction();
       const payoutTxHex = createTestPayoutTransaction(peginTxHex, assertTxHex);
 
       // Use a scriptPubKey that does NOT match the payout output ("a" instead of "d")
@@ -638,7 +670,8 @@ describe("PayoutManager", () => {
           claimerBtcPubkey: TEST_KEYS.VAULT_PROVIDER,
           commissionBps: 500,
           protocolFeeRate: 10n,
-          councilSize: 3,
+          councilMembers: TEST_COUNCIL_MEMBERS,
+          councilQuorum: TEST_COUNCIL_QUORUM,
           vkClaimerPayoutScriptPubKeys: TEST_VK_PAYOUT_SCRIPTS,
           vpCommissionScriptPubKey: TEST_VP_COMMISSION_SCRIPT,
         }),
@@ -649,7 +682,7 @@ describe("PayoutManager", () => {
 
     it("should accept 0x-prefixed scriptPubKey", async () => {
       const peginTxHex = createTestPeginTransaction();
-      const assertTxHex = createTestAssertTransaction();
+      const assertTxHex = await createTestAssertTransaction();
       const payoutTxHex = createTestPayoutTransaction(peginTxHex, assertTxHex);
 
       const btcWallet = new MockBitcoinWallet({
@@ -682,7 +715,8 @@ describe("PayoutManager", () => {
           claimerBtcPubkey: TEST_KEYS.VAULT_PROVIDER,
           commissionBps: 500,
           protocolFeeRate: 10n,
-          councilSize: 3,
+          councilMembers: TEST_COUNCIL_MEMBERS,
+          councilQuorum: TEST_COUNCIL_QUORUM,
           vkClaimerPayoutScriptPubKeys: TEST_VK_PAYOUT_SCRIPTS,
           vpCommissionScriptPubKey: TEST_VP_COMMISSION_SCRIPT,
         }),
@@ -693,7 +727,7 @@ describe("PayoutManager", () => {
 
     it("should throw for invalid hex in registeredPayoutScriptPubKey", async () => {
       const peginTxHex = createTestPeginTransaction();
-      const assertTxHex = createTestAssertTransaction();
+      const assertTxHex = await createTestAssertTransaction();
       const payoutTxHex = createTestPayoutTransaction(peginTxHex, assertTxHex);
 
       const btcWallet = new MockBitcoinWallet({
@@ -721,7 +755,8 @@ describe("PayoutManager", () => {
           claimerBtcPubkey: TEST_KEYS.VAULT_PROVIDER,
           commissionBps: 500,
           protocolFeeRate: 10n,
-          councilSize: 3,
+          councilMembers: TEST_COUNCIL_MEMBERS,
+          councilQuorum: TEST_COUNCIL_QUORUM,
           vkClaimerPayoutScriptPubKeys: TEST_VK_PAYOUT_SCRIPTS,
           vpCommissionScriptPubKey: TEST_VP_COMMISSION_SCRIPT,
         }),
@@ -730,7 +765,7 @@ describe("PayoutManager", () => {
 
     it("rejects a payout where vout 0 keeps the registered script but extra attacker outputs drain value", async () => {
       const peginTxHex = createTestPeginTransaction();
-      const assertTxHex = createTestAssertTransaction();
+      const assertTxHex = await createTestAssertTransaction();
 
       // Build a malicious payout TX: 4 outputs (one more than the protocol's
       // VP-claimer canonical count of 3). outs[0] keeps the registered
@@ -788,7 +823,8 @@ describe("PayoutManager", () => {
           claimerBtcPubkey: TEST_KEYS.VAULT_PROVIDER,
           commissionBps: 500,
           protocolFeeRate: 10n,
-          councilSize: 3,
+          councilMembers: TEST_COUNCIL_MEMBERS,
+          councilQuorum: TEST_COUNCIL_QUORUM,
           vkClaimerPayoutScriptPubKeys: TEST_VK_PAYOUT_SCRIPTS,
           vpCommissionScriptPubKey: TEST_VP_COMMISSION_SCRIPT,
         }),
@@ -797,7 +833,7 @@ describe("PayoutManager", () => {
 
     it("should reject when the wallet swaps the payout output before signing (single)", async () => {
       const peginTxHex = createTestPeginTransaction();
-      const assertTxHex = createTestAssertTransaction();
+      const assertTxHex = await createTestAssertTransaction();
       const payoutTxHex = createTestPayoutTransaction(peginTxHex, assertTxHex);
 
       const tamperedOutputScript = createDummyP2WPKH("e");
@@ -852,7 +888,8 @@ describe("PayoutManager", () => {
           claimerBtcPubkey: TEST_KEYS.VAULT_PROVIDER,
           commissionBps: 500,
           protocolFeeRate: 10n,
-          councilSize: 3,
+          councilMembers: TEST_COUNCIL_MEMBERS,
+          councilQuorum: TEST_COUNCIL_QUORUM,
           vkClaimerPayoutScriptPubKeys: TEST_VK_PAYOUT_SCRIPTS,
           vpCommissionScriptPubKey: TEST_VP_COMMISSION_SCRIPT,
         }),
@@ -861,7 +898,7 @@ describe("PayoutManager", () => {
 
     it("should reject mismatched scriptPubKey in batch signing path", async () => {
       const peginTxHex = createTestPeginTransaction();
-      const assertTxHex = createTestAssertTransaction();
+      const assertTxHex = await createTestAssertTransaction();
       const payoutTxHex = createTestPayoutTransaction(peginTxHex, assertTxHex);
 
       // Use a scriptPubKey that does NOT match the payout output
@@ -893,7 +930,8 @@ describe("PayoutManager", () => {
             claimerBtcPubkey: TEST_KEYS.VAULT_PROVIDER,
             commissionBps: 500,
             protocolFeeRate: 10n,
-            councilSize: 3,
+            councilMembers: TEST_COUNCIL_MEMBERS,
+            councilQuorum: TEST_COUNCIL_QUORUM,
             vkClaimerPayoutScriptPubKeys: TEST_VK_PAYOUT_SCRIPTS,
             vpCommissionScriptPubKey: TEST_VP_COMMISSION_SCRIPT,
           },

--- a/packages/babylon-ts-sdk/src/tbv/core/managers/__tests__/PeginManager.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/__tests__/PeginManager.test.ts
@@ -965,6 +965,10 @@ describe("PeginManager", () => {
   });
 
   describe("signProofOfPossession", () => {
+    // varint(2) ‖ varint(71) ‖ 71B DER sig ‖ varint(33) ‖ 33B pubkey — the
+    // two-item P2WPKH shape the SDK passes through without verifying.
+    const P2WPKH_POP_WITNESS_HEX = `02${"47"}${"11".repeat(71)}${"21"}${"02" + "22".repeat(32)}`;
+
     it("returns signature bound to connected ETH and BTC identities", async () => {
       const btcWallet = new MockBitcoinWallet({
         publicKeyHex: TEST_KEYS.DEPOSITOR,
@@ -1012,7 +1016,30 @@ describe("PeginManager", () => {
       expect(pop.depositorBtcPubkey).toBe(TEST_KEYS.DEPOSITOR);
     });
 
-    it("passes through hex wallet output unchanged (lowercase)", async () => {
+    it("lowercases 0x-prefixed hex wallet output", async () => {
+      const btcWallet = new MockBitcoinWallet({
+        publicKeyHex: TEST_KEYS.DEPOSITOR,
+      });
+      vi.spyOn(btcWallet, "signMessage").mockResolvedValueOnce(
+        `0x${P2WPKH_POP_WITNESS_HEX.toUpperCase()}`,
+      );
+      const ethWallet = new MockEthereumWallet();
+
+      const manager = new PeginManager({
+        btcNetwork: "signet",
+        btcWallet,
+        ethWallet: ethWallet as any,
+        ethChain: TEST_CHAIN,
+        publicClient: TEST_PUBLIC_CLIENT,
+        vaultContracts: { btcVaultRegistry: TEST_CONTRACT_ADDRESS },
+        mempoolApiUrl: MEMPOOL_API_URLS.signet,
+      });
+
+      const pop = await manager.signProofOfPossession();
+      expect(pop.btcPopSignature).toBe(`0x${P2WPKH_POP_WITNESS_HEX}`);
+    });
+
+    it("rejects wallet output that is not a decodable witness", async () => {
       const btcWallet = new MockBitcoinWallet({
         publicKeyHex: TEST_KEYS.DEPOSITOR,
       });
@@ -1029,8 +1056,57 @@ describe("PeginManager", () => {
         mempoolApiUrl: MEMPOOL_API_URLS.signet,
       });
 
+      await expect(manager.signProofOfPossession()).rejects.toThrow(
+        /proof of possession witness/,
+      );
+    });
+
+    it("throws when the wallet returns a P2TR PoP whose signature does not verify", async () => {
+      const btcWallet = new MockBitcoinWallet({
+        publicKeyHex: TEST_KEYS.DEPOSITOR,
+      });
+      // 0x01 0x40 ‖ 64 zero bytes: structurally valid, signature is not.
+      vi.spyOn(btcWallet, "signMessage").mockResolvedValueOnce(
+        `0x0140${"00".repeat(64)}`,
+      );
+      const ethWallet = new MockEthereumWallet();
+
+      const manager = new PeginManager({
+        btcNetwork: "signet",
+        btcWallet,
+        ethWallet: ethWallet as any,
+        ethChain: TEST_CHAIN,
+        publicClient: TEST_PUBLIC_CLIENT,
+        vaultContracts: { btcVaultRegistry: TEST_CONTRACT_ADDRESS },
+        mempoolApiUrl: MEMPOOL_API_URLS.signet,
+      });
+
+      await expect(manager.signProofOfPossession()).rejects.toThrow(
+        /proof of possession signature does not verify/,
+      );
+    });
+
+    it("lets a two-item (P2WPKH) PoP witness through", async () => {
+      const btcWallet = new MockBitcoinWallet({
+        publicKeyHex: TEST_KEYS.DEPOSITOR,
+      });
+      vi.spyOn(btcWallet, "signMessage").mockResolvedValueOnce(
+        `0x${P2WPKH_POP_WITNESS_HEX}`,
+      );
+      const ethWallet = new MockEthereumWallet();
+
+      const manager = new PeginManager({
+        btcNetwork: "signet",
+        btcWallet,
+        ethWallet: ethWallet as any,
+        ethChain: TEST_CHAIN,
+        publicClient: TEST_PUBLIC_CLIENT,
+        vaultContracts: { btcVaultRegistry: TEST_CONTRACT_ADDRESS },
+        mempoolApiUrl: MEMPOOL_API_URLS.signet,
+      });
+
       const pop = await manager.signProofOfPossession();
-      expect(pop.btcPopSignature).toBe("0xdeadbeef");
+      expect(pop.btcPopSignature).toBe(`0x${P2WPKH_POP_WITNESS_HEX}`);
     });
 
     it("rejects an empty signature from the wallet", async () => {
@@ -1098,7 +1174,9 @@ describe("PeginManager", () => {
       const btcWallet = new MockBitcoinWallet({
         publicKeyHex: TEST_KEYS.DEPOSITOR,
       });
-      vi.spyOn(btcWallet, "signMessage").mockResolvedValueOnce("deadbeef");
+      vi.spyOn(btcWallet, "signMessage").mockResolvedValueOnce(
+        P2WPKH_POP_WITNESS_HEX,
+      );
       const ethWallet = new MockEthereumWallet();
 
       const manager = new PeginManager({
@@ -1112,7 +1190,7 @@ describe("PeginManager", () => {
       });
 
       const pop = await manager.signProofOfPossession();
-      expect(pop.btcPopSignature).toBe("0xdeadbeef");
+      expect(pop.btcPopSignature).toBe(`0x${P2WPKH_POP_WITNESS_HEX}`);
     });
 
     it("accepts a compressed sec1 pubkey and drops the prefix byte", async () => {

--- a/packages/babylon-ts-sdk/src/tbv/core/managers/__tests__/PeginManager.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/__tests__/PeginManager.test.ts
@@ -78,6 +78,12 @@ vi.mock("../../primitives/psbt/verifyScriptPathSchnorrSignature", () => ({
   assertScriptPathSchnorrSignature: vi.fn(),
 }));
 
+// Key-path twin of the script-path stub above: real verification lives in
+// primitives/psbt/__tests__/verifyKeyPathSchnorrSignature.test.ts.
+vi.mock("../../primitives/psbt/verifyKeyPathSchnorrSignature", () => ({
+  assertReturnedKeyPathSignatures: vi.fn(),
+}));
+
 // Passthrough observer: records each per-vault PegIn build so the seam test can
 // assert the htlcVout bind-checks run BEFORE deposit-terms approval. The
 // prePeginTamper hook lets one test corrupt the Pre-PegIn result to prove the
@@ -728,6 +734,7 @@ describe("PeginManager", () => {
           approvedTerms = terms;
           peginBuildsAtApproval = peginBuildLog.length;
         },
+        getChangeAddress: async () => TEST_CHANGE_ADDRESS,
       });
 
       const ethWallet = new MockEthereumWallet();
@@ -1307,8 +1314,9 @@ describe("PeginManager", () => {
       // The device froze the commission ceiling from the quote at approval;
       // the chain-current fallback could exceed it, so it is refused.
       const { manager, btcWallet, popSignature } = await makeManagerWithPop();
-      (btcWallet as unknown as Record<string, unknown>).approveDepositTerms =
-        async () => {};
+      const approvalCapable = btcWallet as unknown as Record<string, unknown>;
+      approvalCapable.approveDepositTerms = async () => {};
+      approvalCapable.getChangeAddress = async () => TEST_CHANGE_ADDRESS;
 
       await expect(
         manager.registerPeginOnChain({
@@ -1785,6 +1793,71 @@ describe("PeginManager", () => {
       expect(rebind).toHaveBeenCalledTimes(1);
     });
 
+    it("verifies the returned key-path signatures right after the rebind and aborts before broadcast when they fail", async () => {
+      const { assertPsbtUnsignedTxMatches } = await import(
+        "../../primitives/psbt/assertPsbtUnsignedTxMatches"
+      );
+      const { assertReturnedKeyPathSignatures } = await import(
+        "../../primitives/psbt/verifyKeyPathSchnorrSignature"
+      );
+      const rebind = vi.mocked(assertPsbtUnsignedTxMatches);
+      const verifyKeyPath = vi.mocked(assertReturnedKeyPathSignatures);
+
+      const btcWallet = new MockBitcoinWallet({
+        publicKeyHex: TEST_KEYS.DEPOSITOR,
+      });
+      // Return the requested PSBT unchanged so the rebind (stubbed) and the
+      // verifier (stubbed) both see a parseable pair.
+      vi.spyOn(btcWallet, "signPsbt").mockImplementation(
+        async (psbtHex: string) => psbtHex,
+      );
+      const ethWallet = new MockEthereumWallet();
+      const manager = new PeginManager({
+        btcNetwork: "signet",
+        btcWallet,
+        ethWallet: ethWallet as any,
+        ethChain: TEST_CHAIN,
+        publicClient: TEST_PUBLIC_CLIENT,
+        vaultContracts: { btcVaultRegistry: TEST_CONTRACT_ADDRESS },
+        mempoolApiUrl: MEMPOOL_API_URLS.signet,
+      });
+
+      const prepared = await manager.preparePegin({
+        amounts: [TEST_AMOUNTS.PEGIN],
+        ...BASE_PREPARE_PEGIN_PARAMS,
+      });
+
+      const localPrevouts = TEST_UTXOS.reduce<
+        Record<string, { scriptPubKey: string; value: number }>
+      >((acc, u) => {
+        acc[`${u.txid}:${u.vout}`] = {
+          scriptPubKey: u.scriptPubKey,
+          value: u.value,
+        };
+        return acc;
+      }, {});
+
+      rebind.mockClear();
+      verifyKeyPath.mockClear();
+      verifyKeyPath.mockImplementationOnce(() => {
+        throw new Error("key-path signature for input 0 does not verify");
+      });
+
+      await expect(
+        manager.signAndBroadcast({
+          fundedPrePeginTxHex: prepared.transaction.fundedPrePeginTxHex,
+          depositorBtcPubkey: TEST_KEYS.DEPOSITOR,
+          localPrevouts,
+        }),
+      ).rejects.toThrow(/does not verify/);
+
+      expect(rebind).toHaveBeenCalledTimes(1);
+      expect(verifyKeyPath).toHaveBeenCalledTimes(1);
+      const [{ requestedPsbtHex, returnedPsbtHex }] =
+        verifyKeyPath.mock.calls[0];
+      expect(returnedPsbtHex).toBe(requestedPsbtHex); // the spy echoed the request
+    });
+
     it("runs the intent ceremony (derive then approve) before signing for an approval wallet", async () => {
       const { assertPsbtUnsignedTxMatches } = await import(
         "../../primitives/psbt/assertPsbtUnsignedTxMatches"
@@ -1812,9 +1885,12 @@ describe("PeginManager", () => {
       const approveSpy = vi.fn(async () => {
         order.push("approve");
       });
-      (
-        btcWallet as unknown as { approveDepositTerms: typeof approveSpy }
-      ).approveDepositTerms = approveSpy;
+      const approvalCapable = btcWallet as unknown as {
+        approveDepositTerms: typeof approveSpy;
+        getChangeAddress: () => Promise<string>;
+      };
+      approvalCapable.approveDepositTerms = approveSpy;
+      approvalCapable.getChangeAddress = async () => TEST_CHANGE_ADDRESS;
 
       const ethWallet = new MockEthereumWallet();
       const manager = new PeginManager({
@@ -1901,9 +1977,12 @@ describe("PeginManager", () => {
       // preparePegin is itself a re-approval site, so approval must succeed
       // there; the rejection is injected only for the broadcast ceremony below.
       const approveSpy = vi.fn(async () => {});
-      (
-        btcWallet as unknown as { approveDepositTerms: typeof approveSpy }
-      ).approveDepositTerms = approveSpy;
+      const approvalCapable = btcWallet as unknown as {
+        approveDepositTerms: typeof approveSpy;
+        getChangeAddress: () => Promise<string>;
+      };
+      approvalCapable.approveDepositTerms = approveSpy;
+      approvalCapable.getChangeAddress = async () => TEST_CHANGE_ADDRESS;
 
       const ethWallet = new MockEthereumWallet();
       const manager = new PeginManager({
@@ -2385,6 +2464,40 @@ describe("PeginManager", () => {
       ).rejects.toThrow(
         /Pre-PegIn changeAddress .* is not derived from the connected wallet/i,
       );
+    });
+
+    it("preparePegin requires an approval wallet's own change address (its change branch, not the receive key)", async () => {
+      const { manager, btcWallet } = makeManager();
+      // Turn the mock into an approval wallet the same way the signAndBroadcast
+      // ceremony test does: attach the capability methods.
+      const approval = btcWallet as unknown as {
+        approveDepositTerms: (terms: unknown) => Promise<void>;
+        getChangeAddress: () => Promise<string>;
+      };
+      approval.approveDepositTerms = vi.fn(async () => {});
+      const walletChange = deriveTaprootAddress(
+        TEST_KEYS.VAULT_KEEPER_1,
+        "signet",
+      ); // any address ≠ the receive address
+      approval.getChangeAddress = vi.fn(async () => walletChange);
+
+      // The receive-key change address is now WRONG for an approval wallet.
+      await expect(
+        manager.preparePegin({
+          amounts: [TEST_AMOUNTS.PEGIN],
+          ...BASE_PREPARE_PEGIN_PARAMS,
+        }),
+      ).rejects.toThrow(/is not the approval wallet's change address/);
+
+      // The wallet's own change address passes the gate (and the flow proceeds to sizing).
+      await expect(
+        manager.preparePegin({
+          amounts: [TEST_AMOUNTS.PEGIN],
+          ...BASE_PREPARE_PEGIN_PARAMS,
+          changeAddress: walletChange,
+        }),
+      ).resolves.toBeDefined();
+      expect(approval.getChangeAddress).toHaveBeenCalled();
     });
 
     it("registerPeginOnChain rejects an explicit payout address not derived from the signing pubkey", async () => {

--- a/packages/babylon-ts-sdk/src/tbv/core/managers/__tests__/PeginManager.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/__tests__/PeginManager.test.ts
@@ -973,8 +973,9 @@ describe("PeginManager", () => {
 
   describe("signProofOfPossession", () => {
     // varint(2) ‖ varint(71) ‖ 71B DER sig ‖ varint(33) ‖ 33B pubkey — the
-    // two-item P2WPKH shape the SDK passes through without verifying.
-    const P2WPKH_POP_WITNESS_HEX = `02${"47"}${"11".repeat(71)}${"21"}${"02" + "22".repeat(32)}`;
+    // two-item P2WPKH shape. The embedded pubkey must be the depositor's
+    // (verifyPopWitness mirrors vaultd's WitnessPubkeyMismatch check).
+    const P2WPKH_POP_WITNESS_HEX = `02${"47"}${"11".repeat(71)}${"21"}${"02" + TEST_KEYS.DEPOSITOR}`;
 
     it("returns signature bound to connected ETH and BTC identities", async () => {
       const btcWallet = new MockBitcoinWallet({

--- a/packages/babylon-ts-sdk/src/tbv/core/managers/pegin/__tests__/assertAuthAnchorOpReturn.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/pegin/__tests__/assertAuthAnchorOpReturn.test.ts
@@ -48,9 +48,7 @@ describe("assertAuthAnchorOpReturn", () => {
       opReturnOutput(ANCHOR_HASH),
       htlcOutput(),
     ]);
-    expect(() =>
-      assertAuthAnchorOpReturn(txHex, 1, ANCHOR_HASH),
-    ).not.toThrow();
+    expect(() => assertAuthAnchorOpReturn(txHex, 1, ANCHOR_HASH)).not.toThrow();
   });
 
   it("strips a leading 0x prefix from the funded tx hex", () => {
@@ -69,9 +67,9 @@ describe("assertAuthAnchorOpReturn", () => {
 
   it("throws when the tx has no output at vout=N", () => {
     const txHex = buildTxHex([htlcOutput()]);
-    expect(() =>
-      assertAuthAnchorOpReturn(txHex, 1, ANCHOR_HASH),
-    ).toThrow(/auth-anchor OP_RETURN missing/);
+    expect(() => assertAuthAnchorOpReturn(txHex, 1, ANCHOR_HASH)).toThrow(
+      /auth-anchor OP_RETURN missing/,
+    );
   });
 
   it("throws when the script length is not 34 bytes", () => {
@@ -81,9 +79,9 @@ describe("assertAuthAnchorOpReturn", () => {
       value: 0,
     };
     const txHex = buildTxHex([htlcOutput(), tooShort]);
-    expect(() =>
-      assertAuthAnchorOpReturn(txHex, 1, ANCHOR_HASH),
-    ).toThrow(/unexpected/);
+    expect(() => assertAuthAnchorOpReturn(txHex, 1, ANCHOR_HASH)).toThrow(
+      /unexpected/,
+    );
   });
 
   it("throws when the first opcode is not OP_RETURN (0x6a)", () => {
@@ -93,9 +91,9 @@ describe("assertAuthAnchorOpReturn", () => {
       value: 0,
     };
     const txHex = buildTxHex([htlcOutput(), wrongOpcode]);
-    expect(() =>
-      assertAuthAnchorOpReturn(txHex, 1, ANCHOR_HASH),
-    ).toThrow(/unexpected/);
+    expect(() => assertAuthAnchorOpReturn(txHex, 1, ANCHOR_HASH)).toThrow(
+      /unexpected/,
+    );
   });
 
   it("throws when the push prefix is not OP_PUSH32 (0x20)", () => {
@@ -108,16 +106,16 @@ describe("assertAuthAnchorOpReturn", () => {
       value: 0,
     };
     const txHex = buildTxHex([htlcOutput(), pushdata1]);
-    expect(() =>
-      assertAuthAnchorOpReturn(txHex, 1, ANCHOR_HASH),
-    ).toThrow(/unexpected/);
+    expect(() => assertAuthAnchorOpReturn(txHex, 1, ANCHOR_HASH)).toThrow(
+      /unexpected/,
+    );
   });
 
   it("throws when the pushed payload differs from the expected hash", () => {
     const txHex = buildTxHex([htlcOutput(), opReturnOutput(OTHER_HASH)]);
-    expect(() =>
-      assertAuthAnchorOpReturn(txHex, 1, ANCHOR_HASH),
-    ).toThrow(/payload mismatch/);
+    expect(() => assertAuthAnchorOpReturn(txHex, 1, ANCHOR_HASH)).toThrow(
+      /payload mismatch/,
+    );
   });
 
   it("throws when the OP_RETURN output has non-zero value", () => {
@@ -127,9 +125,9 @@ describe("assertAuthAnchorOpReturn", () => {
       htlcOutput(),
       opReturnOutput(ANCHOR_HASH, /* value */ 546),
     ]);
-    expect(() =>
-      assertAuthAnchorOpReturn(txHex, 1, ANCHOR_HASH),
-    ).toThrow(/non-zero value/);
+    expect(() => assertAuthAnchorOpReturn(txHex, 1, ANCHOR_HASH)).toThrow(
+      /non-zero value/,
+    );
   });
 });
 

--- a/packages/babylon-ts-sdk/src/tbv/core/managers/pegin/__tests__/verifyPopWitness.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/pegin/__tests__/verifyPopWitness.test.ts
@@ -20,8 +20,10 @@ import { verifyPopWitness } from "../verifyPopWitness";
 const fromHex = (h: string) => Uint8Array.from(Buffer.from(h, "hex"));
 
 /** varint(2) ‖ varint(71) ‖ 71B DER sig ‖ varint(33) ‖ 33B compressed pubkey. */
-const P2WPKH_WITNESS =
-  `0x02${"47"}${"11".repeat(71)}${"21"}${"02" + "22".repeat(32)}` as const;
+/** Two-item P2WPKH witness: [DER sig(71B), compressed pubkey] with the given x-only key. */
+function p2wpkhWitness(xOnlyHex: string): `0x${string}` {
+  return `0x02${"47"}${"11".repeat(71)}${"21"}${"02" + xOnlyHex}`;
+}
 
 describe("verifyPopWitness", () => {
   it("verifies a one-item P2TR witness (0x01 0x40 ‖ sig) against the BIP-322 golden vector", () => {
@@ -111,14 +113,38 @@ describe("verifyPopWitness", () => {
     ).toThrow(/bare 64-char x-only hex/);
   });
 
-  it("passes a two-item P2WPKH witness through unverified (follow-up verifier)", () => {
+  it("passes a two-item P2WPKH witness with the depositor's pubkey through unverified (sig verify: #2284)", () => {
     expect(
       verifyPopWitness(
         fromHex(GOLDEN_PAYLOAD_HEX),
         GOLDEN_SIGNING_KEY_XONLY,
-        P2WPKH_WITNESS,
+        p2wpkhWitness(GOLDEN_SIGNING_KEY_XONLY),
       ),
     ).toEqual({ kind: "p2wpkh-unverified" });
+  });
+
+  it("rejects a two-item witness whose embedded pubkey is not the depositor's", () => {
+    // Mirrors vaultd's WitnessPubkeyMismatch — the wrong-account signature
+    // must fail here, not as a permanent InvalidDepositorPop after registration.
+    expect(() =>
+      verifyPopWitness(
+        fromHex(GOLDEN_PAYLOAD_HEX),
+        GOLDEN_SIGNING_KEY_XONLY,
+        p2wpkhWitness("22".repeat(32)),
+      ),
+    ).toThrow(/does not match the depositor key/);
+  });
+
+  it("rejects a two-item witness whose item 1 is not a compressed pubkey", () => {
+    // 32-byte item (x-only, no SEC1 prefix) in the pubkey slot.
+    const badWitness: `0x${string}` = `0x02${"47"}${"11".repeat(71)}${"20"}${"22".repeat(32)}`;
+    expect(() =>
+      verifyPopWitness(
+        fromHex(GOLDEN_PAYLOAD_HEX),
+        GOLDEN_SIGNING_KEY_XONLY,
+        badWitness,
+      ),
+    ).toThrow(/not a compressed public key/);
   });
 
   it("throws on a witness with any other item count or a truncated item", () => {

--- a/packages/babylon-ts-sdk/src/tbv/core/managers/pegin/__tests__/verifyPopWitness.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/pegin/__tests__/verifyPopWitness.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Host-side PoP witness checks.
+ *
+ * The P2TR cases reuse the BIP-322 golden vector emitted by the Rust
+ * reference (`btc-vault/crates/btc-auth/src/server_identity.rs`, signer
+ * seed 7) so a passing test proves the witness path feeds the verifier
+ * exactly what a real signer produced.
+ */
+
+import { Buffer } from "buffer";
+import { describe, expect, it } from "vitest";
+
+import {
+  GOLDEN_PAYLOAD_HEX,
+  GOLDEN_SIGNATURE_HEX,
+  GOLDEN_SIGNING_KEY_XONLY,
+} from "../../../clients/vault-provider/auth/__tests__/goldenVectors";
+import { verifyPopWitness } from "../verifyPopWitness";
+
+const fromHex = (h: string) => Uint8Array.from(Buffer.from(h, "hex"));
+
+/** varint(2) ‖ varint(71) ‖ 71B DER sig ‖ varint(33) ‖ 33B compressed pubkey. */
+const P2WPKH_WITNESS =
+  `0x02${"47"}${"11".repeat(71)}${"21"}${"02" + "22".repeat(32)}` as const;
+
+describe("verifyPopWitness", () => {
+  it("verifies a one-item P2TR witness (0x01 0x40 ‖ sig) against the BIP-322 golden vector", () => {
+    const witness = `0x0140${GOLDEN_SIGNATURE_HEX}` as const;
+
+    expect(
+      verifyPopWitness(
+        fromHex(GOLDEN_PAYLOAD_HEX),
+        GOLDEN_SIGNING_KEY_XONLY,
+        witness,
+      ),
+    ).toEqual({ kind: "p2tr-verified" });
+  });
+
+  it("throws when the P2TR signature does not verify", () => {
+    const tampered =
+      GOLDEN_SIGNATURE_HEX.slice(0, -2) +
+      (GOLDEN_SIGNATURE_HEX.endsWith("00") ? "01" : "00");
+
+    expect(() =>
+      verifyPopWitness(
+        fromHex(GOLDEN_PAYLOAD_HEX),
+        GOLDEN_SIGNING_KEY_XONLY,
+        `0x0140${tampered}`,
+      ),
+    ).toThrow(/proof of possession signature does not verify/);
+  });
+
+  it("accepts the 65-byte SIGHASH_ALL form only with a trailing 0x01 and verifies it under SIGHASH_ALL", () => {
+    // The golden signature is SIGHASH_DEFAULT, so appending 0x01 must FAIL
+    // verification (different digest) rather than be rejected for its length —
+    // that is what proves the SIGHASH_ALL branch is the one taken.
+    expect(() =>
+      verifyPopWitness(
+        fromHex(GOLDEN_PAYLOAD_HEX),
+        GOLDEN_SIGNING_KEY_XONLY,
+        `0x0141${GOLDEN_SIGNATURE_HEX}01`,
+      ),
+    ).toThrow(/does not verify/);
+
+    expect(() =>
+      verifyPopWitness(
+        fromHex(GOLDEN_PAYLOAD_HEX),
+        GOLDEN_SIGNING_KEY_XONLY,
+        `0x0141${GOLDEN_SIGNATURE_HEX}02`,
+      ),
+    ).toThrow(/64-byte Schnorr signature/);
+  });
+
+  it("throws on a non-minimal CompactSize length", () => {
+    // rust-bitcoin's VarInt decoder returns NonMinimalVarInt for these, so
+    // vaultd would reject the witness permanently at ingestion.
+    expect(() =>
+      verifyPopWitness(
+        fromHex(GOLDEN_PAYLOAD_HEX),
+        GOLDEN_SIGNING_KEY_XONLY,
+        `0x01fd4000${GOLDEN_SIGNATURE_HEX}`,
+      ),
+    ).toThrow(/non-minimal/);
+
+    expect(() =>
+      verifyPopWitness(
+        fromHex(GOLDEN_PAYLOAD_HEX),
+        GOLDEN_SIGNING_KEY_XONLY,
+        `0x01fe40000000${GOLDEN_SIGNATURE_HEX}`,
+      ),
+    ).toThrow(/non-minimal/);
+  });
+
+  it("throws when the witness is not even-length lowercase hex", () => {
+    expect(() =>
+      verifyPopWitness(
+        fromHex(GOLDEN_PAYLOAD_HEX),
+        GOLDEN_SIGNING_KEY_XONLY,
+        `0x0140${GOLDEN_SIGNATURE_HEX.slice(0, -2)}zz`,
+      ),
+    ).toThrow(/even-length lowercase hex/);
+  });
+
+  it("throws when the depositor key is not bare x-only hex", () => {
+    expect(() =>
+      verifyPopWitness(
+        fromHex(GOLDEN_PAYLOAD_HEX),
+        `0x${GOLDEN_SIGNING_KEY_XONLY}`,
+        `0x0140${GOLDEN_SIGNATURE_HEX}`,
+      ),
+    ).toThrow(/bare 64-char x-only hex/);
+  });
+
+  it("passes a two-item P2WPKH witness through unverified (follow-up verifier)", () => {
+    expect(
+      verifyPopWitness(
+        fromHex(GOLDEN_PAYLOAD_HEX),
+        GOLDEN_SIGNING_KEY_XONLY,
+        P2WPKH_WITNESS,
+      ),
+    ).toEqual({ kind: "p2wpkh-unverified" });
+  });
+
+  it("throws on a witness with any other item count or a truncated item", () => {
+    expect(() =>
+      verifyPopWitness(
+        fromHex(GOLDEN_PAYLOAD_HEX),
+        GOLDEN_SIGNING_KEY_XONLY,
+        "0x00",
+      ),
+    ).toThrow(/witness/);
+
+    expect(() =>
+      verifyPopWitness(
+        fromHex(GOLDEN_PAYLOAD_HEX),
+        GOLDEN_SIGNING_KEY_XONLY,
+        "0x0140aabb",
+      ),
+    ).toThrow(/witness/);
+
+    expect(() =>
+      verifyPopWitness(
+        fromHex(GOLDEN_PAYLOAD_HEX),
+        GOLDEN_SIGNING_KEY_XONLY,
+        `0x0140${GOLDEN_SIGNATURE_HEX}ff`,
+      ),
+    ).toThrow(/witness/);
+  });
+});

--- a/packages/babylon-ts-sdk/src/tbv/core/managers/pegin/expandPerVaultSecrets.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/pegin/expandPerVaultSecrets.ts
@@ -13,10 +13,7 @@ import {
   uint8ArrayToHex,
 } from "../../primitives/utils/bitcoin";
 import { computeHashlock } from "../../services";
-import {
-  expandHashlockSecret,
-  expandWotsSeed,
-} from "../../vault-secrets";
+import { expandHashlockSecret, expandWotsSeed } from "../../vault-secrets";
 import {
   computeWotsBlockPublicKeysHash,
   deriveWotsBlocksFromSeed,

--- a/packages/babylon-ts-sdk/src/tbv/core/managers/pegin/index.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/pegin/index.ts
@@ -19,3 +19,4 @@ export {
   normalizeXOnlyPubkey,
 } from "./normalizeWalletInputs";
 export { signPsbtsWithFallback } from "./signPsbtsWithFallback";
+export { verifyPopWitness, type PopWitnessVerdict } from "./verifyPopWitness";

--- a/packages/babylon-ts-sdk/src/tbv/core/managers/pegin/verifyPopWitness.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/pegin/verifyPopWitness.ts
@@ -20,6 +20,7 @@
  */
 
 import { Buffer } from "buffer";
+import { decodeWitnessStack } from "../../utils/witness/witnessStack";
 import type { Hex } from "viem";
 
 import { verifyBip322Simple } from "../../clients/vault-provider/auth/bip322Verify";
@@ -33,66 +34,13 @@ const SCHNORR_SIG_BYTES = 64;
 const SIGHASH_DEFAULT = 0x00;
 const SIGHASH_ALL = 0x01;
 
-/** CompactSize discriminators; 0xff (u64) is out of range for a witness. */
-const VARINT_U16_MARKER = 0xfd;
-const VARINT_U32_MARKER = 0xfe;
-/** Smallest value each marker is allowed to carry (see NON_MINIMAL_VARINT below). */
-const VARINT_U16_MIN_VALUE = 0xfd;
-const VARINT_U32_MIN_VALUE = 0x10000;
-
 const X_ONLY_PUBKEY_HEX = /^[0-9a-f]{64}$/i;
 /** `normalizePopSignature` hands us 0x-prefixed lowercase hex; hold it to that. */
 const WITNESS_BODY_HEX = /^(?:[0-9a-f]{2})+$/;
 
-const NON_MINIMAL_VARINT =
-  "proof of possession witness has a non-minimal length encoding";
-
 export type PopWitnessVerdict =
   | { readonly kind: "p2tr-verified" }
   | { readonly kind: "p2wpkh-unverified" };
-
-/**
- * Bitcoin CompactSize: 1 byte < 0xfd; 0xfd ‖ u16LE; 0xfe ‖ u32LE.
- *
- * Over-long encodings are rejected: rust-bitcoin's `VarInt::consensus_decode`
- * (0.32.8 `consensus/encode.rs:493-522`) returns `NonMinimalVarInt` for a 0xfd
- * carrying < 0xfd and a 0xfe carrying < 0x10000, so accepting them here would
- * wave through a witness vaultd rejects permanently at ingestion.
- */
-function readVarint(
-  bytes: Uint8Array,
-  offset: number,
-): { value: number; next: number } {
-  if (offset >= bytes.length) {
-    throw new Error("proof of possession witness is truncated");
-  }
-  const first = bytes[offset];
-  if (first < VARINT_U16_MARKER) return { value: first, next: offset + 1 };
-  if (first === VARINT_U16_MARKER) {
-    if (offset + 3 > bytes.length) {
-      throw new Error("proof of possession witness is truncated");
-    }
-    const value = bytes[offset + 1] | (bytes[offset + 2] << 8);
-    if (value < VARINT_U16_MIN_VALUE) throw new Error(NON_MINIMAL_VARINT);
-    return { value, next: offset + 3 };
-  }
-  if (first === VARINT_U32_MARKER) {
-    if (offset + 5 > bytes.length) {
-      throw new Error("proof of possession witness is truncated");
-    }
-    const value =
-      (bytes[offset + 1] |
-        (bytes[offset + 2] << 8) |
-        (bytes[offset + 3] << 16) |
-        (bytes[offset + 4] << 24)) >>>
-      0;
-    if (value < VARINT_U32_MIN_VALUE) throw new Error(NON_MINIMAL_VARINT);
-    return { value, next: offset + 5 };
-  }
-  throw new Error(
-    "proof of possession witness carries an out-of-range item length",
-  );
-}
 
 function decodeWitnessItems(witnessHex: Hex): Uint8Array[] {
   const body = witnessHex.slice(2);
@@ -102,22 +50,10 @@ function decodeWitnessItems(witnessHex: Hex): Uint8Array[] {
       "proof of possession witness is not even-length lowercase hex",
     );
   }
-  const bytes = Uint8Array.from(Buffer.from(body, "hex"));
-  const { value: count, next: start } = readVarint(bytes, 0);
-  const items: Uint8Array[] = [];
-  let offset = start;
-  for (let i = 0; i < count; i++) {
-    const { value: len, next } = readVarint(bytes, offset);
-    if (next + len > bytes.length) {
-      throw new Error("proof of possession witness is truncated");
-    }
-    items.push(bytes.subarray(next, next + len));
-    offset = next + len;
-  }
-  if (offset !== bytes.length) {
-    throw new Error("proof of possession witness has trailing bytes");
-  }
-  return items;
+  return decodeWitnessStack(
+    Uint8Array.from(Buffer.from(body, "hex")),
+    "proof of possession witness",
+  );
 }
 
 /**

--- a/packages/babylon-ts-sdk/src/tbv/core/managers/pegin/verifyPopWitness.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/pegin/verifyPopWitness.ts
@@ -26,6 +26,8 @@ import { verifyBip322Simple } from "../../clients/vault-provider/auth/bip322Veri
 
 const P2TR_WITNESS_ITEMS = 1;
 const P2WPKH_WITNESS_ITEMS = 2;
+/** SEC1 compressed pubkey: 0x02/0x03 prefix + 32-byte x coordinate. */
+const COMPRESSED_PUBKEY_BYTES = 33;
 const SCHNORR_SIG_BYTES = 64;
 /** BIP-341 hash types: 0x00 default (64-byte sig), 0x01 ALL (65-byte sig with trailing type byte). */
 const SIGHASH_DEFAULT = 0x00;
@@ -176,6 +178,33 @@ export function verifyPopWitness(
   }
 
   if (items.length === P2WPKH_WITNESS_ITEMS) {
+    // Signature verification is deferred (#2284), but vaultd's FIRST check is
+    // a plain pubkey compare (btc-vault crates/btc-signer/src/message.rs:110-123,
+    // WitnessPubkeyMismatch): witness item 1 must be the depositor's compressed
+    // key. Mirror it here — it needs no crypto and catches a wrong-account
+    // signature before it becomes a permanent InvalidDepositorPop.
+    if (!X_ONLY_PUBKEY_HEX.test(depositorXOnlyHex)) {
+      throw new Error(
+        `depositor public key must be bare 64-char x-only hex, got "${depositorXOnlyHex}"`,
+      );
+    }
+    const pubkey = items[1];
+    if (
+      pubkey.length !== COMPRESSED_PUBKEY_BYTES ||
+      (pubkey[0] !== 0x02 && pubkey[0] !== 0x03)
+    ) {
+      throw new Error(
+        `proof of possession P2WPKH witness item 1 is not a compressed public key ` +
+          `(${pubkey.length} bytes, prefix 0x${pubkey[0]?.toString(16) ?? "none"})`,
+      );
+    }
+    const witnessXOnlyHex = Buffer.from(pubkey.subarray(1)).toString("hex");
+    if (witnessXOnlyHex !== depositorXOnlyHex.toLowerCase()) {
+      throw new Error(
+        `proof of possession witness pubkey does not match the depositor key: ` +
+          `witness carries ${witnessXOnlyHex}, expected ${depositorXOnlyHex}`,
+      );
+    }
     return { kind: "p2wpkh-unverified" };
   }
 

--- a/packages/babylon-ts-sdk/src/tbv/core/managers/pegin/verifyPopWitness.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/pegin/verifyPopWitness.ts
@@ -1,0 +1,185 @@
+/**
+ * Host-side check of the BIP-322 proof-of-possession witness a wallet returns,
+ * before it is committed to the Ethereum registration.
+ *
+ * vaultd verifies the PoP off-chain from the consensus-encoded witness
+ * (`btc-vault crates/btc-signer/src/message.rs:94-145`): one item ⇒ P2TR
+ * key-path Schnorr over the BIP-86 tweaked key, two items ⇒ P2WPKH, anything
+ * else ⇒ `UnsupportedWitnessFormat`. A bad PoP is a PERMANENT ingestion
+ * failure (`InvalidDepositorPop`), so catching it here saves a registration.
+ * No wallet test (hardware or software) proves a returned PoP validates —
+ * this is the first place anything checks it.
+ *
+ * P2TR is verified with the package's existing BIP-322 verifier (64-byte
+ * SIGHASH_DEFAULT or 65-byte SIGHASH_ALL, matching what the `bip322` crate
+ * 0.0.10 accepts in `verify.rs:213-236`). P2WPKH witnesses pass through
+ * UNVERIFIED for now (follow-up: a P2WPKH BIP-322 verifier mirroring
+ * `message.rs:107-133`); the verdict says so.
+ *
+ * @module managers/pegin/verifyPopWitness
+ */
+
+import { Buffer } from "buffer";
+import type { Hex } from "viem";
+
+import { verifyBip322Simple } from "../../clients/vault-provider/auth/bip322Verify";
+
+const P2TR_WITNESS_ITEMS = 1;
+const P2WPKH_WITNESS_ITEMS = 2;
+const SCHNORR_SIG_BYTES = 64;
+/** BIP-341 hash types: 0x00 default (64-byte sig), 0x01 ALL (65-byte sig with trailing type byte). */
+const SIGHASH_DEFAULT = 0x00;
+const SIGHASH_ALL = 0x01;
+
+/** CompactSize discriminators; 0xff (u64) is out of range for a witness. */
+const VARINT_U16_MARKER = 0xfd;
+const VARINT_U32_MARKER = 0xfe;
+/** Smallest value each marker is allowed to carry (see NON_MINIMAL_VARINT below). */
+const VARINT_U16_MIN_VALUE = 0xfd;
+const VARINT_U32_MIN_VALUE = 0x10000;
+
+const X_ONLY_PUBKEY_HEX = /^[0-9a-f]{64}$/i;
+/** `normalizePopSignature` hands us 0x-prefixed lowercase hex; hold it to that. */
+const WITNESS_BODY_HEX = /^(?:[0-9a-f]{2})+$/;
+
+const NON_MINIMAL_VARINT =
+  "proof of possession witness has a non-minimal length encoding";
+
+export type PopWitnessVerdict =
+  | { readonly kind: "p2tr-verified" }
+  | { readonly kind: "p2wpkh-unverified" };
+
+/**
+ * Bitcoin CompactSize: 1 byte < 0xfd; 0xfd ‖ u16LE; 0xfe ‖ u32LE.
+ *
+ * Over-long encodings are rejected: rust-bitcoin's `VarInt::consensus_decode`
+ * (0.32.8 `consensus/encode.rs:493-522`) returns `NonMinimalVarInt` for a 0xfd
+ * carrying < 0xfd and a 0xfe carrying < 0x10000, so accepting them here would
+ * wave through a witness vaultd rejects permanently at ingestion.
+ */
+function readVarint(
+  bytes: Uint8Array,
+  offset: number,
+): { value: number; next: number } {
+  if (offset >= bytes.length) {
+    throw new Error("proof of possession witness is truncated");
+  }
+  const first = bytes[offset];
+  if (first < VARINT_U16_MARKER) return { value: first, next: offset + 1 };
+  if (first === VARINT_U16_MARKER) {
+    if (offset + 3 > bytes.length) {
+      throw new Error("proof of possession witness is truncated");
+    }
+    const value = bytes[offset + 1] | (bytes[offset + 2] << 8);
+    if (value < VARINT_U16_MIN_VALUE) throw new Error(NON_MINIMAL_VARINT);
+    return { value, next: offset + 3 };
+  }
+  if (first === VARINT_U32_MARKER) {
+    if (offset + 5 > bytes.length) {
+      throw new Error("proof of possession witness is truncated");
+    }
+    const value =
+      (bytes[offset + 1] |
+        (bytes[offset + 2] << 8) |
+        (bytes[offset + 3] << 16) |
+        (bytes[offset + 4] << 24)) >>>
+      0;
+    if (value < VARINT_U32_MIN_VALUE) throw new Error(NON_MINIMAL_VARINT);
+    return { value, next: offset + 5 };
+  }
+  throw new Error(
+    "proof of possession witness carries an out-of-range item length",
+  );
+}
+
+function decodeWitnessItems(witnessHex: Hex): Uint8Array[] {
+  const body = witnessHex.slice(2);
+  // Buffer.from(_, "hex") stops silently at the first invalid character.
+  if (!WITNESS_BODY_HEX.test(body)) {
+    throw new Error(
+      "proof of possession witness is not even-length lowercase hex",
+    );
+  }
+  const bytes = Uint8Array.from(Buffer.from(body, "hex"));
+  const { value: count, next: start } = readVarint(bytes, 0);
+  const items: Uint8Array[] = [];
+  let offset = start;
+  for (let i = 0; i < count; i++) {
+    const { value: len, next } = readVarint(bytes, offset);
+    if (next + len > bytes.length) {
+      throw new Error("proof of possession witness is truncated");
+    }
+    items.push(bytes.subarray(next, next + len));
+    offset = next + len;
+  }
+  if (offset !== bytes.length) {
+    throw new Error("proof of possession witness has trailing bytes");
+  }
+  return items;
+}
+
+/**
+ * Decode a consensus-encoded PoP witness and, for the P2TR shape, verify the
+ * Schnorr signature against the depositor's key.
+ *
+ * @param messageBytes     - Bytes of the PoP message that was signed.
+ * @param depositorXOnlyHex - Depositor x-only pubkey, bare 64-char hex
+ *                            (enforced, not assumed).
+ * @param witnessHex       - 0x-prefixed consensus-encoded witness.
+ * @throws If the witness is malformed, has an unsupported item count, the
+ *         depositor key is not bare x-only hex, or the P2TR signature does
+ *         not verify.
+ */
+export function verifyPopWitness(
+  messageBytes: Uint8Array,
+  depositorXOnlyHex: string,
+  witnessHex: Hex,
+): PopWitnessVerdict {
+  const items = decodeWitnessItems(witnessHex);
+
+  if (items.length === P2TR_WITNESS_ITEMS) {
+    const [item] = items;
+    // vaultd (bip322 crate `verify.rs:213-236`) accepts 64 bytes = SIGHASH_DEFAULT,
+    // or 65 bytes ending in 0x01 = SIGHASH_ALL; mirror exactly that, nothing looser.
+    let signature: Uint8Array;
+    let hashType: number;
+    if (item.length === SCHNORR_SIG_BYTES) {
+      signature = item;
+      hashType = SIGHASH_DEFAULT;
+    } else if (
+      item.length === SCHNORR_SIG_BYTES + 1 &&
+      item[SCHNORR_SIG_BYTES] === SIGHASH_ALL
+    ) {
+      signature = item.subarray(0, SCHNORR_SIG_BYTES);
+      hashType = SIGHASH_ALL;
+    } else {
+      throw new Error(
+        "proof of possession witness item must be a 64-byte Schnorr signature " +
+          "(or 65 bytes ending in 0x01)",
+      );
+    }
+
+    // Guard the caller contract: a prefixed or short key would decode to the
+    // wrong bytes and surface as "does not verify", hiding the real fault.
+    if (!X_ONLY_PUBKEY_HEX.test(depositorXOnlyHex)) {
+      throw new Error(
+        `depositor public key must be bare 64-char x-only hex, got "${depositorXOnlyHex}"`,
+      );
+    }
+    const xOnly = Uint8Array.from(Buffer.from(depositorXOnlyHex, "hex"));
+    if (!verifyBip322Simple(messageBytes, xOnly, signature, hashType)) {
+      throw new Error(
+        "proof of possession signature does not verify against the depositor key",
+      );
+    }
+    return { kind: "p2tr-verified" };
+  }
+
+  if (items.length === P2WPKH_WITNESS_ITEMS) {
+    return { kind: "p2wpkh-unverified" };
+  }
+
+  throw new Error(
+    `proof of possession witness has ${items.length} items; expected 1 (P2TR) or 2 (P2WPKH)`,
+  );
+}

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/__tests__/challengers.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/__tests__/challengers.test.ts
@@ -1,14 +1,15 @@
 import { describe, expect, it } from "vitest";
 
-import { computeNumLocalChallengers } from "../challengers";
+import {
+  computeNumLocalChallengers,
+  deriveLocalChallengers,
+} from "../challengers";
 
 // 32-byte x-only keys (64 hex chars)
 const VP_KEY =
   "a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2";
-const VK1 =
-  "1111111111111111111111111111111111111111111111111111111111111111";
-const VK2 =
-  "2222222222222222222222222222222222222222222222222222222222222222";
+const VK1 = "1111111111111111111111111111111111111111111111111111111111111111";
+const VK2 = "2222222222222222222222222222222222222222222222222222222222222222";
 const DEPOSITOR =
   "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd";
 
@@ -43,7 +44,11 @@ describe("computeNumLocalChallengers", () => {
     const compressedVK = `03${VK1}`;
     const compressedDepositor = `02${DEPOSITOR}`;
     expect(
-      computeNumLocalChallengers(compressedVP, [compressedVK], compressedDepositor),
+      computeNumLocalChallengers(
+        compressedVP,
+        [compressedVK],
+        compressedDepositor,
+      ),
     ).toBe(2);
   });
 
@@ -63,5 +68,82 @@ describe("computeNumLocalChallengers", () => {
 
   it("counts correctly with no VKs", () => {
     expect(computeNumLocalChallengers(VP_KEY, [], DEPOSITOR)).toBe(1);
+  });
+});
+
+describe("deriveLocalChallengers", () => {
+  const base = {
+    depositorBtcPubkey: DEPOSITOR,
+    vaultProviderBtcPubkey: VP_KEY,
+    vaultKeeperBtcPubkeys: [VK1, VK2],
+  };
+
+  it("returns vault keepers only when the depositor is the claimer", () => {
+    expect(
+      deriveLocalChallengers({ ...base, claimerBtcPubkey: DEPOSITOR }),
+    ).toEqual([VK1, VK2]);
+  });
+
+  it("returns VP plus the other keepers when a vault keeper is the claimer", () => {
+    expect(deriveLocalChallengers({ ...base, claimerBtcPubkey: VK1 })).toEqual(
+      [VK2, VP_KEY].sort(),
+    );
+  });
+
+  it("returns the keepers when the vault provider is the claimer", () => {
+    expect(
+      deriveLocalChallengers({ ...base, claimerBtcPubkey: VP_KEY }),
+    ).toEqual([VK1, VK2].sort());
+  });
+
+  it("deduplicates a vault provider that also appears as a keeper", () => {
+    expect(
+      deriveLocalChallengers({
+        ...base,
+        vaultKeeperBtcPubkeys: [VP_KEY, VK1],
+        claimerBtcPubkey: VK1,
+      }),
+    ).toEqual([VP_KEY]);
+  });
+
+  it("normalizes 0x-prefixed, compressed and mixed-case keys", () => {
+    expect(
+      deriveLocalChallengers({
+        depositorBtcPubkey: `02${DEPOSITOR}`,
+        vaultProviderBtcPubkey: `0x${VP_KEY.toUpperCase()}`,
+        vaultKeeperBtcPubkeys: [`0x${VK1}`, `03${VK2}`],
+        claimerBtcPubkey: DEPOSITOR,
+      }),
+    ).toEqual([VK1, VK2]);
+  });
+
+  it("throws when the depositor-claimer keeper set is empty", () => {
+    expect(() =>
+      deriveLocalChallengers({
+        ...base,
+        vaultKeeperBtcPubkeys: [DEPOSITOR],
+        claimerBtcPubkey: DEPOSITOR,
+      }),
+    ).toThrow(/vault keeper set is empty/);
+  });
+
+  it("throws when the depositor-claimer keeper set has duplicates", () => {
+    expect(() =>
+      deriveLocalChallengers({
+        ...base,
+        vaultKeeperBtcPubkeys: [VK1, VK1],
+        claimerBtcPubkey: DEPOSITOR,
+      }),
+    ).toThrow(/duplicate vaultKeeper key/);
+  });
+
+  it("throws when the claimer is the only vault provider or keeper", () => {
+    expect(() =>
+      deriveLocalChallengers({
+        ...base,
+        vaultKeeperBtcPubkeys: [VP_KEY],
+        claimerBtcPubkey: VP_KEY,
+      }),
+    ).toThrow(/no vault provider or vault keeper remains/);
   });
 });

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/challengers.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/challengers.ts
@@ -1,9 +1,7 @@
 /**
- * Challenger counting utilities.
- *
- * Used for UI-level validation (e.g. computing minimum deposit amounts)
- * where the depositor's identity is known. The transaction builders use
- * `vaultKeeperBtcPubkeys.length` to match the VP's current validation.
+ * Challenger derivation utilities — counting local challengers for UI-level
+ * validation (e.g. minimum deposit amounts) and deriving the exact
+ * local-challenger set a claimer's tx graph is built from.
  */
 
 import { processPublicKeyToXOnly } from "./utils/bitcoin";
@@ -43,4 +41,68 @@ export function computeNumLocalChallengers(
   }
   localSet.delete(normalizeKey(depositorPubkey));
   return localSet.size;
+}
+
+/** Roles a claimer can hold; determines which local-challenger rule applies. */
+export interface DeriveLocalChallengersParams {
+  /** The graph's claimer (VP, a vault keeper, or the depositor). */
+  claimerBtcPubkey: string;
+  /** Depositor registered on-chain for the vault. */
+  depositorBtcPubkey: string;
+  /** Vault provider registered on-chain for the vault. */
+  vaultProviderBtcPubkey: string;
+  /** Vault keepers registered on-chain for the vault. */
+  vaultKeeperBtcPubkeys: string[];
+}
+
+/**
+ * Derive the local-challenger set for a claimer's graph.
+ *
+ * Byte-for-byte mirror of btc-vault `derive_challengers_for`
+ * (`crates/vault/src/tx_graph/graph.rs:257-284`):
+ * - depositor-as-claimer → vault keepers only (VP excluded)
+ * - VP- or VK-claimer → `({VP} ∪ VKs) − {claimer}`, sorted and deduplicated
+ *
+ * The protocol guarantees the depositor is not a vault keeper
+ * (`TxGraphParams::validate`), so the depositor filter in the first branch is
+ * defense-in-depth; it surfaces a clear error if a misconfigured context ever
+ * violates the invariant.
+ *
+ * @throws If no local challenger remains, or (depositor path) the keeper set
+ *   contains duplicates — both mean the signing context is misconfigured.
+ */
+export function deriveLocalChallengers(
+  params: DeriveLocalChallengersParams,
+): string[] {
+  const claimer = normalizeKey(params.claimerBtcPubkey);
+  const depositor = normalizeKey(params.depositorBtcPubkey);
+  const vaultKeepers = params.vaultKeeperBtcPubkeys.map(normalizeKey);
+
+  if (claimer === depositor) {
+    const filtered = vaultKeepers.filter((k) => k !== depositor);
+    if (filtered.length === 0) {
+      throw new Error(
+        "Cannot derive localChallengers: vault keeper set is empty (or contains only the depositor)",
+      );
+    }
+    if (new Set(filtered).size !== filtered.length) {
+      throw new Error(
+        "Cannot derive localChallengers: duplicate vaultKeeper key — signing context is misconfigured",
+      );
+    }
+    return filtered;
+  }
+
+  // Rust sorts then dedups before filtering; a Set keeps insertion order, so
+  // sort after deduping for the same result.
+  const deduped = [
+    ...new Set([normalizeKey(params.vaultProviderBtcPubkey), ...vaultKeepers]),
+  ].sort();
+  const filtered = deduped.filter((k) => k !== claimer);
+  if (filtered.length === 0) {
+    throw new Error(
+      `Cannot derive localChallengers: no vault provider or vault keeper remains after excluding claimer ${claimer}`,
+    );
+  }
+  return filtered;
 }

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/index.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/index.ts
@@ -145,6 +145,15 @@ export type { AssertPsbtUnsignedTxMatchesParams } from "./psbt/assertPsbtUnsigne
 export { assertScriptPathSchnorrSignature } from "./psbt/verifyScriptPathSchnorrSignature";
 export type { VerifyScriptPathSchnorrSignatureParams } from "./psbt/verifyScriptPathSchnorrSignature";
 
+export {
+  assertKeyPathSchnorrSignature,
+  assertReturnedKeyPathSignatures,
+} from "./psbt/verifyKeyPathSchnorrSignature";
+export type {
+  AssertKeyPathSchnorrSignatureParams,
+  AssertReturnedKeyPathSignaturesParams,
+} from "./psbt/verifyKeyPathSchnorrSignature";
+
 export { buildNoPayoutPsbt } from "./psbt/noPayout";
 export type { NoPayoutParams } from "./psbt/noPayout";
 

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/__tests__/helpers.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/__tests__/helpers.ts
@@ -9,6 +9,8 @@
  */
 
 import { initWasm } from "@babylonlabs-io/babylon-tbv-rust-wasm";
+import * as ecc from "@bitcoin-js/tiny-secp256k1-asmjs";
+import { Buffer } from "buffer";
 
 /**
  * Test public key constants derived from deterministic secret keys.
@@ -87,4 +89,20 @@ export const TEST_AMOUNTS = {
  */
 export async function initializeWasmForTests(): Promise<void> {
   await initWasm();
+}
+
+/**
+ * Deterministic distinct valid x-only pubkeys (scalar * G for scalars
+ * offset..offset+count-1), sorted ascending as the protocol requires.
+ */
+export function generateXOnlyKeys(count: number, offset: number): string[] {
+  const keys: string[] = [];
+  for (let i = 0; i < count; i++) {
+    const scalar = Buffer.alloc(32);
+    scalar.writeUInt32BE(offset + i, 28);
+    const point = ecc.pointFromScalar(scalar, true);
+    if (!point) throw new Error(`invalid scalar ${offset + i}`);
+    keys.push(Buffer.from(point.subarray(1, 33)).toString("hex"));
+  }
+  return keys.sort();
 }

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/__tests__/payout.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/__tests__/payout.test.ts
@@ -9,12 +9,17 @@ import { Buffer } from "buffer";
 
 import {
   computePayoutFeeFloor,
+  getAssertPayoutScriptInfo,
   type Network,
 } from "@babylonlabs-io/babylon-tbv-rust-wasm";
-import * as ecc from "@bitcoin-js/tiny-secp256k1-asmjs";
 import { Psbt, Transaction } from "bitcoinjs-lib";
 import { beforeAll, describe, expect, it } from "vitest";
-import { deriveBip86ScriptPubKeyHex } from "../../utils/bitcoin";
+import { deriveLocalChallengers } from "../../challengers";
+import {
+  deriveBip86ScriptPubKeyHex,
+  hexToUint8Array,
+} from "../../utils/bitcoin";
+import { computeTaprootScriptPubKey } from "../../utils/taproot";
 import { PAYOUT_ANCHOR_DUST_SATS, PAYOUT_TX_VERSION } from "../constants";
 import {
   buildPayoutPsbt,
@@ -35,7 +40,11 @@ import {
   createDummyP2TR,
   createDummyP2WPKH,
 } from "./constants";
-import { TEST_KEYS, initializeWasmForTests } from "./helpers";
+import {
+  TEST_KEYS,
+  generateXOnlyKeys,
+  initializeWasmForTests,
+} from "./helpers";
 
 /**
  * Registered depositor payout scriptPubKey used by tests. Matches outs[0] of
@@ -65,8 +74,13 @@ const TEST_TIMELOCK_ASSERT = 144;
  */
 const TEST_PROTOCOL_FEE_RATE = 10n;
 
-/** Council size forwarded to the fee floor; matches the golden generator. */
-const TEST_COUNCIL_SIZE = 3;
+/**
+ * Security council for the fixtures: 3 members, quorum 2. The size matches the
+ * golden fee-floor generator; the keys shape the Assert:0 council leaf.
+ */
+const TEST_COUNCIL_MEMBERS = generateXOnlyKeys(3, 9_000);
+const TEST_COUNCIL_QUORUM = 2;
+const TEST_COUNCIL_SIZE = TEST_COUNCIL_MEMBERS.length;
 
 /**
  * VP commission destination of the canonical test payout transaction
@@ -156,17 +170,52 @@ function createTestPeginTransaction(): string {
 }
 
 /**
- * Creates a test assert transaction (simplified for testing).
- * Single dummy output used to test multi-input Payout PSBT construction.
+ * The Assert:0 scriptPubKey for a parameter set — the taptree the WASM payout
+ * leaf lives in. `buildPayoutPsbt` refuses to attach a leaf that does not bind
+ * to input 1's prevout, so fixtures must pay this script.
  */
-function createTestAssertTransaction(): string {
+async function assertOutputScriptPubKey(
+  overrides: Partial<PayoutParams> = {},
+): Promise<Buffer> {
+  const params = baseParams(overrides);
+  const { payoutScript, payoutControlBlock } = await getAssertPayoutScriptInfo({
+    txGraphVersion: params.vaultCoreVersion,
+    claimer: params.claimerBtcPubkey.toLowerCase(),
+    localChallengers: deriveLocalChallengers({
+      claimerBtcPubkey: params.claimerBtcPubkey,
+      depositorBtcPubkey: params.depositorBtcPubkey,
+      vaultProviderBtcPubkey: params.vaultProviderBtcPubkey,
+      vaultKeeperBtcPubkeys: params.vaultKeeperBtcPubkeys,
+    }),
+    universalChallengers: params.universalChallengerBtcPubkeys,
+    timelockAssert: params.timelockAssert,
+    councilMembers: params.councilMembers,
+    councilQuorum: params.councilQuorum,
+  });
+  return computeTaprootScriptPubKey({
+    leafVersion: TAPSCRIPT_LEAF_VERSION,
+    script: hexToUint8Array(payoutScript),
+    controlBlock: hexToUint8Array(payoutControlBlock),
+  });
+}
+
+/**
+ * Creates a test assert transaction whose output 0 is the real Assert:0
+ * taproot output for `overrides`. Tests that expect a rejection before the
+ * leaf is attached can leave `overrides` at the default.
+ */
+async function createTestAssertTransaction(
+  overrides: Partial<PayoutParams> = {},
+): Promise<string> {
   const tx = new Transaction();
 
   // Dummy input (distinct using DUMMY_TXID_2)
   tx.addInput(DUMMY_TXID_2, 0xffffffff, SEQUENCE_MAX);
 
-  // P2WPKH dummy output (filled with 'c' for identification)
-  tx.addOutput(createDummyP2WPKH("c"), Number(TEST_CLAIM_VALUE));
+  tx.addOutput(
+    await assertOutputScriptPubKey(overrides),
+    Number(TEST_CLAIM_VALUE),
+  );
 
   return tx.toHex();
 }
@@ -243,7 +292,8 @@ function baseParams(overrides: Partial<PayoutParams>): PayoutParams {
     registeredPayoutScriptPubKey: REGISTERED_PAYOUT_SCRIPT_HEX,
     commissionBps: TEST_COMMISSION_BPS,
     protocolFeeRate: TEST_PROTOCOL_FEE_RATE,
-    councilSize: TEST_COUNCIL_SIZE,
+    councilMembers: TEST_COUNCIL_MEMBERS,
+    councilQuorum: TEST_COUNCIL_QUORUM,
     // Defaults mirror an un-rotated network with no custom scripts, where the
     // registry backfills BIP-86 — the state testnet is in today. Tests that
     // care about a custom registration override these.
@@ -251,22 +301,6 @@ function baseParams(overrides: Partial<PayoutParams>): PayoutParams {
     vpCommissionScriptPubKey: CANONICAL_VP_COMMISSION_SCRIPT_HEX,
     ...overrides,
   };
-}
-
-/**
- * Deterministic distinct valid x-only pubkeys (scalar * G for scalars
- * offset..offset+count-1), sorted ascending as the protocol requires.
- */
-function generateXOnlyKeys(count: number, offset: number): string[] {
-  const keys: string[] = [];
-  for (let i = 0; i < count; i++) {
-    const scalar = Buffer.alloc(32);
-    scalar.writeUInt32BE(offset + i, 28);
-    const point = ecc.pointFromScalar(scalar, true);
-    if (!point) throw new Error(`invalid scalar ${offset + i}`);
-    keys.push(Buffer.from(point.subarray(1, 33)).toString("hex"));
-  }
-  return keys.sort();
 }
 
 describe("buildPayoutPsbt", () => {
@@ -282,7 +316,7 @@ describe("buildPayoutPsbt", () => {
       // - Assert: Assert output from claimer (challenge path)
       // - Payout: Spends both pegin and assert outputs (required for correct sighash)
       const peginTxHex = createTestPeginTransaction();
-      const assertTxHex = createTestAssertTransaction();
+      const assertTxHex = await createTestAssertTransaction();
       const payoutTxHex = createTestPayoutTransaction(peginTxHex, assertTxHex);
 
       const params: PayoutParams = {
@@ -301,7 +335,8 @@ describe("buildPayoutPsbt", () => {
         registeredPayoutScriptPubKey: REGISTERED_PAYOUT_SCRIPT_HEX,
         commissionBps: TEST_COMMISSION_BPS,
         protocolFeeRate: TEST_PROTOCOL_FEE_RATE,
-        councilSize: TEST_COUNCIL_SIZE,
+        councilMembers: TEST_COUNCIL_MEMBERS,
+        councilQuorum: TEST_COUNCIL_QUORUM,
         vkClaimerPayoutScriptPubKeys: DEFAULT_VK_PAYOUT_SCRIPTS,
         vpCommissionScriptPubKey: CANONICAL_VP_COMMISSION_SCRIPT_HEX,
       };
@@ -329,15 +364,68 @@ describe("buildPayoutPsbt", () => {
       expect(firstInput.tapInternalKey).toBeDefined();
       expect(firstInput.witnessUtxo).toBeDefined();
 
-      // Verify second input has witnessUtxo but NO tapLeafScript (depositor doesn't sign this)
+      // Second input carries the Assert:0 payout leaf: the depositor does not
+      // sign it, but the Ledger vault app reads it to display the terms.
       const secondInput = psbt.data.inputs[1];
       expect(secondInput.witnessUtxo).toBeDefined();
-      expect(secondInput.tapLeafScript).toBeUndefined();
+      expect(secondInput.tapLeafScript).toHaveLength(1);
+      expect(secondInput.tapLeafScript![0].leafVersion).toBe(
+        TAPSCRIPT_LEAF_VERSION,
+      );
+      expect(secondInput.tapInternalKey).toBeDefined();
+    });
+
+    it("attaches the WASM Assert:0 payout leaf to input 1", async () => {
+      const peginTxHex = createTestPeginTransaction();
+      const assertTxHex = await createTestAssertTransaction();
+      const payoutTxHex = createTestPayoutTransaction(peginTxHex, assertTxHex);
+
+      const result = await buildPayoutPsbt(
+        baseParams({ payoutTxHex, peginTxHex, assertTxHex }),
+      );
+
+      const expected = await getAssertPayoutScriptInfo({
+        txGraphVersion: 1,
+        claimer: TEST_KEYS.VAULT_PROVIDER,
+        localChallengers: [TEST_KEYS.VAULT_KEEPER_1],
+        universalChallengers: [TEST_KEYS.UNIVERSAL_CHALLENGER_1],
+        timelockAssert: TEST_TIMELOCK_ASSERT,
+        councilMembers: TEST_COUNCIL_MEMBERS,
+        councilQuorum: TEST_COUNCIL_QUORUM,
+      });
+
+      const leaf = Psbt.fromHex(result.psbtHex).data.inputs[1]
+        .tapLeafScript![0];
+      expect(leaf.script.toString("hex")).toBe(expected.payoutScript);
+      expect(leaf.controlBlock.toString("hex")).toBe(
+        expected.payoutControlBlock,
+      );
+    });
+
+    it("rejects a payout whose Assert:0 prevout the rebuilt payout leaf cannot spend", async () => {
+      // A VP that hands a payout referencing an Assert built from a different
+      // participant set: the leaf we would show the device would describe terms
+      // that Assert output cannot enforce.
+      const peginTxHex = createTestPeginTransaction();
+      const foreignAssertTx = new Transaction();
+      foreignAssertTx.addInput(DUMMY_TXID_2, 0xffffffff, SEQUENCE_MAX);
+      foreignAssertTx.addOutput(
+        await assertOutputScriptPubKey({ timelockAssert: 200 }),
+        Number(TEST_CLAIM_VALUE),
+      );
+      const assertTxHex = foreignAssertTx.toHex();
+      const payoutTxHex = createTestPayoutTransaction(peginTxHex, assertTxHex);
+
+      await expect(
+        buildPayoutPsbt(baseParams({ payoutTxHex, peginTxHex, assertTxHex })),
+      ).rejects.toThrow(
+        /Rebuilt Assert:0 payout leaf does not spend the Assert output/,
+      );
     });
 
     it("should handle different networks", async () => {
       const peginTxHex = createTestPeginTransaction();
-      const assertTxHex = createTestAssertTransaction();
+      const assertTxHex = await createTestAssertTransaction();
       const payoutTxHex = createTestPayoutTransaction(peginTxHex, assertTxHex);
 
       const networks: Network[] = ["testnet", "regtest"];
@@ -359,7 +447,8 @@ describe("buildPayoutPsbt", () => {
           registeredPayoutScriptPubKey: REGISTERED_PAYOUT_SCRIPT_HEX,
           commissionBps: TEST_COMMISSION_BPS,
           protocolFeeRate: TEST_PROTOCOL_FEE_RATE,
-          councilSize: TEST_COUNCIL_SIZE,
+          councilMembers: TEST_COUNCIL_MEMBERS,
+          councilQuorum: TEST_COUNCIL_QUORUM,
           vkClaimerPayoutScriptPubKeys: DEFAULT_VK_PAYOUT_SCRIPTS,
           vpCommissionScriptPubKey: CANONICAL_VP_COMMISSION_SCRIPT_HEX,
         };
@@ -374,7 +463,7 @@ describe("buildPayoutPsbt", () => {
 
     it("carries btc-vault's pinned version and locktime into the PSBT", async () => {
       const peginTxHex = createTestPeginTransaction();
-      const assertTxHex = createTestAssertTransaction();
+      const assertTxHex = await createTestAssertTransaction();
       const payoutTxHex = createTestPayoutTransaction(peginTxHex, assertTxHex);
 
       // Parse the payout transaction to check its version
@@ -396,7 +485,8 @@ describe("buildPayoutPsbt", () => {
         registeredPayoutScriptPubKey: REGISTERED_PAYOUT_SCRIPT_HEX,
         commissionBps: TEST_COMMISSION_BPS,
         protocolFeeRate: TEST_PROTOCOL_FEE_RATE,
-        councilSize: TEST_COUNCIL_SIZE,
+        councilMembers: TEST_COUNCIL_MEMBERS,
+        councilQuorum: TEST_COUNCIL_QUORUM,
         vkClaimerPayoutScriptPubKeys: DEFAULT_VK_PAYOUT_SCRIPTS,
         vpCommissionScriptPubKey: CANONICAL_VP_COMMISSION_SCRIPT_HEX,
       };
@@ -413,7 +503,7 @@ describe("buildPayoutPsbt", () => {
   describe("Error handling", () => {
     it("should throw error when Payout transaction has fewer than 2 inputs", async () => {
       const peginTxHex = createTestPeginTransaction();
-      const assertTxHex = createTestAssertTransaction();
+      const assertTxHex = await createTestAssertTransaction();
 
       // Create a payout transaction with only 1 input (should fail since we need 2)
       const peginTx = Transaction.fromHex(peginTxHex);
@@ -442,7 +532,8 @@ describe("buildPayoutPsbt", () => {
         registeredPayoutScriptPubKey: REGISTERED_PAYOUT_SCRIPT_HEX,
         commissionBps: TEST_COMMISSION_BPS,
         protocolFeeRate: TEST_PROTOCOL_FEE_RATE,
-        councilSize: TEST_COUNCIL_SIZE,
+        councilMembers: TEST_COUNCIL_MEMBERS,
+        councilQuorum: TEST_COUNCIL_QUORUM,
         vkClaimerPayoutScriptPubKeys: DEFAULT_VK_PAYOUT_SCRIPTS,
         vpCommissionScriptPubKey: CANONICAL_VP_COMMISSION_SCRIPT_HEX,
       };
@@ -461,7 +552,7 @@ describe("buildPayoutPsbt", () => {
       peginTx.addOutput(createDummyP2TR(), Number(TEST_PEGIN_VALUE));
       const peginTxHex = peginTx.toHex();
 
-      const assertTxHex = createTestAssertTransaction();
+      const assertTxHex = await createTestAssertTransaction();
       const assertTx = Transaction.fromHex(assertTxHex);
 
       const wrongTx = new Transaction();
@@ -495,7 +586,8 @@ describe("buildPayoutPsbt", () => {
         registeredPayoutScriptPubKey: REGISTERED_PAYOUT_SCRIPT_HEX,
         commissionBps: TEST_COMMISSION_BPS,
         protocolFeeRate: TEST_PROTOCOL_FEE_RATE,
-        councilSize: TEST_COUNCIL_SIZE,
+        councilMembers: TEST_COUNCIL_MEMBERS,
+        councilQuorum: TEST_COUNCIL_QUORUM,
         vkClaimerPayoutScriptPubKeys: DEFAULT_VK_PAYOUT_SCRIPTS,
         vpCommissionScriptPubKey: CANONICAL_VP_COMMISSION_SCRIPT_HEX,
       };
@@ -547,7 +639,8 @@ describe("buildPayoutPsbt", () => {
         registeredPayoutScriptPubKey: REGISTERED_PAYOUT_SCRIPT_HEX,
         commissionBps: TEST_COMMISSION_BPS,
         protocolFeeRate: TEST_PROTOCOL_FEE_RATE,
-        councilSize: TEST_COUNCIL_SIZE,
+        councilMembers: TEST_COUNCIL_MEMBERS,
+        councilQuorum: TEST_COUNCIL_QUORUM,
         vkClaimerPayoutScriptPubKeys: DEFAULT_VK_PAYOUT_SCRIPTS,
         vpCommissionScriptPubKey: CANONICAL_VP_COMMISSION_SCRIPT_HEX,
       };
@@ -561,7 +654,7 @@ describe("buildPayoutPsbt", () => {
   describe("Integration with WASM", () => {
     it("should successfully use WASM-generated payout script", async () => {
       const peginTxHex = createTestPeginTransaction();
-      const assertTxHex = createTestAssertTransaction();
+      const assertTxHex = await createTestAssertTransaction();
       const payoutTxHex = createTestPayoutTransaction(peginTxHex, assertTxHex);
 
       const params: PayoutParams = {
@@ -580,7 +673,8 @@ describe("buildPayoutPsbt", () => {
         registeredPayoutScriptPubKey: REGISTERED_PAYOUT_SCRIPT_HEX,
         commissionBps: TEST_COMMISSION_BPS,
         protocolFeeRate: TEST_PROTOCOL_FEE_RATE,
-        councilSize: TEST_COUNCIL_SIZE,
+        councilMembers: TEST_COUNCIL_MEMBERS,
+        councilQuorum: TEST_COUNCIL_QUORUM,
         vkClaimerPayoutScriptPubKeys: DEFAULT_VK_PAYOUT_SCRIPTS,
         vpCommissionScriptPubKey: CANONICAL_VP_COMMISSION_SCRIPT_HEX,
       };
@@ -954,7 +1048,7 @@ describe("buildPayoutPsbt — per-role output validation", () => {
 
   it("VP-claimer: accepts a canonical 3-output payout", async () => {
     const peginTxHex = createTestPeginTransaction();
-    const assertTxHex = createTestAssertTransaction();
+    const assertTxHex = await createTestAssertTransaction();
     const payoutTxHex = createTestPayoutTransaction(peginTxHex, assertTxHex);
     await expect(
       buildPayoutPsbt(baseParams({ payoutTxHex, peginTxHex, assertTxHex })),
@@ -963,7 +1057,7 @@ describe("buildPayoutPsbt — per-role output validation", () => {
 
   it("VP-claimer: rejects when an extra attacker output is appended", async () => {
     const peginTxHex = createTestPeginTransaction();
-    const assertTxHex = createTestAssertTransaction();
+    const assertTxHex = await createTestAssertTransaction();
     const payoutTxHex = buildPayoutTxWithOutputs(peginTxHex, assertTxHex, [
       { script: createDummyP2WPKH("a"), value: 80_000 },
       { script: createDummyP2WPKH("e"), value: 1_000 },
@@ -977,7 +1071,7 @@ describe("buildPayoutPsbt — per-role output validation", () => {
 
   it("VP-claimer: rejects when outs[0] script differs from the registered scriptPubKey", async () => {
     const peginTxHex = createTestPeginTransaction();
-    const assertTxHex = createTestAssertTransaction();
+    const assertTxHex = await createTestAssertTransaction();
     const payoutTxHex = buildPayoutTxWithOutputs(peginTxHex, assertTxHex, [
       { script: createDummyP2WPKH("b"), value: 143_454 },
       { script: createDummyP2WPKH("e"), value: 1_000 },
@@ -994,7 +1088,7 @@ describe("buildPayoutPsbt — per-role output validation", () => {
     // commissionBps = 500 → cap = floor(100_000 * 500 / 10_000) = 5_000.
     // Set outs[1] to 6_000 → over the cap.
     const peginTxHex = createTestPeginTransaction();
-    const assertTxHex = createTestAssertTransaction();
+    const assertTxHex = await createTestAssertTransaction();
     const payoutTxHex = buildPayoutTxWithOutputs(peginTxHex, assertTxHex, [
       { script: createDummyP2WPKH("a"), value: 138_454 },
       { script: createDummyP2WPKH("e"), value: 6_000 },
@@ -1009,7 +1103,7 @@ describe("buildPayoutPsbt — per-role output validation", () => {
 
   it("VP-claimer: rejects when CPFP anchor value (outs[2]) is not 546 sats", async () => {
     const peginTxHex = createTestPeginTransaction();
-    const assertTxHex = createTestAssertTransaction();
+    const assertTxHex = await createTestAssertTransaction();
     const payoutTxHex = buildPayoutTxWithOutputs(peginTxHex, assertTxHex, [
       { script: createDummyP2WPKH("a"), value: 143_454 },
       { script: createDummyP2WPKH("e"), value: 1_000 },
@@ -1029,7 +1123,7 @@ describe("buildPayoutPsbt — per-role output validation", () => {
     // cap becomes floor(peginValue * 0 / 10_000) = 0, so the canonical
     // 1_000-sat commission output is rejected by the cap — fail-safe.
     const peginTxHex = createTestPeginTransaction();
-    const assertTxHex = createTestAssertTransaction();
+    const assertTxHex = await createTestAssertTransaction();
     const payoutTxHex = createTestPayoutTransaction(peginTxHex, assertTxHex);
     await expect(
       buildPayoutPsbt(
@@ -1042,7 +1136,7 @@ describe("buildPayoutPsbt — per-role output validation", () => {
 
   it("VP-claimer: rejects commissionBps at or above 10_000 (structural guard)", async () => {
     const peginTxHex = createTestPeginTransaction();
-    const assertTxHex = createTestAssertTransaction();
+    const assertTxHex = await createTestAssertTransaction();
     const payoutTxHex = createTestPayoutTransaction(peginTxHex, assertTxHex);
     await expect(
       buildPayoutPsbt(
@@ -1058,7 +1152,9 @@ describe("buildPayoutPsbt — per-role output validation", () => {
 
   it("depositor-as-claimer: accepts a 2-output payout with registered script at outs[0]", async () => {
     const peginTxHex = createTestPeginTransaction();
-    const assertTxHex = createTestAssertTransaction();
+    const assertTxHex = await createTestAssertTransaction({
+      claimerBtcPubkey: TEST_KEYS.DEPOSITOR,
+    });
     const payoutTxHex = buildPayoutTxWithOutputs(peginTxHex, assertTxHex, [
       { script: createDummyP2WPKH("a"), value: 144_454 },
       { script: createDummyP2WPKH("c"), value: PAYOUT_ANCHOR_DUST_SATS },
@@ -1077,7 +1173,7 @@ describe("buildPayoutPsbt — per-role output validation", () => {
 
   it("depositor-as-claimer: rejects when count is the VP-claimer shape (3 outputs)", async () => {
     const peginTxHex = createTestPeginTransaction();
-    const assertTxHex = createTestAssertTransaction();
+    const assertTxHex = await createTestAssertTransaction();
     const payoutTxHex = createTestPayoutTransaction(peginTxHex, assertTxHex);
     await expect(
       buildPayoutPsbt(
@@ -1095,7 +1191,7 @@ describe("buildPayoutPsbt — per-role output validation", () => {
 
   it("depositor-as-claimer: rejects when CPFP anchor value (outs[1]) is not 546 sats", async () => {
     const peginTxHex = createTestPeginTransaction();
-    const assertTxHex = createTestAssertTransaction();
+    const assertTxHex = await createTestAssertTransaction();
     const payoutTxHex = buildPayoutTxWithOutputs(peginTxHex, assertTxHex, [
       { script: createDummyP2WPKH("a"), value: 144_000 },
       { script: createDummyP2WPKH("c"), value: 1_000 },
@@ -1116,7 +1212,9 @@ describe("buildPayoutPsbt — per-role output validation", () => {
 
   it("vk-claimer: accepts a 2-output payout with outs[0] = bip86(vk)", async () => {
     const peginTxHex = createTestPeginTransaction();
-    const assertTxHex = createTestAssertTransaction();
+    const assertTxHex = await createTestAssertTransaction({
+      claimerBtcPubkey: TEST_KEYS.VAULT_KEEPER_1,
+    });
     const vkScriptHex = deriveBip86ScriptPubKeyHex(TEST_KEYS.VAULT_KEEPER_1);
     // deriveBip86ScriptPubKeyHex returns a `0x`-prefixed hex string; strip
     // the prefix before constructing the raw script buffer.
@@ -1141,7 +1239,7 @@ describe("buildPayoutPsbt — per-role output validation", () => {
     // outs[0] uses the registered depositor script instead of bip86(vk) —
     // mirrors a VP trying to redirect VK payout to the depositor address.
     const peginTxHex = createTestPeginTransaction();
-    const assertTxHex = createTestAssertTransaction();
+    const assertTxHex = await createTestAssertTransaction();
     const payoutTxHex = buildPayoutTxWithOutputs(peginTxHex, assertTxHex, [
       { script: createDummyP2WPKH("a"), value: 144_454 },
       { script: createDummyP2WPKH("c"), value: PAYOUT_ANCHOR_DUST_SATS },
@@ -1164,7 +1262,9 @@ describe("buildPayoutPsbt — per-role output validation", () => {
     // The RFC-006 case that breaks the legacy path: a keeper whose payouts go
     // to cold custody, not to the BIP-86 address of its operation key.
     const peginTxHex = createTestPeginTransaction();
-    const assertTxHex = createTestAssertTransaction();
+    const assertTxHex = await createTestAssertTransaction({
+      claimerBtcPubkey: TEST_KEYS.VAULT_KEEPER_1,
+    });
     const registeredScript = createDummyP2WPKH("d");
     const payoutTxHex = buildPayoutTxWithOutputs(peginTxHex, assertTxHex, [
       { script: registeredScript, value: 144_454 },
@@ -1192,7 +1292,9 @@ describe("buildPayoutPsbt — per-role output validation", () => {
     // keeper destination locally. Graphs are never rebuilt, so rejecting this
     // would strand the vault permanently.
     const peginTxHex = createTestPeginTransaction();
-    const assertTxHex = createTestAssertTransaction();
+    const assertTxHex = await createTestAssertTransaction({
+      claimerBtcPubkey: TEST_KEYS.VAULT_KEEPER_1,
+    });
     const bip86Script = Buffer.from(
       deriveBip86ScriptPubKeyHex(TEST_KEYS.VAULT_KEEPER_1).replace(/^0x/, ""),
       "hex",
@@ -1222,7 +1324,7 @@ describe("buildPayoutPsbt — per-role output validation", () => {
     // Dual-accept widens the accepted set to exactly two operator-controlled
     // destinations. A third script is still a diversion.
     const peginTxHex = createTestPeginTransaction();
-    const assertTxHex = createTestAssertTransaction();
+    const assertTxHex = await createTestAssertTransaction();
     const payoutTxHex = buildPayoutTxWithOutputs(peginTxHex, assertTxHex, [
       { script: createDummyP2WPKH("f"), value: 144_454 },
       { script: createDummyP2WPKH("c"), value: PAYOUT_ANCHOR_DUST_SATS },
@@ -1250,7 +1352,7 @@ describe("buildPayoutPsbt — per-role output validation", () => {
     // Must never silently fall back to BIP-86 — a gap means the resolution was
     // incomplete, not that this keeper is on the default.
     const peginTxHex = createTestPeginTransaction();
-    const assertTxHex = createTestAssertTransaction();
+    const assertTxHex = await createTestAssertTransaction();
     const payoutTxHex = buildPayoutTxWithOutputs(peginTxHex, assertTxHex, [
       { script: createDummyP2WPKH("d"), value: 144_454 },
       { script: createDummyP2WPKH("c"), value: PAYOUT_ANCHOR_DUST_SATS },
@@ -1273,7 +1375,7 @@ describe("buildPayoutPsbt — per-role output validation", () => {
     // The registry stores whatever the operator wrote. Pinning outs[0] to an
     // OP_RETURN would have the depositor pre-sign an unclaimable payout.
     const peginTxHex = createTestPeginTransaction();
-    const assertTxHex = createTestAssertTransaction();
+    const assertTxHex = await createTestAssertTransaction();
     const opReturn = Buffer.from("6a0401020304", "hex");
     const payoutTxHex = buildPayoutTxWithOutputs(peginTxHex, assertTxHex, [
       { script: opReturn, value: 144_454 },
@@ -1297,7 +1399,7 @@ describe("buildPayoutPsbt — per-role output validation", () => {
 
   it("vp-claimer: pins outs[1] to the registered commission script", async () => {
     const peginTxHex = createTestPeginTransaction();
-    const assertTxHex = createTestAssertTransaction();
+    const assertTxHex = await createTestAssertTransaction();
     const commissionScript = createDummyP2WPKH("e");
     const payoutTxHex = buildPayoutTxWithOutputs(peginTxHex, assertTxHex, [
       { script: createDummyP2WPKH("a"), value: 144_454 },
@@ -1320,7 +1422,7 @@ describe("buildPayoutPsbt — per-role output validation", () => {
 
   it("vp-claimer: rejects a substituted commission destination", async () => {
     const peginTxHex = createTestPeginTransaction();
-    const assertTxHex = createTestAssertTransaction();
+    const assertTxHex = await createTestAssertTransaction();
     const payoutTxHex = buildPayoutTxWithOutputs(peginTxHex, assertTxHex, [
       { script: createDummyP2WPKH("a"), value: 144_454 },
       { script: createDummyP2WPKH("f"), value: 100 },
@@ -1347,7 +1449,7 @@ describe("buildPayoutPsbt — per-role output validation", () => {
     // commission destination locally. Graphs are never rebuilt, so rejecting
     // this would strand the vault permanently.
     const peginTxHex = createTestPeginTransaction();
-    const assertTxHex = createTestAssertTransaction();
+    const assertTxHex = await createTestAssertTransaction();
     const bip86VpScript = Buffer.from(
       deriveBip86ScriptPubKeyHex(TEST_KEYS.VAULT_PROVIDER).replace(/^0x/, ""),
       "hex",
@@ -1374,7 +1476,7 @@ describe("buildPayoutPsbt — per-role output validation", () => {
   it("vp-claimer: still enforces the commission value cap when the script matches", async () => {
     // The script pin is added precision, not a replacement for the value cap.
     const peginTxHex = createTestPeginTransaction();
-    const assertTxHex = createTestAssertTransaction();
+    const assertTxHex = await createTestAssertTransaction();
     const commissionScript = createDummyP2WPKH("e");
     const payoutTxHex = buildPayoutTxWithOutputs(peginTxHex, assertTxHex, [
       { script: createDummyP2WPKH("a"), value: 144_454 },
@@ -1397,7 +1499,7 @@ describe("buildPayoutPsbt — per-role output validation", () => {
 
   it("unknown claimer: rejects pubkey not matching VP, depositor, or any registered VK", async () => {
     const peginTxHex = createTestPeginTransaction();
-    const assertTxHex = createTestAssertTransaction();
+    const assertTxHex = await createTestAssertTransaction();
     const payoutTxHex = createTestPayoutTransaction(peginTxHex, assertTxHex);
     const strangerPubkey = "1".repeat(64);
     await expect(
@@ -1472,7 +1574,7 @@ describe("buildPayoutPsbt — fee-band and domain wiring", () => {
     // output so the fee is 50_000 → trip the bound. Keep the canonical
     // VP-claimer 3-output shape so role validation passes before the fee check.
     const peginTxHex = createTestPeginTransaction();
-    const assertTxHex = createTestAssertTransaction();
+    const assertTxHex = await createTestAssertTransaction();
     const payoutTxHex = makePayoutWithFee(peginTxHex, assertTxHex, 50_000);
 
     await expect(
@@ -1491,7 +1593,10 @@ describe("buildPayoutPsbt — fee-band and domain wiring", () => {
       tx.addOutput(createDummyP2TR(), 500_000);
       return tx.toHex();
     })();
-    const assertTxHex = createTestAssertTransaction();
+    const assertTxHex = await createTestAssertTransaction({
+      vaultKeeperBtcPubkeys: generateXOnlyKeys(32, 1_000),
+      universalChallengerBtcPubkeys: generateXOnlyKeys(32, 2_000),
+    });
     const inputTotal = 500_000 + Number(TEST_CLAIM_VALUE);
     const payoutTxHex = makePayoutWithFee(
       smallVaultPegin,
@@ -1518,7 +1623,7 @@ describe("buildPayoutPsbt — fee-band and domain wiring", () => {
     // Floor = the smallest fee any known VP output-sizing model produces,
     // recomputed here through the same WASM export production consults.
     const peginTxHex = createTestPeginTransaction();
-    const assertTxHex = createTestAssertTransaction();
+    const assertTxHex = await createTestAssertTransaction();
     // Fixture scripts are P2WPKH: out0 = 22 bytes (registered), out1 = 22.
     const floor = await computePayoutFeeFloor(
       1,
@@ -1556,7 +1661,10 @@ describe("buildPayoutPsbt — fee-band and domain wiring", () => {
     const keepers = generateXOnlyKeys(2, 5_000);
     const challenger = [TEST_KEYS.UNIVERSAL_CHALLENGER_1];
     const peginTxHex = createTestPeginTransaction();
-    const assertTxHex = createTestAssertTransaction();
+    const assertTxHex = await createTestAssertTransaction({
+      vaultKeeperBtcPubkeys: keepers,
+      universalChallengerBtcPubkeys: challenger,
+    });
     const floor = await computePayoutFeeFloor(
       1,
       2,
@@ -1605,7 +1713,7 @@ describe("buildPayoutPsbt — fee-band and domain wiring", () => {
     // ceiling (6_100) would reject a legitimate fee; the extended ceiling admits it.
     const bigScript = Buffer.alloc(128, 0x51);
     const peginTxHex = createTestPeginTransaction();
-    const assertTxHex = createTestAssertTransaction();
+    const assertTxHex = await createTestAssertTransaction();
     const inputTotal = Number(TEST_PEGIN_VALUE) + Number(TEST_CLAIM_VALUE);
     const makeBigScriptPayout = (feeSats: number) =>
       makeDeflatedPayoutTxHex(peginTxHex, assertTxHex, [
@@ -1638,7 +1746,7 @@ describe("buildPayoutPsbt — fee-band and domain wiring", () => {
     // separate per-version connector code (vault-wasm tx_graph.rs v1 vs v2),
     // so a version that never varies in tests would let a hardcoded 1 pass.
     const peginTxHex = createTestPeginTransaction();
-    const assertTxHex = createTestAssertTransaction();
+    const assertTxHex = await createTestAssertTransaction();
     const payoutTxHex = makePayoutWithFee(peginTxHex, assertTxHex, 5_000);
 
     const v1 = await buildPayoutPsbt(
@@ -1666,7 +1774,7 @@ describe("buildPayoutPsbt — fee-band and domain wiring", () => {
     // sequence = the PegIn CSV and input 1 sequence = the Assert CSV
     // (transactions/payout.rs). The depositor's sighash commits to all four.
     const peginTxHex = createTestPeginTransaction();
-    const assertTxHex = createTestAssertTransaction();
+    const assertTxHex = await createTestAssertTransaction();
     const peginTx = Transaction.fromHex(peginTxHex);
     const assertTx = Transaction.fromHex(assertTxHex);
 
@@ -1712,7 +1820,7 @@ describe("buildPayoutPsbt — fee-band and domain wiring", () => {
 
   it("rejects participant counts outside each role's supported range", async () => {
     const peginTxHex = createTestPeginTransaction();
-    const assertTxHex = createTestAssertTransaction();
+    const assertTxHex = await createTestAssertTransaction();
     const payoutTxHex = makePayoutWithFee(peginTxHex, assertTxHex, 5_000);
     const params = baseParams({ payoutTxHex, assertTxHex, peginTxHex });
 
@@ -1738,20 +1846,20 @@ describe("buildPayoutPsbt — fee-band and domain wiring", () => {
     ).rejects.toThrow(/supported range/);
   });
 
-  it("rejects a councilSize outside the accepted domain", async () => {
+  it("rejects an empty council (size outside the accepted domain)", async () => {
     const peginTxHex = createTestPeginTransaction();
-    const assertTxHex = createTestAssertTransaction();
+    const assertTxHex = await createTestAssertTransaction();
     const payoutTxHex = makePayoutWithFee(peginTxHex, assertTxHex, 5_000);
     const params = baseParams({ payoutTxHex, assertTxHex, peginTxHex });
 
     await expect(
-      buildPayoutPsbt({ ...params, councilSize: 0 }),
+      buildPayoutPsbt({ ...params, councilMembers: [] }),
     ).rejects.toThrow(/councilSize must be an integer/);
   });
 
   it("rejects a non-positive or above-u32 protocolFeeRate before any validation", async () => {
     const peginTxHex = createTestPeginTransaction();
-    const assertTxHex = createTestAssertTransaction();
+    const assertTxHex = await createTestAssertTransaction();
     const payoutTxHex = makePayoutWithFee(peginTxHex, assertTxHex, 5_000);
     const params = baseParams({ payoutTxHex, assertTxHex, peginTxHex });
 
@@ -1768,7 +1876,7 @@ describe("buildPayoutPsbt — fee-band and domain wiring", () => {
     // Outputs (200_000) > inputs (150_000) — invalid Bitcoin transaction,
     // caught before any signing.
     const peginTxHex = createTestPeginTransaction();
-    const assertTxHex = createTestAssertTransaction();
+    const assertTxHex = await createTestAssertTransaction();
     const payoutTxHex = makeDeflatedPayoutTxHex(peginTxHex, assertTxHex, [
       { script: createDummyP2WPKH("a"), value: 198_454 },
       { script: createDummyP2WPKH("e"), value: 1_000 },
@@ -1792,7 +1900,8 @@ describe("buildPayoutPsbt — fee-band and domain wiring", () => {
         registeredPayoutScriptPubKey: REGISTERED_PAYOUT_SCRIPT_HEX,
         commissionBps: TEST_COMMISSION_BPS,
         protocolFeeRate: TEST_PROTOCOL_FEE_RATE,
-        councilSize: TEST_COUNCIL_SIZE,
+        councilMembers: TEST_COUNCIL_MEMBERS,
+        councilQuorum: TEST_COUNCIL_QUORUM,
         vkClaimerPayoutScriptPubKeys: DEFAULT_VK_PAYOUT_SCRIPTS,
         vpCommissionScriptPubKey: CANONICAL_VP_COMMISSION_SCRIPT_HEX,
       }),

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/__tests__/verifyKeyPathSchnorrSignature.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/__tests__/verifyKeyPathSchnorrSignature.test.ts
@@ -282,6 +282,29 @@ describe("assertReturnedKeyPathSignatures", () => {
     ).toThrow(/truncated/);
   });
 
+  it("rejects a non-minimal CompactSize length, as rust-bitcoin does", () => {
+    // vaultd decodes with rust-bitcoin, whose VarInt::consensus_decode returns
+    // NonMinimalVarInt for 0xfd carrying < 0xfd — accepting it here would wave
+    // through a witness the network rejects.
+    const req = requestedPsbt();
+    const nonMinimal = Psbt.fromHex(req.toHex());
+    nonMinimal.updateInput(0, {
+      // item count 1, then 0xfd-encoded length 0x0040 instead of the 1-byte 0x40.
+      finalScriptWitness: Buffer.concat([
+        Buffer.from([0x01, 0xfd, 0x40, 0x00]),
+        sign(req, 0),
+      ]),
+    });
+    nonMinimal.updateInput(1, { tapKeySig: sign(req, 1) });
+
+    expect(() =>
+      assertReturnedKeyPathSignatures({
+        requestedPsbtHex: req.toHex(),
+        returnedPsbtHex: nonMinimal.toHex(),
+      }),
+    ).toThrow(/non-minimal/);
+  });
+
   it("skips inputs that are not key-path eligible (script-path inputs are the script-path verifier's job)", () => {
     const req = new Psbt();
     req.addInput({

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/__tests__/verifyKeyPathSchnorrSignature.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/__tests__/verifyKeyPathSchnorrSignature.test.ts
@@ -1,0 +1,308 @@
+/**
+ * Tests for the key-path twin of the script-path verifier: BIP-340 verification
+ * of wallet-returned Taproot KEY-PATH signatures against an independently
+ * recomputed sighash over the PSBT we requested.
+ *
+ * The positive cases sign the real BIP-341 key-path sighash with a BIP-86
+ * tweaked test key. The negative cases model what the guard exists for: a
+ * tampered signature, a missing signature, a substituted input set, and a
+ * malformed finalized witness.
+ */
+
+import { Buffer } from "buffer";
+
+import * as ecc from "@bitcoin-js/tiny-secp256k1-asmjs";
+import {
+  crypto as bcrypto,
+  initEccLib,
+  payments,
+  Psbt,
+  Transaction,
+} from "bitcoinjs-lib";
+import { describe, expect, it } from "vitest";
+
+import {
+  assertKeyPathSchnorrSignature,
+  assertReturnedKeyPathSignatures,
+} from "../verifyKeyPathSchnorrSignature";
+
+initEccLib(ecc);
+
+// Deterministic test key; BIP-86 tweak the private key so we can sign key-path.
+const PRIV = Buffer.alloc(32, 7);
+const PUB = Buffer.from(ecc.pointFromScalar(PRIV, true)!); // 33 bytes
+const X_ONLY = PUB.subarray(1);
+function tweakedPrivateKey(): Buffer {
+  const priv = PUB[0] === 0x03 ? Buffer.from(ecc.privateNegate(PRIV)) : PRIV; // even-Y for BIP-340
+  const tweak = bcrypto.taggedHash("TapTweak", X_ONLY);
+  return Buffer.from(ecc.privateAdd(priv, tweak)!);
+}
+const P2TR = payments.p2tr({ internalPubkey: X_ONLY }).output!;
+const OUTPUT_KEY = P2TR.subarray(2);
+
+function requestedPsbt(): Psbt {
+  const psbt = new Psbt();
+  psbt.addInput({
+    hash: Buffer.alloc(32, 1),
+    index: 0,
+    witnessUtxo: { script: P2TR, value: 100_000 },
+    tapInternalKey: X_ONLY,
+  });
+  psbt.addInput({
+    hash: Buffer.alloc(32, 2),
+    index: 1,
+    witnessUtxo: { script: P2TR, value: 50_000 },
+    tapInternalKey: X_ONLY,
+  });
+  psbt.addOutput({
+    script: Buffer.concat([Buffer.from([0x51, 0x20]), Buffer.alloc(32, 0xaa)]),
+    value: 140_000,
+  });
+  return psbt;
+}
+function keyPathSighash(
+  psbt: Psbt,
+  inputIndex: number,
+  hashType: number,
+): Buffer {
+  const tx = Transaction.fromBuffer(psbt.data.globalMap.unsignedTx.toBuffer());
+  const scripts = psbt.data.inputs.map((i) => i.witnessUtxo!.script);
+  const values = psbt.data.inputs.map((i) => i.witnessUtxo!.value);
+  return tx.hashForWitnessV1(inputIndex, scripts, values, hashType);
+}
+function sign(
+  psbt: Psbt,
+  inputIndex: number,
+  hashType = Transaction.SIGHASH_DEFAULT,
+): Buffer {
+  return Buffer.from(
+    ecc.signSchnorr(
+      keyPathSighash(psbt, inputIndex, hashType),
+      tweakedPrivateKey(),
+      Buffer.alloc(32, 0),
+    ),
+  );
+}
+
+describe("assertKeyPathSchnorrSignature", () => {
+  it("accepts a valid key-path signature over the requested PSBT", () => {
+    const psbt = requestedPsbt();
+    expect(() =>
+      assertKeyPathSchnorrSignature({
+        requestedPsbtHex: psbt.toHex(),
+        signatureHex: sign(psbt, 1).toString("hex"),
+        inputIndex: 1,
+      }),
+    ).not.toThrow();
+    // Sanity: the signature really is against the tweaked output key.
+    expect(
+      ecc.verifySchnorr(keyPathSighash(psbt, 1, 0), OUTPUT_KEY, sign(psbt, 1)),
+    ).toBe(true);
+  });
+
+  it("rejects a tampered signature", () => {
+    const psbt = requestedPsbt();
+    const sig = sign(psbt, 0);
+    sig[5] ^= 0x01;
+    expect(() =>
+      assertKeyPathSchnorrSignature({
+        requestedPsbtHex: psbt.toHex(),
+        signatureHex: sig.toString("hex"),
+        inputIndex: 0,
+      }),
+    ).toThrow(/does not verify/);
+  });
+
+  it("rejects inputs that are not key-path (tapLeafScript / tapMerkleRoot / missing tapInternalKey / non-P2TR)", () => {
+    const p = requestedPsbt();
+    p.updateInput(0, { tapMerkleRoot: Buffer.alloc(32, 3) });
+    expect(() =>
+      assertKeyPathSchnorrSignature({
+        requestedPsbtHex: p.toHex(),
+        signatureHex: "00".repeat(64),
+        inputIndex: 0,
+      }),
+    ).toThrow(/key-path/);
+    const q = new Psbt();
+    q.addInput({
+      hash: Buffer.alloc(32, 1),
+      index: 0,
+      witnessUtxo: {
+        script: Buffer.from("0014" + "11".repeat(20), "hex"),
+        value: 1,
+      },
+    });
+    q.addOutput({ script: Buffer.from([0x6a]), value: 0 });
+    expect(() =>
+      assertKeyPathSchnorrSignature({
+        requestedPsbtHex: q.toHex(),
+        signatureHex: "00".repeat(64),
+        inputIndex: 0,
+      }),
+    ).toThrow(/key-path/);
+  });
+});
+
+describe("assertReturnedKeyPathSignatures", () => {
+  it("verifies tapKeySig on every eligible input (unfinalized return)", () => {
+    const req = requestedPsbt();
+    const ret = Psbt.fromHex(req.toHex());
+    ret.updateInput(0, { tapKeySig: sign(req, 0) });
+    ret.updateInput(1, { tapKeySig: sign(req, 1) });
+    expect(() =>
+      assertReturnedKeyPathSignatures({
+        requestedPsbtHex: req.toHex(),
+        returnedPsbtHex: ret.toHex(),
+      }),
+    ).not.toThrow();
+  });
+
+  it("verifies the single finalized witness item when the wallet auto-finalized", () => {
+    const req = requestedPsbt();
+    const ret = Psbt.fromHex(req.toHex());
+    ret.updateInput(0, { tapKeySig: sign(req, 0) });
+    ret.updateInput(1, { tapKeySig: sign(req, 1) });
+    ret.finalizeAllInputs(); // drops tapKeySig, keeps finalScriptWitness = 01 40 ‖ sig
+    expect(() =>
+      assertReturnedKeyPathSignatures({
+        requestedPsbtHex: req.toHex(),
+        returnedPsbtHex: ret.toHex(),
+      }),
+    ).not.toThrow();
+  });
+
+  it("accepts an input carrying both a tapKeySig and a matching finalized witness", () => {
+    const req = requestedPsbt();
+    const ret = Psbt.fromHex(req.toHex());
+    const sig0 = sign(req, 0);
+    ret.updateInput(0, {
+      tapKeySig: sig0,
+      finalScriptWitness: Buffer.concat([Buffer.from([0x01, 0x40]), sig0]),
+    });
+    ret.updateInput(1, { tapKeySig: sign(req, 1) });
+    expect(() =>
+      assertReturnedKeyPathSignatures({
+        requestedPsbtHex: req.toHex(),
+        returnedPsbtHex: ret.toHex(),
+      }),
+    ).not.toThrow();
+  });
+
+  it("throws when the finalized witness disagrees with the tapKeySig on the same input", () => {
+    // The consumers broadcast the witness bytes, so a valid tapKeySig must not
+    // launder a different witness signature past the check.
+    const req = requestedPsbt();
+    const ret = Psbt.fromHex(req.toHex());
+    const other = sign(req, 1); // valid signature, wrong input
+    ret.updateInput(0, {
+      tapKeySig: sign(req, 0),
+      finalScriptWitness: Buffer.concat([Buffer.from([0x01, 0x40]), other]),
+    });
+    ret.updateInput(1, { tapKeySig: other });
+    expect(() =>
+      assertReturnedKeyPathSignatures({
+        requestedPsbtHex: req.toHex(),
+        returnedPsbtHex: ret.toHex(),
+      }),
+    ).toThrow(/input 0 finalized witness does not match its tapKeySig/);
+  });
+
+  it("accepts a 65-byte SIGHASH_ALL tapKeySig and verifies it under SIGHASH_ALL", () => {
+    const req = requestedPsbt();
+    const ret = Psbt.fromHex(req.toHex());
+    ret.updateInput(0, {
+      tapKeySig: Buffer.concat([
+        sign(req, 0, Transaction.SIGHASH_ALL),
+        Buffer.from([0x01]),
+      ]),
+    });
+    ret.updateInput(1, { tapKeySig: sign(req, 1) });
+    expect(() =>
+      assertReturnedKeyPathSignatures({
+        requestedPsbtHex: req.toHex(),
+        returnedPsbtHex: ret.toHex(),
+      }),
+    ).not.toThrow();
+  });
+
+  it("throws when an eligible input has no signature, or the returned PSBT has a different input count", () => {
+    const req = requestedPsbt();
+    const ret = Psbt.fromHex(req.toHex());
+    ret.updateInput(0, { tapKeySig: sign(req, 0) });
+    expect(() =>
+      assertReturnedKeyPathSignatures({
+        requestedPsbtHex: req.toHex(),
+        returnedPsbtHex: ret.toHex(),
+      }),
+    ).toThrow(/input 1 .*no key-path signature/);
+    const fewer = new Psbt();
+    fewer.addInput({
+      hash: Buffer.alloc(32, 1),
+      index: 0,
+      witnessUtxo: { script: P2TR, value: 1 },
+      tapInternalKey: X_ONLY,
+    });
+    fewer.addOutput({ script: Buffer.from([0x6a]), value: 0 });
+    expect(() =>
+      assertReturnedKeyPathSignatures({
+        requestedPsbtHex: req.toHex(),
+        returnedPsbtHex: fewer.toHex(),
+      }),
+    ).toThrow(/input count/);
+  });
+
+  it("rejects a finalized witness with trailing bytes or a truncated multi-byte length", () => {
+    const req = requestedPsbt();
+    const sig = sign(req, 0);
+    const withTrailing = Psbt.fromHex(req.toHex());
+    withTrailing.updateInput(0, {
+      finalScriptWitness: Buffer.concat([
+        Buffer.from([0x01, 0x40]),
+        sig,
+        Buffer.from([0xff]),
+      ]),
+    });
+    withTrailing.updateInput(1, { tapKeySig: sign(req, 1) });
+    expect(() =>
+      assertReturnedKeyPathSignatures({
+        requestedPsbtHex: req.toHex(),
+        returnedPsbtHex: withTrailing.toHex(),
+      }),
+    ).toThrow(/trailing bytes/);
+    const truncated = Psbt.fromHex(req.toHex());
+    truncated.updateInput(0, {
+      finalScriptWitness: Buffer.from([0x01, 0xfd, 0x40]),
+    });
+    truncated.updateInput(1, { tapKeySig: sign(req, 1) });
+    expect(() =>
+      assertReturnedKeyPathSignatures({
+        requestedPsbtHex: req.toHex(),
+        returnedPsbtHex: truncated.toHex(),
+      }),
+    ).toThrow(/truncated/);
+  });
+
+  it("skips inputs that are not key-path eligible (script-path inputs are the script-path verifier's job)", () => {
+    const req = new Psbt();
+    req.addInput({
+      hash: Buffer.alloc(32, 1),
+      index: 0,
+      witnessUtxo: { script: P2TR, value: 1 },
+      tapInternalKey: X_ONLY,
+      tapLeafScript: [
+        {
+          leafVersion: 0xc0,
+          script: Buffer.from([0x51]),
+          controlBlock: Buffer.concat([Buffer.from([0xc0]), X_ONLY]),
+        },
+      ],
+    });
+    req.addOutput({ script: Buffer.from([0x6a]), value: 0 });
+    expect(() =>
+      assertReturnedKeyPathSignatures({
+        requestedPsbtHex: req.toHex(),
+        returnedPsbtHex: req.toHex(),
+      }),
+    ).not.toThrow();
+  });
+});

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts
@@ -11,11 +11,13 @@
  */
 
 import {
-  type Network,
+  getAssertPayoutScriptInfo,
   tapInternalPubkey,
+  type Network,
 } from "@babylonlabs-io/babylon-tbv-rust-wasm";
 import { Psbt, Transaction, type TxInput, type TxOutput } from "bitcoinjs-lib";
 import { Buffer } from "buffer";
+import { deriveLocalChallengers } from "../challengers";
 import { createPayoutScript } from "../scripts/payout";
 import {
   TAPSCRIPT_LEAF_VERSION,
@@ -25,6 +27,7 @@ import {
   stripHexPrefix,
   uint8ArrayToHex,
 } from "../utils/bitcoin";
+import { computeTaprootScriptPubKey } from "../utils/taproot";
 import {
   assertPayoutFeeBandDomain,
   assertPayoutFeeInBand,
@@ -152,13 +155,21 @@ export interface PayoutParams {
   protocolFeeRate: bigint;
 
   /**
-   * Security council member count from the locked offchain params version.
-   * Mirrors the upstream estimator's signature; at the current model pins the
-   * council occupies a single taptree leaf regardless of size, so the floor
-   * is council-size-invariant — passed for forward compatibility with future
-   * pinned models.
+   * Security council member x-only public keys (hex) from the locked offchain
+   * params version — `getOffchainParamsByVersion(...).securityCouncilKeys`.
+   * The council occupies the last leaf of the Assert:0 taptree
+   * (btc-vault `crates/vault/src/connectors/assert_payout_nopayout_council.rs`),
+   * so the keys are needed to rebuild input 1's payout leaf, and the count
+   * feeds the fee-band domain.
    */
-  councilSize: number;
+  councilMembers: string[];
+
+  /**
+   * M-of-N council quorum from the locked offchain params version —
+   * `getOffchainParamsByVersion(...).councilQuorum`. Shapes the council leaf's
+   * multisig script, and with it the Assert:0 taptree root.
+   */
+  councilQuorum: number;
 
   /**
    * RFC-006. Expected `outs[0].script` per vault-keeper claimer, keyed by
@@ -209,6 +220,9 @@ export interface PayoutPsbtResult {
  * - Input 0: from PeginTx output0 (signed by depositor)
  * - Input 1: from Assert output0 (NOT signed by depositor)
  *
+ * Both inputs carry their taproot script-path leaf. Input 1's is not signed
+ * here — it is what a hardware signer reads to display the payout terms.
+ *
  * @param params - Payout parameters
  * @returns Unsigned PSBT ready for depositor to sign
  *
@@ -220,7 +234,7 @@ export interface PayoutPsbtResult {
  * @throws If the implicit fee (inputs − outputs) is outside the fee band —
  *   below the floor or above the fee-band ceiling (see
  *   {@link assertPayoutFeeInBand})
- * @throws If `protocolFeeRate`, a participant count, or `councilSize` is
+ * @throws If `protocolFeeRate`, a participant count, or the council size is
  *   outside the accepted input domain (see {@link assertPayoutFeeBandDomain})
  * @throws If a non-anchor scriptPubKey length is outside `[1,
  *   {@link MAX_PAYOUT_SCRIPT_LEN}]`
@@ -228,6 +242,8 @@ export interface PayoutPsbtResult {
  * @throws If payout output count, outs[0] script, outs[last] anchor value, or
  *   (VP-claimer) outs[1] commission cap do not match the protocol layout
  * @throws If `commissionBps` is not a non-negative integer below 10_000
+ * @throws If the locally rebuilt Assert:0 payout leaf does not bind to the
+ *   Assert output input 1 spends
  */
 export async function buildPayoutPsbt(
   params: PayoutParams,
@@ -236,7 +252,7 @@ export async function buildPayoutPsbt(
     vaultCoreVersion: params.vaultCoreVersion,
     numVaultKeepers: params.vaultKeeperBtcPubkeys.length,
     numUniversalChallengers: params.universalChallengerBtcPubkeys.length,
-    councilSize: params.councilSize,
+    councilSize: params.councilMembers.length,
     protocolFeeRate: params.protocolFeeRate,
   };
   assertPayoutFeeBandDomain(feeBandParams);
@@ -297,7 +313,7 @@ export async function buildPayoutPsbt(
   // Assert:0's value is deliberately NOT validated: the taproot sighash
   // commits to input 1's amount and outpoint, so a misstated value yields a
   // signature invalid against the real Assert tx — nothing to protect. (The
-  // device's ==546 pin here is the known-buggy firmware behavior, Q15.)
+  // device pins the band [546, 546 + base_fee_rate*500] here, Q15.)
 
   // Per-role output validation — blocks an extra attacker output or value
   // routed into a non-payout slot. Returns the layout-trusted script lengths
@@ -324,7 +340,7 @@ export async function buildPayoutPsbt(
     out1Len,
   });
 
-  // Only assembly needs the WASM-derived script — derive it after the
+  // Only assembly needs the WASM-derived scripts — derive them after the
   // transaction has passed every validation gate.
   const payoutConnector = await createPayoutScript({
     vaultCoreVersion: params.vaultCoreVersion,
@@ -336,14 +352,78 @@ export async function buildPayoutPsbt(
     network: params.network,
   });
 
+  const assertPayoutLeaf = await resolveAssertPayoutLeaf(params, assertPrevOut);
+
   return {
     psbtHex: assemblePayoutPsbt(
       payoutTx,
       peginPrevOut,
       assertPrevOut,
       payoutConnector,
+      assertPayoutLeaf,
     ),
   };
+}
+
+/** The Assert:0 payout tapscript leaf, as attached to payout input 1. */
+interface AssertPayoutLeaf {
+  script: Uint8Array;
+  controlBlock: Uint8Array;
+}
+
+/**
+ * Rebuild the Assert:0 payout leaf from the vault's on-chain participant set
+ * and assert it spends `assertPrevOut`.
+ *
+ * The depositor does not sign input 1, but the Ledger vault app reads this leaf
+ * off the PSBT to display the payout terms
+ * (`sign_psbt_validate.c::vault_read_payout_leaf_script`), so a leaf that
+ * belonged to a different taptree would show the depositor terms the
+ * transaction cannot actually enforce. Critical Path #3: derive, then bind to
+ * the real previous output — never forward VP-supplied bytes.
+ *
+ * @internal Helper invoked by {@link buildPayoutPsbt}.
+ */
+async function resolveAssertPayoutLeaf(
+  params: PayoutParams,
+  assertPrevOut: TxOutput,
+): Promise<AssertPayoutLeaf> {
+  const { payoutScript, payoutControlBlock } = await getAssertPayoutScriptInfo({
+    txGraphVersion: params.vaultCoreVersion,
+    claimer: stripHexPrefix(params.claimerBtcPubkey).toLowerCase(),
+    localChallengers: deriveLocalChallengers({
+      claimerBtcPubkey: params.claimerBtcPubkey,
+      depositorBtcPubkey: params.depositorBtcPubkey,
+      vaultProviderBtcPubkey: params.vaultProviderBtcPubkey,
+      vaultKeeperBtcPubkeys: params.vaultKeeperBtcPubkeys,
+    }),
+    universalChallengers: params.universalChallengerBtcPubkeys.map((k) =>
+      stripHexPrefix(k).toLowerCase(),
+    ),
+    timelockAssert: params.timelockAssert,
+    councilMembers: params.councilMembers.map((k) =>
+      stripHexPrefix(k).toLowerCase(),
+    ),
+    councilQuorum: params.councilQuorum,
+  });
+
+  const script = hexToUint8Array(payoutScript);
+  const controlBlock = hexToUint8Array(payoutControlBlock);
+  const boundScriptPubKey = computeTaprootScriptPubKey({
+    leafVersion: TAPSCRIPT_LEAF_VERSION,
+    script,
+    controlBlock,
+  });
+  if (!assertPrevOut.script.equals(boundScriptPubKey)) {
+    throw new Error(
+      `Rebuilt Assert:0 payout leaf does not spend the Assert output being ` +
+        `referenced: leaf binds to ${boundScriptPubKey.toString("hex")}, ` +
+        `Assert:${ASSERT_PAYOUT_OUTPUT_INDEX} pays ` +
+        `${assertPrevOut.script.toString("hex")}; refusing to sign payout.`,
+    );
+  }
+
+  return { script, controlBlock };
 }
 
 /**
@@ -395,6 +475,7 @@ function assemblePayoutPsbt(
   peginPrevOut: TxOutput,
   assertPrevOut: TxOutput,
   payoutConnector: { payoutScript: string; payoutControlBlock: string },
+  assertPayoutLeaf: AssertPayoutLeaf,
 ): string {
   const psbt = new Psbt();
   psbt.setVersion(payoutTx.version);
@@ -424,8 +505,8 @@ function assemblePayoutPsbt(
     // sighashType omitted - defaults to SIGHASH_DEFAULT (0x00) for Taproot
   });
 
-  // Input 1: from Assert — witnessUtxo only (in sighash, not signed by the
-  // depositor), so no tapLeafScript.
+  // Input 1: from Assert — not signed by the depositor, but the Ledger vault
+  // app reads the payout leaf here to display the terms, so it must be present.
   psbt.addInput({
     hash: input1.hash,
     index: input1.index,
@@ -434,6 +515,14 @@ function assemblePayoutPsbt(
       script: assertPrevOut.script,
       value: assertPrevOut.value,
     },
+    tapLeafScript: [
+      {
+        leafVersion: TAPSCRIPT_LEAF_VERSION,
+        script: Buffer.from(assertPayoutLeaf.script),
+        controlBlock: Buffer.from(assertPayoutLeaf.controlBlock),
+      },
+    ],
+    tapInternalKey: Buffer.from(tapInternalPubkey),
   });
 
   for (const output of payoutTx.outs) {

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/verifyKeyPathSchnorrSignature.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/verifyKeyPathSchnorrSignature.ts
@@ -1,0 +1,313 @@
+/**
+ * Far-side verification of Taproot KEY-PATH Schnorr signatures a wallet
+ * returned, over the PSBT we requested (trusted prevouts) — the key-path twin
+ * of `assertScriptPathSchnorrSignature`. Reference: btc-vault
+ * `crates/btc-wallet-remote/src/client.rs check_signatures_valid` (output key taken
+ * from the prevout scriptPubKey, all prevouts committed). The wallet's
+ * success/finalization is never trusted on its own (CLAUDE.md §8).
+ *
+ * Why verify against the *requested* PSBT: `assertPsbtUnsignedTxMatches` pins
+ * the unsigned transaction but deliberately skips per-input metadata, so a
+ * wallet could rewrite `witnessUtxo` in its response and make a wrong-message
+ * signature self-validate. Prevout scripts and values therefore come from the
+ * PSBT we built; only the signature bytes come from the wallet.
+ *
+ * @module tbv/core/primitives/psbt/verifyKeyPathSchnorrSignature
+ */
+
+import * as ecc from "@bitcoin-js/tiny-secp256k1-asmjs";
+import { Psbt, Transaction } from "bitcoinjs-lib";
+
+import { Buffer } from "buffer";
+
+import { hexToUint8Array, stripHexPrefix } from "../utils/bitcoin";
+
+const SCHNORR_SIG_BYTES = 64;
+const SIGHASH_DEFAULT = Transaction.SIGHASH_DEFAULT; // 0x00
+const SIGHASH_ALL = Transaction.SIGHASH_ALL; // 0x01
+
+// P2TR scriptPubKey is exactly `OP_1 OP_PUSHBYTES_32 <32-byte output key>`.
+const P2TR_SCRIPT_LEN = 34;
+const OP_1 = 0x51;
+const OP_PUSHBYTES_32 = 0x20;
+const P2TR_OUTPUT_KEY_OFFSET = 2;
+
+// Bitcoin CompactSize (varint) prefix markers — values fixed by the protocol.
+// https://developer.bitcoin.org/reference/transactions.html#compactsize-unsigned-integers
+const COMPACT_SIZE_UINT16_PREFIX = 0xfd; // 0xfd + uint16 LE
+const COMPACT_SIZE_UINT32_PREFIX = 0xfe; // 0xfe + uint32 LE
+const COMPACT_SIZE_UINT16_BYTES = 3; // marker + 2
+const COMPACT_SIZE_UINT32_BYTES = 5; // marker + 4
+
+function isP2trScript(script: Uint8Array | undefined): script is Uint8Array {
+  return (
+    script !== undefined &&
+    script.length === P2TR_SCRIPT_LEN &&
+    script[0] === OP_1 &&
+    script[1] === OP_PUSHBYTES_32
+  );
+}
+
+/** BIP-341: 64 bytes ⇒ SIGHASH_DEFAULT; 65 bytes ⇒ the trailing byte is the hash type (we accept ALL only). */
+function splitHashType(
+  sig: Uint8Array,
+  inputIndex: number,
+): { signature: Uint8Array; hashType: number } {
+  if (sig.length === SCHNORR_SIG_BYTES) {
+    return { signature: sig, hashType: SIGHASH_DEFAULT };
+  }
+  if (
+    sig.length === SCHNORR_SIG_BYTES + 1 &&
+    sig[SCHNORR_SIG_BYTES] === SIGHASH_ALL
+  ) {
+    return {
+      signature: sig.subarray(0, SCHNORR_SIG_BYTES),
+      hashType: SIGHASH_ALL,
+    };
+  }
+  throw new Error(
+    `Key-path signature for input ${inputIndex} must be 64 bytes (SIGHASH_DEFAULT) or ` +
+      `65 bytes ending in 0x01 (SIGHASH_ALL), got ${sig.length}.`,
+  );
+}
+
+export interface AssertKeyPathSchnorrSignatureParams {
+  /** Hex of the PSBT we built and sent (trusted prevout scripts/values). NOT the wallet's. */
+  requestedPsbtHex: string;
+  /** 64- or 65-byte signature, hex. */
+  signatureHex: string;
+  /** Index of the input the signature is for. */
+  inputIndex: number;
+}
+
+/**
+ * Assert that `signatureHex` is a valid BIP-340 Schnorr signature over the
+ * Taproot key-path sighash of `requestedPsbtHex` input `inputIndex`, under the
+ * tweaked output key taken from that input's prevout scriptPubKey.
+ *
+ * @throws If the input is not a key-path P2TR spend, the requested PSBT lacks
+ *         the prevout data needed to recompute the sighash, or the signature
+ *         does not verify.
+ */
+export function assertKeyPathSchnorrSignature(
+  params: AssertKeyPathSchnorrSignatureParams,
+): void {
+  const { requestedPsbtHex, signatureHex, inputIndex } = params;
+
+  const psbt = Psbt.fromHex(requestedPsbtHex);
+
+  if (inputIndex < 0 || inputIndex >= psbt.data.inputs.length) {
+    throw new Error(
+      `Input index ${inputIndex} out of range (${psbt.data.inputs.length} inputs).`,
+    );
+  }
+
+  if (!isKeyPathEligible(psbt.data.inputs[inputIndex])) {
+    throw new Error(
+      `Input ${inputIndex} of the requested PSBT is not a key-path P2TR input.`,
+    );
+  }
+
+  // Taproot's sighash commits to every input's prevout (script + value), so all
+  // inputs must carry a witnessUtxo. A missing one is a build error, not a
+  // value we can default — fail loudly.
+  const prevOutScripts: Buffer[] = [];
+  const values: number[] = [];
+  for (let i = 0; i < psbt.data.inputs.length; i++) {
+    const prevout = psbt.data.inputs[i].witnessUtxo;
+    if (!prevout) {
+      throw new Error(
+        `Cannot verify signature: input ${i} of the requested PSBT has no witnessUtxo ` +
+          `(required to recompute the Taproot sighash).`,
+      );
+    }
+    prevOutScripts.push(prevout.script);
+    values.push(prevout.value);
+  }
+
+  const { signature, hashType } = splitHashType(
+    hexToUint8Array(stripHexPrefix(signatureHex)),
+    inputIndex,
+  );
+
+  const tx = Transaction.fromBuffer(psbt.data.globalMap.unsignedTx.toBuffer());
+  const sighash = tx.hashForWitnessV1(
+    inputIndex,
+    prevOutScripts,
+    values,
+    hashType,
+  );
+
+  // Key-path signatures verify against the TWEAKED output key = the prevout's
+  // witness program.
+  const outputKey = prevOutScripts[inputIndex].subarray(P2TR_OUTPUT_KEY_OFFSET);
+
+  if (!ecc.verifySchnorr(sighash, outputKey, signature)) {
+    throw new Error(
+      `Key-path Schnorr signature for input ${inputIndex} does not verify against the ` +
+        `requested PSBT's prevout (output key ${Buffer.from(outputKey).toString("hex")}). ` +
+        `The wallet may have signed a different transaction or key.`,
+    );
+  }
+}
+
+/**
+ * A key-path P2TR input: an internal key, no script-path material, and a
+ * taproot prevout. Script-path inputs are the script-path verifier's job.
+ */
+function isKeyPathEligible(input: {
+  tapInternalKey?: Uint8Array;
+  tapLeafScript?: unknown;
+  tapMerkleRoot?: Uint8Array;
+  witnessUtxo?: { script: Uint8Array };
+}): boolean {
+  return (
+    input.tapInternalKey !== undefined &&
+    input.tapLeafScript === undefined &&
+    input.tapMerkleRoot === undefined &&
+    isP2trScript(input.witnessUtxo?.script)
+  );
+}
+
+/**
+ * Bitcoin CompactSize decode of a witness stack: item count, then (len, bytes)*.
+ * Strict: reads are bounds-checked and every byte must be accounted for.
+ */
+function witnessItems(witness: Uint8Array): Uint8Array[] {
+  let offset = 0;
+
+  const readCompactSize = (): number => {
+    if (offset >= witness.length) {
+      throw new Error("finalScriptWitness is truncated");
+    }
+    const first = witness[offset];
+    if (first < COMPACT_SIZE_UINT16_PREFIX) {
+      offset += 1;
+      return first;
+    }
+    if (first === COMPACT_SIZE_UINT16_PREFIX) {
+      if (offset + COMPACT_SIZE_UINT16_BYTES > witness.length) {
+        throw new Error("finalScriptWitness is truncated");
+      }
+      const value = witness[offset + 1] | (witness[offset + 2] << 8);
+      offset += COMPACT_SIZE_UINT16_BYTES;
+      return value;
+    }
+    if (first === COMPACT_SIZE_UINT32_PREFIX) {
+      if (offset + COMPACT_SIZE_UINT32_BYTES > witness.length) {
+        throw new Error("finalScriptWitness is truncated");
+      }
+      const value =
+        (witness[offset + 1] |
+          (witness[offset + 2] << 8) |
+          (witness[offset + 3] << 16) |
+          (witness[offset + 4] << 24)) >>>
+        0;
+      offset += COMPACT_SIZE_UINT32_BYTES;
+      return value;
+    }
+    // 0xff (uint64) cannot address a witness this side of the block limit.
+    throw new Error("finalScriptWitness item length out of range");
+  };
+
+  const count = readCompactSize();
+  const items: Uint8Array[] = [];
+  for (let i = 0; i < count; i++) {
+    const len = readCompactSize();
+    if (offset + len > witness.length) {
+      throw new Error("finalScriptWitness is truncated");
+    }
+    items.push(witness.subarray(offset, offset + len));
+    offset += len;
+  }
+  if (offset !== witness.length) {
+    throw new Error("finalScriptWitness has trailing bytes");
+  }
+  return items;
+}
+
+/** The lone stack item of a finalized key-path witness. */
+function singleWitnessItem(
+  finalScriptWitness: Uint8Array,
+  inputIndex: number,
+): Uint8Array {
+  const items = witnessItems(finalScriptWitness);
+  if (items.length !== 1) {
+    throw new Error(
+      `Returned PSBT input ${inputIndex}: a finalized key-path witness must have ` +
+        `exactly one item, got ${items.length}.`,
+    );
+  }
+  return items[0];
+}
+
+function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
+  return a.length === b.length && a.every((byte, i) => byte === b[i]);
+}
+
+export interface AssertReturnedKeyPathSignaturesParams {
+  /** PSBT we built locally and asked the wallet to sign. */
+  requestedPsbtHex: string;
+  /** PSBT the wallet returned after signing. */
+  returnedPsbtHex: string;
+}
+
+/**
+ * Verify every key-path-eligible input of the REQUESTED PSBT against what the
+ * wallet RETURNED: `tapKeySig`, or the single finalized witness item for wallets
+ * that auto-finalize — and when both are present they must be the same bytes.
+ * Script-path inputs are skipped (they have their own check).
+ *
+ * @throws If the input counts differ, an eligible input carries no signature, a
+ *         finalized witness disagrees with its `tapKeySig`, or any signature
+ *         does not verify.
+ */
+export function assertReturnedKeyPathSignatures(
+  params: AssertReturnedKeyPathSignaturesParams,
+): void {
+  const { requestedPsbtHex, returnedPsbtHex } = params;
+
+  const requested = Psbt.fromHex(requestedPsbtHex);
+  const returned = Psbt.fromHex(returnedPsbtHex);
+
+  if (returned.data.inputs.length !== requested.data.inputs.length) {
+    throw new Error(
+      `Returned PSBT input count ${returned.data.inputs.length} differs from the ` +
+        `requested ${requested.data.inputs.length}.`,
+    );
+  }
+
+  requested.data.inputs.forEach((input, inputIndex) => {
+    if (!isKeyPathEligible(input)) return;
+
+    const returnedInput = returned.data.inputs[inputIndex];
+    const tapKeySig = returnedInput.tapKeySig;
+    const witnessSig = returnedInput.finalScriptWitness
+      ? singleWitnessItem(returnedInput.finalScriptWitness, inputIndex)
+      : undefined;
+
+    // Both fields can be present, and the consumers broadcast the WITNESS
+    // bytes — so the two must agree, not just one of them verify. Matches
+    // btc-vault `crates/btc-wallet-remote/src/client.rs:1053-1072,1102-1121`,
+    // which checks each independently.
+    if (tapKeySig && witnessSig && !bytesEqual(tapKeySig, witnessSig)) {
+      throw new Error(
+        `Returned PSBT input ${inputIndex} finalized witness does not match its tapKeySig.`,
+      );
+    }
+
+    const sig = tapKeySig ?? witnessSig;
+    if (!sig) {
+      throw new Error(
+        `Returned PSBT input ${inputIndex} carries no key-path signature ` +
+          `(no tapKeySig, not finalized).`,
+      );
+    }
+
+    assertKeyPathSchnorrSignature({
+      requestedPsbtHex,
+      signatureHex: Buffer.from(sig).toString("hex"),
+      inputIndex,
+    });
+  });
+}

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/verifyKeyPathSchnorrSignature.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/verifyKeyPathSchnorrSignature.ts
@@ -21,6 +21,7 @@ import { Psbt, Transaction } from "bitcoinjs-lib";
 import { Buffer } from "buffer";
 
 import { hexToUint8Array, stripHexPrefix } from "../utils/bitcoin";
+import { decodeWitnessStack } from "../../utils/witness/witnessStack";
 
 const SCHNORR_SIG_BYTES = 64;
 const SIGHASH_DEFAULT = Transaction.SIGHASH_DEFAULT; // 0x00
@@ -31,13 +32,6 @@ const P2TR_SCRIPT_LEN = 34;
 const OP_1 = 0x51;
 const OP_PUSHBYTES_32 = 0x20;
 const P2TR_OUTPUT_KEY_OFFSET = 2;
-
-// Bitcoin CompactSize (varint) prefix markers — values fixed by the protocol.
-// https://developer.bitcoin.org/reference/transactions.html#compactsize-unsigned-integers
-const COMPACT_SIZE_UINT16_PREFIX = 0xfd; // 0xfd + uint16 LE
-const COMPACT_SIZE_UINT32_PREFIX = 0xfe; // 0xfe + uint32 LE
-const COMPACT_SIZE_UINT16_BYTES = 3; // marker + 2
-const COMPACT_SIZE_UINT32_BYTES = 5; // marker + 4
 
 function isP2trScript(script: Uint8Array | undefined): script is Uint8Array {
   return (
@@ -170,68 +164,15 @@ function isKeyPathEligible(input: {
 }
 
 /**
- * Bitcoin CompactSize decode of a witness stack: item count, then (len, bytes)*.
- * Strict: reads are bounds-checked and every byte must be accounted for.
+ * The lone stack item of a finalized key-path witness. An annex would add a
+ * second item, but Bitcoin Core rejects annexes as nonstandard
+ * (`src/policy/policy.cpp:327-329`), so such a spend could never broadcast.
  */
-function witnessItems(witness: Uint8Array): Uint8Array[] {
-  let offset = 0;
-
-  const readCompactSize = (): number => {
-    if (offset >= witness.length) {
-      throw new Error("finalScriptWitness is truncated");
-    }
-    const first = witness[offset];
-    if (first < COMPACT_SIZE_UINT16_PREFIX) {
-      offset += 1;
-      return first;
-    }
-    if (first === COMPACT_SIZE_UINT16_PREFIX) {
-      if (offset + COMPACT_SIZE_UINT16_BYTES > witness.length) {
-        throw new Error("finalScriptWitness is truncated");
-      }
-      const value = witness[offset + 1] | (witness[offset + 2] << 8);
-      offset += COMPACT_SIZE_UINT16_BYTES;
-      return value;
-    }
-    if (first === COMPACT_SIZE_UINT32_PREFIX) {
-      if (offset + COMPACT_SIZE_UINT32_BYTES > witness.length) {
-        throw new Error("finalScriptWitness is truncated");
-      }
-      const value =
-        (witness[offset + 1] |
-          (witness[offset + 2] << 8) |
-          (witness[offset + 3] << 16) |
-          (witness[offset + 4] << 24)) >>>
-        0;
-      offset += COMPACT_SIZE_UINT32_BYTES;
-      return value;
-    }
-    // 0xff (uint64) cannot address a witness this side of the block limit.
-    throw new Error("finalScriptWitness item length out of range");
-  };
-
-  const count = readCompactSize();
-  const items: Uint8Array[] = [];
-  for (let i = 0; i < count; i++) {
-    const len = readCompactSize();
-    if (offset + len > witness.length) {
-      throw new Error("finalScriptWitness is truncated");
-    }
-    items.push(witness.subarray(offset, offset + len));
-    offset += len;
-  }
-  if (offset !== witness.length) {
-    throw new Error("finalScriptWitness has trailing bytes");
-  }
-  return items;
-}
-
-/** The lone stack item of a finalized key-path witness. */
 function singleWitnessItem(
   finalScriptWitness: Uint8Array,
   inputIndex: number,
 ): Uint8Array {
-  const items = witnessItems(finalScriptWitness);
+  const items = decodeWitnessStack(finalScriptWitness, "finalScriptWitness");
   if (items.length !== 1) {
     throw new Error(
       `Returned PSBT input ${inputIndex}: a finalized key-path witness must have ` +
@@ -258,13 +199,17 @@ export interface AssertReturnedKeyPathSignaturesParams {
  * that auto-finalize — and when both are present they must be the same bytes.
  * Script-path inputs are skipped (they have their own check).
  *
+ * @returns How many inputs were actually verified. 0 means NO input was
+ *          key-path eligible — a caller that knows every input is taproot
+ *          key-path must assert this equals its input count, or a P2WPKH
+ *          depositor would read "nothing verified" as "all verified".
  * @throws If the input counts differ, an eligible input carries no signature, a
  *         finalized witness disagrees with its `tapKeySig`, or any signature
  *         does not verify.
  */
 export function assertReturnedKeyPathSignatures(
   params: AssertReturnedKeyPathSignaturesParams,
-): void {
+): number {
   const { requestedPsbtHex, returnedPsbtHex } = params;
 
   const requested = Psbt.fromHex(requestedPsbtHex);
@@ -277,8 +222,10 @@ export function assertReturnedKeyPathSignatures(
     );
   }
 
+  let verified = 0;
   requested.data.inputs.forEach((input, inputIndex) => {
     if (!isKeyPathEligible(input)) return;
+    verified++;
 
     const returnedInput = returned.data.inputs[inputIndex];
     const tapKeySig = returnedInput.tapKeySig;
@@ -310,4 +257,6 @@ export function assertReturnedKeyPathSignatures(
       inputIndex,
     });
   });
+
+  return verified;
 }

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/verifyScriptPathSchnorrSignature.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/verifyScriptPathSchnorrSignature.ts
@@ -23,13 +23,14 @@
  * Reuses the exact primitives `bip322Verify.ts` already depends on — no new
  * dependency:
  *   - `@bitcoin-js/tiny-secp256k1-asmjs` → `verifySchnorr`
- *   - `bitcoinjs-lib` → `Transaction.hashForWitnessV1`, `crypto.taggedHash` (TapLeaf hash)
+ *   - `bitcoinjs-lib` → `Transaction.hashForWitnessV1`
+ *   - `../utils/taproot` → `computeTapLeafHash`
  *
  * @module tbv/core/primitives/psbt/verifyScriptPathSchnorrSignature
  */
 
 import * as ecc from "@bitcoin-js/tiny-secp256k1-asmjs";
-import { Psbt, Transaction, crypto as bcrypto } from "bitcoinjs-lib";
+import { Psbt, Transaction } from "bitcoinjs-lib";
 
 import { Buffer } from "buffer";
 
@@ -40,51 +41,7 @@ import {
   hexToUint8Array,
   stripHexPrefix,
 } from "../utils/bitcoin";
-
-// Bitcoin CompactSize (varint) prefix markers — values fixed by the protocol.
-// https://developer.bitcoin.org/reference/transactions.html#compactsize-unsigned-integers
-const COMPACT_SIZE_UINT16_PREFIX = 0xfd; // value in [0xfd, 0xffff] → 0xfd + uint16 LE
-const COMPACT_SIZE_UINT32_PREFIX = 0xfe; // value in [0x10000, 0xffffffff] → 0xfe + uint32 LE
-const COMPACT_SIZE_UINT16_MAX = 0xffff;
-const COMPACT_SIZE_UINT32_MAX = 0xffffffff;
-
-/**
- * Encode a length as a Bitcoin CompactSize (varint). Tapscript leaf scripts can
- * exceed 252 bytes (WOTS scripts), so the multi-byte forms are required, not
- * just the single-byte fast path.
- */
-function encodeCompactSize(n: number): Buffer {
-  if (n < COMPACT_SIZE_UINT16_PREFIX) {
-    return Buffer.from([n]);
-  }
-  if (n <= COMPACT_SIZE_UINT16_MAX) {
-    const value = Buffer.alloc(2); // uint16, little-endian
-    value.writeUInt16LE(n);
-    return Buffer.concat([Buffer.from([COMPACT_SIZE_UINT16_PREFIX]), value]);
-  }
-  if (n <= COMPACT_SIZE_UINT32_MAX) {
-    const value = Buffer.alloc(4); // uint32, little-endian
-    value.writeUInt32LE(n);
-    return Buffer.concat([Buffer.from([COMPACT_SIZE_UINT32_PREFIX]), value]);
-  }
-  throw new Error(`Script too large to encode as CompactSize: ${n} bytes`);
-}
-
-/** BIP-341 tag for the TapLeaf hash. */
-const TAPLEAF_TAG = "TapLeaf";
-
-/**
- * Compute the BIP-341 TapLeaf hash for a tapscript leaf:
- * `tagged_hash("TapLeaf", leaf_version || compact_size(script) || script)`.
- */
-function computeTapLeafHash(leafVersion: number, script: Uint8Array): Buffer {
-  const preimage = Buffer.concat([
-    Buffer.from([leafVersion]),
-    encodeCompactSize(script.length),
-    Buffer.from(script),
-  ]);
-  return bcrypto.taggedHash(TAPLEAF_TAG, preimage);
-}
+import { computeTapLeafHash } from "../utils/taproot";
 
 export interface VerifyScriptPathSchnorrSignatureParams {
   /**

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/utils/__tests__/taproot.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/utils/__tests__/taproot.test.ts
@@ -158,24 +158,30 @@ describe("computeTaprootScriptPubKey", () => {
     });
   }
 
-  it("agrees with bitcoinjs-lib across tree sizes and leaf positions", () => {
-    for (let leafCount = 1; leafCount <= 8; leafCount++) {
-      for (let redeemIndex = 0; redeemIndex < leafCount; redeemIndex++) {
-        const { output, script, controlBlock } = buildTaptree(
-          leafCount,
-          redeemIndex,
-          leafCount * 100 + redeemIndex + 1,
-        );
-        expect(
-          computeTaprootScriptPubKey({
-            leafVersion: TAPSCRIPT_LEAF_VERSION,
-            script,
-            controlBlock,
-          }).toString("hex"),
-        ).toBe(output.toString("hex"));
+  // 36 bitcoinjs-lib p2tr taptree builds on asm.js secp256k1: ~1.4s here,
+  // 6.6s on a 4-vCPU runner, against vitest's 5s default.
+  it(
+    "agrees with bitcoinjs-lib across tree sizes and leaf positions",
+    { timeout: 30_000 },
+    () => {
+      for (let leafCount = 1; leafCount <= 8; leafCount++) {
+        for (let redeemIndex = 0; redeemIndex < leafCount; redeemIndex++) {
+          const { output, script, controlBlock } = buildTaptree(
+            leafCount,
+            redeemIndex,
+            leafCount * 100 + redeemIndex + 1,
+          );
+          expect(
+            computeTaprootScriptPubKey({
+              leafVersion: TAPSCRIPT_LEAF_VERSION,
+              script,
+              controlBlock,
+            }).toString("hex"),
+          ).toBe(output.toString("hex"));
+        }
       }
-    }
-  });
+    },
+  );
 
   it("rejects a control block whose length is not 33 + 32*m", () => {
     const { script, controlBlock } = buildTaptree(4, 1, 42);

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/utils/__tests__/taproot.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/utils/__tests__/taproot.test.ts
@@ -1,0 +1,220 @@
+/**
+ * Tests for the BIP-341 taproot primitives.
+ *
+ * Two independent oracles:
+ * - the official BIP-341 wallet test vectors
+ *   (https://github.com/bitcoin/bips/blob/master/bip-0341/wallet-test-vectors.json),
+ *   which publish an internal key, a script tree and the control block for
+ *   every leaf alongside the resulting scriptPubKey;
+ * - bitcoinjs-lib's own `payments.p2tr`, which builds a taptree and emits both
+ *   the output script and a leaf's control block.
+ */
+
+import * as ecc from "@bitcoin-js/tiny-secp256k1-asmjs";
+import { payments } from "bitcoinjs-lib";
+import { Buffer } from "buffer";
+import { describe, expect, it } from "vitest";
+
+import { TAPSCRIPT_LEAF_VERSION } from "../bitcoin";
+import { computeTapLeafHash, computeTaprootScriptPubKey } from "../taproot";
+
+/**
+ * BIP-341 wallet test vectors, `scriptPubKey` cases 1, 4, 5 and 6 — every case
+ * with a script tree, one entry per leaf, pairing each leaf script with the
+ * control block the vector publishes for it.
+ */
+const BIP341_VECTORS: ReadonlyArray<{
+  name: string;
+  script: string;
+  controlBlock: string;
+  scriptPubKey: string;
+}> = [
+  {
+    name: "case 1 — single leaf, empty merkle path",
+    script:
+      "20d85a959b0290bf19bb89ed43c916be835475d013da4b362117393e25a48229b8ac",
+    controlBlock:
+      "c1187791b6f712a8ea41c8ecdd0ee77fab3e85263b37e1ec18a3651926b3a6cf27",
+    scriptPubKey:
+      "5120147c9c57132f6e7ecddba9800bb0c4449251c92a1e60371ee77557b6620f3ea3",
+  },
+  {
+    name: "case 4 — two leaves, leaf 0",
+    script:
+      "2044b178d64c32c4a05cc4f4d1407268f764c940d20ce97abfd44db5c3592b72fdac",
+    controlBlock:
+      "c1f9f400803e683727b14f463836e1e78e1c64417638aa066919291a225f0e8dd82cb2b90daa543b544161530c925f285b06196940d6085ca9474d41dc3822c5cb",
+    scriptPubKey:
+      "512077e30a5522dd9f894c3f8b8bd4c4b2cf82ca7da8a3ea6a239655c39c050ab220",
+  },
+  {
+    name: "case 4 — two leaves, leaf 1 (non-pubkey script)",
+    script: "07546170726f6f74",
+    controlBlock:
+      "c1f9f400803e683727b14f463836e1e78e1c64417638aa066919291a225f0e8dd864512fecdb5afa04f98839b50e6f0cb7b1e539bf6f205f67934083cdcc3c8d89",
+    scriptPubKey:
+      "512077e30a5522dd9f894c3f8b8bd4c4b2cf82ca7da8a3ea6a239655c39c050ab220",
+  },
+  {
+    name: "case 5 — unbalanced tree, depth-1 leaf",
+    script:
+      "2072ea6adcf1d371dea8fba1035a09f3d24ed5a059799bae114084130ee5898e69ac",
+    controlBlock:
+      "c0e0dfe2300b0dd746a3f8674dfd4525623639042569d829c7f0eed9602d263e6fffe578e9ea769027e4f5a3de40732f75a88a6353a09d767ddeb66accef85e553",
+    scriptPubKey:
+      "512091b64d5324723a985170e4dc5a0f84c041804f2cd12660fa5dec09fc21783605",
+  },
+  {
+    name: "case 5 — unbalanced tree, depth-2 leaf",
+    script:
+      "202352d137f2f3ab38d1eaa976758873377fa5ebb817372c71e2c542313d4abda8ac",
+    controlBlock:
+      "c0e0dfe2300b0dd746a3f8674dfd4525623639042569d829c7f0eed9602d263e6f9e31407bffa15fefbf5090b149d53959ecdf3f62b1246780238c24501d5ceaf62645a02e0aac1fe69d69755733a9b7621b694bb5b5cde2bbfc94066ed62b9817",
+    scriptPubKey:
+      "512091b64d5324723a985170e4dc5a0f84c041804f2cd12660fa5dec09fc21783605",
+  },
+  {
+    name: "case 6 — unbalanced tree, depth-2 leaf",
+    script:
+      "20c440b462ad48c7a77f94cd4532d8f2119dcebbd7c9764557e62726419b08ad4cac",
+    controlBlock:
+      "c155adf4e8967fbd2e29f20ac896e60c3b0f1d5b0efa9d34941b5958c7b0a0312d737ed1fe30bc42b8022d717b44f0d93516617af64a64753b7a06bf16b26cd711f154e8e8e17c31d3462d7132589ed29353c6fafdb884c5a6e04ea938834f0d9d",
+    scriptPubKey:
+      "512075169f4001aa68f15bbed28b218df1d0a62cbbcf1188c6665110c293c907b831",
+  },
+];
+
+/** Deterministic valid x-only pubkey for scalar `n` (n * G). */
+function xOnlyKey(n: number): Buffer {
+  const scalar = Buffer.alloc(32);
+  scalar.writeUInt32BE(n, 28);
+  const point = ecc.pointFromScalar(scalar, true);
+  if (!point) throw new Error(`invalid scalar ${n}`);
+  return Buffer.from(point.subarray(1, 33));
+}
+
+/** A single-signature tapscript leaf: `<pubkey> OP_CHECKSIG`. */
+function leafScript(n: number): Buffer {
+  return Buffer.concat([Buffer.from([0x20]), xOnlyKey(n), Buffer.from([0xac])]);
+}
+
+/**
+ * Build a right-leaning taptree of `leafCount` leaves via bitcoinjs-lib and
+ * return its output script plus the control block published for `redeemIndex`.
+ */
+function buildTaptree(
+  leafCount: number,
+  redeemIndex: number,
+  internalKeyScalar: number,
+): { output: Buffer; script: Buffer; controlBlock: Buffer } {
+  const leaves = Array.from({ length: leafCount }, (_, i) => ({
+    output: leafScript(i + 1),
+    version: TAPSCRIPT_LEAF_VERSION,
+  }));
+  let scriptTree: Parameters<typeof payments.p2tr>[0]["scriptTree"] =
+    leaves[leaves.length - 1];
+  for (let i = leaves.length - 2; i >= 0; i--) {
+    scriptTree = [leaves[i], scriptTree];
+  }
+
+  const redeem = leaves[redeemIndex];
+  const payment = payments.p2tr({
+    internalPubkey: xOnlyKey(internalKeyScalar),
+    scriptTree,
+    redeem: { output: redeem.output, redeemVersion: TAPSCRIPT_LEAF_VERSION },
+  });
+  if (!payment.output || !payment.witness) {
+    throw new Error("bitcoinjs-lib produced no p2tr output/witness");
+  }
+  return {
+    output: payment.output,
+    script: redeem.output,
+    controlBlock: payment.witness[payment.witness.length - 1],
+  };
+}
+
+describe("computeTapLeafHash", () => {
+  it("matches the BIP-341 leaf hash for the case-1 vector", () => {
+    const leafHash = computeTapLeafHash(
+      TAPSCRIPT_LEAF_VERSION,
+      Buffer.from(BIP341_VECTORS[0].script, "hex"),
+    );
+    expect(leafHash.toString("hex")).toBe(
+      "5b75adecf53548f3ec6ad7d78383bf84cc57b55a3127c72b9a2481752dd88b21",
+    );
+  });
+});
+
+describe("computeTaprootScriptPubKey", () => {
+  for (const vector of BIP341_VECTORS) {
+    it(`recovers the BIP-341 scriptPubKey — ${vector.name}`, () => {
+      expect(
+        computeTaprootScriptPubKey({
+          leafVersion: TAPSCRIPT_LEAF_VERSION,
+          script: Buffer.from(vector.script, "hex"),
+          controlBlock: Buffer.from(vector.controlBlock, "hex"),
+        }).toString("hex"),
+      ).toBe(vector.scriptPubKey);
+    });
+  }
+
+  it("agrees with bitcoinjs-lib across tree sizes and leaf positions", () => {
+    for (let leafCount = 1; leafCount <= 8; leafCount++) {
+      for (let redeemIndex = 0; redeemIndex < leafCount; redeemIndex++) {
+        const { output, script, controlBlock } = buildTaptree(
+          leafCount,
+          redeemIndex,
+          leafCount * 100 + redeemIndex + 1,
+        );
+        expect(
+          computeTaprootScriptPubKey({
+            leafVersion: TAPSCRIPT_LEAF_VERSION,
+            script,
+            controlBlock,
+          }).toString("hex"),
+        ).toBe(output.toString("hex"));
+      }
+    }
+  });
+
+  it("rejects a control block whose length is not 33 + 32*m", () => {
+    const { script, controlBlock } = buildTaptree(4, 1, 42);
+    expect(() =>
+      computeTaprootScriptPubKey({
+        leafVersion: TAPSCRIPT_LEAF_VERSION,
+        script,
+        controlBlock: controlBlock.subarray(0, controlBlock.length - 1),
+      }),
+    ).toThrow(/Malformed Taproot control block/);
+  });
+
+  it("rejects a leaf version that disagrees with the control block", () => {
+    const { script, controlBlock } = buildTaptree(4, 1, 43);
+    expect(() =>
+      computeTaprootScriptPubKey({
+        leafVersion: 0x50,
+        script,
+        controlBlock,
+      }),
+    ).toThrow(/does not match the tapLeafScript leaf version/);
+  });
+
+  it("does not recover the output script when a merkle-path node is altered", () => {
+    const { output, script, controlBlock } = buildTaptree(4, 1, 44);
+    const tampered = Buffer.from(controlBlock);
+    tampered[40] ^= 0xff;
+    // A different root usually yields a different key, but can also contradict
+    // the parity bit — either way the triple must not pass as the same output.
+    let recovered: string | null = null;
+    try {
+      recovered = computeTaprootScriptPubKey({
+        leafVersion: TAPSCRIPT_LEAF_VERSION,
+        script,
+        controlBlock: tampered,
+      }).toString("hex");
+    } catch {
+      recovered = null;
+    }
+    expect(recovered).not.toBe(output.toString("hex"));
+  });
+});

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/utils/taproot.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/utils/taproot.ts
@@ -1,0 +1,173 @@
+/**
+ * BIP-341 Taproot primitives shared by the PSBT builders and verifiers.
+ *
+ * Everything here is a byte-level restatement of BIP-341; the spec is the
+ * source of truth for each constant and each hash preimage.
+ *
+ * @see https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki
+ * @module tbv/core/primitives/utils/taproot
+ */
+
+import * as ecc from "@bitcoin-js/tiny-secp256k1-asmjs";
+import { crypto as bcrypto } from "bitcoinjs-lib";
+import { Buffer } from "buffer";
+
+// Bitcoin CompactSize (varint) prefix markers — values fixed by the protocol.
+// https://developer.bitcoin.org/reference/transactions.html#compactsize-unsigned-integers
+const COMPACT_SIZE_UINT16_PREFIX = 0xfd; // value in [0xfd, 0xffff] → 0xfd + uint16 LE
+const COMPACT_SIZE_UINT32_PREFIX = 0xfe; // value in [0x10000, 0xffffffff] → 0xfe + uint32 LE
+const COMPACT_SIZE_UINT16_MAX = 0xffff;
+const COMPACT_SIZE_UINT32_MAX = 0xffffffff;
+
+/** BIP-341 tag for the TapLeaf hash. */
+const TAPLEAF_TAG = "TapLeaf";
+/** BIP-341 tag for an internal merkle node of the taptree. */
+const TAPBRANCH_TAG = "TapBranch";
+/** BIP-341 tag for the output-key tweak. */
+const TAPTWEAK_TAG = "TapTweak";
+
+/** BIP-341 control block prefix: 1 leaf-version/parity byte + 32-byte internal key. */
+const CONTROL_BLOCK_PREFIX_LEN = 33;
+/** Each merkle-path element in a control block is a 32-byte node hash. */
+const CONTROL_BLOCK_NODE_LEN = 32;
+/** BIP-341 caps the taptree at 128 levels, so the path holds at most 128 nodes. */
+const CONTROL_BLOCK_MAX_NODES = 128;
+/** Low bit of control-block byte 0 carries the output key's y-parity. */
+const CONTROL_BLOCK_PARITY_MASK = 0x01;
+/** Remaining bits of control-block byte 0 carry the leaf version. */
+const CONTROL_BLOCK_LEAF_VERSION_MASK = 0xfe;
+
+/** A P2TR scriptPubKey is `OP_1 <32-byte push>` followed by the output key. */
+const P2TR_SCRIPT_PUBKEY_PREFIX = Buffer.from([0x51, 0x20]);
+
+/**
+ * Encode a length as a Bitcoin CompactSize (varint). Tapscript leaf scripts can
+ * exceed 252 bytes (WOTS scripts), so the multi-byte forms are required, not
+ * just the single-byte fast path.
+ */
+function encodeCompactSize(n: number): Buffer {
+  if (n < COMPACT_SIZE_UINT16_PREFIX) {
+    return Buffer.from([n]);
+  }
+  if (n <= COMPACT_SIZE_UINT16_MAX) {
+    const value = Buffer.alloc(2); // uint16, little-endian
+    value.writeUInt16LE(n);
+    return Buffer.concat([Buffer.from([COMPACT_SIZE_UINT16_PREFIX]), value]);
+  }
+  if (n <= COMPACT_SIZE_UINT32_MAX) {
+    const value = Buffer.alloc(4); // uint32, little-endian
+    value.writeUInt32LE(n);
+    return Buffer.concat([Buffer.from([COMPACT_SIZE_UINT32_PREFIX]), value]);
+  }
+  throw new Error(`Script too large to encode as CompactSize: ${n} bytes`);
+}
+
+/**
+ * Compute the BIP-341 TapLeaf hash for a tapscript leaf:
+ * `tagged_hash("TapLeaf", leaf_version || compact_size(script) || script)`.
+ */
+export function computeTapLeafHash(
+  leafVersion: number,
+  script: Uint8Array,
+): Buffer {
+  const preimage = Buffer.concat([
+    Buffer.from([leafVersion]),
+    encodeCompactSize(script.length),
+    Buffer.from(script),
+  ]);
+  return bcrypto.taggedHash(TAPLEAF_TAG, preimage);
+}
+
+export interface TaprootScriptPathBinding {
+  /** Tapscript leaf version, e.g. `0xc0`. */
+  leafVersion: number;
+  /** The tapscript leaf being spent. */
+  script: Uint8Array;
+  /** BIP-341 control block: version/parity byte, internal key, merkle path. */
+  controlBlock: Uint8Array;
+}
+
+/**
+ * Recompute the P2TR scriptPubKey that a `(leafVersion, script, controlBlock)`
+ * triple can spend, by walking the control block's merkle path to the taptree
+ * root and tweaking the control block's internal key with it (BIP-341
+ * "Script validation rules").
+ *
+ * Comparing the result against a real previous output is what proves the triple
+ * belongs to that output rather than to some other taptree.
+ *
+ * @throws If the control block is malformed, the leaf version disagrees with
+ *   the control block, the tweak is off-curve, or the recovered output key's
+ *   parity contradicts the control block.
+ */
+export function computeTaprootScriptPubKey(
+  binding: TaprootScriptPathBinding,
+): Buffer {
+  const { leafVersion, script, controlBlock } = binding;
+
+  const pathLen = controlBlock.length - CONTROL_BLOCK_PREFIX_LEN;
+  if (
+    pathLen < 0 ||
+    pathLen % CONTROL_BLOCK_NODE_LEN !== 0 ||
+    pathLen / CONTROL_BLOCK_NODE_LEN > CONTROL_BLOCK_MAX_NODES
+  ) {
+    throw new Error(
+      `Malformed Taproot control block: length ${controlBlock.length} must be ` +
+        `${CONTROL_BLOCK_PREFIX_LEN} + 32*m with 0 <= m <= ${CONTROL_BLOCK_MAX_NODES}`,
+    );
+  }
+
+  const controlLeafVersion = controlBlock[0] & CONTROL_BLOCK_LEAF_VERSION_MASK;
+  if (controlLeafVersion !== leafVersion) {
+    throw new Error(
+      `Taproot control block leaf version 0x${controlLeafVersion.toString(16)} ` +
+        `does not match the tapLeafScript leaf version 0x${leafVersion.toString(16)}`,
+    );
+  }
+
+  const internalKey = Buffer.from(
+    controlBlock.subarray(1, CONTROL_BLOCK_PREFIX_LEN),
+  );
+
+  // Fold the merkle path into the taptree root; siblings are hashed in
+  // lexicographic order (BIP-341).
+  let node = computeTapLeafHash(leafVersion, script);
+  for (
+    let offset = CONTROL_BLOCK_PREFIX_LEN;
+    offset < controlBlock.length;
+    offset += CONTROL_BLOCK_NODE_LEN
+  ) {
+    const sibling = Buffer.from(
+      controlBlock.subarray(offset, offset + CONTROL_BLOCK_NODE_LEN),
+    );
+    node = bcrypto.taggedHash(
+      TAPBRANCH_TAG,
+      Buffer.compare(node, sibling) <= 0
+        ? Buffer.concat([node, sibling])
+        : Buffer.concat([sibling, node]),
+    );
+  }
+
+  const tweak = bcrypto.taggedHash(
+    TAPTWEAK_TAG,
+    Buffer.concat([internalKey, node]),
+  );
+  const tweaked = ecc.xOnlyPointAddTweak(internalKey, tweak);
+  if (tweaked === null) {
+    throw new Error(
+      "Taproot control block does not yield a valid output key (tweak is off-curve)",
+    );
+  }
+  const expectedParity = controlBlock[0] & CONTROL_BLOCK_PARITY_MASK;
+  if (tweaked.parity !== expectedParity) {
+    throw new Error(
+      `Taproot output key parity ${tweaked.parity} contradicts the control ` +
+        `block's parity bit ${expectedParity}`,
+    );
+  }
+
+  return Buffer.concat([
+    P2TR_SCRIPT_PUBKEY_PREFIX,
+    Buffer.from(tweaked.xOnlyPubkey),
+  ]);
+}

--- a/packages/babylon-ts-sdk/src/tbv/core/services/deposit/__tests__/runDepositorPresignFlow.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/deposit/__tests__/runDepositorPresignFlow.test.ts
@@ -155,6 +155,7 @@ function createCapabilityWallet(
     approveDepositTerms: vi.fn(async (terms: DepositTerms) => {
       onApprove?.(terms);
     }),
+    getChangeAddress: vi.fn(async () => "tb1pchange"),
   } as unknown as BitcoinWallet & DepositTermsApprover;
 }
 

--- a/packages/babylon-ts-sdk/src/tbv/core/services/deposit/__tests__/runDepositorPresignFlow.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/deposit/__tests__/runDepositorPresignFlow.test.ts
@@ -610,7 +610,8 @@ describe("runDepositorPresignFlow", () => {
         registeredPayoutScriptPubKey: context.registeredPayoutScriptPubKey,
         commissionBps: context.commissionBps,
         protocolFeeRate: context.protocolFeeRate,
-        councilSize: context.councilMembers.length,
+        councilMembers: context.councilMembers,
+        councilQuorum: context.councilQuorum,
       });
     }
   });

--- a/packages/babylon-ts-sdk/src/tbv/core/services/deposit/__tests__/signDepositorGraph.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/deposit/__tests__/signDepositorGraph.test.ts
@@ -72,6 +72,10 @@ vi.mock("bitcoinjs-lib", () => ({
 }));
 
 vi.mock("../../../primitives/utils/bitcoin", () => ({
+  processPublicKeyToXOnly: (pk: string) => {
+    const stripped = pk.startsWith("0x") ? pk.slice(2) : pk;
+    return stripped.length === 66 ? stripped.slice(2) : stripped;
+  },
   stripHexPrefix: (s: string) => (s.startsWith("0x") ? s.slice(2) : s),
   uint8ArrayToHex: (bytes: Uint8Array) => Buffer.from(bytes).toString("hex"),
   validateWalletPubkey: (walletRaw: string, expectedDepositor: string) => {
@@ -329,7 +333,8 @@ describe("signDepositorGraph", () => {
       registeredPayoutScriptPubKey: ctx.registeredPayoutScriptPubKey,
       commissionBps: 1,
       protocolFeeRate: ctx.protocolFeeRate,
-      councilSize: ctx.councilMembers.length,
+      councilMembers: ctx.councilMembers,
+      councilQuorum: ctx.councilQuorum,
     });
   });
 

--- a/packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts
@@ -68,14 +68,14 @@ export interface PayoutSigningContext {
    * Security council member x-only public keys (hex, no prefix).
    * Source: ProtocolParams contract via
    * `getOffchainParamsByVersion(...).securityCouncilKeys`.
-   * Required for the depositor-graph NoPayout local rebuild.
+   * Required to rebuild every Assert:0 leaf (payout and NoPayout) locally.
    */
   councilMembers: string[];
   /**
    * M-of-N council quorum threshold.
    * Source: ProtocolParams contract via
    * `getOffchainParamsByVersion(...).councilQuorum`.
-   * Required for the depositor-graph NoPayout local rebuild.
+   * Required to rebuild every Assert:0 leaf (payout and NoPayout) locally.
    */
   councilQuorum: number;
   /** BTC network (Mainnet, Testnet, etc.) */
@@ -346,7 +346,8 @@ function buildPayoutSigningInput(
     claimerBtcPubkey: tx.claimerPubkeyXOnly,
     commissionBps: context.commissionBps,
     protocolFeeRate: context.protocolFeeRate,
-    councilSize: context.councilMembers.length,
+    councilMembers: context.councilMembers,
+    councilQuorum: context.councilQuorum,
     vkClaimerPayoutScriptPubKeys: context.vkClaimerPayoutScriptPubKeys,
     vpCommissionScriptPubKey: context.vpCommissionScriptPubKey,
   };

--- a/packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts
@@ -32,6 +32,7 @@ import type {
   PresignDataPerChallenger,
 } from "../../clients/vault-provider/types";
 import { signPsbtsWithFallback } from "../../managers/pegin/signPsbtsWithFallback";
+import { deriveLocalChallengers } from "../../primitives/challengers";
 import {
   assertPsbtUnsignedTxMatches,
   type AssertPsbtUnsignedTxMatchesParams,
@@ -84,43 +85,6 @@ interface CollectedDepositorGraphPsbts {
 // ============================================================================
 // Helpers
 // ============================================================================
-
-/**
- * Compute the local-challenger set for the depositor-as-claimer flow.
- *
- * Per btc-vault `crates/vault/src/tx_graph/graph.rs:144-150` (introduced in
- * PR #1092 / commit 3133b698, 2026-02-18):
- *   Depositor-as-claimer: LocalChallengers = VKs only (VP excluded)
- *
- * Note: the docstring at `crates/vault/src/lib.rs:332` still says
- * `{VaultProvider, VaultKeepers} - {Claimer}` — that wording is stale and
- * predates the depositor-as-claimer special case. This function follows the
- * actual implementation, not the stale docstring.
- *
- * The protocol guarantees the depositor is not a vault keeper
- * (`TxGraphParams::validate` enforces it), so the depositor filter here is
- * defense-in-depth; it surfaces a clear error if a misconfigured context
- * ever violates the invariant.
- */
-function deriveLocalChallengers(
-  vaultKeeperBtcPubkeys: string[],
-  depositorBtcPubkey: string,
-): string[] {
-  const depositor = stripHexPrefix(depositorBtcPubkey).toLowerCase();
-  const vks = vaultKeeperBtcPubkeys.map((k) => stripHexPrefix(k).toLowerCase());
-  const filtered = vks.filter((k) => k !== depositor);
-  if (filtered.length === 0) {
-    throw new Error(
-      "Cannot derive localChallengers: vault keeper set is empty (or contains only the depositor)",
-    );
-  }
-  if (new Set(filtered).size !== filtered.length) {
-    throw new Error(
-      "Cannot derive localChallengers: duplicate vaultKeeper key — signing context is misconfigured",
-    );
-  }
-  return filtered;
-}
 
 /**
  * Reject VP-supplied `challenger_presign_data` whose pubkey set does not
@@ -235,10 +199,12 @@ async function collectDepositorGraphPsbts(
 
   // 1. Fail-fast on a malformed VP response BEFORE doing any PSBT-build
   //    work that would be wasted if the challenger set is wrong.
-  const localChallengers = deriveLocalChallengers(
-    ctx.vaultKeeperBtcPubkeys,
-    ctx.depositorBtcPubkey,
-  );
+  const localChallengers = deriveLocalChallengers({
+    claimerBtcPubkey: ctx.depositorBtcPubkey,
+    depositorBtcPubkey: ctx.depositorBtcPubkey,
+    vaultProviderBtcPubkey: ctx.vaultProviderBtcPubkey,
+    vaultKeeperBtcPubkeys: ctx.vaultKeeperBtcPubkeys,
+  });
   assertChallengerSetMatchesExpected(
     depositorGraph.challenger_presign_data,
     localChallengers,
@@ -266,7 +232,8 @@ async function collectDepositorGraphPsbts(
     registeredPayoutScriptPubKey: ctx.registeredPayoutScriptPubKey,
     commissionBps: DEPOSITOR_PATH_UNUSED_COMMISSION_BPS,
     protocolFeeRate: ctx.protocolFeeRate,
-    councilSize: ctx.councilMembers.length,
+    councilMembers: ctx.councilMembers,
+    councilQuorum: ctx.councilQuorum,
   });
   psbtHexes.push(builtPayout.psbtHex);
   signOptions.push(

--- a/packages/babylon-ts-sdk/src/tbv/core/utils/witness/witnessStack.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/utils/witness/witnessStack.ts
@@ -1,0 +1,91 @@
+/**
+ * Consensus witness-stack decoding, shared by every module that reads a
+ * witness we did not build.
+ *
+ * Two independent decoders drifted apart before this existed: one accepted
+ * non-minimal CompactSize encodings, the other rejected them. vaultd decodes
+ * with rust-bitcoin, whose `VarInt::consensus_decode`
+ * (0.32.8 `consensus/encode.rs:493-522`) returns `NonMinimalVarInt` for a 0xfd
+ * carrying < 0xfd and a 0xfe carrying < 0x10000 — so the strict reading is the
+ * only one that matches what the network will accept.
+ *
+ * @module tbv/core/utils/witness/witnessStack
+ */
+
+/** CompactSize discriminators; 0xff (u64) is out of range for a witness. */
+const COMPACT_SIZE_UINT16_PREFIX = 0xfd;
+const COMPACT_SIZE_UINT32_PREFIX = 0xfe;
+const COMPACT_SIZE_UINT16_BYTES = 3;
+const COMPACT_SIZE_UINT32_BYTES = 5;
+const COMPACT_SIZE_UINT16_MIN_VALUE = 0xfd;
+const COMPACT_SIZE_UINT32_MIN_VALUE = 0x10000;
+
+/**
+ * Decode a consensus-encoded witness stack: item count, then (len, bytes)*.
+ *
+ * @param witness - The consensus-encoded witness bytes.
+ * @param subject - Names the witness in error messages (e.g. "finalScriptWitness").
+ * @returns The stack items, as views over `witness`.
+ * @throws If the encoding is truncated, non-minimal, out of range, or leaves
+ *         trailing bytes.
+ */
+export function decodeWitnessStack(
+  witness: Uint8Array,
+  subject: string,
+): Uint8Array[] {
+  let offset = 0;
+
+  const readCompactSize = (): number => {
+    if (offset >= witness.length) {
+      throw new Error(`${subject} is truncated`);
+    }
+    const first = witness[offset];
+    if (first < COMPACT_SIZE_UINT16_PREFIX) {
+      offset += 1;
+      return first;
+    }
+    if (first === COMPACT_SIZE_UINT16_PREFIX) {
+      if (offset + COMPACT_SIZE_UINT16_BYTES > witness.length) {
+        throw new Error(`${subject} is truncated`);
+      }
+      const value = witness[offset + 1] | (witness[offset + 2] << 8);
+      if (value < COMPACT_SIZE_UINT16_MIN_VALUE) {
+        throw new Error(`${subject} has a non-minimal length encoding`);
+      }
+      offset += COMPACT_SIZE_UINT16_BYTES;
+      return value;
+    }
+    if (first === COMPACT_SIZE_UINT32_PREFIX) {
+      if (offset + COMPACT_SIZE_UINT32_BYTES > witness.length) {
+        throw new Error(`${subject} is truncated`);
+      }
+      const value =
+        (witness[offset + 1] |
+          (witness[offset + 2] << 8) |
+          (witness[offset + 3] << 16) |
+          (witness[offset + 4] << 24)) >>>
+        0;
+      if (value < COMPACT_SIZE_UINT32_MIN_VALUE) {
+        throw new Error(`${subject} has a non-minimal length encoding`);
+      }
+      offset += COMPACT_SIZE_UINT32_BYTES;
+      return value;
+    }
+    throw new Error(`${subject} carries an out-of-range item length`);
+  };
+
+  const count = readCompactSize();
+  const items: Uint8Array[] = [];
+  for (let i = 0; i < count; i++) {
+    const len = readCompactSize();
+    if (offset + len > witness.length) {
+      throw new Error(`${subject} is truncated`);
+    }
+    items.push(witness.subarray(offset, offset + len));
+    offset += len;
+  }
+  if (offset !== witness.length) {
+    throw new Error(`${subject} has trailing bytes`);
+  }
+  return items;
+}

--- a/packages/babylon-ts-sdk/src/testing/MockBitcoinWallet.ts
+++ b/packages/babylon-ts-sdk/src/testing/MockBitcoinWallet.ts
@@ -1,6 +1,10 @@
 import { sha256 } from "@noble/hashes/sha2.js";
+import { Buffer } from "buffer";
 
-import { BitcoinNetworks, type BitcoinNetwork } from "../shared/wallets/interfaces";
+import {
+  BitcoinNetworks,
+  type BitcoinNetwork,
+} from "../shared/wallets/interfaces";
 import type {
   BitcoinWallet,
   SignPsbtOptions,
@@ -95,10 +99,7 @@ export class MockBitcoinWallet implements BitcoinWallet {
     return this.config.address;
   }
 
-  async signPsbt(
-    psbtHex: string,
-    _options?: SignPsbtOptions,
-  ): Promise<string> {
+  async signPsbt(psbtHex: string, _options?: SignPsbtOptions): Promise<string> {
     if (this.config.shouldFailSigning) {
       throw new Error("Mock signing failed");
     }
@@ -149,6 +150,12 @@ export class MockBitcoinWallet implements BitcoinWallet {
     for (let i = 0; i < derSignature.length; i++) {
       derSignature[i] = digest[i % digest.length];
     }
+    // Witness item 1 must carry the wallet's own key — verifyPopWitness
+    // mirrors vaultd's WitnessPubkeyMismatch check. Length-aware: config may
+    // hold a compressed (66-char) or x-only (64-char) key.
+    const cleanKey = this.config.publicKeyHex.replace(/^0x/, "").toLowerCase();
+    const xOnlyHex = cleanKey.length === 66 ? cleanKey.slice(2) : cleanKey;
+    const xOnlyBytes = Uint8Array.from(Buffer.from(xOnlyHex, "hex"));
     return `0x${uint8ArrayToHex(
       Uint8Array.from([
         MOCK_WITNESS_ITEM_COUNT,
@@ -156,7 +163,7 @@ export class MockBitcoinWallet implements BitcoinWallet {
         ...derSignature,
         MOCK_WITNESS_PUBKEY_BYTES,
         COMPRESSED_PUBKEY_EVEN_PREFIX,
-        ...digest,
+        ...xOnlyBytes,
       ]),
     )}`;
   }

--- a/packages/babylon-ts-sdk/src/testing/MockBitcoinWallet.ts
+++ b/packages/babylon-ts-sdk/src/testing/MockBitcoinWallet.ts
@@ -1,5 +1,4 @@
 import { sha256 } from "@noble/hashes/sha2.js";
-import { Buffer } from "buffer";
 
 import { BitcoinNetworks, type BitcoinNetwork } from "../shared/wallets/interfaces";
 import type {
@@ -49,6 +48,16 @@ const defaultDeriveContextHash = async (
   buf.set(ctxBytes, 4 + nameBytes.length + 4);
   return uint8ArrayToHex(sha256(buf));
 };
+
+/**
+ * Shape of the mock BIP-322 witness: `varint(2) ‖ varint(71) ‖ DER sig ‖
+ * varint(33) ‖ compressed pubkey` — the P2WPKH form, with the DER signature
+ * at its maximum encoded length.
+ */
+const MOCK_WITNESS_ITEM_COUNT = 2;
+const MOCK_WITNESS_DER_SIG_BYTES = 71;
+const MOCK_WITNESS_PUBKEY_BYTES = 33;
+const COMPRESSED_PUBKEY_EVEN_PREFIX = 0x02;
 
 const DEFAULT_CONFIG: Required<MockBitcoinWalletConfig> = {
   publicKeyHex:
@@ -127,12 +136,29 @@ export class MockBitcoinWallet implements BitcoinWallet {
       throw new Error("Invalid message: empty string");
     }
 
-    // In a real implementation, this would create a proper signature
-    // For the mock, we return a base64-like mock signature
-    const mockSignature = Buffer.from(
-      `mock-signature-${type}-${message}-${this.config.publicKeyHex}`,
-    ).toString("base64");
-    return mockSignature;
+    // The SDK decodes what a wallet returns (`verifyPopWitness`), so the mock
+    // has to emit a structurally valid two-item P2WPKH witness. The bytes are
+    // derived from the inputs so different messages still give different
+    // signatures; they are not a real signature and are never verified.
+    const digest = sha256(
+      new TextEncoder().encode(
+        `mock-signature-${type}-${message}-${this.config.publicKeyHex}`,
+      ),
+    );
+    const derSignature = new Uint8Array(MOCK_WITNESS_DER_SIG_BYTES);
+    for (let i = 0; i < derSignature.length; i++) {
+      derSignature[i] = digest[i % digest.length];
+    }
+    return `0x${uint8ArrayToHex(
+      Uint8Array.from([
+        MOCK_WITNESS_ITEM_COUNT,
+        MOCK_WITNESS_DER_SIG_BYTES,
+        ...derSignature,
+        MOCK_WITNESS_PUBKEY_BYTES,
+        COMPRESSED_PUBKEY_EVEN_PREFIX,
+        ...digest,
+      ]),
+    )}`;
   }
 
   async getNetwork(): Promise<BitcoinNetwork> {

--- a/packages/babylon-wallet-connector/src/core/wallets/btc/ledger-vault/__tests__/provider.test.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/ledger-vault/__tests__/provider.test.ts
@@ -30,6 +30,12 @@ import { ERROR_CODES, WalletError } from "@/error";
 /** BIP-86 first-address vector: x-only key and its published P2TR address. */
 const VECTOR_XONLY = "cc8a4bc64d897bddc5fbc2f670f7a8ba0b386779106cf1223c6fc5d7cd6fc115";
 const VECTOR_MAINNET_ADDRESS = "bc1p5cyxnuxmeuwuvkwfem96lqzszd02n6xdcjrs20cac6yqjjwudpxqkedrcr";
+/**
+ * The device's depositor key — the `0/0` child of {@link ACCOUNT_XPUB}. The
+ * provider cross-checks the two reads against each other, so a key unrelated
+ * to the xpub would (correctly) be rejected as an inconsistent device.
+ */
+const DEVICE_XONLY = "dc8d2f9eff0c4f4dbde070a48e330efc908b62a766568d91e658f284b324b878";
 /** The `m/86'/1'/0'` account xpub the device reports (testnet versions). */
 const ACCOUNT_XPUB =
   "tpubDDKYE6BREvDsSWMazgHoyQWiJwYaDDYPbCFjYxN3HFXJP5fokeiK4hwK5tTLBNEDBwrDXn8cQ4v9b2xdW62Xr5yxoQdMu1v6c7UDXYVH27U";
@@ -47,7 +53,7 @@ const dmkSessionMock = vi.hoisted(() => ({
 }));
 
 const derivationMock = vi.hoisted(() => ({
-  getXOnlyPublicKeyHex: vi.fn(async () => VECTOR_XONLY),
+  getXOnlyPublicKeyHex: vi.fn(async () => DEVICE_XONLY),
   getMasterFingerprintHex: vi.fn(async () => "73c5da0a"),
   getExtendedPublicKey: vi.fn(async () => ACCOUNT_XPUB),
 }));
@@ -172,14 +178,17 @@ describe("LedgerVaultProvider", () => {
 
     const [address, pubkey] = await Promise.all([provider.getAddress(), provider.getPublicKeyHex()]);
 
-    expect(pubkey).toBe(VECTOR_XONLY);
+    expect(pubkey).toBe(DEVICE_XONLY);
     // The address is never read from the device — it is derived locally from
     // the pubkey, so it must equal the util's derivation for the same network.
-    expect(address).toBe(getTaprootAddress(VECTOR_XONLY, Network.SIGNET));
+    expect(address).toBe(getTaprootAddress(DEVICE_XONLY, Network.SIGNET));
     expect(derivationMock.getXOnlyPublicKeyHex).toHaveBeenCalledTimes(1);
   });
 
   it("derives the published BIP-86 vector address on mainnet", async () => {
+    // Pins getTaprootAddress against the BIP-86 published vector, so this one
+    // reads the vector key rather than the fixture device's own.
+    derivationMock.getXOnlyPublicKeyHex.mockResolvedValueOnce(VECTOR_XONLY);
     const provider = new LedgerVaultProvider(Network.MAINNET);
     await provider.connectWallet();
 
@@ -191,7 +200,7 @@ describe("LedgerVaultProvider", () => {
     derivationMock.getXOnlyPublicKeyHex.mockRejectedValueOnce(new Error("device unplugged"));
 
     await expect(provider.getPublicKeyHex()).rejects.toThrow("device unplugged");
-    await expect(provider.getPublicKeyHex()).resolves.toBe(VECTOR_XONLY);
+    await expect(provider.getPublicKeyHex()).resolves.toBe(DEVICE_XONLY);
   });
 
   it("refuses device reads before connecting", async () => {
@@ -335,7 +344,7 @@ describe("LedgerVaultProvider", () => {
       );
       const prepareArgs = signMock.prepareSignPsbt.mock.calls[0][0];
       expect(prepareArgs.walletPolicy?.keyInfo).toMatch(/^\[73c5da0a\/86'\/1'\/0'\]tpubDDKYE6B/);
-      expect(prepareArgs.depositorXOnlyHex).toBe(VECTOR_XONLY);
+      expect(prepareArgs.depositorXOnlyHex).toBe(DEVICE_XONLY);
       // The PSBT handed to prepare is a PoP PSBT (version 0, message in the proprietary key).
       expect(prepareArgs.psbtHex).toMatch(/^70736274ff/);
       expect(Buffer.from(prepareArgs.psbtHex, "hex").toString("latin1")).toContain(POP_MESSAGE);
@@ -522,13 +531,13 @@ describe("LedgerVaultProvider", () => {
      * the depositor's BIP-86 P2TR.
      */
     function keyPathPsbtHex(outputScripts: Buffer[], inputCount = 1): string {
-      const depositorKey = Buffer.from(VECTOR_XONLY, "hex");
+      const depositorKey = Buffer.from(DEVICE_XONLY, "hex");
       const psbt = new Psbt();
       for (let i = 0; i < inputCount; i++) {
         psbt.addInput({
           hash: Buffer.alloc(32, i + 1),
           index: 0,
-          witnessUtxo: { script: bip86Script(VECTOR_XONLY), value: 100_000 },
+          witnessUtxo: { script: bip86Script(DEVICE_XONLY), value: 100_000 },
           tapInternalKey: depositorKey,
         });
       }
@@ -636,7 +645,7 @@ describe("LedgerVaultProvider", () => {
               {
                 kind: "tapscript",
                 expectedLeafHashHexes: new Set(["11".repeat(32)]),
-                expectedSignerXOnlyHex: VECTOR_XONLY,
+                expectedSignerXOnlyHex: DEVICE_XONLY,
               },
             ],
           ]),
@@ -942,6 +951,23 @@ describe("LedgerVaultProvider", () => {
       await expect(p.getChangeAddress()).rejects.toMatchObject({ code: ERROR_CODES.WALLET_NOT_CONNECTED });
     });
 
+    it("refuses a device whose account xpub does not derive the depositor key", async () => {
+      // Two independent reads. If they disagree the wallet policy would bind a
+      // different key than the intent, and the device would answer an opaque
+      // 0x6A80 only after the user had approved.
+      const p = await connected();
+      // try/finally, not a trailing restore: beforeEach only mockClear()s, so a
+      // failed assertion would leak this key into every later test.
+      derivationMock.getXOnlyPublicKeyHex.mockResolvedValue(VECTOR_XONLY);
+      try {
+        await expect(p.getChangeAddress()).rejects.toMatchObject({
+          code: ERROR_CODES.CONNECTION_FAILED,
+        });
+      } finally {
+        derivationMock.getXOnlyPublicKeyHex.mockResolvedValue(DEVICE_XONLY);
+      }
+    });
+
     it("refuses an xpub read that resolved after a disconnect", async () => {
       // Returning the previous device's address would route Pre-PegIn change
       // to a key the reconnected wallet cannot spend.
@@ -1029,14 +1055,14 @@ describe("LedgerVaultProvider", () => {
   });
 
   it("rejects terms whose roster reuses the depositor's own key before the ceremony", async () => {
-    // VECTOR_XONLY is the device pubkey; the firmware rejects this only after
+    // DEVICE_XONLY is the device pubkey; the firmware rejects this only after
     // the whole ceremony, so the provider pre-empts it as a shaped error before
     // any approval APDU (approveApdus is empty).
     const provider = await derived();
     h.sent.length = 0;
 
     await expect(
-      provider.approveDepositTerms({ ...TERMS, vaultKeeperBtcPubkeys: [VECTOR_XONLY] }),
+      provider.approveDepositTerms({ ...TERMS, vaultKeeperBtcPubkeys: [DEVICE_XONLY] }),
     ).rejects.toMatchObject({ name: "DepositTermsRejectedError", reason: "device-envelope" });
     expect(approveApdus()).toHaveLength(0);
   });

--- a/packages/babylon-wallet-connector/src/core/wallets/btc/ledger-vault/__tests__/provider.test.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/ledger-vault/__tests__/provider.test.ts
@@ -1038,6 +1038,111 @@ describe("LedgerVaultProvider", () => {
     await expect(provider.getAddress()).rejects.toThrow(/not connected/);
   });
 
+  describe("holdsApprovedDepositTerms", () => {
+    it("is false before any approval and true after approving the byte-equal terms", async () => {
+      const provider = await derived();
+      await expect(provider.holdsApprovedDepositTerms(TERMS)).resolves.toBe(false);
+
+      await provider.approveDepositTerms(TERMS);
+      h.sent.length = 0;
+
+      await expect(provider.holdsApprovedDepositTerms(TERMS)).resolves.toBe(true);
+      // Mirror read only — the probe must not touch the device.
+      expect(h.sent).toHaveLength(0);
+    });
+
+    it("is false for terms that differ from the approved intent", async () => {
+      const provider = await derived();
+      await provider.approveDepositTerms(TERMS);
+
+      await expect(
+        provider.holdsApprovedDepositTerms({
+          ...TERMS,
+          vaults: [{ ...TERMS.vaults[0], peginAmount: TERMS.vaults[0].peginAmount + 1n }],
+        }),
+      ).resolves.toBe(false);
+    });
+
+    it("is false after a later derive wipes the loaded intent", async () => {
+      const provider = await derived();
+      await provider.approveDepositTerms(TERMS);
+      await provider.deriveContextHash("app", "bb".repeat(32));
+
+      await expect(provider.holdsApprovedDepositTerms(TERMS)).resolves.toBe(false);
+    });
+
+    it("returns false instead of throwing for unencodable terms", async () => {
+      const provider = await derived();
+      await provider.approveDepositTerms(TERMS);
+
+      await expect(provider.holdsApprovedDepositTerms({ ...TERMS, prepeginTxid: "nothex" })).resolves.toBe(false);
+    });
+
+    it("is false after disconnect tears the mirror down", async () => {
+      const provider = await derived();
+      await provider.approveDepositTerms(TERMS);
+      await provider.disconnect();
+
+      await expect(provider.holdsApprovedDepositTerms(TERMS)).resolves.toBe(false);
+    });
+
+    it("is false for terms differing only in vaultCoreVersion", async () => {
+      // vaultCoreVersion is envelope-gated but never reaches the intent wire
+      // bytes, so a fingerprint over the wire alone would compare equal here.
+      const provider = await derived();
+      await provider.approveDepositTerms(TERMS);
+
+      await expect(
+        provider.holdsApprovedDepositTerms({ ...TERMS, vaultCoreVersion: TERMS.vaultCoreVersion + 1 }),
+      ).resolves.toBe(false);
+    });
+
+    it("is false once a PSBT was signed under the intent, so a broadcast retry re-ceremonies", async () => {
+      // The one-shot cap + stagePsbt's pre-I/O replay guard mean a held-but-
+      // consumed intent cannot sign again; a true here would trap the retry
+      // in the replay throw with the mirror never resetting.
+      const provider = await derived();
+      await provider.approveDepositTerms(TERMS);
+      await provider.signPsbt("aa".repeat(40));
+
+      await expect(provider.holdsApprovedDepositTerms(TERMS)).resolves.toBe(false);
+    });
+
+    it("is false after a sign failure drops the mirror", async () => {
+      const provider = await derived();
+      await provider.approveDepositTerms(TERMS);
+      signMock.signPreparedVaultPsbt.mockRejectedValueOnce(new LedgerDeviceError(0xb007, "SW_BAD_STATE"));
+      await expect(provider.signPsbt("aa".repeat(40))).rejects.toThrow(/no longer holds the approved intent/);
+
+      await expect(provider.holdsApprovedDepositTerms(TERMS)).resolves.toBe(false);
+    });
+
+    it("stays true across a PoP signature — the intended fast path", async () => {
+      // The deposit flow signs the PoP between approval and the Pre-PegIn
+      // broadcast; PoP is state-independent on-device and must not consume
+      // the probe either.
+      const provider = await derived();
+      await provider.approveDepositTerms(TERMS);
+      signMock.signPreparedVaultPsbt.mockImplementationOnce(async () => ({
+        signedPsbtHex: "unused",
+        yields: [
+          {
+            kind: "taproot-keypath",
+            inputIndex: 0,
+            outputKeyHex: "00".repeat(32),
+            signature: Buffer.from("ab".repeat(64), "hex"),
+          },
+        ],
+      }));
+      await provider.signMessage(
+        "0xabcdef1234567890abcdef1234567890abcdef12:11155111:pegin:0x1234567890abcdef1234567890abcdef12345678",
+        "bip322-simple",
+      );
+
+      await expect(provider.holdsApprovedDepositTerms(TERMS)).resolves.toBe(true);
+    });
+  });
+
   it("reports a dismissed device picker as a user rejection", async () => {
     // DMK errors are not Error instances — they carry _tag and originalError —
     // and cancelling the WebHID chooser resolves empty, which DMK wraps as

--- a/packages/babylon-wallet-connector/src/core/wallets/btc/ledger-vault/__tests__/provider.test.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/ledger-vault/__tests__/provider.test.ts
@@ -1,9 +1,9 @@
 /**
  * Provider-level tests. The DMK layers are mocked; what matters here is the
  * orchestration contract — that the envelope gate runs before any device I/O,
- * that the derive → approve state machine matches the device's, that unwired
- * methods fail with a typed capability error rather than a silent wrong
- * result, and that the intent carries the right byte order.
+ * that the derive → approve state machine matches the device's, that
+ * unsupported requests fail with a typed capability error rather than a silent
+ * wrong result, and that the intent carries the right byte order.
  */
 
 // @vitest-environment node
@@ -22,7 +22,7 @@ import {
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { Network } from "@/core/types";
-import { getTaprootAddress } from "@/core/utils/wallet";
+import { getTaprootAddress, toNetwork } from "@/core/utils/wallet";
 import { ERROR_CODES, WalletError } from "@/error";
 
 /** BIP-86 first-address vector: x-only key and its published P2TR address. */
@@ -43,6 +43,11 @@ const dmkSessionMock = vi.hoisted(() => ({
 
 const derivationMock = vi.hoisted(() => ({
   getXOnlyPublicKeyHex: vi.fn(async () => VECTOR_XONLY),
+  getMasterFingerprintHex: vi.fn(async () => "73c5da0a"),
+  getExtendedPublicKey: vi.fn(
+    async () =>
+      "tpubDDKYE6BREvDsSWMazgHoyQWiJwYaDDYPbCFjYxN3HFXJP5fokeiK4hwK5tTLBNEDBwrDXn8cQ4v9b2xdW62Xr5yxoQdMu1v6c7UDXYVH27U",
+  ),
 }));
 
 // The SIGN_PSBT core is the signer package's own tested surface; here it is
@@ -119,6 +124,8 @@ beforeEach(() => {
   h.sent.length = 0;
   h.failNext = undefined;
   derivationMock.getXOnlyPublicKeyHex.mockClear();
+  derivationMock.getMasterFingerprintHex.mockClear();
+  derivationMock.getExtendedPublicKey.mockClear();
   dmkSessionMock.connectDmkSession.mockReset();
   dmkSessionMock.connectDmkSession.mockResolvedValue(h.session);
   dmkSessionMock.isSessionAlive.mockReset();
@@ -279,11 +286,146 @@ describe("LedgerVaultProvider", () => {
     expect(dmkSessionMock.connectDmkSession).toHaveBeenCalledTimes(2);
   });
 
-  it("fails signMessage with a capability error rather than a wrong result", async () => {
-    const provider = await connected();
+  describe("signMessage (BIP-322 PoP)", () => {
+    const POP_MESSAGE =
+      "0xabcdef1234567890abcdef1234567890abcdef12:11155111:pegin:0x1234567890abcdef1234567890abcdef12345678";
+    const SIG = "ab".repeat(64);
 
-    await expect(provider.signMessage("m", "bip322-simple")).rejects.toMatchObject({
-      code: ERROR_CODES.WALLET_METHOD_NOT_SUPPORTED,
+    beforeEach(() => {
+      signMock.signPreparedVaultPsbt.mockImplementation(async () => ({
+        signedPsbtHex: "unused",
+        yields: [
+          {
+            kind: "taproot-keypath",
+            inputIndex: 0,
+            outputKeyHex: "00".repeat(32),
+            signature: Buffer.from(SIG, "hex"),
+          },
+        ],
+      }));
+    });
+
+    it("signs a PoP under the default tr(@0/**) policy and returns the 66-byte witness as 0x-hex", async () => {
+      const p = await connected();
+
+      const out = await p.signMessage(POP_MESSAGE, "bip322-simple");
+
+      expect(out).toBe(`0x0140${SIG}`);
+      // Policy built from the device reads, with the account path (3 levels) and the testnet versions.
+      expect(derivationMock.getMasterFingerprintHex).toHaveBeenCalledTimes(1);
+      expect(derivationMock.getExtendedPublicKey).toHaveBeenCalledTimes(1);
+      expect(derivationMock.getExtendedPublicKey).toHaveBeenCalledWith(
+        expect.anything(),
+        [86 + 0x80000000, 1 + 0x80000000, 0 + 0x80000000],
+        toNetwork(Network.SIGNET).bip32,
+      );
+      const prepareArgs = signMock.prepareSignPsbt.mock.calls[0][0];
+      expect(prepareArgs.walletPolicy?.keyInfo).toMatch(/^\[73c5da0a\/86'\/1'\/0'\]tpubDDKYE6B/);
+      expect(prepareArgs.depositorXOnlyHex).toBe(VECTOR_XONLY);
+      // The PSBT handed to prepare is a PoP PSBT (version 0, message in the proprietary key).
+      expect(prepareArgs.psbtHex).toMatch(/^70736274ff/);
+      expect(Buffer.from(prepareArgs.psbtHex, "hex").toString("latin1")).toContain(POP_MESSAGE);
+    });
+
+    it("does not require an approved intent (PoP is state-independent on the device)", async () => {
+      const p = await connected(); // connected, NO deriveContextHash/approveDepositTerms
+
+      await expect(p.signMessage(POP_MESSAGE, "bip322-simple")).resolves.toMatch(/^0x0140/);
+    });
+
+    it("caches the wallet policy per connection and drops it on teardown", async () => {
+      const p = await connected();
+      await p.signMessage(POP_MESSAGE, "bip322-simple");
+      await p.signMessage(POP_MESSAGE, "bip322-simple");
+
+      expect(derivationMock.getMasterFingerprintHex).toHaveBeenCalledTimes(1);
+
+      await p.disconnect();
+      await p.connectWallet();
+      await p.signMessage(POP_MESSAGE, "bip322-simple");
+
+      expect(derivationMock.getMasterFingerprintHex).toHaveBeenCalledTimes(2);
+    });
+
+    it("rejects ecdsa with WALLET_METHOD_NOT_SUPPORTED without touching the device", async () => {
+      const p = await connected();
+
+      await expect(p.signMessage(POP_MESSAGE, "ecdsa")).rejects.toMatchObject({
+        code: ERROR_CODES.WALLET_METHOD_NOT_SUPPORTED,
+      });
+      expect(signMock.prepareSignPsbt).not.toHaveBeenCalled();
+    });
+
+    it("fails when the device returns no key-path yield (the no-policy silent-success shape)", async () => {
+      signMock.signPreparedVaultPsbt.mockImplementation(async () => ({ signedPsbtHex: "unused", yields: [] }));
+      const p = await connected();
+
+      await expect(p.signMessage(POP_MESSAGE, "bip322-simple")).rejects.toThrow(/no key-path signature/);
+    });
+
+    it("leaves the intent mirror and signed-fingerprint set untouched", async () => {
+      const p = await connected();
+      await p.deriveContextHash("app", "aa".repeat(32));
+      await p.approveDepositTerms(TERMS);
+
+      await p.signMessage(POP_MESSAGE, "bip322-simple");
+
+      // A tapscript signPsbt after PoP must still pass the intent gate and sign.
+      // `prepareSignPsbt`/`signPreparedVaultPsbt` are mocked in this file, so restore the
+      // file's default signing stub for this call.
+      signMock.signPreparedVaultPsbt.mockImplementationOnce(async (_send, prepared: { originalPsbtHex: string }) => ({
+        signedPsbtHex: `signed:${prepared.originalPsbtHex}`,
+        yields: [],
+      }));
+      await expect(p.signPsbt("70736274ff00", { autoFinalized: false })).resolves.toBe("signed:70736274ff00");
+    });
+
+    it("disconnect aborts the in-flight PoP and surfaces it as a disconnection", async () => {
+      const p = await connected();
+      // Hang until teardown's abort fires, exactly like the signPsbt loop does.
+      signMock.signPreparedVaultPsbt.mockImplementationOnce(
+        (_send, _prepared, opts: { signal: AbortSignal }) =>
+          new Promise((_resolve, reject) => {
+            opts.signal.addEventListener("abort", () => reject(new LedgerSignPsbtAbortedError(0, true)));
+          }),
+      );
+      const inFlight = p.signMessage(POP_MESSAGE, "bip322-simple");
+      inFlight.catch(() => {});
+      await vi.waitFor(() => expect(signMock.signPreparedVaultPsbt).toHaveBeenCalledTimes(1));
+
+      await p.disconnect();
+
+      // Not UNKNOWN_ERROR: #2110's UX routes cancellation on this code.
+      await expect(inFlight).rejects.toMatchObject({ code: ERROR_CODES.WALLET_NOT_CONNECTED });
+    });
+
+    it("a failed PoP leaves the approved intent and the replay guard untouched", async () => {
+      const p = await connected();
+      await p.deriveContextHash("app", "aa".repeat(32));
+      await p.approveDepositTerms(TERMS);
+      await p.signPsbt("70736274ff00", { autoFinalized: false });
+      signMock.signPreparedVaultPsbt.mockRejectedValueOnce(
+        new LedgerDeviceError(0x6f42, "The device rejected the request"),
+      );
+
+      await expect(p.signMessage(POP_MESSAGE, "bip322-simple")).rejects.toThrow(/signMessage/);
+
+      // The device never invalidates its vault context on a PoP, so the mirror
+      // must survive — and the earlier signature must still be fingerprinted.
+      await expect(p.signPsbt("70736274ff00", { autoFinalized: false })).rejects.toThrow(/already signed/);
+      signMock.signPreparedVaultPsbt.mockImplementationOnce(async (_send, prepared: { originalPsbtHex: string }) => ({
+        signedPsbtHex: `signed:${prepared.originalPsbtHex}`,
+        yields: [],
+      }));
+      await expect(p.signPsbt("70736274ff11", { autoFinalized: false })).resolves.toBe("signed:70736274ff11");
+    });
+
+    it("refuses before connecting", async () => {
+      const p = new LedgerVaultProvider(Network.SIGNET);
+
+      await expect(p.signMessage(POP_MESSAGE, "bip322-simple")).rejects.toMatchObject({
+        code: ERROR_CODES.WALLET_NOT_CONNECTED,
+      });
     });
   });
 
@@ -351,7 +493,7 @@ describe("LedgerVaultProvider", () => {
       expect(signMock.signPreparedVaultPsbt).not.toHaveBeenCalled();
     });
 
-    it("rejects a keypath table actionably — Pre-PegIn/PoP need the wallet-policy path", async () => {
+    it("rejects a keypath table actionably — Pre-PegIn needs the wallet-policy path", async () => {
       const provider = await approved();
       signMock.prepareSignPsbt.mockImplementationOnce(({ psbtHex }: { psbtHex: string }) =>
         fakePrepared(psbtHex, "taproot-keypath"),

--- a/packages/babylon-wallet-connector/src/core/wallets/btc/ledger-vault/__tests__/provider.test.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/ledger-vault/__tests__/provider.test.ts
@@ -19,6 +19,8 @@ import {
   LedgerSignPsbtProtocolError,
   LedgerUserRefusedError,
 } from "@babylonlabs-io/ledger-vault-signer";
+import * as ecc from "@bitcoin-js/tiny-secp256k1-asmjs";
+import { initEccLib, payments, Psbt } from "bitcoinjs-lib";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { Network } from "@/core/types";
@@ -28,6 +30,9 @@ import { ERROR_CODES, WalletError } from "@/error";
 /** BIP-86 first-address vector: x-only key and its published P2TR address. */
 const VECTOR_XONLY = "cc8a4bc64d897bddc5fbc2f670f7a8ba0b386779106cf1223c6fc5d7cd6fc115";
 const VECTOR_MAINNET_ADDRESS = "bc1p5cyxnuxmeuwuvkwfem96lqzszd02n6xdcjrs20cac6yqjjwudpxqkedrcr";
+/** The `m/86'/1'/0'` account xpub the device reports (testnet versions). */
+const ACCOUNT_XPUB =
+  "tpubDDKYE6BREvDsSWMazgHoyQWiJwYaDDYPbCFjYxN3HFXJP5fokeiK4hwK5tTLBNEDBwrDXn8cQ4v9b2xdW62Xr5yxoQdMu1v6c7UDXYVH27U";
 
 const h = vi.hoisted(() => ({
   session: { dmk: {}, sessionId: "s1", appName: "Babylon Vault", appVersion: "0.9.5" },
@@ -44,10 +49,7 @@ const dmkSessionMock = vi.hoisted(() => ({
 const derivationMock = vi.hoisted(() => ({
   getXOnlyPublicKeyHex: vi.fn(async () => VECTOR_XONLY),
   getMasterFingerprintHex: vi.fn(async () => "73c5da0a"),
-  getExtendedPublicKey: vi.fn(
-    async () =>
-      "tpubDDKYE6BREvDsSWMazgHoyQWiJwYaDDYPbCFjYxN3HFXJP5fokeiK4hwK5tTLBNEDBwrDXn8cQ4v9b2xdW62Xr5yxoQdMu1v6c7UDXYVH27U",
-  ),
+  getExtendedPublicKey: vi.fn(async () => ACCOUNT_XPUB),
 }));
 
 // The SIGN_PSBT core is the signer package's own tested surface; here it is
@@ -107,17 +109,29 @@ const approveApdus = () => h.sent.filter((a) => a.ins === INS_APPROVE_VAULT_INTE
  * signer's discriminant so a rename breaks this file's compile), the request
  * identity, and the merge source the device mock echoes back.
  */
-function fakePrepared(psbtHex: string, kind: InputSigExpectation["kind"] = "tapscript", unsignedTxid?: string) {
-  const expectation =
-    kind === "tapscript"
-      ? { kind, expectedLeafHashHexes: new Set(["ef".repeat(32)]), expectedSignerXOnlyHex: "ab".repeat(32) }
-      : { kind, expectedOutputKeyHex: "cd".repeat(32) };
+function fakePrepared(psbtHex: string, unsignedTxid?: string) {
+  const expectation: InputSigExpectation = {
+    kind: "tapscript",
+    expectedLeafHashHexes: new Set(["ef".repeat(32)]),
+    expectedSignerXOnlyHex: "ab".repeat(32),
+  };
   return {
     originalPsbtHex: psbtHex,
     // Case-insensitive like the real txid (decoded bytes, not hex casing).
     unsignedTxid: unsignedTxid ?? `txid-${psbtHex.toLowerCase()}`,
     table: { byInput: new Map([[0, expectation]]), expectedYieldCount: 1 },
   };
+}
+
+/** The unmocked signer package — these tests drive its real prepare/derive paths. */
+function actualSigner() {
+  return vi.importActual<typeof import("@babylonlabs-io/ledger-vault-signer")>("@babylonlabs-io/ledger-vault-signer");
+}
+
+/** x-only key at `m/86'/1'/0'/1/0` under {@link ACCOUNT_XPUB} — the device's change key. */
+async function changeXOnlyHex(): Promise<string> {
+  const { deriveChangeXOnlyHex } = await actualSigner();
+  return deriveChangeXOnlyHex(ACCOUNT_XPUB, toNetwork(Network.SIGNET).bip32, 0);
 }
 
 beforeEach(() => {
@@ -493,16 +507,160 @@ describe("LedgerVaultProvider", () => {
       expect(signMock.signPreparedVaultPsbt).not.toHaveBeenCalled();
     });
 
-    it("rejects a keypath table actionably — Pre-PegIn needs the wallet-policy path", async () => {
-      const provider = await approved();
-      signMock.prepareSignPsbt.mockImplementationOnce(({ psbtHex }: { psbtHex: string }) =>
-        fakePrepared(psbtHex, "taproot-keypath"),
+    /** BIP-86 P2TR script of an x-only key. */
+    function bip86Script(xOnlyHex: string): Buffer {
+      initEccLib(ecc);
+      return payments.p2tr({ internalPubkey: Buffer.from(xOnlyHex, "hex") }).output!;
+    }
+
+    /** An HTLC-shaped P2TR output: a raw witness program the wallet does not own. */
+    const HTLC_SCRIPT = Buffer.concat([Buffer.from([0x51, 0x20]), Buffer.alloc(32, 0xbb)]);
+
+    /**
+     * A real key-path Pre-PegIn-shaped PSBT so the REAL `prepareSignPsbt` (not
+     * mocked in these tests) classifies it as taproot-keypath: every input is
+     * the depositor's BIP-86 P2TR.
+     */
+    function keyPathPsbtHex(outputScripts: Buffer[], inputCount = 1): string {
+      const depositorKey = Buffer.from(VECTOR_XONLY, "hex");
+      const psbt = new Psbt();
+      for (let i = 0; i < inputCount; i++) {
+        psbt.addInput({
+          hash: Buffer.alloc(32, i + 1),
+          index: 0,
+          witnessUtxo: { script: bip86Script(VECTOR_XONLY), value: 100_000 },
+          tapInternalKey: depositorKey,
+        });
+      }
+      for (const script of outputScripts) psbt.addOutput({ script, value: 90_000 });
+      return psbt.toHex();
+    }
+
+    it("routes an all-key-path PSBT through wallet-policy mode with derivation fields added", async () => {
+      const { prepareSignPsbt: realPrepare } = await actualSigner();
+      signMock.prepareSignPsbt.mockImplementation(realPrepare);
+      signMock.signPreparedVaultPsbt.mockImplementation(async () => ({ signedPsbtHex: "signed-keypath", yields: [] }));
+      const p = await approved();
+      const changeXOnly = await changeXOnlyHex();
+
+      await expect(
+        p.signPsbt(keyPathPsbtHex([HTLC_SCRIPT, bip86Script(changeXOnly)]), { autoFinalized: false }),
+      ).resolves.toBe("signed-keypath");
+
+      const [prepareArgs] = signMock.prepareSignPsbt.mock.calls.at(-1)!;
+      expect(prepareArgs.walletPolicy?.keyInfo).toMatch(/^\[73c5da0a\/86'\/1'\/0'\]tpubDDKYE6B/);
+      const augmented = Psbt.fromHex(prepareArgs.psbtHex);
+      expect(augmented.data.inputs[0].tapBip32Derivation?.[0].path).toBe("m/86'/1'/0'/0/0");
+      expect(Buffer.from(augmented.data.inputs[0].tapBip32Derivation![0].masterFingerprint).toString("hex")).toBe(
+        "73c5da0a",
+      );
+      // The change output carries the branch-1 derivation the device needs to
+      // mark it internal — without it `_validate_prepegin` rejects the output.
+      expect(augmented.data.outputs[1].tapBip32Derivation?.[0].path).toBe("m/86'/1'/0'/1/0");
+      expect(Buffer.from(augmented.data.outputs[1].tapInternalKey!).toString("hex")).toBe(changeXOnly);
+      // The HTLC output is not ours — marking it internal would fail on-device.
+      expect(augmented.data.outputs[0].tapBip32Derivation).toBeUndefined();
+    });
+
+    it("adds no output derivation when the PSBT pays the wallet no change", async () => {
+      const { prepareSignPsbt: realPrepare } = await actualSigner();
+      signMock.prepareSignPsbt.mockImplementation(realPrepare);
+      signMock.signPreparedVaultPsbt.mockImplementation(async () => ({ signedPsbtHex: "signed-keypath", yields: [] }));
+      const p = await approved();
+
+      await expect(p.signPsbt(keyPathPsbtHex([bip86Script("aa".repeat(32))]), { autoFinalized: false })).resolves.toBe(
+        "signed-keypath",
       );
 
-      await expect(provider.signPsbt(PSBT_A)).rejects.toThrow(/wallet-policy path/);
+      const [prepareArgs] = signMock.prepareSignPsbt.mock.calls.at(-1)!;
+      expect(prepareArgs.walletPolicy?.keyInfo).toMatch(/^\[73c5da0a\/86'\/1'\/0'\]tpubDDKYE6B/);
+      const augmented = Psbt.fromHex(prepareArgs.psbtHex);
+      expect(augmented.data.inputs[0].tapBip32Derivation?.[0].path).toBe("m/86'/1'/0'/0/0");
+      expect(augmented.data.outputs.every((out) => !out.tapBip32Derivation)).toBe(true);
+    });
+
+    it("signs a change-less Max sweep — every depositor input marked, no change output", async () => {
+      // computeMaxDeposit emits no change (`peginFeeMath.ts:162-165`), and
+      // dust-revert drops it too; the firmware accepts zero change.
+      const { prepareSignPsbt: realPrepare } = await actualSigner();
+      signMock.prepareSignPsbt.mockImplementation(realPrepare);
+      signMock.signPreparedVaultPsbt.mockImplementation(async () => ({ signedPsbtHex: "signed-sweep", yields: [] }));
+      const p = await approved();
+
+      await expect(p.signPsbt(keyPathPsbtHex([HTLC_SCRIPT], 2), { autoFinalized: false })).resolves.toBe(
+        "signed-sweep",
+      );
+
+      const [prepareArgs] = signMock.prepareSignPsbt.mock.calls.at(-1)!;
+      const augmented = Psbt.fromHex(prepareArgs.psbtHex);
+      expect(augmented.data.inputs.map((input) => input.tapBip32Derivation?.[0].path)).toEqual([
+        "m/86'/1'/0'/0/0",
+        "m/86'/1'/0'/0/0",
+      ]);
+      expect(augmented.data.outputs[0].tapBip32Derivation).toBeUndefined();
+    });
+
+    it("surfaces a disconnect during the policy read as a disconnection, not a bad PSBT", async () => {
+      const { prepareSignPsbt: realPrepare } = await actualSigner();
+      signMock.prepareSignPsbt.mockImplementation(realPrepare);
+      const p = await approved();
+      const psbtHex = keyPathPsbtHex([bip86Script(await changeXOnlyHex())]);
+      derivationMock.getExtendedPublicKey.mockImplementationOnce(async () => {
+        await p.disconnect();
+        return ACCOUNT_XPUB;
+      });
+
+      await expect(p.signPsbt(psbtHex, { autoFinalized: false })).rejects.toMatchObject({
+        code: ERROR_CODES.WALLET_NOT_CONNECTED,
+      });
       expect(signMock.signPreparedVaultPsbt).not.toHaveBeenCalled();
-      // The rejection cost no ceremony: the intent still signs.
-      await expect(provider.signPsbt(PSBT_A)).resolves.toBe(`signed:${PSBT_A}`);
+    });
+
+    it("keeps tapscript PSBTs on the no-policy path (walletPolicy undefined)", async () => {
+      const p = await approved();
+
+      await p.signPsbt(PSBT_A, { autoFinalized: false });
+
+      const [prepareArgs] = signMock.prepareSignPsbt.mock.calls.at(-1)!;
+      expect(prepareArgs.walletPolicy).toBeUndefined();
+    });
+
+    it("rejects a PSBT mixing key-path and tapscript inputs before any device I/O", async () => {
+      signMock.prepareSignPsbt.mockImplementation(({ psbtHex }: { psbtHex: string }) => ({
+        ...fakePrepared(psbtHex),
+        table: {
+          byInput: new Map([
+            [0, { kind: "taproot-keypath", expectedOutputKeyHex: "00".repeat(32) }],
+            [
+              1,
+              {
+                kind: "tapscript",
+                expectedLeafHashHexes: new Set(["11".repeat(32)]),
+                expectedSignerXOnlyHex: VECTOR_XONLY,
+              },
+            ],
+          ]),
+          expectedYieldCount: 2,
+        },
+      }));
+      const p = await approved();
+
+      await expect(p.signPsbt(PSBT_A, { autoFinalized: false })).rejects.toMatchObject({
+        code: ERROR_CODES.INVALID_PARAMS,
+      });
+      expect(signMock.signPreparedVaultPsbt).not.toHaveBeenCalled();
+    });
+
+    it("still requires an approved intent for key-path PSBTs", async () => {
+      const { prepareSignPsbt: realPrepare } = await actualSigner();
+      signMock.prepareSignPsbt.mockImplementation(realPrepare);
+      const p = await connected(); // no intent
+
+      await expect(
+        p.signPsbt(keyPathPsbtHex([bip86Script(await changeXOnlyHex())]), { autoFinalized: false }),
+      ).rejects.toMatchObject({
+        message: expect.stringMatching(/holds no approved intent/),
+      });
     });
 
     it("a prepare-time rejection leaves the mirror and the intent untouched", async () => {
@@ -608,7 +766,7 @@ describe("LedgerVaultProvider", () => {
       await provider.signPsbt(PSBT_A);
       // Different wire bytes, same unsigned tx and expectations (an extra
       // unknown global, say) — identity keying catches what byte-hashing missed.
-      signMock.prepareSignPsbt.mockImplementationOnce(() => fakePrepared(PSBT_B, "tapscript", `txid-${PSBT_A}`));
+      signMock.prepareSignPsbt.mockImplementationOnce(() => fakePrepared(PSBT_B, `txid-${PSBT_A}`));
 
       await expect(provider.signPsbt(PSBT_B)).rejects.toThrow(/already signed/);
       expect(signMock.signPreparedVaultPsbt).toHaveBeenCalledTimes(1);
@@ -767,6 +925,21 @@ describe("LedgerVaultProvider", () => {
       await provider.approveDepositTerms(TERMS);
 
       await expect(provider.signPsbt(PSBT_A)).resolves.toBe(`signed:${PSBT_A}`);
+    });
+  });
+
+  describe("getChangeAddress", () => {
+    it("returns the P2TR address of m/86'/coin'/0'/1/0 derived from the device's account xpub", async () => {
+      const p = await connected();
+
+      await expect(p.getChangeAddress()).resolves.toBe(getTaprootAddress(await changeXOnlyHex(), Network.SIGNET));
+      expect(derivationMock.getMasterFingerprintHex).toHaveBeenCalledTimes(1); // shares the PolicyContext cache
+    });
+
+    it("refuses before connecting", async () => {
+      const p = new LedgerVaultProvider(Network.SIGNET);
+
+      await expect(p.getChangeAddress()).rejects.toMatchObject({ code: ERROR_CODES.WALLET_NOT_CONNECTED });
     });
   });
 

--- a/packages/babylon-wallet-connector/src/core/wallets/btc/ledger-vault/__tests__/provider.test.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/ledger-vault/__tests__/provider.test.ts
@@ -941,6 +941,25 @@ describe("LedgerVaultProvider", () => {
 
       await expect(p.getChangeAddress()).rejects.toMatchObject({ code: ERROR_CODES.WALLET_NOT_CONNECTED });
     });
+
+    it("refuses an xpub read that resolved after a disconnect", async () => {
+      // Returning the previous device's address would route Pre-PegIn change
+      // to a key the reconnected wallet cannot spend.
+      const p = await connected();
+      let releaseXpub: (xpub: string) => void = () => {};
+      derivationMock.getExtendedPublicKey.mockImplementationOnce(
+        () =>
+          new Promise<string>((resolve) => {
+            releaseXpub = resolve;
+          }),
+      );
+
+      const pending = p.getChangeAddress();
+      await p.disconnect();
+      releaseXpub(ACCOUNT_XPUB);
+
+      await expect(pending).rejects.toMatchObject({ code: ERROR_CODES.WALLET_NOT_CONNECTED });
+    });
   });
 
   it("runs the envelope gate before any device I/O", async () => {

--- a/packages/babylon-wallet-connector/src/core/wallets/btc/ledger-vault/__tests__/provider.test.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/ledger-vault/__tests__/provider.test.ts
@@ -1097,15 +1097,24 @@ describe("LedgerVaultProvider", () => {
       ).resolves.toBe(false);
     });
 
-    it("is false once a PSBT was signed under the intent, so a broadcast retry re-ceremonies", async () => {
-      // The one-shot cap + stagePsbt's pre-I/O replay guard mean a held-but-
-      // consumed intent cannot sign again; a true here would trap the retry
-      // in the replay throw with the mirror never resetting.
+    it("is false once the terms' Pre-PegIn was signed, so a broadcast retry re-ceremonies", async () => {
+      // A true here would trap the retry in the replay throw forever.
+      const provider = await derived();
+      await provider.approveDepositTerms(TERMS);
+      const psbt = "aa".repeat(40);
+      signMock.prepareSignPsbt.mockImplementationOnce(() => fakePrepared(psbt, TERMS.prepeginTxid));
+      await provider.signPsbt(psbt);
+
+      await expect(provider.holdsApprovedDepositTerms(TERMS)).resolves.toBe(false);
+    });
+
+    it("stays true after signing a different tx (the PegIn PSBTs preparePegin signs)", async () => {
+      // PegIn signatures spend a separate device counter — must not kill the fast path.
       const provider = await derived();
       await provider.approveDepositTerms(TERMS);
       await provider.signPsbt("aa".repeat(40));
 
-      await expect(provider.holdsApprovedDepositTerms(TERMS)).resolves.toBe(false);
+      await expect(provider.holdsApprovedDepositTerms(TERMS)).resolves.toBe(true);
     });
 
     it("is false after a sign failure drops the mirror", async () => {
@@ -1118,11 +1127,32 @@ describe("LedgerVaultProvider", () => {
     });
 
     it("stays true across a PoP signature — the intended fast path", async () => {
-      // The deposit flow signs the PoP between approval and the Pre-PegIn
-      // broadcast; PoP is state-independent on-device and must not consume
-      // the probe either.
+      // PoP is state-independent on-device; it must not consume the probe.
       const provider = await derived();
       await provider.approveDepositTerms(TERMS);
+      signMock.signPreparedVaultPsbt.mockImplementationOnce(async () => ({
+        signedPsbtHex: "unused",
+        yields: [
+          {
+            kind: "taproot-keypath",
+            inputIndex: 0,
+            outputKeyHex: "00".repeat(32),
+            signature: Buffer.from("ab".repeat(64), "hex"),
+          },
+        ],
+      }));
+      await provider.signMessage(
+        "0xabcdef1234567890abcdef1234567890abcdef12:11155111:pegin:0x1234567890abcdef1234567890abcdef12345678",
+        "bip322-simple",
+      );
+
+      await expect(provider.holdsApprovedDepositTerms(TERMS)).resolves.toBe(true);
+    });
+
+    it("stays true through the full fresh-flow sequence: approve, batch PegIn signs, PoP", async () => {
+      const provider = await derived();
+      await provider.approveDepositTerms(TERMS);
+      await provider.signPsbts(["aa".repeat(40), "bb".repeat(40)]);
       signMock.signPreparedVaultPsbt.mockImplementationOnce(async () => ({
         signedPsbtHex: "unused",
         yields: [

--- a/packages/babylon-wallet-connector/src/core/wallets/btc/ledger-vault/provider.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/ledger-vault/provider.ts
@@ -9,6 +9,7 @@ import {
   createDmkRawApduSender,
   DepositTermsRejectedError,
   deriveChangeXOnlyHex,
+  deriveReceiveXOnlyHex,
   deriveContextHash,
   disconnectDmkSession,
   encodeIntentGroup,
@@ -366,11 +367,36 @@ export class LedgerVaultProvider implements IBTCProvider {
   private getPolicyContext(): Promise<PolicyContext> {
     if (!this.policyContextPromise) {
       const send = this.requireSender();
+      const generation = this.connectionGeneration;
       const read = (async (): Promise<PolicyContext> => {
-        const [masterFingerprintHex, accountXpub] = await Promise.all([
+        const [masterFingerprintHex, accountXpub, depositorXOnlyHex] = await Promise.all([
           getMasterFingerprintHex(send),
           getExtendedPublicKey(send, this.accountPath, toNetwork(this.network).bip32),
+          this.getDevicePubkeyHex(),
         ]);
+        // Before comparing: a teardown mid-read must report the disconnection,
+        // not a key mismatch.
+        this.assertSameConnection(generation);
+        // Our two read paths must agree on the depositor key. The device does
+        // byte-compare the policy xpub against its own derivation
+        // (`base:policy.c:1483-1495` @ e400d8d8, via `init_global_state.c:230-236`),
+        // but only at SIGN_PSBT — by then approveDepositTerms has already spent
+        // the intent ceremony. This guards a host-side desync (depositorPath vs
+        // accountPath, coin type, a refactor of either getter), not a device fault.
+        const derivedXOnlyHex = deriveReceiveXOnlyHex(
+          accountXpub,
+          toNetwork(this.network).bip32,
+          ADDRESS_INDEX,
+        );
+        if (derivedXOnlyHex !== depositorXOnlyHex) {
+          throw new WalletError({
+            code: ERROR_CODES.CONNECTION_FAILED,
+            message:
+              `${WALLET_PROVIDER_NAME} account xpub does not derive the depositor key; ` +
+              `the wallet policy would bind a different key than the intent.`,
+            wallet: WALLET_PROVIDER_NAME,
+          });
+        }
         const policy = buildDefaultTaprootPolicy({
           masterFingerprintHex,
           coinType: COIN_TYPE_BY_NETWORK[this.network],

--- a/packages/babylon-wallet-connector/src/core/wallets/btc/ledger-vault/provider.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/ledger-vault/provider.ts
@@ -467,6 +467,73 @@ export class LedgerVaultProvider implements IBTCProvider {
   approveDepositTerms = async (terms: DepositTerms): Promise<void> =>
     this.withDeviceOperation("approveDepositTerms", () => this.doApproveDepositTerms(terms));
 
+  /**
+   * DepositTermsApprover.holdsApprovedDepositTerms: true iff this connection
+   * still holds an approval for the byte-equal intent AND nothing has been
+   * signed under it yet (held-but-consumed must read false — see the seam
+   * JSDoc). Host mirror read only — no device I/O, never throws. A stale true
+   * is caught fail-closed by the signing gate (device state error → mirror
+   * reset → retry runs the full ceremony), so a true answer can only skip a
+   * redundant ceremony, never authorize one.
+   */
+  holdsApprovedDepositTerms = async (terms: DepositTerms): Promise<boolean> => {
+    const state = this.deviceState;
+    if (state.phase !== "intent-loaded") return false;
+    // Anything already signed under this intent means the next Pre-PegIn
+    // signature needs a fresh ceremony (device one-shot cap; the host replay
+    // guard in stagePsbt pre-empts it without touching the mirror) — so the
+    // approval is held but not reusable, and reporting true would trap a
+    // broadcast-failure retry in the replay throw forever.
+    if (this.signedFingerprints.size > 0) return false;
+    try {
+      return state.termsKey === this.fingerprintTerms(terms);
+    } catch {
+      // Unencodable terms cannot equal an approved fingerprint; the ceremony
+      // path surfaces the shaped rejection instead of this probe throwing.
+      return false;
+    }
+  };
+
+  /**
+   * Idempotence key: the encoded intent wire bytes plus vaultCoreVersion,
+   * which the envelope gates but the TLV never carries (the wire's protocol
+   * version is a constant) — without it, terms differing only in version
+   * would compare equal.
+   */
+  private fingerprintTerms = (terms: DepositTerms): string =>
+    `${terms.vaultCoreVersion}:${fingerprintIntent(this.buildIntentFromTerms(terms))}`;
+
+  /** Pure translation of seam terms into the device intent. No I/O, no state. */
+  private buildIntentFromTerms = (terms: DepositTerms) => {
+    const scalars: IntentScalars = {
+      coinType: COIN_TYPE_BY_NETWORK[this.network],
+      baseFeeRate: terms.protocolFeeRate,
+      peginCsvTimelock: terms.timelockPegin,
+      payoutTimelock: terms.timelockAssert,
+      prepeginTxidInternal: displayTxidToInternal(terms.prepeginTxid),
+      htlcRefundTimelock: terms.timelockRefund,
+      depositorPath: this.depositorPath,
+      keeperCount: terms.vaultKeeperBtcPubkeys.length,
+      challengerCount: terms.universalChallengerBtcPubkeys.length,
+      vaultCount: terms.vaults.length,
+      prepeginMaxFee: terms.prepeginMaxFee,
+    };
+    const groups: IntentVaultGroup[] = terms.vaults.map((vault) => ({
+      htlcVout: vault.htlcVout,
+      vaultProviderPubkey: hexToXOnly(vault.vaultProviderBtcPubkey, "vaultProviderBtcPubkey"),
+      vaultAmount: vault.peginAmount,
+      commissionFee: vault.commissionFee,
+      depositorClaimValue: vault.depositorClaimValue,
+      peginMaxFee: vault.peginMaxFee,
+    }));
+    return {
+      scalars,
+      groups,
+      keeperPubkeys: terms.vaultKeeperBtcPubkeys.map((k) => hexToXOnly(k, "vaultKeeperBtcPubkey")),
+      challengerPubkeys: terms.universalChallengerBtcPubkeys.map((k) => hexToXOnly(k, "universalChallengerBtcPubkey")),
+    };
+  };
+
   private doApproveDepositTerms = async (terms: DepositTerms): Promise<void> => {
     assertDepositTermsDeviceCompatible(terms);
 
@@ -487,19 +554,6 @@ export class LedgerVaultProvider implements IBTCProvider {
       });
     }
     this.assertSameConnection(generation);
-    const scalars: IntentScalars = {
-      coinType: COIN_TYPE_BY_NETWORK[this.network],
-      baseFeeRate: terms.protocolFeeRate,
-      peginCsvTimelock: terms.timelockPegin,
-      payoutTimelock: terms.timelockAssert,
-      prepeginTxidInternal: displayTxidToInternal(terms.prepeginTxid),
-      htlcRefundTimelock: terms.timelockRefund,
-      depositorPath: this.depositorPath,
-      keeperCount: terms.vaultKeeperBtcPubkeys.length,
-      challengerCount: terms.universalChallengerBtcPubkeys.length,
-      vaultCount: terms.vaults.length,
-      prepeginMaxFee: terms.prepeginMaxFee,
-    };
 
     // The device rejects any roster/VP key equal to the depositor's own key,
     // but only after the whole ceremony (approve_vault_intent_core.h). Pre-empt
@@ -518,23 +572,9 @@ export class LedgerVaultProvider implements IBTCProvider {
       );
     }
 
-    const groups: IntentVaultGroup[] = terms.vaults.map((vault) => ({
-      htlcVout: vault.htlcVout,
-      vaultProviderPubkey: hexToXOnly(vault.vaultProviderBtcPubkey, "vaultProviderBtcPubkey"),
-      vaultAmount: vault.peginAmount,
-      commissionFee: vault.commissionFee,
-      depositorClaimValue: vault.depositorClaimValue,
-      peginMaxFee: vault.peginMaxFee,
-    }));
+    const intent = this.buildIntentFromTerms(terms);
 
-    const intent = {
-      scalars,
-      groups,
-      keeperPubkeys: terms.vaultKeeperBtcPubkeys.map((k) => hexToXOnly(k, "vaultKeeperBtcPubkey")),
-      challengerPubkeys: terms.universalChallengerBtcPubkeys.map((k) => hexToXOnly(k, "universalChallengerBtcPubkey")),
-    };
-
-    const key = fingerprintIntent(intent);
+    const key = this.fingerprintTerms(terms);
 
     // One ceremony per derive: a byte-equal re-approval (the SDK approves in
     // both preparePegin and runDepositorPresignFlow) must be a no-op, and

--- a/packages/babylon-wallet-connector/src/core/wallets/btc/ledger-vault/provider.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/ledger-vault/provider.ts
@@ -468,38 +468,29 @@ export class LedgerVaultProvider implements IBTCProvider {
     this.withDeviceOperation("approveDepositTerms", () => this.doApproveDepositTerms(terms));
 
   /**
-   * DepositTermsApprover.holdsApprovedDepositTerms: true iff this connection
-   * still holds an approval for the byte-equal intent AND nothing has been
-   * signed under it yet (held-but-consumed must read false — see the seam
-   * JSDoc). Host mirror read only — no device I/O, never throws. A stale true
-   * is caught fail-closed by the signing gate (device state error → mirror
-   * reset → retry runs the full ceremony), so a true answer can only skip a
-   * redundant ceremony, never authorize one.
+   * DepositTermsApprover.holdsApprovedDepositTerms: mirror read, no device
+   * I/O, never throws. A stale true fails closed at the signing gate.
    */
   holdsApprovedDepositTerms = async (terms: DepositTerms): Promise<boolean> => {
     const state = this.deviceState;
     if (state.phase !== "intent-loaded") return false;
-    // Anything already signed under this intent means the next Pre-PegIn
-    // signature needs a fresh ceremony (device one-shot cap; the host replay
-    // guard in stagePsbt pre-empts it without touching the mirror) — so the
-    // approval is held but not reusable, and reporting true would trap a
-    // broadcast-failure retry in the replay throw forever.
-    if (this.signedFingerprints.size > 0) return false;
     try {
+      // A signed Pre-PegIn is one-shot — its retry needs a fresh ceremony, and
+      // the replay guard never resets the mirror. Other txids (the PegIn PSBTs
+      // preparePegin signs) spend separate device counters and stay fine.
+      const prepeginTxid = terms.prepeginTxid.replace(/^0x/, "").toLowerCase();
+      for (const key of this.signedFingerprints) {
+        if (key.startsWith(`${prepeginTxid}|`)) return false;
+      }
       return state.termsKey === this.fingerprintTerms(terms);
     } catch {
-      // Unencodable terms cannot equal an approved fingerprint; the ceremony
-      // path surfaces the shaped rejection instead of this probe throwing.
+      // Never-throw seam: unencodable terms can't match an approved key; the
+      // ceremony path surfaces the real error.
       return false;
     }
   };
 
-  /**
-   * Idempotence key: the encoded intent wire bytes plus vaultCoreVersion,
-   * which the envelope gates but the TLV never carries (the wire's protocol
-   * version is a constant) — without it, terms differing only in version
-   * would compare equal.
-   */
+  /** Idempotence key: wire bytes + vaultCoreVersion (the TLV never carries it). */
   private fingerprintTerms = (terms: DepositTerms): string =>
     `${terms.vaultCoreVersion}:${fingerprintIntent(this.buildIntentFromTerms(terms))}`;
 

--- a/packages/babylon-wallet-connector/src/core/wallets/btc/ledger-vault/provider.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/ledger-vault/provider.ts
@@ -1,12 +1,14 @@
 import {
   approveVaultIntent,
   assertDepositTermsDeviceCompatible,
+  augmentPsbtForWalletPolicy,
   buildDefaultTaprootPolicy,
   buildPopPsbtHex,
   connectDmkSession,
   createDmkApduSender,
   createDmkRawApduSender,
   DepositTermsRejectedError,
+  deriveChangeXOnlyHex,
   deriveContextHash,
   disconnectDmkSession,
   encodeIntentGroup,
@@ -24,6 +26,7 @@ import {
   isLedgerYieldMismatchError,
   isSessionAlive,
   prepareSignPsbt,
+  psbtPaysChangeScript,
   signPreparedVaultPsbt,
   SW_BAD_STATE,
   SW_CAP_EXCEEDED,
@@ -61,6 +64,8 @@ const COIN_TYPE_BY_NETWORK: Record<Network, number> = {
 const ACCOUNT_INDEX = 0;
 const CHANGE_INDEX = 0;
 const ADDRESS_INDEX = 0;
+const CHANGE_BRANCH = 1;
+const FIRST_CHANGE_INDEX = 0;
 const HARDENED = 0x80000000;
 
 /** BIP-322 simple P2TR witness: one item — `varint(1) ‖ varint(64) ‖ sig` (`message.rs:105-144`, `BTCProofOfPossession.sol` accepts exactly this 66-byte shape). */
@@ -121,8 +126,8 @@ function signingRequestKey(prepared: PreparedSignPsbt): string {
  *
  * Ships behind `NEXT_PUBLIC_FF_ENABLE_LEDGER_VAULT_WALLET` (default off).
  * Covers connect, the key read, the intent ceremony, SIGN_PSBT for the
- * no-policy tapscript flows (#2219), and the BIP-322 PoP under the default
- * wallet policy (#2221). Pre-PegIn key-path signing is still to come (#2222).
+ * no-policy tapscript flows (#2219), the BIP-322 PoP under the default wallet
+ * policy (#2221), and key-path Pre-PegIn signing under that same policy (#2222).
  */
 export class LedgerVaultProvider implements IBTCProvider {
   private session: DmkSessionHandle | undefined;
@@ -211,6 +216,11 @@ export class LedgerVaultProvider implements IBTCProvider {
   /** `m/86'/coin'/0'` — the key-info origin of the default policy (`test_screen7_pop.py:135-142`). */
   private get accountPath(): number[] {
     return [BIP86_PURPOSE + HARDENED, COIN_TYPE_BY_NETWORK[this.network] + HARDENED, ACCOUNT_INDEX + HARDENED];
+  }
+
+  /** `m/86'/coin'/0'/1/0` — the first BIP-86 change address, the only change the device marks internal. */
+  private get changePath(): number[] {
+    return [...this.accountPath, CHANGE_BRANCH, FIRST_CHANGE_INDEX];
   }
 
   private requireSession(): DmkSessionHandle {
@@ -393,6 +403,23 @@ export class LedgerVaultProvider implements IBTCProvider {
   /** x-only public key at the same leaf the intent pins. */
   getPublicKeyHex = async (): Promise<string> => this.getDevicePubkeyHex();
 
+  private async getChangeXOnlyHex(): Promise<string> {
+    const { accountXpub } = await this.getPolicyContext();
+    return deriveChangeXOnlyHex(accountXpub, toNetwork(this.network).bip32, FIRST_CHANGE_INDEX);
+  }
+
+  /**
+   * Pre-PegIn change must sit on the BIP-86 change branch: the base app marks
+   * an output internal only there (`process_in_outs.c:114-117`), and
+   * `_validate_prepegin` accepts change only when internal. Derived host-side
+   * from the device's verbatim account xpub; the device re-derives and
+   * byte-compares the script at signing time.
+   */
+  getChangeAddress = async (): Promise<string> =>
+    this.withDeviceOperation("getChangeAddress", async () =>
+      getTaprootAddress(await this.getChangeXOnlyHex(), this.network),
+    );
+
   /**
    * Derive the 32-byte context root, always with the approval screen — a
    * silent derivation produces a root that can never load an intent.
@@ -565,25 +592,31 @@ export class LedgerVaultProvider implements IBTCProvider {
   }
 
   /**
-   * SIGN_PSBT under the loaded intent (#2219 B3). Never finalizes — the SDK
-   * extracts signatures and finalizes itself. Every rejection before the
-   * device loop starts leaves the mirror and the loaded intent untouched.
+   * SIGN_PSBT under the loaded intent (#2219 B3). Tapscript PSBTs sign in
+   * no-policy mode; all-key-path ones (Pre-PegIn, #2222) sign under the default
+   * wallet policy after {@link augmentPsbtForWalletPolicy} adds the derivation
+   * fields. Never finalizes — the SDK extracts signatures and finalizes itself.
+   * Every rejection before the device loop starts leaves the mirror and the
+   * loaded intent untouched.
    */
   signPsbt = async (psbtHex: string, options?: SignPsbtOptions): Promise<string> =>
     this.withDeviceOperation("signPsbt", () =>
       this.withSignAbort(async (controller) => {
         const ctx = await this.gateSignContext();
-        const staged = this.stagePsbt(psbtHex, options, "signPsbt", new Set(), ctx.depositorXOnlyHex);
+        const staged = await this.stagePsbt(psbtHex, options, "signPsbt", new Set(), ctx.depositorXOnlyHex);
+        // Staging awaits the policy read; a reconnect during it would leave the
+        // captured sender stale (signPsbts guards the same way per element).
+        this.assertSameConnection(ctx.generation);
         return this.signStaged(staged, ctx, controller);
       }),
     );
 
   /**
    * Device ceremonies run strictly sequentially, array order, fail-fast — a
-   * concurrent APDU would be eaten with 0x6A80 and desync the loop. All
-   * host-only gates run for the WHOLE batch before the first ceremony, so a
-   * host-detectable defect at element k cannot burn k approvals whose
-   * signatures the fail-fast reject would discard.
+   * concurrent APDU would be eaten with 0x6A80 and desync the loop. The WHOLE
+   * batch is staged before the first ceremony, so a host-detectable defect at
+   * element k cannot burn k approvals whose signatures the fail-fast reject
+   * would discard.
    */
   signPsbts = async (psbtsHexes: string[], options?: SignPsbtOptions[]): Promise<string[]> =>
     this.withDeviceOperation("signPsbts", () =>
@@ -597,11 +630,18 @@ export class LedgerVaultProvider implements IBTCProvider {
         }
         const ctx = await this.gateSignContext();
         const stagedKeys = new Set<string>();
-        const staged = psbtsHexes.map((hex, index) => {
-          const one = this.stagePsbt(hex, options?.[index], `signPsbts[${index}]`, stagedKeys, ctx.depositorXOnlyHex);
+        const staged: StagedPsbt[] = [];
+        for (const [index, hex] of psbtsHexes.entries()) {
+          const one = await this.stagePsbt(
+            hex,
+            options?.[index],
+            `signPsbts[${index}]`,
+            stagedKeys,
+            ctx.depositorXOnlyHex,
+          );
           stagedKeys.add(one.fingerprintKey);
-          return one;
-        });
+          staged.push(one);
+        }
         const signed: string[] = [];
         for (const one of staged) {
           // A cancel landing BETWEEN elements must stop the batch — inside an
@@ -671,16 +711,18 @@ export class LedgerVaultProvider implements IBTCProvider {
   }
 
   /**
-   * Host-only gates for one PSBT — pure, zero device I/O, and every throw
-   * leaves the mirror and the loaded intent untouched (plan D7).
+   * Host-only gates for one PSBT, plus the key-path policy routing. The only
+   * device reads are the cached silent ones behind {@link getPolicyContext};
+   * no ceremony runs, so every throw leaves the mirror and the loaded intent
+   * untouched (plan D7).
    */
-  private stagePsbt(
+  private async stagePsbt(
     psbtHex: string,
     options: SignPsbtOptions | undefined,
     label: string,
     stagedKeys: ReadonlySet<string>,
     depositorXOnlyHex: string,
-  ): StagedPsbt {
+  ): Promise<StagedPsbt> {
     // Never finalize, and never silently ignore a request to — the SDK
     // extracts signatures and finalizes itself.
     if (options?.autoFinalized === true) {
@@ -704,27 +746,46 @@ export class LedgerVaultProvider implements IBTCProvider {
     try {
       prepared = prepareSignPsbt({ psbtHex, depositorXOnlyHex });
     } catch (error) {
-      throw new WalletError(
-        {
-          code: ERROR_CODES.INVALID_PARAMS,
-          message: `${label} rejected before device I/O: ${error instanceof Error ? error.message : String(error)}`,
-          wallet: WALLET_PROVIDER_NAME,
-        },
-        { cause: error instanceof Error ? error : undefined },
-      );
+      throw toStagingWalletError(error, `${label} rejected before device I/O`);
     }
-    // signPsbt is the no-policy tapscript path: a keypath expectation here means
-    // Pre-PegIn, which needs the wallet-policy path. (PoP is key-path too, but it
-    // goes through signMessage.) Reject actionably rather than take an opaque 0x6A80.
-    for (const expectation of prepared.table.byInput.values()) {
-      if (expectation.kind === "taproot-keypath") {
+    const kinds = new Set(Array.from(prepared.table.byInput.values(), (expectation) => expectation.kind));
+    if (kinds.has("taproot-keypath")) {
+      if (kinds.size > 1) {
         throw new WalletError({
-          code: ERROR_CODES.WALLET_METHOD_NOT_SUPPORTED,
-          message:
-            `${WALLET_PROVIDER_NAME} cannot sign key-path inputs (${label}) yet — ` +
-            `Pre-PegIn needs the wallet-policy path (#2222); proof of possession goes through signMessage.`,
+          code: ERROR_CODES.INVALID_PARAMS,
+          message: `${label}: a vault PSBT is either all key-path (Pre-PegIn) or all tapscript — mixed inputs are not a vault flow.`,
           wallet: WALLET_PROVIDER_NAME,
         });
+      }
+      // Key-path flows sign under the default wallet policy: derivation fields
+      // make the inputs (and the change output) internal on-device, and the
+      // policy id routes the base app into sign_internal_inputs (`sign_psbt.c:142-148`).
+      const { policy, masterFingerprintHex } = await this.getPolicyContext();
+      // Read outside the try: a disconnect here is a connection error, and
+      // re-wrapping it as INVALID_PARAMS would blame the caller's PSBT.
+      const changeXOnlyHex = await this.getChangeXOnlyHex();
+      let augmented: string;
+      try {
+        augmented = augmentPsbtForWalletPolicy({
+          psbtHex,
+          depositorXOnlyHex,
+          masterFingerprintHex,
+          depositorPath: this.depositorPath,
+          // A Pre-PegIn legitimately has no change (dust-revert, and the Max
+          // sweep by design) — marking it only when the PSBT actually pays it.
+          change: psbtPaysChangeScript(psbtHex, changeXOnlyHex)
+            ? { xOnlyHex: changeXOnlyHex, path: this.changePath }
+            : undefined,
+        });
+      } catch (error) {
+        throw toStagingWalletError(error, `${label} rejected before device I/O`);
+      }
+      try {
+        // Pass the AUGMENTED hex: the signer's merge target is whatever hex it
+        // prepared, so the SDK gets the derivation fields back with the tapKeySig.
+        prepared = prepareSignPsbt({ psbtHex: augmented, depositorXOnlyHex, walletPolicy: policy });
+      } catch (error) {
+        throw toStagingWalletError(error, `${label} rejected at policy-mode prepare`);
       }
     }
     // NEVER resubmit a signed request: the device dedup mask answers 0xB00A
@@ -877,14 +938,7 @@ export class LedgerVaultProvider implements IBTCProvider {
         try {
           prepared = prepareSignPsbt({ psbtHex, depositorXOnlyHex: ctx.depositorXOnlyHex, walletPolicy: policy });
         } catch (error) {
-          throw new WalletError(
-            {
-              code: ERROR_CODES.INVALID_PARAMS,
-              message: `signMessage rejected before device I/O: ${error instanceof Error ? error.message : String(error)}`,
-              wallet: WALLET_PROVIDER_NAME,
-            },
-            { cause: error instanceof Error ? error : undefined },
-          );
+          throw toStagingWalletError(error, "signMessage rejected before device I/O");
         }
         let result: SignVaultPsbtResult;
         try {
@@ -933,6 +987,18 @@ export class LedgerVaultProvider implements IBTCProvider {
   getWalletProviderName = async (): Promise<string> => WALLET_PROVIDER_NAME;
 
   getWalletProviderIcon = async (): Promise<string> => logo;
+}
+
+/** A staging rejection (prepare, augmentation): typed, cause preserved, no ceremony run. */
+function toStagingWalletError(error: unknown, context: string): WalletError {
+  return new WalletError(
+    {
+      code: ERROR_CODES.INVALID_PARAMS,
+      message: `${context}: ${error instanceof Error ? error.message : String(error)}`,
+      wallet: WALLET_PROVIDER_NAME,
+    },
+    { cause: error instanceof Error ? error : undefined },
+  );
 }
 
 /**

--- a/packages/babylon-wallet-connector/src/core/wallets/btc/ledger-vault/provider.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/ledger-vault/provider.ts
@@ -1,6 +1,8 @@
 import {
   approveVaultIntent,
   assertDepositTermsDeviceCompatible,
+  buildDefaultTaprootPolicy,
+  buildPopPsbtHex,
   connectDmkSession,
   createDmkApduSender,
   createDmkRawApduSender,
@@ -10,6 +12,8 @@ import {
   encodeIntentGroup,
   encodeIntentScalars,
   encodeKeyBatches,
+  getExtendedPublicKey,
+  getMasterFingerprintHex,
   getXOnlyPublicKeyHex,
   isLedgerDeviceError,
   isLedgerDeviceLockedError,
@@ -24,12 +28,14 @@ import {
   SW_BAD_STATE,
   SW_CAP_EXCEEDED,
   type ApduSender,
+  type DefaultTaprootWalletPolicy,
   type DepositTerms,
   type DmkSessionHandle,
   type IntentScalars,
   type IntentVaultGroup,
   type PreparedSignPsbt,
   type RawApduSender,
+  type SignVaultPsbtResult,
 } from "@babylonlabs-io/ledger-vault-signer";
 
 import type { IBTCProvider, InscriptionIdentifier, SignPsbtOptions } from "@/core/types";
@@ -57,6 +63,10 @@ const CHANGE_INDEX = 0;
 const ADDRESS_INDEX = 0;
 const HARDENED = 0x80000000;
 
+/** BIP-322 simple P2TR witness: one item — `varint(1) ‖ varint(64) ‖ sig` (`message.rs:105-144`, `BTCProofOfPossession.sol` accepts exactly this 66-byte shape). */
+const BIP322_P2TR_WITNESS_PREFIX_HEX = "0140";
+const SCHNORR_SIG_BYTES = 64;
+
 /**
  * Mirror of the device's vault state machine (`vault_context.h`: IDLE →
  * HASH_DERIVED → INTENT_LOADED). HASH_DERIVED is single-use — every ceremony
@@ -71,6 +81,14 @@ interface SignContext {
   readonly rawSend: RawApduSender;
   readonly generation: number;
   readonly depositorXOnlyHex: string;
+}
+
+/** Device reads behind the default policy; cached per connection, cleared in teardownSession. */
+interface PolicyContext {
+  readonly policy: DefaultTaprootWalletPolicy;
+  readonly masterFingerprintHex: string;
+  /** Verbatim base58 account xpub — Part B derives the change key from it. */
+  readonly accountXpub: string;
 }
 
 /** One host-gated PSBT, ready for its device ceremony. */
@@ -102,9 +120,9 @@ function signingRequestKey(prepared: PreparedSignPsbt): string {
  * intent ceremony instead of wallet policies.
  *
  * Ships behind `NEXT_PUBLIC_FF_ENABLE_LEDGER_VAULT_WALLET` (default off).
- * Covers connect, the key read, the intent ceremony, and SIGN_PSBT for the
- * no-policy tapscript flows (#2219). Key-path signing (Pre-PegIn, PoP) needs
- * the wallet-policy path (#2222/#2221).
+ * Covers connect, the key read, the intent ceremony, SIGN_PSBT for the
+ * no-policy tapscript flows (#2219), and the BIP-322 PoP under the default
+ * wallet policy (#2221). Pre-PegIn key-path signing is still to come (#2222).
  */
 export class LedgerVaultProvider implements IBTCProvider {
   private session: DmkSessionHandle | undefined;
@@ -117,6 +135,8 @@ export class LedgerVaultProvider implements IBTCProvider {
    * this one device read.
    */
   private pubkeyHexPromise: Promise<string> | undefined;
+  /** See {@link PolicyContext}. Single in-flight read per connection, like {@link pubkeyHexPromise}. */
+  private policyContextPromise: Promise<PolicyContext> | undefined;
   /**
    * In-flight connect, so two overlapping `connectWallet()` calls (a
    * double-click) share one session instead of opening — and leaking — a
@@ -188,6 +208,11 @@ export class LedgerVaultProvider implements IBTCProvider {
     ];
   }
 
+  /** `m/86'/coin'/0'` — the key-info origin of the default policy (`test_screen7_pop.py:135-142`). */
+  private get accountPath(): number[] {
+    return [BIP86_PURPOSE + HARDENED, COIN_TYPE_BY_NETWORK[this.network] + HARDENED, ACCOUNT_INDEX + HARDENED];
+  }
+
   private requireSession(): DmkSessionHandle {
     if (!this.session) {
       throw new WalletError({
@@ -208,14 +233,6 @@ export class LedgerVaultProvider implements IBTCProvider {
       });
     }
     return this.send;
-  }
-
-  private notWired(method: string): never {
-    throw new WalletError({
-      code: ERROR_CODES.WALLET_METHOD_NOT_SUPPORTED,
-      message: `${WALLET_PROVIDER_NAME} does not implement ${method} yet.`,
-      wallet: WALLET_PROVIDER_NAME,
-    });
   }
 
   /**
@@ -308,6 +325,7 @@ export class LedgerVaultProvider implements IBTCProvider {
     // Next connect may be a different device: reset state and the pubkey cache.
     this.deviceState = { phase: "idle" };
     this.pubkeyHexPromise = undefined;
+    this.policyContextPromise = undefined;
     this.signedFingerprints = new Set();
     this.loopAbandoned = false;
     // Release the ceremony lock and stop an in-flight signing loop NOW — the
@@ -334,6 +352,35 @@ export class LedgerVaultProvider implements IBTCProvider {
       this.pubkeyHexPromise = read;
     }
     return this.pubkeyHexPromise;
+  }
+
+  /**
+   * Default `tr(@0/**)` policy over the device's master fingerprint and the
+   * verbatim account xpub — key-path signing (PoP, Pre-PegIn) needs it.
+   * Two silent reads, cached per connection; a failure clears the cache.
+   */
+  private getPolicyContext(): Promise<PolicyContext> {
+    if (!this.policyContextPromise) {
+      const send = this.requireSender();
+      const read = (async (): Promise<PolicyContext> => {
+        const [masterFingerprintHex, accountXpub] = await Promise.all([
+          getMasterFingerprintHex(send),
+          getExtendedPublicKey(send, this.accountPath, toNetwork(this.network).bip32),
+        ]);
+        const policy = buildDefaultTaprootPolicy({
+          masterFingerprintHex,
+          coinType: COIN_TYPE_BY_NETWORK[this.network],
+          accountIndex: ACCOUNT_INDEX,
+          accountXpub,
+        });
+        return { policy, masterFingerprintHex, accountXpub };
+      })().catch((error) => {
+        if (this.policyContextPromise === read) this.policyContextPromise = undefined;
+        throw error;
+      });
+      this.policyContextPromise = read;
+    }
+    return this.policyContextPromise;
   }
 
   /**
@@ -592,8 +639,11 @@ export class LedgerVaultProvider implements IBTCProvider {
    * intent, cached depositor key. A dead session tears everything down —
    * the device state is gone with it (generation-guarded against a racing
    * reconnect's fresh state).
+   *
+   * `requireIntent: false` is for the state-independent PoP — every other
+   * caller keeps the default.
    */
-  private async gateSignContext(): Promise<SignContext> {
+  private async gateSignContext(requireIntent = true): Promise<SignContext> {
     const { session, rawSend } = this.requireSignContext();
     const generation = this.connectionGeneration;
     if (!(await this.probeSessionAlive(session))) {
@@ -605,7 +655,7 @@ export class LedgerVaultProvider implements IBTCProvider {
       });
     }
     this.assertSameConnection(generation);
-    if (this.deviceState.phase !== "intent-loaded") {
+    if (requireIntent && this.deviceState.phase !== "intent-loaded") {
       throw new WalletError({
         code: ERROR_CODES.WALLET_NOT_CONNECTED,
         message:
@@ -663,16 +713,16 @@ export class LedgerVaultProvider implements IBTCProvider {
         { cause: error instanceof Error ? error : undefined },
       );
     }
-    // B1 signs the no-policy tapscript flows only: a keypath expectation means
-    // Pre-PegIn/PoP, which need the wallet-policy path. Reject actionably here
-    // instead of letting the device answer an opaque 0x6A80 mid-loop.
+    // signPsbt is the no-policy tapscript path: a keypath expectation here means
+    // Pre-PegIn, which needs the wallet-policy path. (PoP is key-path too, but it
+    // goes through signMessage.) Reject actionably rather than take an opaque 0x6A80.
     for (const expectation of prepared.table.byInput.values()) {
       if (expectation.kind === "taproot-keypath") {
         throw new WalletError({
           code: ERROR_CODES.WALLET_METHOD_NOT_SUPPORTED,
           message:
             `${WALLET_PROVIDER_NAME} cannot sign key-path inputs (${label}) yet — ` +
-            `Pre-PegIn and proof-of-possession need the wallet-policy path (#2222/#2221).`,
+            `Pre-PegIn needs the wallet-policy path (#2222); proof of possession goes through signMessage.`,
           wallet: WALLET_PROVIDER_NAME,
         });
       }
@@ -720,39 +770,55 @@ export class LedgerVaultProvider implements IBTCProvider {
       this.loopAbandoned = false;
       return result.signedPsbtHex;
     } catch (error) {
-      // A stale rejection must not touch the new connection's state.
-      if (generation !== this.connectionGeneration) {
-        throw new WalletError(
-          {
-            code: ERROR_CODES.WALLET_NOT_CONNECTED,
-            message: `${WALLET_PROVIDER_NAME} connection changed during signing; restart from derivation.`,
-            wallet: WALLET_PROVIDER_NAME,
-          },
-          { cause: error instanceof Error ? error : undefined },
-        );
+      const walletError = this.classifySignFailure(error, generation, label);
+      // Mirror reset is signPsbt-only (a PoP failure never invalidates the
+      // device's vault context). Skip it for the two classifications that
+      // commit nothing: a stale rejection and an abandonment.
+      if (generation === this.connectionGeneration && !isLedgerSignPsbtAbortedError(error)) {
+        // Pessimistically assume the device dropped the intent (error-path
+        // invalidation is mixed in firmware — never assume survival).
+        this.deviceState = { phase: "idle" };
+        this.signedFingerprints = new Set();
+        this.loopAbandoned = false;
       }
-      if (isLedgerSignPsbtAbortedError(error)) {
-        // The intent MAY survive an abandonment (hint only) — keep the mirror.
-        // Arm the one-shot 0x6A80 recovery only if a dispatcher is actually
-        // mid-interruption. NB: unreachable in B3 — teardown (the only abort
-        // source) bumps the generation first; goes live with #2110's cancel.
-        if (error.dispatcherInterrupted) this.loopAbandoned = true;
-        throw new WalletError(
-          {
-            code: ERROR_CODES.WALLET_NOT_CONNECTED,
-            message: `${label === "signPsbt" ? "" : `${label}: `}${WALLET_PROVIDER_NAME} stopped signing (disconnected); reconnect and retry.`,
-            wallet: WALLET_PROVIDER_NAME,
-          },
-          { cause: error },
-        );
-      }
-      // Everything else: pessimistically assume the device dropped the intent
-      // (error-path invalidation is mixed in firmware — never assume survival).
-      this.deviceState = { phase: "idle" };
-      this.signedFingerprints = new Set();
-      this.loopAbandoned = false;
-      throw toSignFailureWalletError(error, label);
+      throw walletError;
     }
+  }
+
+  /**
+   * Classify one device-ceremony failure, for every SIGN_PSBT caller: a
+   * disconnect must surface as WALLET_NOT_CONNECTED, never as a generic
+   * UNKNOWN_ERROR. Touches only {@link loopAbandoned} — the intent mirror is
+   * the caller's to reset, since PoP must never touch it.
+   */
+  private classifySignFailure(error: unknown, generation: number, label: string): WalletError {
+    // A stale rejection must not touch the new connection's state.
+    if (generation !== this.connectionGeneration) {
+      return new WalletError(
+        {
+          code: ERROR_CODES.WALLET_NOT_CONNECTED,
+          message: `${WALLET_PROVIDER_NAME} connection changed during signing; restart from derivation.`,
+          wallet: WALLET_PROVIDER_NAME,
+        },
+        { cause: error instanceof Error ? error : undefined },
+      );
+    }
+    if (isLedgerSignPsbtAbortedError(error)) {
+      // The intent MAY survive an abandonment (hint only) — keep the mirror.
+      // Arm the one-shot 0x6A80 recovery only if a dispatcher is actually
+      // mid-interruption. NB: unreachable while teardown (the only abort
+      // source) bumps the generation first; goes live with #2110's cancel.
+      if (error.dispatcherInterrupted) this.loopAbandoned = true;
+      return new WalletError(
+        {
+          code: ERROR_CODES.WALLET_NOT_CONNECTED,
+          message: `${label === "signPsbt" ? "" : `${label}: `}${WALLET_PROVIDER_NAME} stopped signing (disconnected); reconnect and retry.`,
+          wallet: WALLET_PROVIDER_NAME,
+        },
+        { cause: error },
+      );
+    }
+    return toSignFailureWalletError(error, label);
   }
 
   /**
@@ -780,10 +846,80 @@ export class LedgerVaultProvider implements IBTCProvider {
     return { session, rawSend };
   }
 
-  // TODO(#2221): BIP-322 PoP — a SIGN_PSBT with tx_version 0, not the base
-  // app's SIGN_MESSAGE.
+  /**
+   * BIP-322 simple proof of possession via SIGN_PSBT tx_version 0 (#2221).
+   * State-independent on the device (`sign_psbt_validate.c:3205-3213`): no
+   * approved intent is required, and signing it never touches the intent
+   * mirror or the signed-fingerprint set. When an intent IS loaded the device
+   * requires the PoP key to equal the intent's depositor key (`:2764-2769`) —
+   * both derive from `depositorPath`, so that holds by construction.
+   */
   signMessage = async (message: string, type: "bip322-simple" | "ecdsa"): Promise<string> =>
-    this.notWired(`signMessage (${type}, ${message.length} chars)`);
+    this.withDeviceOperation("signMessage", () =>
+      this.withSignAbort(async (controller) => {
+        if (type !== "bip322-simple") {
+          throw new WalletError({
+            code: ERROR_CODES.WALLET_METHOD_NOT_SUPPORTED,
+            message: `${WALLET_PROVIDER_NAME} signs BIP-322 (bip322-simple) messages only; ${type} is not supported.`,
+            wallet: WALLET_PROVIDER_NAME,
+          });
+        }
+        const ctx = await this.gateSignContext(false);
+        const { policy, masterFingerprintHex } = await this.getPolicyContext();
+        this.assertSameConnection(ctx.generation);
+        const psbtHex = buildPopPsbtHex({
+          message,
+          depositorXOnlyHex: ctx.depositorXOnlyHex,
+          masterFingerprintHex,
+          depositorPath: this.depositorPath,
+        });
+        let prepared: PreparedSignPsbt;
+        try {
+          prepared = prepareSignPsbt({ psbtHex, depositorXOnlyHex: ctx.depositorXOnlyHex, walletPolicy: policy });
+        } catch (error) {
+          throw new WalletError(
+            {
+              code: ERROR_CODES.INVALID_PARAMS,
+              message: `signMessage rejected before device I/O: ${error instanceof Error ? error.message : String(error)}`,
+              wallet: WALLET_PROVIDER_NAME,
+            },
+            { cause: error instanceof Error ? error : undefined },
+          );
+        }
+        let result: SignVaultPsbtResult;
+        try {
+          result = await signPreparedVaultPsbt(ctx.rawSend, prepared, {
+            signal: controller.signal,
+            appIdentity:
+              ctx.session.appName !== undefined
+                ? { appName: ctx.session.appName, appVersion: ctx.session.appVersion }
+                : undefined,
+            resendOnceOnIncorrectData: this.loopAbandoned,
+          });
+        } catch (error) {
+          throw this.classifySignFailure(error, ctx.generation, "signMessage");
+        }
+        this.assertSameConnection(ctx.generation);
+        // Without a wallet policy the device answers SW_OK with NO yield
+        // (`sign_custom_inputs.c:101-107`); the collector's completion check
+        // already throws on that, this narrows the one yield we package.
+        const [yielded] = result.yields;
+        if (
+          result.yields.length !== 1 ||
+          yielded.kind !== "taproot-keypath" ||
+          yielded.signature.length !== SCHNORR_SIG_BYTES
+        ) {
+          throw new WalletError({
+            code: ERROR_CODES.INVALID_PARAMS,
+            message: `${WALLET_PROVIDER_NAME} returned no key-path signature for the proof of possession.`,
+            wallet: WALLET_PROVIDER_NAME,
+          });
+        }
+        // The loop ran to completion, so no dispatcher is mid-interruption.
+        this.loopAbandoned = false;
+        return `0x${BIP322_P2TR_WITNESS_PREFIX_HEX}${Buffer.from(yielded.signature).toString("hex")}`;
+      }),
+    );
 
   getNetwork = async (): Promise<Network> => this.network;
 

--- a/packages/babylon-wallet-connector/src/core/wallets/btc/ledger-vault/provider.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/ledger-vault/provider.ts
@@ -64,7 +64,6 @@ const COIN_TYPE_BY_NETWORK: Record<Network, number> = {
 const ACCOUNT_INDEX = 0;
 const CHANGE_INDEX = 0;
 const ADDRESS_INDEX = 0;
-const CHANGE_BRANCH = 1;
 const FIRST_CHANGE_INDEX = 0;
 const HARDENED = 0x80000000;
 
@@ -216,11 +215,6 @@ export class LedgerVaultProvider implements IBTCProvider {
   /** `m/86'/coin'/0'` — the key-info origin of the default policy (`test_screen7_pop.py:135-142`). */
   private get accountPath(): number[] {
     return [BIP86_PURPOSE + HARDENED, COIN_TYPE_BY_NETWORK[this.network] + HARDENED, ACCOUNT_INDEX + HARDENED];
-  }
-
-  /** `m/86'/coin'/0'/1/0` — the first BIP-86 change address, the only change the device marks internal. */
-  private get changePath(): number[] {
-    return [...this.accountPath, CHANGE_BRANCH, FIRST_CHANGE_INDEX];
   }
 
   private requireSession(): DmkSessionHandle {
@@ -382,6 +376,7 @@ export class LedgerVaultProvider implements IBTCProvider {
           coinType: COIN_TYPE_BY_NETWORK[this.network],
           accountIndex: ACCOUNT_INDEX,
           accountXpub,
+          bip32Versions: toNetwork(this.network).bip32,
         });
         return { policy, masterFingerprintHex, accountXpub };
       })().catch((error) => {
@@ -416,9 +411,14 @@ export class LedgerVaultProvider implements IBTCProvider {
    * byte-compares the script at signing time.
    */
   getChangeAddress = async (): Promise<string> =>
-    this.withDeviceOperation("getChangeAddress", async () =>
-      getTaprootAddress(await this.getChangeXOnlyHex(), this.network),
-    );
+    this.withDeviceOperation("getChangeAddress", async () => {
+      // A cached xpub read can outlive its connection; without this a
+      // reconnect mid-read would hand back the previous device's address.
+      const generation = this.connectionGeneration;
+      const changeXOnlyHex = await this.getChangeXOnlyHex();
+      this.assertSameConnection(generation);
+      return getTaprootAddress(changeXOnlyHex, this.network);
+    });
 
   /**
    * Derive the 32-byte context root, always with the approval screen — a
@@ -791,7 +791,7 @@ export class LedgerVaultProvider implements IBTCProvider {
       // Key-path flows sign under the default wallet policy: derivation fields
       // make the inputs (and the change output) internal on-device, and the
       // policy id routes the base app into sign_internal_inputs (`sign_psbt.c:142-148`).
-      const { policy, masterFingerprintHex } = await this.getPolicyContext();
+      const { policy } = await this.getPolicyContext();
       // Read outside the try: a disconnect here is a connection error, and
       // re-wrapping it as INVALID_PARAMS would blame the caller's PSBT.
       const changeXOnlyHex = await this.getChangeXOnlyHex();
@@ -800,13 +800,11 @@ export class LedgerVaultProvider implements IBTCProvider {
         augmented = augmentPsbtForWalletPolicy({
           psbtHex,
           depositorXOnlyHex,
-          masterFingerprintHex,
+          walletPolicy: policy,
           depositorPath: this.depositorPath,
           // A Pre-PegIn legitimately has no change (dust-revert, and the Max
           // sweep by design) — marking it only when the PSBT actually pays it.
-          change: psbtPaysChangeScript(psbtHex, changeXOnlyHex)
-            ? { xOnlyHex: changeXOnlyHex, path: this.changePath }
-            : undefined,
+          change: psbtPaysChangeScript(psbtHex, changeXOnlyHex) ? { addressIndex: FIRST_CHANGE_INDEX } : undefined,
         });
       } catch (error) {
         throw toStagingWalletError(error, `${label} rejected before device I/O`);

--- a/packages/babylon-wallet-connector/vite.config.ts
+++ b/packages/babylon-wallet-connector/vite.config.ts
@@ -18,6 +18,13 @@ export default defineConfig({
   build: {
     outDir: "dist",
     sourcemap: true,
+    commonjsOptions: {
+      // Bundled CJS (@bitcoinerlab/descriptors) does `require("bitcoinjs-lib").payments`.
+      // plugin-commonjs renders requires of externals as *default* imports unless the id
+      // is listed here, and bitcoinjs-lib is __esModule with no default export — so the
+      // default is undefined once a consumer pre-bundles us. Namespace import instead.
+      esmExternals: ["bitcoinjs-lib"],
+    },
     lib: {
       entry: {
         index: path.resolve(__dirname, "src/index.tsx"),

--- a/services/vault/e2e/fixtures/__tests__/mockBtcWallet.test.ts
+++ b/services/vault/e2e/fixtures/__tests__/mockBtcWallet.test.ts
@@ -21,6 +21,29 @@ describe("createMockBtcWallet defaults", () => {
     expect(await provider.getPublicKeyHex()).toBe(pk);
   });
 
+  it("signs a P2WPKH witness carrying the public key the wallet advertises", async () => {
+    // The SDK's proof-of-possession gate compares the witness pubkey item
+    // against the depositor key, so a fixed key here would fail every flow.
+    const { provider } = createMockBtcWallet();
+    const witness = Buffer.from(
+      (await provider.signMessage("msg", "bip322-simple")).slice(2),
+      "hex",
+    );
+
+    const sigLen = witness[1];
+    const pubkey = witness.subarray(1 + 1 + sigLen + 1);
+    expect(witness[0]).toBe(2);
+    expect(pubkey.toString("hex")).toBe(await provider.getPublicKeyHex());
+  });
+
+  it("signs a witness carrying an overridden public key", async () => {
+    const publicKeyHex = `03${"cd".repeat(32)}`;
+    const { provider } = createMockBtcWallet({ publicKeyHex });
+    const witness = await provider.signMessage("msg", "bip322-simple");
+
+    expect(witness.endsWith(publicKeyHex)).toBe(true);
+  });
+
   it("returns 64-char lowercase hex from deriveContextHash", async () => {
     const { provider } = createMockBtcWallet();
     const hash = await provider.deriveContextHash("vault-app", "ab".repeat(8));

--- a/services/vault/e2e/fixtures/mockBtcWallet.ts
+++ b/services/vault/e2e/fixtures/mockBtcWallet.ts
@@ -42,7 +42,16 @@ const DEFAULT_PROVIDER_ICON = "data:image/svg+xml;base64,PHN2Zy8+";
 // The SDK decodes the BIP-322 witness a wallet returns, so this has to be a
 // structurally valid two-item P2WPKH witness (the one shape it passes through
 // unverified): varint(2) ‖ varint(71) ‖ 71B DER sig ‖ varint(33) ‖ 33B pubkey.
-const SIGNED_MESSAGE_HEX = `0x02${"47"}${"11".repeat(71)}${"21"}${"02" + "22".repeat(32)}`;
+const POP_WITNESS_ITEM_COUNT = "02";
+const POP_DER_SIG_LEN = "47";
+const POP_DER_SIG = "11".repeat(71);
+const POP_PUBKEY_LEN = "21";
+
+// The pubkey item must be the key this wallet advertises: the SDK's proof-of-
+// possession gate rejects a witness whose key is not the depositor's.
+function buildSignedMessageHex(publicKeyHex: string): string {
+  return `0x${POP_WITNESS_ITEM_COUNT}${POP_DER_SIG_LEN}${POP_DER_SIG}${POP_PUBKEY_LEN}${publicKeyHex}`;
+}
 
 export interface MockBtcWalletOptions {
   publicKeyHex?: string;
@@ -176,7 +185,10 @@ export function createMockBtcWallet(
     signPsbt: (psbtHex: string) => applyScript("signPsbt", () => psbtHex),
     signPsbts: (psbtsHexes: string[]) =>
       applyScript("signPsbts", () => [...psbtsHexes]),
-    signMessage: () => applyScript("signMessage", () => SIGNED_MESSAGE_HEX),
+    signMessage: () =>
+      applyScript("signMessage", () =>
+        buildSignedMessageHex(config.publicKeyHex),
+      ),
     deriveContextHash: (appName: string, context: string) =>
       applyScript("deriveContextHash", () =>
         sha256Hex(`${appName}:${context}`),

--- a/services/vault/e2e/fixtures/mockBtcWallet.ts
+++ b/services/vault/e2e/fixtures/mockBtcWallet.ts
@@ -39,7 +39,10 @@ const DEFAULT_ADDRESS = "tb1qce0n0rv27dwx37dfvhxaaly4lnwelqjuqywvka";
 const DEFAULT_NETWORK: Network = "signet" as Network;
 const DEFAULT_PROVIDER_NAME = "E2E Mock BTC";
 const DEFAULT_PROVIDER_ICON = "data:image/svg+xml;base64,PHN2Zy8+";
-const SIGNED_MESSAGE_HEX = "cd".repeat(64);
+// The SDK decodes the BIP-322 witness a wallet returns, so this has to be a
+// structurally valid two-item P2WPKH witness (the one shape it passes through
+// unverified): varint(2) ‖ varint(71) ‖ 71B DER sig ‖ varint(33) ‖ 33B pubkey.
+const SIGNED_MESSAGE_HEX = `0x02${"47"}${"11".repeat(71)}${"21"}${"02" + "22".repeat(32)}`;
 
 export interface MockBtcWalletOptions {
   publicKeyHex?: string;

--- a/services/vault/src/components/deposit/PayoutSignModal/__tests__/usePayoutSigningState.test.tsx
+++ b/services/vault/src/components/deposit/PayoutSignModal/__tests__/usePayoutSigningState.test.tsx
@@ -727,6 +727,9 @@ describe("usePayoutSigningState", () => {
         this.#approvedWith.push(terms);
         return Promise.resolve();
       }
+      getChangeAddress(): Promise<string> {
+        return Promise.resolve("tb1pledgerchange");
+      }
     }
 
     it("forwards a prototype-method approveDepositTerms through the payout wallet wrapper", async () => {

--- a/services/vault/src/hooks/deposit/__tests__/useDepositFlow.test.tsx
+++ b/services/vault/src/hooks/deposit/__tests__/useDepositFlow.test.tsx
@@ -265,6 +265,9 @@ class PrototypeApprovalBtcWallet {
     this.#approvedWith.push(terms);
     return Promise.resolve();
   }
+  getChangeAddress(): Promise<string> {
+    return Promise.resolve("tb1pledgerchange");
+  }
 }
 
 const MOCK_ETH_WALLET = {
@@ -537,6 +540,7 @@ describe("useDepositFlow", () => {
             vaultKeeperBtcPubkeys: MOCK_PARAMS.vaultKeeperBtcPubkeys,
             universalChallengerBtcPubkeys:
               MOCK_PARAMS.universalChallengerBtcPubkeys,
+            changeAddress: "bc1qtest",
           }),
         );
       });
@@ -1682,6 +1686,13 @@ describe("useDepositFlow", () => {
         }),
       );
       await executeDepositFlow(result);
+
+      // Approval wallets dictate the Pre-PegIn change address.
+      expect(preparePeginTransaction).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.objectContaining({ changeAddress: "tb1pledgerchange" }),
+      );
 
       expect(peginWallet).toBeDefined();
       expect(supportsDepositApproval(peginWallet!)).toBe(true);

--- a/services/vault/src/hooks/deposit/__tests__/useVaultActions.test.ts
+++ b/services/vault/src/hooks/deposit/__tests__/useVaultActions.test.ts
@@ -1325,6 +1325,7 @@ describe("useVaultActions — handleBroadcast intent (Ledger) resume branch", ()
           signPsbt: mockSignPsbt,
           deriveContextHash: vi.fn().mockResolvedValue("ab".repeat(32)),
           approveDepositTerms: vi.fn().mockResolvedValue(undefined),
+          getChangeAddress: vi.fn().mockResolvedValue("tb1pledgerchange"),
         },
       },
     } as never);
@@ -1438,6 +1439,7 @@ describe("useVaultActions — handleBroadcast intent (Ledger) resume branch", ()
           getAddress: vi.fn().mockResolvedValue("bc1qdepositor"),
           signPsbt: mockSignPsbt,
           approveDepositTerms: vi.fn().mockResolvedValue(undefined),
+          getChangeAddress: vi.fn().mockResolvedValue("tb1pledgerchange"),
         },
       },
     } as never);

--- a/services/vault/src/hooks/deposit/depositFlowSteps/__tests__/ensureAuthenticatedVpClient.test.ts
+++ b/services/vault/src/hooks/deposit/depositFlowSteps/__tests__/ensureAuthenticatedVpClient.test.ts
@@ -146,6 +146,7 @@ describe("ensureAuthenticatedVpClient", () => {
     const approvalWallet = {
       deriveContextHash: vi.fn(),
       approveDepositTerms: vi.fn(),
+      getChangeAddress: vi.fn(),
     } as never;
     await ensureAuthenticatedVpClient({
       btcWallet: approvalWallet,
@@ -176,6 +177,7 @@ describe("ensureAuthenticatedVpClient", () => {
     const approvalWallet = {
       deriveContextHash: vi.fn(),
       approveDepositTerms: vi.fn(),
+      getChangeAddress: vi.fn(),
     } as never;
     await ensureAuthenticatedVpClient({
       btcWallet: approvalWallet,

--- a/services/vault/src/hooks/deposit/useDepositFlow.ts
+++ b/services/vault/src/hooks/deposit/useDepositFlow.ts
@@ -19,6 +19,7 @@ import {
   isDepositTermsRejectedError,
   isRegisteredVaultVersionMismatchError,
   stripHexPrefix,
+  supportsDepositApproval,
   validateOnChainParticipantKeys,
   verifyRegisteredParticipantKeys,
   verifyRegisteredVaultVersions,
@@ -541,6 +542,14 @@ export function useDepositFlow(
         // commit pass drives the wallet popup(s).
         setPeginSigningProgress({ completed: 0, total: vaultAmounts.length });
 
+        // Approval (policy) wallets dictate the change address (BIP-86 change
+        // branch); software wallets keep change on the connected address.
+        const prePeginChangeAddress = supportsDepositApproval(
+          phaseTrackingBtcWallet,
+        )
+          ? await phaseTrackingBtcWallet.getChangeAddress()
+          : confirmedBtcAddress;
+
         const batchResult = await preparePeginTransaction(
           phaseTrackingBtcWallet,
           walletClient,
@@ -555,7 +564,7 @@ export function useDepositFlow(
             protocolFeeRate: config.offchainParams.feeRate,
             minPeginFeeRate: config.offchainParams.minPeginFeeRate,
             mempoolFeeRate,
-            changeAddress: confirmedBtcAddress,
+            changeAddress: prePeginChangeAddress,
             vaultProviderBtcPubkey: validatedKeys.vaultProviderBtcPubkeyXOnly,
             commissionBps: quotedCommissionBps,
             vaultKeeperBtcPubkeys: validatedKeys.vaultKeeperBtcPubkeysSorted,

--- a/services/vault/src/hooks/deposit/useDepositFlow.ts
+++ b/services/vault/src/hooks/deposit/useDepositFlow.ts
@@ -18,6 +18,7 @@ import {
   forwardDepositApproval,
   isDepositTermsRejectedError,
   isRegisteredVaultVersionMismatchError,
+  requireChangeAddress,
   stripHexPrefix,
   supportsDepositApproval,
   validateOnChainParticipantKeys,
@@ -547,7 +548,7 @@ export function useDepositFlow(
         const prePeginChangeAddress = supportsDepositApproval(
           phaseTrackingBtcWallet,
         )
-          ? await phaseTrackingBtcWallet.getChangeAddress()
+          ? await requireChangeAddress(phaseTrackingBtcWallet)
           : confirmedBtcAddress;
 
         const batchResult = await preparePeginTransaction(

--- a/services/vault/src/services/vault/__tests__/vaultPeginBroadcastService.test.ts
+++ b/services/vault/src/services/vault/__tests__/vaultPeginBroadcastService.test.ts
@@ -3,7 +3,10 @@ import {
   DepositTermsRejectedError,
   type DepositTerms,
 } from "@babylonlabs-io/ts-sdk/tbv/core";
-import { assertPsbtUnsignedTxMatches } from "@babylonlabs-io/ts-sdk/tbv/core/primitives";
+import {
+  assertPsbtUnsignedTxMatches,
+  assertReturnedKeyPathSignatures,
+} from "@babylonlabs-io/ts-sdk/tbv/core/primitives";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // Use vi.hoisted so mocks can reference these before module initialization
@@ -89,6 +92,7 @@ vi.mock(
     return {
       ...actual,
       assertPsbtUnsignedTxMatches: vi.fn(),
+      assertReturnedKeyPathSignatures: vi.fn(),
     };
   },
 );
@@ -369,6 +373,43 @@ describe("broadcastPrePeginTransaction — resolveInputUtxo behavior", () => {
     });
   });
 
+  it("verifies the returned key-path signatures after the rebind, with the requested/returned pair", async () => {
+    vi.mocked(assertReturnedKeyPathSignatures).mockClear();
+    vi.mocked(pushTx).mockClear();
+    const customWallet = {
+      signPsbt: vi.fn().mockResolvedValue("wallet-returned-psbt-hex"),
+    };
+
+    await broadcastPrePeginTransaction({
+      ...baseParams,
+      btcWalletProvider: customWallet,
+      expectedUtxos: undefined,
+    });
+
+    expect(assertReturnedKeyPathSignatures).toHaveBeenCalledTimes(1);
+    expect(assertReturnedKeyPathSignatures).toHaveBeenCalledWith({
+      requestedPsbtHex: "mock-psbt-hex",
+      returnedPsbtHex: "wallet-returned-psbt-hex",
+    });
+  });
+
+  it("aborts before finalize/broadcast when a returned key-path signature does not verify", async () => {
+    vi.mocked(assertReturnedKeyPathSignatures).mockImplementationOnce(() => {
+      throw new Error("key-path signature for input 0 does not verify");
+    });
+    vi.mocked(pushTx).mockClear();
+
+    await expect(
+      broadcastPrePeginTransaction({
+        ...baseParams,
+        expectedUtxos: undefined,
+      }),
+    ).rejects.toThrow(/does not verify/);
+
+    expect(pushTx).not.toHaveBeenCalled();
+    expect(mockSignedPsbt.extractTransaction).not.toHaveBeenCalled();
+  });
+
   it("preserves PSBT finalization errors when the wallet returns a partially signed PSBT", async () => {
     mockSignedPsbt.finalizeAllInputs.mockImplementationOnce(() => {
       throw new Error("Input #1 is not signed");
@@ -434,6 +475,7 @@ describe("broadcastPrePeginTransaction — intent-approval ceremony", () => {
       approveDepositTerms: vi.fn(async () => {
         order.push("approve");
       }),
+      getChangeAddress: vi.fn(async () => "tb1pledgerchange"),
     };
 
     const txid = await broadcastPrePeginTransaction({
@@ -457,6 +499,7 @@ describe("broadcastPrePeginTransaction — intent-approval ceremony", () => {
       approveDepositTerms: vi.fn(async () => {
         throw rejection;
       }),
+      getChangeAddress: vi.fn(async () => "tb1pledgerchange"),
     };
 
     await expect(

--- a/services/vault/src/services/vault/__tests__/vaultPeginBroadcastService.test.ts
+++ b/services/vault/src/services/vault/__tests__/vaultPeginBroadcastService.test.ts
@@ -410,6 +410,28 @@ describe("broadcastPrePeginTransaction — resolveInputUtxo behavior", () => {
     expect(mockSignedPsbt.extractTransaction).not.toHaveBeenCalled();
   });
 
+  it("attaches the original wallet error as the broadcast wrapper's cause", async () => {
+    // The cause-walking mappers (user cancellation, method-not-supported)
+    // classify by the inner error's code, which the wrapper message loses.
+    const inner = Object.assign(new Error("nope"), {
+      code: "CONNECTION_REJECTED",
+    });
+    const signPsbt = vi.fn().mockRejectedValue(inner);
+
+    await expect(
+      broadcastPrePeginTransaction({
+        ...baseParams,
+        btcWalletProvider: { signPsbt },
+        expectedUtxos: undefined,
+      }),
+    ).rejects.toMatchObject({
+      message: expect.stringContaining(
+        "Failed to broadcast Pre-PegIn transaction",
+      ),
+      cause: inner,
+    });
+  });
+
   it("preserves PSBT finalization errors when the wallet returns a partially signed PSBT", async () => {
     mockSignedPsbt.finalizeAllInputs.mockImplementationOnce(() => {
       throw new Error("Input #1 is not signed");

--- a/services/vault/src/services/vault/__tests__/vaultPeginBroadcastService.test.ts
+++ b/services/vault/src/services/vault/__tests__/vaultPeginBroadcastService.test.ts
@@ -92,7 +92,9 @@ vi.mock(
     return {
       ...actual,
       assertPsbtUnsignedTxMatches: vi.fn(),
-      assertReturnedKeyPathSignatures: vi.fn(),
+      // Returns how many inputs it verified; the mocked PSBT carries one, and
+      // the approval-wallet path refuses to broadcast a partial count.
+      assertReturnedKeyPathSignatures: vi.fn(() => 1),
     };
   },
 );
@@ -408,28 +410,6 @@ describe("broadcastPrePeginTransaction — resolveInputUtxo behavior", () => {
 
     expect(pushTx).not.toHaveBeenCalled();
     expect(mockSignedPsbt.extractTransaction).not.toHaveBeenCalled();
-  });
-
-  it("attaches the original wallet error as the broadcast wrapper's cause", async () => {
-    // The cause-walking mappers (user cancellation, method-not-supported)
-    // classify by the inner error's code, which the wrapper message loses.
-    const inner = Object.assign(new Error("nope"), {
-      code: "CONNECTION_REJECTED",
-    });
-    const signPsbt = vi.fn().mockRejectedValue(inner);
-
-    await expect(
-      broadcastPrePeginTransaction({
-        ...baseParams,
-        btcWalletProvider: { signPsbt },
-        expectedUtxos: undefined,
-      }),
-    ).rejects.toMatchObject({
-      message: expect.stringContaining(
-        "Failed to broadcast Pre-PegIn transaction",
-      ),
-      cause: inner,
-    });
   });
 
   it("preserves PSBT finalization errors when the wallet returns a partially signed PSBT", async () => {

--- a/services/vault/src/services/vault/vaultPeginBroadcastService.ts
+++ b/services/vault/src/services/vault/vaultPeginBroadcastService.ts
@@ -257,6 +257,7 @@ async function createPsbtFromTransaction(
 async function signAndFinalizePsbt(
   psbtHex: string,
   btcWalletProvider: { signPsbt: (psbtHex: string) => Promise<string> },
+  expectAllInputsKeyPath: boolean,
 ): Promise<string> {
   const signedPsbtHex = await btcWalletProvider.signPsbt(psbtHex);
 
@@ -267,10 +268,19 @@ async function signAndFinalizePsbt(
 
   // Never trust the wallet's finalization: verify the returned key-path
   // signatures against the PSBT we asked it to sign before extracting.
-  assertReturnedKeyPathSignatures({
+  const verifiedInputs = assertReturnedKeyPathSignatures({
     requestedPsbtHex: psbtHex,
     returnedPsbtHex: signedPsbtHex,
   });
+  // An approval wallet signs every input key-path, so a zero here would mean
+  // the check covered nothing rather than that everything was verified.
+  const inputCount = Psbt.fromHex(psbtHex).data.inputs.length;
+  if (expectAllInputsKeyPath && verifiedInputs !== inputCount) {
+    throw new Error(
+      `Key-path verification covered ${verifiedInputs} of ${inputCount} Pre-PegIn inputs; ` +
+        `refusing to broadcast partially verified signatures.`,
+    );
+  }
 
   const signedPsbt = Psbt.fromHex(signedPsbtHex);
 
@@ -346,6 +356,7 @@ export async function broadcastPrePeginTransaction(
     const signedTxHex = await signAndFinalizePsbt(
       psbt.toHex(),
       btcWalletProvider,
+      typeof btcWalletProvider.approveDepositTerms === "function",
     );
 
     // Broadcast to network

--- a/services/vault/src/services/vault/vaultPeginBroadcastService.ts
+++ b/services/vault/src/services/vault/vaultPeginBroadcastService.ts
@@ -17,7 +17,10 @@ import {
   type DepositTerms,
   type PrePeginApprovalWallet,
 } from "@babylonlabs-io/ts-sdk/tbv/core";
-import { assertPsbtUnsignedTxMatches } from "@babylonlabs-io/ts-sdk/tbv/core/primitives";
+import {
+  assertPsbtUnsignedTxMatches,
+  assertReturnedKeyPathSignatures,
+} from "@babylonlabs-io/ts-sdk/tbv/core/primitives";
 import { getPsbtInputFields } from "@babylonlabs-io/ts-sdk/tbv/core/utils";
 import { Psbt, Transaction } from "bitcoinjs-lib";
 import { Buffer } from "buffer";
@@ -258,6 +261,13 @@ async function signAndFinalizePsbt(
   const signedPsbtHex = await btcWalletProvider.signPsbt(psbtHex);
 
   assertPsbtUnsignedTxMatches({
+    requestedPsbtHex: psbtHex,
+    returnedPsbtHex: signedPsbtHex,
+  });
+
+  // Never trust the wallet's finalization: verify the returned key-path
+  // signatures against the PSBT we asked it to sign before extracting.
+  assertReturnedKeyPathSignatures({
     requestedPsbtHex: psbtHex,
     returnedPsbtHex: signedPsbtHex,
   });


### PR DESCRIPTION
Ledger vault app support for the depositor flow: BIP-322 proof of possession, and Pre-PegIn signing under the device's default BIP-86 wallet policy (tr(@0/**)) — without a policy the device answers SW_OK with no signature.