### PR TITLE
fix(vault): save the artifact payload, not its json-rpc envelope

### DIFF
--- a/services/vault/src/services/artifacts/__tests__/artifactDownloadService.test.ts
+++ b/services/vault/src/services/artifacts/__tests__/artifactDownloadService.test.ts
@@ -70,6 +70,15 @@ function validEnvelope(): string {
 }
 
 /**
+ * What the saved file must contain: the envelope's `result` value alone.
+ * Bytes are sliced from the wire, so the file is the literal source span —
+ * which for a `JSON.stringify`d envelope is exactly the payload re-stringified.
+ */
+function expectedSavedPayload(result: unknown = VALID_ARTIFACT_RESULT): string {
+  return JSON.stringify(result);
+}
+
+/**
  * Build a Response backed by a real ReadableStream, with Content-Length only
  * when asked. A stream body never auto-populates the header, which is what
  * lets the header-absent fallback be tested deterministically.
@@ -144,9 +153,10 @@ describe("fetchAndDownloadArtifacts", () => {
   });
 
   describe("a valid response", () => {
-    it("writes the whole body and commits it", async () => {
-      const body = validEnvelope();
-      vi.mocked(fetch).mockResolvedValueOnce(streamingResponse(body));
+    it("writes the unwrapped payload and commits it", async () => {
+      vi.mocked(fetch).mockResolvedValueOnce(
+        streamingResponse(validEnvelope()),
+      );
       const { target, commit, discard, savedBytes } = fakeSaveTarget();
 
       await fetchAndDownloadArtifacts(
@@ -156,14 +166,16 @@ describe("fetchAndDownloadArtifacts", () => {
         target,
       );
 
-      expect(new TextDecoder().decode(savedBytes())).toBe(body);
+      expect(new TextDecoder().decode(savedBytes())).toBe(
+        expectedSavedPayload(),
+      );
       expect(commit).toHaveBeenCalledTimes(1);
       expect(discard).not.toHaveBeenCalled();
     });
 
-    it("returns a receipt describing what was saved", async () => {
+    it("returns a receipt describing the saved file, not the wire body", async () => {
       const body = validEnvelope();
-      const byteLength = new TextEncoder().encode(body).byteLength;
+      const saved = new TextEncoder().encode(expectedSavedPayload());
       vi.mocked(fetch).mockResolvedValueOnce(streamingResponse(body));
       const { target } = fakeSaveTarget();
 
@@ -174,12 +186,17 @@ describe("fetchAndDownloadArtifacts", () => {
         target,
       );
 
+      // The digest has to be reproducible by `sha256sum` on the file the user
+      // ends up with, so it covers the payload rather than the envelope.
       expect(outcome).toEqual({
         filename: "babylon-vault-artifacts-aaaaaaaa.json",
-        byteLength,
-        sha256: bytesToHex(sha256(new TextEncoder().encode(body))),
+        byteLength: saved.byteLength,
+        sha256: bytesToHex(sha256(saved)),
         method: "file-system-access",
       });
+      expect(outcome.byteLength).toBeLessThan(
+        new TextEncoder().encode(body).byteLength,
+      );
     });
 
     it("reassembles a body split across many chunks", async () => {
@@ -205,7 +222,9 @@ describe("fetchAndDownloadArtifacts", () => {
         target,
       );
 
-      expect(new TextDecoder().decode(savedBytes())).toBe(body);
+      expect(new TextDecoder().decode(savedBytes())).toBe(
+        expectedSavedPayload(),
+      );
     });
 
     it("accepts a result body that nests an error key", async () => {
@@ -231,6 +250,104 @@ describe("fetchAndDownloadArtifacts", () => {
       );
 
       expect(commit).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("envelope unwrapping", () => {
+    /** Run a body through the service and return what reached the file. */
+    async function savedTextFor(
+      body: string,
+      chunkSizeBytes?: number,
+    ): Promise<string> {
+      vi.mocked(fetch).mockResolvedValueOnce(
+        streamingResponse(body, { chunkSizeBytes }),
+      );
+      const { target, savedBytes } = fakeSaveTarget();
+      await fetchAndDownloadArtifacts(
+        PROVIDER_ADDRESS,
+        PEGIN_TXID,
+        DEPOSITOR_PK,
+        target,
+      );
+      return new TextDecoder().decode(savedBytes());
+    }
+
+    it("saves a file with no transport framing left in it", async () => {
+      const saved = JSON.parse(await savedTextFor(validEnvelope())) as Record<
+        string,
+        unknown
+      >;
+
+      expect(Object.keys(saved).sort()).toEqual([
+        "babe_sessions",
+        "tx_graph_json",
+        "verifying_key_hex",
+      ]);
+      expect(saved).not.toHaveProperty("jsonrpc");
+      expect(saved).not.toHaveProperty("id");
+      expect(saved).not.toHaveProperty("result");
+    });
+
+    it("matches the layout btc-vault's artifact-downloader writes", async () => {
+      // The CLI writes {tx_graph_json, verifying_key_hex, babe_sessions} at
+      // the top level; a bundle saved here has to be interchangeable with one
+      // fetched that way, or docs/delegated_claim.md fits only one of them.
+      const saved = JSON.parse(await savedTextFor(validEnvelope()));
+
+      expect(saved).toEqual(VALID_ARTIFACT_RESULT);
+    });
+
+    it("strips the envelope wherever result sits in it", async () => {
+      // The proxy guarantees field order only on its gRPC path, so a result
+      // that trails `id` must unwrap exactly like one that precedes it.
+      const resultLast = JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        result: VALID_ARTIFACT_RESULT,
+      });
+
+      expect(await savedTextFor(resultLast)).toBe(expectedSavedPayload());
+    });
+
+    it("ignores envelope fields it does not consume", async () => {
+      const withExtras = JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        error: null,
+        someFutureField: "ignored",
+        result: VALID_ARTIFACT_RESULT,
+      });
+
+      expect(await savedTextFor(withExtras)).toBe(expectedSavedPayload());
+    });
+
+    it("drops the framing of a pretty-printed envelope", async () => {
+      // Whitespace *inside* result is part of the payload span and is kept;
+      // only the framing around it goes. The file still has to parse.
+      const pretty = JSON.stringify(
+        { jsonrpc: "2.0", id: 1, result: VALID_ARTIFACT_RESULT },
+        null,
+        2,
+      );
+      const saved = await savedTextFor(pretty);
+
+      expect(saved.startsWith("{")).toBe(true);
+      expect(saved.endsWith("}")).toBe(true);
+      expect(JSON.parse(saved)).toEqual(VALID_ARTIFACT_RESULT);
+    });
+
+    it("puts the payload boundaries in the same place at every chunk size", async () => {
+      // The span is tracked across chunk boundaries, so a `{` or `}` landing
+      // on a split is what would corrupt the file. Sizes here are co-prime-ish
+      // with the body so the cuts land in different places; byte-at-a-time
+      // splitting is covered in the validator's own suite, which needs no
+      // async write per chunk and can afford it.
+      const body = validEnvelope();
+      const expected = expectedSavedPayload();
+
+      for (const chunkSizeBytes of [64, 997, 65_536]) {
+        expect(await savedTextFor(body, chunkSizeBytes)).toBe(expected);
+      }
     });
   });
 

