### PR TITLE
feat(vault): deposit cluster restyle

### DIFF
--- a/services/vault/src/components/deposit/RefundModal/RefundReviewContent.tsx
+++ b/services/vault/src/components/deposit/RefundModal/RefundReviewContent.tsx
@@ -1,10 +1,4 @@
-import {
-  Button,
-  Callout,
-  Heading,
-  Loader,
-  Text,
-} from "@babylonlabs-io/core-ui";
+import { Button, Callout, Heading, Loader } from "@babylonlabs-io/core-ui";
 import {
   estimateRefundFeeSats,
   REFUND_MAX_FEE_FRACTION_DENOMINATOR,
@@ -13,6 +7,7 @@ import {
 } from "@babylonlabs-io/ts-sdk/tbv/core/services";
 import { useEffect, useState } from "react";
 
+import { ReviewDetailRow } from "@/components/shared/DetailRow";
 import { FALLBACK_FEE_RATE_SATS_VB } from "@/constants";
 import { useBTCWallet } from "@/context/wallet";
 import { COPY } from "@/copy";
@@ -153,24 +148,24 @@ export function RefundReviewContent({
       </div>
 
       <div className="rounded-b-2xl border border-secondary-strokeLight bg-surface p-6">
-        <div className="flex flex-col gap-4">
-          <DetailRow
+        <div className="flex flex-col gap-6">
+          <ReviewDetailRow
             label={COPY.deposit.refundReview.refundAmount}
-            primary={
+            value={
               amountBtc !== null
                 ? `${formatBtcValue(amountBtc)} ${symbol}`
                 : "—"
             }
-            secondary={
+            secondaryValue={
               amountBtc !== null && btcPriceUSD > 0
                 ? `${formatUsd(amountBtc * btcPriceUSD)} USD`
                 : undefined
             }
           />
 
-          <DetailRow
+          <ReviewDetailRow
             label={COPY.deposit.refundReview.networkFeeRate}
-            primaryNode={
+            value={
               feeRate !== null ? (
                 <FeeRateField
                   value={feeRate}
@@ -183,14 +178,14 @@ export function RefundReviewContent({
             }
           />
 
-          <DetailRow
+          <ReviewDetailRow
             label={COPY.deposit.refundReview.btcNetworkFee}
-            primary={
+            value={
               networkFeeBtc !== null
                 ? `${formatBtcValue(networkFeeBtc)} ${symbol}`
                 : "—"
             }
-            secondary={
+            secondaryValue={
               networkFeeBtc !== null && btcPriceUSD > 0
                 ? `${formatUsd(networkFeeBtc * btcPriceUSD)} USD`
                 : undefined
@@ -199,19 +194,18 @@ export function RefundReviewContent({
 
           <div className="my-1 border-t border-secondary-strokeLight" />
 
-          <DetailRow
+          <ReviewDetailRow
             label={COPY.deposit.refundReview.youReceive}
-            primary={
+            value={
               youReceiveBtc !== null
                 ? `${formatBtcValue(youReceiveBtc)} ${symbol}`
                 : "—"
             }
-            secondary={
+            secondaryValue={
               youReceiveBtc !== null && btcPriceUSD > 0
                 ? `${formatUsd(youReceiveBtc * btcPriceUSD)} USD`
                 : undefined
             }
-            emphasis
           />
 
           {walletLocked && (
@@ -254,45 +248,6 @@ export function RefundReviewContent({
             )}
           </Button>
         </div>
-      </div>
-    </div>
-  );
-}
-
-interface DetailRowProps {
-  label: string;
-  primary?: string;
-  primaryNode?: React.ReactNode;
-  secondary?: string;
-  emphasis?: boolean;
-}
-
-function DetailRow({
-  label,
-  primary,
-  primaryNode,
-  secondary,
-  emphasis = false,
-}: DetailRowProps) {
-  return (
-    <div className="flex items-start justify-between gap-6">
-      <Text
-        variant="body1"
-        className={emphasis ? "text-accent-primary" : "text-accent-secondary"}
-      >
-        {label}
-      </Text>
-      <div className="flex flex-col items-end">
-        {primaryNode ?? (
-          <Text variant="body1" className="text-right text-accent-primary">
-            {primary}
-          </Text>
-        )}
-        {secondary && (
-          <Text variant="body2" className="text-right text-accent-disabled">
-            {secondary}
-          </Text>
-        )}
       </div>
     </div>
   );

--- a/services/vault/src/components/deposit/RefundModal/__tests__/RefundModal.test.tsx
+++ b/services/vault/src/components/deposit/RefundModal/__tests__/RefundModal.test.tsx
@@ -96,6 +96,13 @@ describe("RefundModal", () => {
     );
 
     expect(await screen.findByText("Review Refund")).toBeInTheDocument();
+
+    // The shared review row splits each figure across an amount line and a
+    // secondary conversion line; the figures themselves are unchanged.
+    // 1,000,000 sats = 0.01 BTC at $50,000 = $500.00.
+    expect(screen.getByText("Refund Amount")).toBeInTheDocument();
+    expect(screen.getByText("0.01 sBTC")).toBeInTheDocument();
+    expect(screen.getByText("$500.00 USD")).toBeInTheDocument();
   });
 
   it("disables Confirm and shows the rate-cap banner when mempool returns a malicious fee rate", async () => {

--- a/services/vault/src/components/shared/DetailRow.tsx
+++ b/services/vault/src/components/shared/DetailRow.tsx
@@ -1,0 +1,56 @@
+/**
+ * Shared v3 label/value rows, the counterpart to `ListRow` for surfaces that
+ * present a stack of metrics rather than a list of records.
+ *
+ * `FeeDetailRow` is the fee line from Figma "Fees" (4110-65950): a body2 label
+ * on the left — carrying core-ui's 16px info icon when it has a tooltip — and a
+ * right-aligned amount whose USD conversion trails it in secondary text. The
+ * deposit breakdown and the protocol-parameter panel both render through it so
+ * the two lists on the deposit form stay one row system.
+ *
+ * Not a core-ui component: the pairing of app copy, tooltip and conversion
+ * suffix is vault-specific, and core-ui has no equivalent primitive.
+ */
+
+import { Hint } from "@babylonlabs-io/core-ui";
+import type { ReactNode } from "react";
+
+interface FeeDetailRowProps {
+  label: ReactNode;
+  tooltip?: string;
+  value: ReactNode;
+  /** Trailing conversion (e.g. "($12.24 USD)"), rendered in secondary text. */
+  secondaryValue?: ReactNode;
+  /** Renders the value in the error colour without changing its text. */
+  valueIsError?: boolean;
+}
+
+export function FeeDetailRow({
+  label,
+  tooltip,
+  value,
+  secondaryValue,
+  valueIsError = false,
+}: FeeDetailRowProps) {
+  return (
+    <div className="flex items-start justify-between gap-6 text-sm leading-[1.43] tracking-[0.17px]">
+      {tooltip ? (
+        <Hint tooltip={tooltip}>
+          <span>{label}</span>
+        </Hint>
+      ) : (
+        <span className="text-accent-primary">{label}</span>
+      )}
+      <span className="text-right">
+        <span
+          className={valueIsError ? "text-error-main" : "text-accent-primary"}
+        >
+          {value}
+        </span>
+        {secondaryValue ? (
+          <span className="text-accent-secondary"> {secondaryValue}</span>
+        ) : null}
+      </span>
+    </div>
+  );
+}

--- a/services/vault/src/components/shared/DetailRow.tsx
+++ b/services/vault/src/components/shared/DetailRow.tsx
@@ -8,6 +8,11 @@
  * deposit breakdown and the protocol-parameter panel both render through it so
  * the two lists on the deposit form stay one row system.
  *
+ * `ReviewDetailRow` is the confirm-screen line from Figma "Review Withdraw"
+ * (10088-38704): a body1 label on the left and a right-aligned value whose
+ * conversion sits on a second, secondary line rather than trailing it. The
+ * withdraw and refund review cards share it.
+ *
  * Not a core-ui component: the pairing of app copy, tooltip and conversion
  * suffix is vault-specific, and core-ui has no equivalent primitive.
  */
@@ -51,6 +56,31 @@ export function FeeDetailRow({
           <span className="text-accent-secondary"> {secondaryValue}</span>
         ) : null}
       </span>
+    </div>
+  );
+}
+
+interface ReviewDetailRowProps {
+  label: string;
+  value: ReactNode;
+  /** Sub-line under the value (e.g. the USD conversion), in secondary text. */
+  secondaryValue?: ReactNode;
+}
+
+export function ReviewDetailRow({
+  label,
+  value,
+  secondaryValue,
+}: ReviewDetailRowProps) {
+  return (
+    <div className="flex items-start justify-between gap-6 text-base leading-[1.5] tracking-[0.15px]">
+      <span className="text-accent-primary">{label}</span>
+      <div className="flex flex-col items-end text-right text-accent-primary">
+        {value}
+        {secondaryValue ? (
+          <span className="text-accent-secondary">{secondaryValue}</span>
+        ) : null}
+      </div>
     </div>
   );
 }

--- a/services/vault/src/components/simple/DashboardPage.tsx
+++ b/services/vault/src/components/simple/DashboardPage.tsx
@@ -16,6 +16,7 @@ import {
   ENTRY_CONTENT_CLASS,
   PAGE_CONTENT_CLASS,
 } from "@/components/shared/layoutClasses";
+import { isDepositBlocked } from "@/components/shared/protocolStatus";
 import featureFlags from "@/config/featureFlags";
 import { useConnection, useETHWallet } from "@/context/wallet";
 import { COPY } from "@/copy";
@@ -23,6 +24,7 @@ import { useApplicationCap } from "@/hooks/useApplicationCap";
 import { useDashboardState } from "@/hooks/useDashboardState";
 import { useLoanActions } from "@/hooks/useLoanActions";
 import { usePrices } from "@/hooks/usePrices";
+import { useProtocolGateState } from "@/hooks/useProtocolGate";
 import {
   resolveShownHealthFactor,
   useHealthFactorOverride,
@@ -52,6 +54,7 @@ export function DashboardPage() {
   const { openDeposit } = useOutletContext<RootLayoutContext>();
   const { address } = useETHWallet();
   const { isConnected } = useConnection();
+  const gate = useProtocolGateState();
 
   // Dev-only banner override driven by the position-notifications section of
   // the god-mode panel (see @/overrides/position). Always null in production,
@@ -258,6 +261,7 @@ export function DashboardPage() {
           borrowCapacityError={borrowCapacityError}
           borrowedMeterPercent={borrowedMeterPercent}
           onDeposit={openDeposit}
+          isDepositDisabled={isDepositBlocked(gate)}
           onBorrow={openBorrowPicker}
           onRepay={openRepay}
           canBorrow={canBorrow}

--- a/services/vault/src/components/simple/DepositFeesBreakdown.tsx
+++ b/services/vault/src/components/simple/DepositFeesBreakdown.tsx
@@ -1,6 +1,6 @@
-import { Hint } from "@babylonlabs-io/core-ui";
 import { useMemo } from "react";
 
+import { FeeDetailRow } from "@/components/shared/DetailRow";
 import { COPY } from "@/copy";
 import { satoshiToBtcNumber } from "@/utils/btcConversion";
 import {
@@ -32,46 +32,6 @@ interface DepositFeesBreakdownProps {
    * `undefined` while a two-vault split's per-vault amounts are loading.
    */
   commissionBaseValues?: readonly bigint[];
-}
-
-interface FeeLineProps {
-  label: string;
-  tooltip?: string;
-  amount: string;
-  amountIsError?: boolean;
-  price: string;
-}
-
-function FeeLine({
-  label,
-  tooltip,
-  amount,
-  amountIsError,
-  price,
-}: FeeLineProps) {
-  return (
-    <div className="flex items-center justify-between text-sm">
-      {tooltip ? (
-        <Hint
-          tooltip={tooltip}
-          attachToChildren
-          className="text-accent-primary"
-        >
-          <span>{label}</span>
-        </Hint>
-      ) : (
-        <span className="text-accent-primary">{label}</span>
-      )}
-      <span>
-        <span
-          className={amountIsError ? "text-error-main" : "text-accent-primary"}
-        >
-          {amount}
-        </span>
-        {price && <span className="text-accent-secondary"> {price}</span>}
-      </span>
-    </div>
-  );
 }
 
 export function DepositFeesBreakdown({
@@ -140,30 +100,30 @@ export function DepositFeesBreakdown({
 
   return (
     <div className="flex flex-col gap-2">
-      <FeeLine
+      <FeeDetailRow
         label={FORM_COPY.transactionReserveLabel}
         tooltip={FORM_COPY.transactionReserveTooltip}
-        amount={transactionReserve.amount}
-        price={transactionReserve.price}
+        value={transactionReserve.amount}
+        secondaryValue={transactionReserve.price}
       />
-      <FeeLine
+      <FeeDetailRow
         label={FORM_COPY.depositFeeLabel}
         tooltip={FORM_COPY.depositFeeTooltip}
-        amount={protocolFeeAmount}
-        amountIsError={protocolFeeIsError}
-        price={protocolFeePrice}
+        value={protocolFeeAmount}
+        valueIsError={protocolFeeIsError}
+        secondaryValue={protocolFeePrice}
       />
-      <FeeLine
+      <FeeDetailRow
         label={commissionLabel}
         tooltip={FORM_COPY.vpCommissionTooltip}
-        amount={commission.amount}
-        price={commission.price}
+        value={commission.amount}
+        secondaryValue={commission.price}
       />
-      <FeeLine
+      <FeeDetailRow
         label={FORM_COPY.netPayoutLabel}
         tooltip={FORM_COPY.netPayoutTooltip}
-        amount={netPayout.amount}
-        price={netPayout.price}
+        value={netPayout.amount}
+        secondaryValue={netPayout.price}
       />
     </div>
   );

--- a/services/vault/src/components/simple/FeesSection.tsx
+++ b/services/vault/src/components/simple/FeesSection.tsx
@@ -1,7 +1,8 @@
-import { Accordion, AccordionDetails, Hint } from "@babylonlabs-io/core-ui";
+import { Accordion, AccordionDetails } from "@babylonlabs-io/core-ui";
 import { type ReactNode, useId, useState } from "react";
 import { IoAdd, IoRemove } from "react-icons/io5";
 
+import { FeeDetailRow } from "@/components/shared/DetailRow";
 import { COPY } from "@/copy";
 
 export interface FeeRow {
@@ -18,15 +19,12 @@ function FeeRows({ rows }: FeesSectionProps) {
   return (
     <>
       {rows.map((row) => (
-        <div
+        <FeeDetailRow
           key={row.label}
-          className="flex items-center justify-between text-sm"
-        >
-          <Hint tooltip={row.tooltip} className="text-accent-secondary">
-            <span>{row.label}</span>
-          </Hint>
-          <span className="text-accent-secondary">{row.value}</span>
-        </div>
+          label={row.label}
+          tooltip={row.tooltip}
+          value={row.value}
+        />
       ))}
     </>
   );

--- a/services/vault/src/components/simple/OverviewSection.tsx
+++ b/services/vault/src/components/simple/OverviewSection.tsx
@@ -26,6 +26,8 @@ interface OverviewSectionProps {
   borrowCapacityLoading: boolean;
   borrowCapacityError: Error | null;
   onDeposit: () => void;
+  /** True while `isDepositBlocked` holds — greys the Deposit CTA (issue #2068). */
+  isDepositDisabled: boolean;
   onBorrow: () => void;
   onRepay: () => void;
   canBorrow: boolean;
@@ -42,6 +44,7 @@ export function OverviewSection({
   borrowCapacityLoading,
   borrowCapacityError,
   onDeposit,
+  isDepositDisabled,
   onBorrow,
   onRepay,
   canBorrow,
@@ -62,7 +65,7 @@ export function OverviewSection({
         caption: collateralBtc,
         actionLabel: COPY.overview.depositAction,
         onAction: onDeposit,
-        actionDisabled: false,
+        actionDisabled: isDepositDisabled,
       },
       ...buildBorrowCapacityCards({
         availableToBorrow,
@@ -81,6 +84,7 @@ export function OverviewSection({
       totalCollateralValue,
       collateralBtc,
       onDeposit,
+      isDepositDisabled,
       availableToBorrow,
       availableMeterPercent,
       borrowCapacityLoading,

--- a/services/vault/src/components/simple/WithdrawFlow/HealthFactorDelta.tsx
+++ b/services/vault/src/components/simple/WithdrawFlow/HealthFactorDelta.tsx
@@ -1,4 +1,9 @@
-import { formatHealthFactor } from "@/applications/aave/utils";
+import {
+  formatHealthFactor,
+  getHealthFactorColor,
+  getHealthFactorStatusFromValue,
+} from "@/applications/aave/utils";
+import { HeartIcon } from "@/components/shared/icons/HeartIcon";
 
 interface HealthFactorDeltaProps {
   /** Current on-chain health factor, or null when the user has no debt. */
@@ -10,16 +15,30 @@ interface HealthFactorDeltaProps {
 /**
  * Compact "current → projected" health factor rendering shared by the
  * withdraw selector and review steps.
+ *
+ * Per Figma 10088-38704 the outgoing value and the arrow read as secondary
+ * text while the projected value carries the position's colour and its heart.
+ * The colour comes from the projected value's own status, so a withdrawal that
+ * moves the position into warning or danger is not painted healthy green.
  */
 export function HealthFactorDelta({
   current,
   projected,
 }: HealthFactorDeltaProps) {
+  const projectedColor = getHealthFactorColor(
+    getHealthFactorStatusFromValue(projected),
+  );
+
   return (
-    <span>
-      {formatHealthFactor(current)}
-      <span className="mx-1 text-accent-secondary">&rarr;</span>
-      {Number.isFinite(projected) ? formatHealthFactor(projected) : "∞"}
+    <span className="flex items-center gap-1">
+      <span className="text-accent-secondary">
+        {formatHealthFactor(current)}
+      </span>
+      <span className="text-accent-secondary">&rarr;</span>
+      <span style={{ color: projectedColor }}>
+        {Number.isFinite(projected) ? formatHealthFactor(projected) : "∞"}
+      </span>
+      <HeartIcon color={projectedColor} className="size-[18px]" />
     </span>
   );
 }

--- a/services/vault/src/components/simple/WithdrawFlow/WithdrawReviewContent.tsx
+++ b/services/vault/src/components/simple/WithdrawFlow/WithdrawReviewContent.tsx
@@ -13,6 +13,7 @@ import {
   WITHDRAW_HF_WARNING_THRESHOLD,
 } from "@/applications/aave/constants";
 import { getWithdrawHfWarningState } from "@/applications/aave/utils";
+import { ReviewDetailRow } from "@/components/shared/DetailRow";
 import { BTC_BLOCK_TIME_MINS } from "@/constants";
 import { useProtocolParamsContext } from "@/context/ProtocolParamsContext";
 import { COPY } from "@/copy";
@@ -26,10 +27,14 @@ import {
 import { HealthFactorDelta } from "./HealthFactorDelta";
 import { NominatedAddressValue } from "./NominatedAddressValue";
 
+const REVIEW_COPY = COPY.withdraw.review;
+
 /** A single label/value pair rendered in the review card. */
 interface DetailRow {
   label: string;
   value: ReactNode;
+  /** Conversion shown on a second, secondary line under the value. */
+  secondaryValue?: ReactNode;
 }
 
 interface WithdrawReviewContentProps {
@@ -80,7 +85,7 @@ export function WithdrawReviewContent({
       currentHealthFactor === null
         ? null
         : {
-            label: "Health factor",
+            label: REVIEW_COPY.healthFactorLabel,
             value: (
               <HealthFactorDelta
                 current={currentHealthFactor}
@@ -91,37 +96,27 @@ export function WithdrawReviewContent({
 
     const baseRows: DetailRow[] = [
       {
-        label: "Withdrawal amount",
-        value: (
-          <span>
-            {formatBtcAmount(totalAmountBtc)}{" "}
-            <span className="text-accent-secondary">
-              {formatUsdValue(totalAmountUsd)}
-            </span>
-          </span>
-        ),
+        label: REVIEW_COPY.withdrawAmountLabel,
+        value: formatBtcAmount(totalAmountBtc),
+        secondaryValue: formatUsdValue(totalAmountUsd),
       },
       {
-        label: "Network fee rate",
+        label: REVIEW_COPY.networkFeeRateLabel,
         value:
           defaultFeeRate > 0
             ? `${defaultFeeRate} sats/vB`
             : COPY.common.loading,
       },
-      {
-        label: "VP commission",
-        value:
-          minVpCommissionBps > 0 ? (
-            <span>
-              {formatBtcAmount(vpCommissionBtc)}{" "}
-              <span className="text-accent-secondary">
-                {formatUsdValue(vpCommissionUsd)}
-              </span>
-            </span>
-          ) : (
-            "None"
-          ),
-      },
+      minVpCommissionBps > 0
+        ? {
+            label: REVIEW_COPY.vpCommissionLabel,
+            value: formatBtcAmount(vpCommissionBtc),
+            secondaryValue: formatUsdValue(vpCommissionUsd),
+          }
+        : {
+            label: REVIEW_COPY.vpCommissionLabel,
+            value: REVIEW_COPY.noCommission,
+          },
     ];
 
     const withHf = hfRow
@@ -163,7 +158,7 @@ export function WithdrawReviewContent({
     <div className="w-full">
       <div className="rounded-t-2xl border border-b-0 border-secondary-strokeLight p-6">
         <Heading variant="h5" className="font-normal text-accent-primary">
-          Review withdrawal
+          {REVIEW_COPY.heading}
         </Heading>
       </div>
 
@@ -171,17 +166,12 @@ export function WithdrawReviewContent({
         <div className="flex flex-col gap-6">
           <div className="flex flex-col gap-6">
             {rows.map((row) => (
-              <div
+              <ReviewDetailRow
                 key={row.label}
-                className="flex items-start justify-between gap-6"
-              >
-                <Text variant="body1" className="text-accent-primary">
-                  {row.label}
-                </Text>
-                <div className="flex flex-col items-end text-right text-base text-accent-primary">
-                  {row.value}
-                </div>
-              </div>
+                label={row.label}
+                value={row.value}
+                secondaryValue={row.secondaryValue}
+              />
             ))}
           </div>
 
@@ -191,9 +181,9 @@ export function WithdrawReviewContent({
               className="text-error-main"
               data-testid="withdraw-hf-block-warning"
             >
-              This withdrawal would drop your health factor below{" "}
-              {WITHDRAW_HF_BLOCK_THRESHOLD.toFixed(1)} and be rejected on-chain.
-              Reduce the selection or repay debt first.
+              {REVIEW_COPY.hfBlockWarning(
+                WITHDRAW_HF_BLOCK_THRESHOLD.toFixed(1),
+              )}
             </Text>
           )}
           {isAtRisk && (
@@ -202,9 +192,9 @@ export function WithdrawReviewContent({
               className="text-warning-main"
               data-testid="withdraw-hf-at-risk-warning"
             >
-              Your position will be at risk of liquidation after this withdrawal
-              (health factor below {WITHDRAW_HF_WARNING_THRESHOLD.toFixed(1)}).
-              Consider withdrawing less or repaying debt.
+              {REVIEW_COPY.hfAtRiskWarning(
+                WITHDRAW_HF_WARNING_THRESHOLD.toFixed(1),
+              )}
             </Text>
           )}
 
@@ -225,11 +215,11 @@ export function WithdrawReviewContent({
                   variant="body2"
                   className="text-accent-contrast"
                 >
-                  Processing
+                  {REVIEW_COPY.processing}
                 </Text>
               </span>
             ) : (
-              "Confirm"
+              REVIEW_COPY.confirmButton
             )}
           </Button>
 

--- a/services/vault/src/components/simple/WithdrawFlow/__tests__/WithdrawReviewContent.test.tsx
+++ b/services/vault/src/components/simple/WithdrawFlow/__tests__/WithdrawReviewContent.test.tsx
@@ -1,0 +1,82 @@
+/**
+ * Review Withdraw card (issue #2067). The restyle moved every row onto the
+ * shared v3 review row, so these pin what the rows must still say: the same
+ * amounts, the same conversions, and a projected health factor coloured by its
+ * own status rather than always green.
+ */
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { HEALTH_FACTOR_COLORS } from "@/applications/aave/utils";
+
+import { WithdrawReviewContent } from "../WithdrawReviewContent";
+
+vi.mock("@/hooks/useNetworkFees", () => ({
+  useNetworkFees: () => ({ defaultFeeRate: 3 }),
+}));
+
+vi.mock("@/context/ProtocolParamsContext", () => ({
+  useProtocolParamsContext: () => ({ minVpCommissionBps: 250 }),
+}));
+
+const baseProps = {
+  totalAmountBtc: 0.6,
+  totalAmountUsd: 21_686.17,
+  currentHealthFactor: 1.6,
+  projectedHealthFactor: 1.3,
+  payoutAddresses: ["bc1qexampleaddress"],
+  assertTimelockBlocks: 144,
+  isProcessing: false,
+  error: null,
+  onConfirm: () => {},
+};
+
+describe("WithdrawReviewContent", () => {
+  it("renders each row's amount with its USD conversion on a second line", () => {
+    render(<WithdrawReviewContent {...baseProps} />);
+
+    expect(screen.getByText("Withdraw Amount")).toBeInTheDocument();
+    expect(screen.getByText("0.6 sBTC")).toBeInTheDocument();
+    expect(screen.getByText("$21,686.17 USD")).toBeInTheDocument();
+
+    expect(screen.getByText("Network Fee Rate")).toBeInTheDocument();
+    expect(screen.getByText("3 sats/vB")).toBeInTheDocument();
+
+    // 2.5% of 0.6 BTC = 0.015 BTC / $542.15 — unchanged by the restyle.
+    // (The test env is signet, so the coin symbol renders as sBTC.)
+    expect(screen.getByText("VP Commission")).toBeInTheDocument();
+    expect(screen.getByText("0.015 sBTC")).toBeInTheDocument();
+    expect(screen.getByText("$542.15 USD")).toBeInTheDocument();
+  });
+
+  it("colours the projected health factor by the projected status, not the current one", () => {
+    // Healthy now, danger after: painting the delta from the current status
+    // would show this withdrawal as green.
+    render(
+      <WithdrawReviewContent
+        {...baseProps}
+        currentHealthFactor={1.6}
+        projectedHealthFactor={0.9}
+      />,
+    );
+
+    // The outgoing value reads as plain secondary text; only the projection
+    // carries the position colour.
+    expect(screen.getByText("1.60")).not.toHaveAttribute("style");
+    expect(screen.getByText("0.90")).toHaveStyle({
+      color: HEALTH_FACTOR_COLORS.RED,
+    });
+  });
+
+  it("blocks confirmation and explains why when the projection breaches the floor", () => {
+    render(
+      <WithdrawReviewContent {...baseProps} projectedHealthFactor={0.9} />,
+    );
+
+    expect(screen.getByTestId("withdraw-hf-block-warning")).toHaveTextContent(
+      "would drop your health factor below 1.0",
+    );
+    expect(screen.getByTestId("withdraw-confirm-button")).toBeDisabled();
+  });
+});

--- a/services/vault/src/components/simple/__tests__/DepositFeesBreakdown.test.tsx
+++ b/services/vault/src/components/simple/__tests__/DepositFeesBreakdown.test.tsx
@@ -77,6 +77,28 @@ describe("DepositFeesBreakdown commission disclosure", () => {
     expect(screen.getAllByText("--").length).toBeGreaterThanOrEqual(2);
   });
 
+  it("exposes every tooltip through its own row trigger", () => {
+    render(
+      <DepositFeesBreakdown
+        {...baseProps}
+        amountSats={100_000_000n}
+        depositorClaimValue={3_000_000n}
+        commissionBaseValues={[100_000_000n]}
+        commissionBps={250}
+      />,
+    );
+
+    // The shared fee row hangs the tooltip off core-ui's info icon rather than
+    // the bare label, so each of the four lines carries its own trigger.
+    const tooltips = Array.from(
+      document.querySelectorAll("[data-tooltip-content]"),
+    ).map((node) => node.getAttribute("data-tooltip-content"));
+
+    expect(tooltips).toHaveLength(4);
+    expect(tooltips.every((content) => Boolean(content))).toBe(true);
+    expect(new Set(tooltips).size).toBe(4);
+  });
+
   it("floors commission per vault for split deposits", () => {
     render(
       <DepositFeesBreakdown

--- a/services/vault/src/components/simple/__tests__/FeesSection.test.tsx
+++ b/services/vault/src/components/simple/__tests__/FeesSection.test.tsx
@@ -5,7 +5,11 @@ import { FeesSection, type FeeRow } from "../FeesSection";
 
 const rows: FeeRow[] = [
   { label: "Min deposit", value: "0.0005 BTC" },
-  { label: "Collateral Factor", value: "72%" },
+  {
+    label: "Collateral Factor",
+    value: "72%",
+    tooltip: "Share of your collateral you can borrow against.",
+  },
 ];
 
 describe("FeesSection", () => {
@@ -45,6 +49,18 @@ describe("FeesSection", () => {
     expect(toggle).toHaveAttribute("aria-expanded", "true");
     expect(screen.getByText("Min deposit")).toBeVisible();
     expect(screen.getByText("Collateral Factor")).toBeVisible();
+  });
+
+  it("gives a row with a tooltip its own trigger and leaves the others bare", () => {
+    render(<FeesSection rows={rows} />);
+
+    const tooltips = Array.from(
+      document.querySelectorAll("[data-tooltip-content]"),
+    ).map((node) => node.getAttribute("data-tooltip-content"));
+
+    expect(tooltips).toEqual([
+      "Share of your collateral you can borrow against.",
+    ]);
   });
 
   it("keeps the collapsed panel out of the layout at zero height", () => {

--- a/services/vault/src/components/simple/__tests__/OverviewSection.test.tsx
+++ b/services/vault/src/components/simple/__tests__/OverviewSection.test.tsx
@@ -26,6 +26,7 @@ function renderSection(overrides: Record<string, unknown> = {}) {
       borrowCapacityError={null}
       borrowedMeterPercent={0.25}
       onDeposit={onDeposit}
+      isDepositDisabled={false}
       onBorrow={onBorrow}
       onRepay={onRepay}
       canBorrow={true}
@@ -40,6 +41,22 @@ beforeEach(() => {
 });
 
 describe("OverviewSection", () => {
+  it("greys the Deposit action out while deposits are blocked", () => {
+    renderSection({ isDepositDisabled: true });
+
+    const deposit = screen.getByRole("button", {
+      name: COPY.overview.depositAction,
+    });
+    expect(deposit).toBeDisabled();
+    fireEvent.click(deposit);
+    expect(onDeposit).not.toHaveBeenCalled();
+
+    // The gate is deposit-scoped: borrow and repay keep their own conditions.
+    expect(
+      screen.getByRole("button", { name: COPY.overview.borrowAction }),
+    ).toBeEnabled();
+  });
+
   it("renders the three stat values and their action buttons", () => {
     renderSection();
 

--- a/services/vault/src/components/vaults/VaultsSummaryCard.tsx
+++ b/services/vault/src/components/vaults/VaultsSummaryCard.tsx
@@ -14,7 +14,7 @@ import {
   formatHealthFactor,
   getHealthFactorColor,
 } from "@/applications/aave/utils";
-import { HeartIcon } from "@/components/shared";
+import { HeartIcon } from "@/components/shared/icons/HeartIcon";
 import {
   PositionStatCards,
   type PositionStatCard,

--- a/services/vault/src/components/vaults/__tests__/VaultsSummaryCard.test.tsx
+++ b/services/vault/src/components/vaults/__tests__/VaultsSummaryCard.test.tsx
@@ -1,0 +1,59 @@
+/**
+ * Vaults summary strip (issue #2068). The populated /vaults page keeps its
+ * Deposit CTA in this card, so the blocked-deposit state has to reach it — and
+ * only it: freeze blocks entry, not the reorder the user can still perform.
+ */
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { COPY } from "@/copy";
+
+import { VaultsSummaryCard } from "../VaultsSummaryCard";
+
+const onDeposit = vi.fn();
+const onReorder = vi.fn();
+
+function renderCard(overrides: Record<string, unknown> = {}) {
+  return render(
+    <VaultsSummaryCard
+      totalCollateralBtc="1.1 BTC"
+      totalCollateralUsd="$90,600 USD"
+      activeVaultsCount={3}
+      liquidationOrder={null}
+      healthFactor={1.02}
+      healthFactorStatus="danger"
+      onDeposit={onDeposit}
+      isDepositDisabled={false}
+      onReorder={onReorder}
+      isReorderDisabled={false}
+      {...overrides}
+    />,
+  );
+}
+
+describe("VaultsSummaryCard", () => {
+  it("keeps the Deposit CTA usable while deposits are allowed", () => {
+    renderCard();
+
+    const deposit = screen.getByRole("button", {
+      name: COPY.vaults.empty.depositAction,
+    });
+    expect(deposit).toBeEnabled();
+    fireEvent.click(deposit);
+    expect(onDeposit).toHaveBeenCalledTimes(1);
+  });
+
+  it("greys the Deposit CTA out while deposits are blocked, leaving Reorder alone", () => {
+    renderCard({ isDepositDisabled: true });
+
+    const deposit = screen.getByRole("button", {
+      name: COPY.vaults.empty.depositAction,
+    });
+    expect(deposit).toBeDisabled();
+
+    expect(
+      screen.getByRole("button", { name: COPY.vaults.actions.reorder }),
+    ).toBeEnabled();
+  });
+});

--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -467,7 +467,7 @@ export const COPY = {
     refundReview: {
       heading: "Review Refund",
       refundAmount: "Refund Amount",
-      networkFeeRate: "Network fee rate",
+      networkFeeRate: "Network Fee Rate",
       btcNetworkFee: "BTC Network Fee",
       youReceive: "You'll receive",
       fallbackFeeWarning:
@@ -1085,6 +1085,24 @@ export const COPY = {
     // Shared labels (review + initiated screens).
     estimatedTimeLabel: "Estimated time until payout",
     nominatedAddressLabel: "Nominated address",
+    // Review Withdraw card. Row labels are Title Case to match the sibling
+    // Review Refund card (and Figma 10088-38704); the two labels above are
+    // rows Figma does not draw, so they keep their existing wording.
+    review: {
+      heading: "Review Withdraw",
+      withdrawAmountLabel: "Withdraw Amount",
+      healthFactorLabel: "Health Factor",
+      networkFeeRateLabel: "Network Fee Rate",
+      vpCommissionLabel: "VP Commission",
+      // Shown when the vault providers charge no commission at all.
+      noCommission: "None",
+      confirmButton: "Confirm",
+      processing: "Processing",
+      hfBlockWarning: (threshold: string) =>
+        `This withdrawal would drop your health factor below ${threshold} and be rejected on-chain. Reduce the selection or repay debt first.`,
+      hfAtRiskWarning: (threshold: string) =>
+        `Your position will be at risk of liquidation after this withdrawal (health factor below ${threshold}). Consider withdrawing less or repaying debt.`,
+    },
     initiated: {
       title: "Withdrawal initiated",
       // Describes the real claim -> challenge period -> payout path.


### PR DESCRIPTION
Three v3 restyles across the deposit cluster, one commit each. Presentation only — every amount, calculation, precision, ordering, loading state and transaction path is unchanged.

Two shared row primitives now live in `services/vault/src/components/shared/DetailRow.tsx`, next to the existing `ListRow.tsx`:

- `FeeDetailRow` — the fee line (body2 label, info icon when the line has a tooltip, amount with its USD conversion trailing in secondary text).
- `ReviewDetailRow` — the confirm-screen line (body1 label, right-aligned value, conversion on a second secondary line).

Closes #2065
Closes #2067
Closes #2068

## #2065 — Fees breakdown alignment

Figma read: [Fee row variants `4110-65950`](https://www.figma.com/design/NgDfn7fVnkQZP0XH9Uki63?node-id=4110-65950) (Default + Active), [`10055-34317`](https://www.figma.com/design/NgDfn7fVnkQZP0XH9Uki63?node-id=10055-34317).

`DepositFeesBreakdown` and the protocol-parameter panel (`FeesSection`) — the two fee-row lists on the deposit form — now render through `FeeDetailRow` instead of two near-identical local rows. The tooltip moves onto core-ui's 16px info icon (4px gap, secondary colour), which is how Figma draws a tooltipped fee label; the label and amount take `text/primary` and the conversion `text/secondary`, both as app tokens rather than hex, so light and dark follow automatically.

**Figma vs. the issue.** The issue labels `10055-34317` "Deposit fee breakdown". It is not — it is the "Babylon Feess" list-row component set (Vault / Loan / Artifacts / Activation / Withdraw / Reclaim rows), already implemented as `components/shared/ListRow.tsx`. The fee-row design is `4110-65950`, and it draws plain lines with no card chrome, so the fee rows deliberately do **not** get `ListRowCard`. Resolved in Figma's favour.

**"the corresponding withdrawal breakdown"** is the Review Withdraw fee rows, which Figma draws at body1 with a stacked conversion rather than the body2 inline fee row. They are restyled in the second commit, onto the same shared file, because they live in the files #2067 covers — splitting them would have both commits editing `WithdrawReviewContent`.

Values unchanged: `DepositFeesBreakdown.test.tsx` keeps its existing commission and net-payout assertions (commission floored per vault, the `--` placeholder states, the 2.5% label), all still passing against the same fixtures. One test added: each of the four lines exposes its own distinct tooltip trigger.

## #2067 — Withdraw & refund restyle

Figma read: [Review Withdraw `10088-38704`](https://www.figma.com/design/NgDfn7fVnkQZP0XH9Uki63?node-id=10088-38704), [Review Refund `6288-85814`](https://www.figma.com/design/NgDfn7fVnkQZP0XH9Uki63?node-id=6288-85814).

Both review cards move onto `ReviewDetailRow`, extracted from the local copy that already lived in `RefundReviewContent`. The USD conversion drops to a second secondary line, labels read `text/primary`, and the refund card's row rhythm goes 16px → 24px to match. Withdraw row labels take Figma's Title Case, which also removes the drift against the sibling Review Refund card ("Refund Amount", "BTC Network Fee"); its inline strings moved to `copy.ts` under `withdraw.review`.

The health-factor delta gets Figma's treatment: the outgoing value and arrow in secondary, the projected value and a heart in the position colour. The colour is derived from the **projected** status, not hardcoded green — Figma only draws the healthy case, and a withdrawal that moves the position into warning or danger must not be painted green.

Signing, submission, polling, completion and retry are untouched; the open question is answered visual-only, so there is no second transaction state machine and no multi-step withdraw progress.

Deliberate deltas from the frames:

- Figma's Review Withdraw drops the VP commission, ETA and payout-address rows and adds a BTC Network Fee row plus a withdrawal-latency callout. Those are data changes, not styling, so the existing row set stands and is restyled in place.
- The fee-rate row in Figma carries an edit affordance. Withdraw has no fee-rate editing today, so it is not added; refund keeps its existing `FeeRateField`.
- The "Review Refund" frame is a stale duplicate of Review Withdraw — its title text literally reads "Review Withdraw". The refund card keeps its own heading rather than shipping the copy-paste.
- Refund success and not-broadcast states are not drawn in Figma. Their current v3 cards stand.
- `WithdrawVaults/` and `ExpiredDepositSection` named in the issue no longer exist in the tree.

Values unchanged: `RefundModal.test.tsx` gains assertions that the refund amount still reads 0.01 sBTC / $500.00 USD across the new two-line row; a new `WithdrawReviewContent.test.tsx` pins the amount, conversion, fee rate and 2.5% commission figures, the projected-status colouring, and that a breaching projection still disables Confirm.

## #2068 — Disabled Deposits states

Figma read: [Overview deposits disabled `10084-28515`](https://www.figma.com/design/NgDfn7fVnkQZP0XH9Uki63?node-id=10084-28515) (dark), [Vaults deposits disabled `10084-29572`](https://www.figma.com/design/NgDfn7fVnkQZP0XH9Uki63?node-id=10084-29572) (light).

Both frames show the same treatment: the existing orange top banner, plus a greyed-out Deposit control. Everything else on the page keeps working — Reorder, Withdraw and Repay stay enabled.

Vaults was already wired: `VaultsPage` passes `isDepositBlocked(gate)` to both the empty state and the summary card. Overview was not — `OverviewSection` hardcoded `actionDisabled: false` on the Deposit stat card. It now takes the predicate, and `DashboardPage` supplies it from the same `useProtocolGateState()` + `isDepositBlocked` pair the Vaults page uses. No second predicate is introduced.

`VaultsSummaryCard` and `HealthFactorDelta` import `HeartIcon` from its module rather than the `components/shared` barrel; the barrel pulls a stylesheet that the test transform cannot parse, which otherwise makes those components untestable.

The Liquidation Analysis empty state's Deposit CTA is not gated: it renders only while `isConnected` is false on `EmptyState`, so that path shows the connect control rather than a Deposit button, and nothing there initiates a deposit today.

Coverage: `OverviewSection.test.tsx` asserts the Deposit action is disabled and unclickable when blocked while Borrow keeps its own condition; a new `VaultsSummaryCard.test.tsx` asserts the same on the populated Vaults strip, with Reorder still enabled; `VaultsPage.test.tsx`'s existing gate test covers the empty state.

## Verification

`tsc --noEmit -p tsconfig.lib.json`, `eslint` on every touched path, `nx build vault`, and the full vault suite — 295 files, 3395 tests passing.