--- a/services/vault/src/services/artifacts/__tests__/streamingArtifactValidator.test.ts
+++ b/services/vault/src/services/artifacts/__tests__/streamingArtifactValidator.test.ts
@@ -610,3 +610,72 @@ describe("ArtifactStreamValidator — JSON-RPC error envelopes", () => {
     expect(() => validate(wire)).toThrow(JsonRpcError);
   });
 });
+
+describe("ArtifactStreamValidator — reports the result span", () => {
+  /**
+   * Feed `wire` in fixed-size chunks and concatenate the spans the validator
+   * reports, reproducing what the download service writes to disk.
+   */
+  function spannedText(wire: string, chunkSize?: number): string {
+    const validator = new ArtifactStreamValidator();
+    const bytes = encoder.encode(wire);
+    const size = chunkSize ?? bytes.length;
+    let out = "";
+    for (let offset = 0; offset < bytes.length; offset += size) {
+      const chunk = bytes.subarray(offset, offset + size);
+      const span = validator.update(chunk);
+      if (span) {
+        out += new TextDecoder().decode(chunk.subarray(span.start, span.end));
+      }
+    }
+    validator.finish();
+    return out;
+  }
+
+  it("spans exactly the result value's source", () => {
+    expect(spannedText(envelope(VALID_RESULT))).toBe(
+      JSON.stringify(VALID_RESULT),
+    );
+  });
+
+  it("reports the same span however the bytes are chunked", () => {
+    const wire = envelope(VALID_RESULT);
+    const expected = JSON.stringify(VALID_RESULT);
+
+    // Size 1 puts every structural byte on its own chunk boundary, which is
+    // where an off-by-one in the start/end offsets would show up.
+    for (const chunkSize of [1, 2, 5, 64, 1024]) {
+      expect(spannedText(wire, chunkSize)).toBe(expected);
+    }
+  });
+
+  it("spans the result wherever it sits among the envelope's keys", () => {
+    const resultFirst = JSON.stringify({
+      result: VALID_RESULT,
+      jsonrpc: "2.0",
+      id: 7,
+    });
+
+    expect(spannedText(resultFirst, 3)).toBe(JSON.stringify(VALID_RESULT));
+  });
+
+  it("excludes a sibling key whose value nests braces", () => {
+    // A nested object after `result` closes must not reopen the span.
+    const wire = JSON.stringify({
+      jsonrpc: "2.0",
+      result: VALID_RESULT,
+      meta: { nested: { deeper: [1, 2, 3] } },
+      id: 7,
+    });
+
+    expect(spannedText(wire, 11)).toBe(JSON.stringify(VALID_RESULT));
+  });
+
+  it("reports no span for an envelope it rejects before result", () => {
+    const validator = new ArtifactStreamValidator();
+
+    expect(validator.update(encoder.encode('{"jsonrpc":"2.0","id":7,'))).toBe(
+      null,
+    );
+  });
+});

--- a/services/vault/src/services/artifacts/artifactDownloadService.ts
+++ b/services/vault/src/services/artifacts/artifactDownloadService.ts
@@ -17,6 +17,15 @@
  * Bytes are validated, hashed, and written chunk-by-chunk in a single pass,
  * so the full body is never held in memory on the File System Access path.
  *
+ * What lands on disk is the envelope's `result` value alone, not the JSON-RPC
+ * response around it. `jsonrpc` and `id` are transport framing with no meaning
+ * in a saved file, and the unwrapped shape is what the rest of the toolchain
+ * already reads — btc-vault's `tools/artifact-downloader` writes the identical
+ * layout, so a bundle saved here and one fetched with the CLI are
+ * interchangeable. The validator reports the payload's byte range as it parses
+ * (see `streamingArtifactValidator.ts`), so stripping the envelope costs no
+ * extra pass and no buffering.
+ *
  * The bundle is also bound to the deposit it was requested for: the envelope
  * names no vault, but the transaction graph inside it does, so its claim and
  * payout transactions are checked against the requested pegin txid and its
@@ -94,8 +103,12 @@ export interface FetchArtifactsOptions {
 /** Evidence that a validated bundle was written to disk. */
 export interface ArtifactDownloadOutcome {
   filename: string;
+  /** Size of the saved file, which excludes the JSON-RPC envelope. */
   byteLength: number;
-  /** SHA-256 of the response body, computed during the same streaming pass. */
+  /**
+   * SHA-256 of the saved file, computed during the same streaming pass — so
+   * a user running `sha256sum` on the artifact file reproduces it.
+   */
   sha256: string;
   method: ArtifactSaveMethod;
 }
@@ -195,7 +208,10 @@ export async function downloadArtifactsFromResponse(
   const validator = new ArtifactStreamValidator();
   const hasher = sha256.create();
   const reader = response.body.getReader();
+  /** Bytes read off the wire; bounds the transfer and drives progress. */
   let received = 0;
+  /** Bytes actually written — the envelope-stripped payload. */
+  let written = 0;
 
   options?.onProgress?.(0, totalBytes);
 
@@ -220,9 +236,16 @@ export async function downloadArtifactsFromResponse(
         throw new ArtifactDownloadTooLargeError(received, target.maxBytes);
       }
 
-      validator.update(chunk.value);
-      hasher.update(chunk.value);
-      await stream.write(chunk.value);
+      // Only the bytes inside the envelope's `result` are saved; the
+      // JSON-RPC framing is dropped so the file matches what the CLI
+      // toolchain reads. The validator still sees every byte.
+      const span = validator.update(chunk.value);
+      if (span) {
+        const payload = chunk.value.subarray(span.start, span.end);
+        hasher.update(payload);
+        await stream.write(payload);
+        written += payload.byteLength;
+      }
 
       options?.onProgress?.(received, totalBytes);
     }
@@ -238,6 +261,15 @@ export async function downloadArtifactsFromResponse(
       Object.keys(validated.result.babe_sessions),
       binding,
     );
+
+    // Unreachable while `finish()` requires a schema-valid result object, but
+    // a receipt is only meaningful if it describes real bytes on disk — so
+    // the invariant is asserted rather than assumed across future edits.
+    if (written === 0) {
+      throw new VpResponseValidationError(
+        "Artifact response yielded no payload bytes to save",
+      );
+    }
   } catch (err) {
     await discardQuietly(stream);
     throw err;
@@ -257,7 +289,7 @@ export async function downloadArtifactsFromResponse(
 
   return {
     filename: target.filename,
-    byteLength: received,
+    byteLength: written,
     sha256: bytesToHex(hasher.digest()),
     method: target.method,
   };

--- a/services/vault/src/services/artifacts/streamingArtifactValidator.ts
+++ b/services/vault/src/services/artifacts/streamingArtifactValidator.ts
@@ -8,6 +8,15 @@
  * success envelope wrapping a schema-valid artifact payload, while holding
  * only a few KB of state.
  *
+ * It also reports, per chunk, which bytes fall inside the envelope's `result`
+ * value, so the caller can save the payload alone. The envelope is transport
+ * framing: `jsonrpc` and `id` mean nothing on disk, and the unwrapped file is
+ * the layout every consumer already expects — `tools/artifact-downloader` in
+ * btc-vault writes exactly that shape, and `docs/delegated_claim.md` treats it
+ * as the starting point for building the watchtower's `artifacts.json`. Since
+ * the machine already knows the document's structure, the span costs a byte
+ * offset rather than a second pass.
+ *
  * Why a byte-level machine rather than an incremental `TextDecoder`: every
  * JSON structural character is ASCII, and every byte of a multi-byte UTF-8
  * sequence is >= 0x80, so a byte scanner can never mistake payload text for
@@ -211,6 +220,22 @@ interface Frame {
   seenKeys: Set<string> | null;
 }
 
+/**
+ * Half-open `[start, end)` offsets into the chunk just handed to
+ * {@link ArtifactStreamValidator.update}, bounding the bytes that belong to
+ * the envelope's `result` value.
+ *
+ * Offsets rather than a `subarray` view so the caller slices with its own
+ * buffer type — the File System Access sink requires a view over a
+ * non-shared `ArrayBuffer`, which a view produced here could not promise.
+ */
+export interface ResultByteSpan {
+  /** Inclusive start offset within the chunk. */
+  start: number;
+  /** Exclusive end offset within the chunk. */
+  end: number;
+}
+
 export interface ArtifactStreamValidationResult {
   /**
    * The reconstructed payload handed to the SDK validator. Its
@@ -280,6 +305,12 @@ export class ArtifactStreamValidator {
   private errorCapture: CaptureBuffer | null = null;
 
   private resultSeen = false;
+  /**
+   * Where the parse sits relative to the envelope's `result` value. Drives
+   * the span {@link update} reports so the caller can persist the payload
+   * without the JSON-RPC framing around it.
+   */
+  private resultCapture: "before" | "inside" | "after" = "before";
   private txGraphJson: string | null = null;
   private verifyingKeyHex: string | null = null;
   private babeSessionsSeen = false;
@@ -290,11 +321,22 @@ export class ArtifactStreamValidator {
   /**
    * Feed the next chunk of the response body.
    *
+   * Returns the sub-range of *this* chunk that lies inside the envelope's
+   * `result` value, or null when the chunk contributes none — see
+   * {@link ResultByteSpan}. The caller writes only that range, so the saved
+   * file is the artifact payload rather than the JSON-RPC envelope around it.
+   *
    * Throws synchronously — `JsonRpcError` for a JSON-RPC error envelope,
    * `VpResponseValidationError` for anything malformed — so the caller can
    * abort the file write before the offending bytes are committed to disk.
    */
-  update(chunk: Uint8Array): void {
+  update(chunk: Uint8Array): ResultByteSpan | null {
+    // The result value occupies one contiguous span of the document, so a
+    // chunk can only continue that span, open it, close it, or fall outside
+    // it — never contribute two disjoint runs.
+    let spanStart = this.resultCapture === "inside" ? 0 : -1;
+    let spanEnd = -1;
+
     let index = 0;
     while (index < chunk.length) {
       // Hot path: inside a decryptor_artifacts_hex value, consume the run of
@@ -329,12 +371,27 @@ export class ArtifactStreamValidator {
         }
       }
 
+      const byteIndex = index;
       const byte = chunk[index++];
       if (this.errorCapture !== null) {
         this.errorCapture.push(byte);
       }
+
+      const wasInside = this.resultCapture === "inside";
       this.processByte(byte);
+
+      if (this.resultCapture === "inside") {
+        // Opening `{`: the span starts at this byte, inclusive.
+        if (!wasInside) spanStart = byteIndex;
+      } else if (wasInside) {
+        // Closing `}`: the span ends after this byte, inclusive.
+        spanEnd = index;
+      }
     }
+
+    if (spanStart < 0) return null;
+    const end = spanEnd >= 0 ? spanEnd : chunk.length;
+    return end > spanStart ? { start: spanStart, end } : null;
   }
 
   /**
@@ -570,7 +627,12 @@ export class ArtifactStreamValidator {
     }
 
     if (byte === BYTE_OPEN_BRACE) {
-      if (path === "result") this.resultSeen = true;
+      if (path === "result") {
+        this.resultSeen = true;
+        // This byte is the result object's `{` — the first byte of the span
+        // the caller writes to disk.
+        this.resultCapture = "inside";
+      }
       if (path === "babe_sessions") this.babeSessionsSeen = true;
       this.pushFrame("object");
       return;
@@ -841,6 +903,12 @@ export class ArtifactStreamValidator {
     }
     if (this.errorCapture !== null && this.frames.length === 1) {
       this.throwWireError(this.errorCapture);
+    }
+    if (this.resultCapture === "inside" && this.frames.length === 1) {
+      // Only the result object itself can return the parse to envelope depth
+      // while we are inside it — anything nested pops to depth >= 2 — so this
+      // byte is its closing `}` and the last byte of the span.
+      this.resultCapture = "after";
     }
     this.state = this.frames.length === 0 ? "done" : "after_value";
   }

--- a/services/vault/src/utils/artifactDownloadStorage.ts
+++ b/services/vault/src/utils/artifactDownloadStorage.ts
@@ -38,7 +38,7 @@ export interface ArtifactDownloadReceipt {
   peginTxid: string;
   filename: string;
   byteLength: number;
-  /** SHA-256 of the response body, lowercase hex. */
+  /** SHA-256 of the saved file, lowercase hex. */
   sha256: string;
   savedAt: number;
   method: ArtifactSaveMethod;


### PR DESCRIPTION
How it is **now**: when user clicks on button to download artifacts they receive full json response including json-rpc i.e.
```
{
  "jsonrpc": "2.0",
  "result":  <real data for artifacts>,
  "id": 1
}
```

It doesn't hurt (since data is still there - and I was able to claim vault using artifacts). It just looks a bit strange.

How it should **be** (changes in this PR): user downloads file that contains data only from the result field (no json-rpc envelope)

**Notes:**
- in theory it could be done on vault-provider-proxy side, but it's wrong: the response should be always consistent (same json-rpc envelope for errors and good responses)