### PR TITLE
feat(vault): per-row USD value and live deposit status on the Activity page

### DIFF
--- a/services/vault/src/__tests__/router.test.tsx
+++ b/services/vault/src/__tests__/router.test.tsx
@@ -187,6 +187,12 @@ vi.mock("@/hooks/usePendingDeposits", () => ({
   }),
 }));
 
+// Same reason: the Activity feed's price source imports the built
+// wallet-connector bundle for its network enum.
+vi.mock("@/hooks/usePrices", () => ({
+  usePrices: () => ({ prices: {} }),
+}));
+
 vi.mock("@/context/ProtocolParamsContext", () => ({
   ProtocolParamsProvider: ({ children }: { children: ReactNode }) => children,
 }));

--- a/services/vault/src/__tests__/router.test.tsx
+++ b/services/vault/src/__tests__/router.test.tsx
@@ -188,9 +188,14 @@ vi.mock("@/hooks/usePendingDeposits", () => ({
 }));
 
 // Same reason: the Activity feed's price source imports the built
-// wallet-connector bundle for its network enum.
+// wallet-connector bundle for its network enum, and its vault read wants a
+// depositor address this suite never connects.
 vi.mock("@/hooks/usePrices", () => ({
   usePrices: () => ({ prices: {} }),
+}));
+
+vi.mock("@/hooks/useVaults", () => ({
+  useVaults: () => ({ data: undefined }),
 }));
 
 vi.mock("@/context/ProtocolParamsContext", () => ({

--- a/services/vault/src/components/Activity/ActivityList.tsx
+++ b/services/vault/src/components/Activity/ActivityList.tsx
@@ -55,6 +55,8 @@ const FILTER_OPTIONS = (
 interface ActivityListProps {
   activities: ActivityRow[];
   isConnected: boolean;
+  /** Current USD price per token symbol, for each row's USD sub-line. */
+  prices?: Record<string, number>;
   /** Vault ids of expired deposits whose HTLC refund is still outstanding —
    *  those rows get the Withdraw action. Matched against a row's `vaultId`,
    *  never its `id` (see ActivityLog). */
@@ -65,6 +67,7 @@ interface ActivityListProps {
 export function ActivityList({
   activities,
   isConnected,
+  prices,
   refundableVaultIds,
   onWithdraw,
 }: ActivityListProps) {
@@ -148,6 +151,7 @@ export function ActivityList({
                       <ListRowCard>
                         <ActivityRowV3
                           row={r}
+                          prices={prices}
                           action={
                             r.vaultId &&
                             refundableVaultIds?.has(r.vaultId) &&

--- a/services/vault/src/components/Activity/ActivityList.tsx
+++ b/services/vault/src/components/Activity/ActivityList.tsx
@@ -57,6 +57,9 @@ interface ActivityListProps {
   isConnected: boolean;
   /** Current USD price per token symbol, for each row's USD sub-line. */
   prices?: Record<string, number>;
+  /** Vault ids ACTIVE on chain, for a deposit row's live status. `undefined`
+   *  while the vault read is in flight. */
+  activeVaultIds?: ReadonlySet<string>;
   /** Vault ids of expired deposits whose HTLC refund is still outstanding —
    *  those rows get the Withdraw action. Matched against a row's `vaultId`,
    *  never its `id` (see ActivityLog). */
@@ -68,6 +71,7 @@ export function ActivityList({
   activities,
   isConnected,
   prices,
+  activeVaultIds,
   refundableVaultIds,
   onWithdraw,
 }: ActivityListProps) {
@@ -152,6 +156,7 @@ export function ActivityList({
                         <ActivityRowV3
                           row={r}
                           prices={prices}
+                          activeVaultIds={activeVaultIds}
                           action={
                             r.vaultId &&
                             refundableVaultIds?.has(r.vaultId) &&

--- a/services/vault/src/components/Activity/ActivityListWithRefund.tsx
+++ b/services/vault/src/components/Activity/ActivityListWithRefund.tsx
@@ -14,11 +14,14 @@
  */
 
 import { useCallback, useMemo } from "react";
+import type { Address } from "viem";
 
 import { PendingDepositModals } from "@/components/simple/PendingDepositModals";
 import { ProtocolParamsProvider } from "@/context/ProtocolParamsContext";
 import { usePendingDeposits } from "@/hooks/usePendingDeposits";
 import { usePrices } from "@/hooks/usePrices";
+import { useVaults } from "@/hooks/useVaults";
+import { ContractStatus } from "@/models/peginStateMachine";
 import type { ActivityRow } from "@/types/activityLog";
 
 import { ActivityList } from "./ActivityList";
@@ -43,6 +46,26 @@ export function ActivityListWithRefund({
   // Current prices for the rows' USD sub-lines. A row whose symbol has no price
   // renders no sub-line.
   const { prices } = usePrices();
+
+  // Live vault state for a deposit row's status. Same query key as the deposit
+  // lifecycle above, so this shares that cache instead of fetching again.
+  const { data: vaults } = useVaults(ethAddress as Address | undefined);
+
+  // Undefined until the vaults resolve, which is what keeps a settled deposit
+  // on its type-derived "In use" label instead of flashing "Done" (see
+  // ActivityRowV3.getActivityStatus). A vault that left ACTIVE — redeemed,
+  // withdrawn, liquidated, expired — is no longer holding collateral.
+  const activeVaultIds = useMemo(
+    () =>
+      vaults
+        ? new Set(
+            vaults
+              .filter((vault) => vault.status === ContractStatus.ACTIVE)
+              .map((vault) => vault.id),
+          )
+        : undefined,
+    [vaults],
+  );
 
   // Deposits that expired before activation and have not been reclaimed yet,
   // keyed by vault id. Correlate these against a row's `vaultId` and never its
@@ -74,6 +97,7 @@ export function ActivityListWithRefund({
       activities={rows}
       isConnected={isConnected}
       prices={prices}
+      activeVaultIds={activeVaultIds}
       refundableVaultIds={refundableVaultIds}
       onWithdraw={handleWithdraw}
     />

--- a/services/vault/src/components/Activity/ActivityListWithRefund.tsx
+++ b/services/vault/src/components/Activity/ActivityListWithRefund.tsx
@@ -18,6 +18,7 @@ import { useCallback, useMemo } from "react";
 import { PendingDepositModals } from "@/components/simple/PendingDepositModals";
 import { ProtocolParamsProvider } from "@/context/ProtocolParamsContext";
 import { usePendingDeposits } from "@/hooks/usePendingDeposits";
+import { usePrices } from "@/hooks/usePrices";
 import type { ActivityRow } from "@/types/activityLog";
 
 import { ActivityList } from "./ActivityList";
@@ -38,6 +39,10 @@ export function ActivityListWithRefund({
     refundModal,
     emergencyWithdrawModal,
   } = usePendingDeposits();
+
+  // Current prices for the rows' USD sub-lines. A row whose symbol has no price
+  // renders no sub-line.
+  const { prices } = usePrices();
 
   // Deposits that expired before activation and have not been reclaimed yet,
   // keyed by vault id. Correlate these against a row's `vaultId` and never its
@@ -68,6 +73,7 @@ export function ActivityListWithRefund({
     <ActivityList
       activities={rows}
       isConnected={isConnected}
+      prices={prices}
       refundableVaultIds={refundableVaultIds}
       onWithdraw={handleWithdraw}
     />

--- a/services/vault/src/components/Activity/ActivityRowV3.tsx
+++ b/services/vault/src/components/Activity/ActivityRowV3.tsx
@@ -47,19 +47,32 @@ interface ActivityRowV3Props {
    * no USD sub-line.
    */
   prices?: Record<string, number>;
+  /**
+   * Vault ids that are ACTIVE on chain right now. `undefined` means the vault
+   * read has not resolved yet, and a deposit keeps its type-derived status
+   * rather than flashing the wrong one.
+   */
+  activeVaultIds?: ReadonlySet<string>;
   /** Rendered flush right — the expired deposit's Withdraw, when refundable. */
   action?: ReactNode;
 }
 
 /**
- * Status dot + label for a standard activity row, from current data only:
- * expired (red) and pending (amber) take precedence; otherwise a settled
- * deposit's collateral is "In use" and every other settled action (borrow /
- * repay / withdraw / redeem) is "Done" (both green). This reflects the row
- * type, not a live collateral check. Liquidation rows render separately and
- * never reach here.
+ * Status dot + label for a standard activity row: expired (red) and pending
+ * (amber) take precedence; otherwise a settled deposit whose vault is still
+ * ACTIVE is "In use" and every other settled action (a withdrawn deposit,
+ * borrow / repay / withdraw / redeem) is "Done" (both green). Liquidation rows
+ * render separately and never reach here.
+ *
+ * The deposit branch needs `activeVaultIds` to tell "In use" from "Done". While
+ * it is undefined — the vault read is in flight — or the row carries no vault
+ * id to correlate, the deposit keeps reading "In use" rather than flashing a
+ * status the data has not confirmed.
  */
-function getActivityStatus(row: ActivityLog): ActivityStatus {
+function getActivityStatus(
+  row: ActivityLog,
+  activeVaultIds: ReadonlySet<string> | undefined,
+): ActivityStatus {
   if (row.isExpired) {
     return { dotClass: STATUS_DOT.expired, label: COPY.activity.statusExpired };
   }
@@ -68,7 +81,13 @@ function getActivityStatus(row: ActivityLog): ActivityStatus {
   }
   const type = row.type === PENDING_DEPOSIT_TYPE ? "Deposit" : row.type;
   if (type === "Deposit") {
-    return { dotClass: STATUS_DOT.settled, label: COPY.activity.statusInUse };
+    const collateralInUse =
+      activeVaultIds === undefined ||
+      !row.vaultId ||
+      activeVaultIds.has(row.vaultId);
+    if (collateralInUse) {
+      return { dotClass: STATUS_DOT.settled, label: COPY.activity.statusInUse };
+    }
   }
   return { dotClass: STATUS_DOT.settled, label: COPY.activity.statusDone };
 }
@@ -89,14 +108,19 @@ function getUsdSubLine(
   return formatUsdValue(usd);
 }
 
-export function ActivityRowV3({ row, prices, action }: ActivityRowV3Props) {
+export function ActivityRowV3({
+  row,
+  prices,
+  activeVaultIds,
+  action,
+}: ActivityRowV3Props) {
   return (
     <ActivityRowLayout
       icon={row.tokenIcon}
       iconAlt={row.amount.symbol}
       amount={`${row.amount.value} ${row.amount.symbol}`}
       usdValue={getUsdSubLine(row.amount, prices)}
-      status={getActivityStatus(row)}
+      status={getActivityStatus(row, activeVaultIds)}
       // The type column label comes from the copy catalog; "Pending Deposit"
       // (an internal type kept out of the filter menu) maps to a "Deposit".
       typeLabel={COPY.activity.typeLabels[row.type]}

--- a/services/vault/src/components/Activity/ActivityRowV3.tsx
+++ b/services/vault/src/components/Activity/ActivityRowV3.tsx
@@ -5,8 +5,8 @@
  * timestamp (the calendar day lives in the group header), with an optional
  * action slot pinned right. Renders the columns only — the caller supplies the
  * card and its padding, so the same row works standalone (one card per row) and
- * stacked inside a liquidation group's shared card. Per-row USD value from the
- * Figma frame is deferred (not backed by current activity data).
+ * stacked inside a liquidation group's shared card. The amount cell carries the
+ * Figma sub-line with the row's USD value at the CURRENT price.
  */
 
 import { Avatar } from "@babylonlabs-io/core-ui";
@@ -19,7 +19,7 @@ import {
 import { COPY } from "@/copy";
 import { type ActivityLog, PENDING_DEPOSIT_TYPE } from "@/types/activityLog";
 import { getExplorerTxUrl } from "@/utils/explorer";
-import { formatActivityTime } from "@/utils/formatting";
+import { formatActivityTime, formatUsdValue } from "@/utils/formatting";
 
 import { ActivityHashLink } from "./ActivityHashLink";
 import { STATUS_DOT } from "./statusDot";
@@ -28,8 +28,11 @@ import { STATUS_DOT } from "./statusDot";
  *  amount length. */
 const COLUMN_CLASS = `flex items-center ${LIST_ROW_COLUMN_CLASS}`;
 
-/** Figma body 2 — every cell's text except the deferred USD sub-line. */
+/** Figma body 2 — every cell's text except the USD sub-line. */
 const CELL_TEXT_CLASS = "text-sm leading-[1.43] tracking-[0.17px]";
+
+/** Figma caption — the USD sub-line under the amount. */
+const SUB_LINE_TEXT_CLASS = "text-xs leading-[1.4] tracking-[0.4px]";
 
 export interface ActivityStatus {
   dotClass: string;
@@ -38,6 +41,12 @@ export interface ActivityStatus {
 
 interface ActivityRowV3Props {
   row: ActivityLog;
+  /**
+   * Current USD price per token symbol (`usePrices().prices`). A row whose
+   * symbol is absent from it — or whose amount has no numeric form — renders
+   * no USD sub-line.
+   */
+  prices?: Record<string, number>;
   /** Rendered flush right — the expired deposit's Withdraw, when refundable. */
   action?: ReactNode;
 }
@@ -64,12 +73,29 @@ function getActivityStatus(row: ActivityLog): ActivityStatus {
   return { dotClass: STATUS_DOT.settled, label: COPY.activity.statusDone };
 }
 
-export function ActivityRowV3({ row, action }: ActivityRowV3Props) {
+/**
+ * The row's USD value at the current price, or null when it cannot be priced —
+ * no numeric amount, no price for the symbol, or a non-positive product. Null
+ * renders no sub-line at all, never a "$0 USD" one.
+ */
+function getUsdSubLine(
+  amount: ActivityLog["amount"],
+  prices: Record<string, number> | undefined,
+): string | null {
+  const price = prices?.[amount.symbol];
+  if (amount.numeric === undefined || price === undefined) return null;
+  const usd = amount.numeric * price;
+  if (!Number.isFinite(usd) || usd <= 0) return null;
+  return formatUsdValue(usd);
+}
+
+export function ActivityRowV3({ row, prices, action }: ActivityRowV3Props) {
   return (
     <ActivityRowLayout
       icon={row.tokenIcon}
       iconAlt={row.amount.symbol}
       amount={`${row.amount.value} ${row.amount.symbol}`}
+      usdValue={getUsdSubLine(row.amount, prices)}
       status={getActivityStatus(row)}
       // The type column label comes from the copy catalog; "Pending Deposit"
       // (an internal type kept out of the filter menu) maps to a "Deposit".
@@ -97,6 +123,8 @@ interface ActivityRowLayoutProps {
   icon: string;
   iconAlt: string;
   amount: string;
+  /** Sub-line under the amount, already formatted. Null renders no sub-line. */
+  usdValue?: string | null;
   status: ActivityStatus;
   typeLabel: string;
   hash: ReactNode;
@@ -111,6 +139,7 @@ export function ActivityRowLayout({
   icon,
   iconAlt,
   amount,
+  usdValue,
   status,
   typeLabel,
   hash,
@@ -124,11 +153,18 @@ export function ActivityRowLayout({
             cell can now shrink to its 120px floor — without this a long amount
             squashes the circle into an ellipse. */}
         <Avatar url={icon} alt={iconAlt} size="medium" className="shrink-0" />
-        <span
-          className={`min-w-0 truncate ${CELL_TEXT_CLASS} text-accent-primary`}
-        >
-          {amount}
-        </span>
+        <div className="flex min-w-0 flex-col">
+          <span className={`truncate ${CELL_TEXT_CLASS} text-accent-primary`}>
+            {amount}
+          </span>
+          {usdValue && (
+            <span
+              className={`truncate ${SUB_LINE_TEXT_CLASS} text-accent-secondary`}
+            >
+              {usdValue}
+            </span>
+          )}
+        </div>
       </div>
 
       <div className={`${COLUMN_CLASS} gap-1`}>

--- a/services/vault/src/components/Activity/__tests__/ActivityRowV3.test.tsx
+++ b/services/vault/src/components/Activity/__tests__/ActivityRowV3.test.tsx
@@ -13,7 +13,7 @@ const baseRow: ActivityLog = {
   id: "tx-1",
   date: new Date(2025, 8, 8, 14, 32, 7), // Sep 8, 2025 14:32:07 local
   type: "Deposit",
-  amount: { value: "1.0", symbol: "BTC" },
+  amount: { value: "1.0", symbol: "BTC", numeric: 1 },
   chain: "BTC",
   transactionHash: FULL_HASH,
   tokenIcon: "test://btc.svg",
@@ -70,6 +70,65 @@ describe("ActivityRowV3", () => {
 
     expect(screen.getByText("Expired")).toBeInTheDocument();
     expect(screen.queryByText("Pending")).not.toBeInTheDocument();
+  });
+
+  it("renders the USD sub-line from amount x current price", () => {
+    render(
+      <ActivityRowV3
+        row={{
+          ...baseRow,
+          amount: { value: "1.5", symbol: "BTC", numeric: 1.5 },
+        }}
+        prices={{ BTC: 90000 }}
+      />,
+    );
+
+    expect(screen.getByText("1.5 BTC")).toBeInTheDocument();
+    expect(screen.getByText("$135,000.00 USD")).toBeInTheDocument();
+  });
+
+  it("prices a stable-side borrow row from its own symbol", () => {
+    render(
+      <ActivityRowV3
+        row={{
+          ...baseRow,
+          type: "Borrow",
+          amount: { value: "5,200", symbol: "USDC", numeric: 5200 },
+        }}
+        prices={{ BTC: 90000, USDC: 0.999 }}
+      />,
+    );
+
+    expect(screen.getByText("$5,194.80 USD")).toBeInTheDocument();
+  });
+
+  it("renders no sub-line when the row's symbol has no price", () => {
+    render(<ActivityRowV3 row={baseRow} prices={{ USDC: 1 }} />);
+
+    expect(screen.queryByText(/USD$/)).not.toBeInTheDocument();
+  });
+
+  it("renders no sub-line when the amount has no numeric form", () => {
+    render(
+      <ActivityRowV3
+        row={{ ...baseRow, amount: { value: "1.0", symbol: "BTC" } }}
+        prices={{ BTC: 90000 }}
+      />,
+    );
+
+    expect(screen.getByText("1.0 BTC")).toBeInTheDocument();
+    expect(screen.queryByText(/USD$/)).not.toBeInTheDocument();
+  });
+
+  it("renders no sub-line instead of '$0 USD' for a zero-value row", () => {
+    render(
+      <ActivityRowV3
+        row={{ ...baseRow, amount: { value: "0", symbol: "BTC", numeric: 0 } }}
+        prices={{ BTC: 90000 }}
+      />,
+    );
+
+    expect(screen.queryByText(/USD$/)).not.toBeInTheDocument();
   });
 
   it("renders the pending placeholder instead of a link when there is no hash", () => {

--- a/services/vault/src/components/Activity/__tests__/ActivityRowV3.test.tsx
+++ b/services/vault/src/components/Activity/__tests__/ActivityRowV3.test.tsx
@@ -11,6 +11,7 @@ const FULL_HASH =
 const baseRow: ActivityLog = {
   kind: "row",
   id: "tx-1",
+  vaultId: "0xvault1",
   date: new Date(2025, 8, 8, 14, 32, 7), // Sep 8, 2025 14:32:07 local
   type: "Deposit",
   amount: { value: "1.0", symbol: "BTC", numeric: 1 },
@@ -34,12 +35,55 @@ describe("ActivityRowV3", () => {
     expect(screen.queryByText(/2025-09-08/)).not.toBeInTheDocument();
   });
 
-  it("shows 'In use' for a settled deposit", () => {
+  it("shows 'In use' for a deposit whose vault is still active", () => {
+    render(
+      <ActivityRowV3
+        row={baseRow}
+        activeVaultIds={new Set(["0xvault1", "0xvault2"])}
+      />,
+    );
+
+    expect(screen.getByText("In use")).toBeInTheDocument();
+    expect(screen.queryByText("Done")).not.toBeInTheDocument();
+  });
+
+  it("shows 'Done' for a deposit whose vault has left the active set", () => {
+    render(
+      <ActivityRowV3 row={baseRow} activeVaultIds={new Set(["0xvault2"])} />,
+    );
+
+    expect(screen.getByText("Done")).toBeInTheDocument();
+    expect(screen.queryByText("In use")).not.toBeInTheDocument();
+  });
+
+  it("keeps a deposit on 'In use' while the vault read is unresolved", () => {
     render(<ActivityRowV3 row={baseRow} />);
 
     expect(screen.getByText("In use")).toBeInTheDocument();
-    expect(screen.queryByText("Pending")).not.toBeInTheDocument();
-    expect(screen.queryByText("Expired")).not.toBeInTheDocument();
+    expect(screen.queryByText("Done")).not.toBeInTheDocument();
+  });
+
+  it("keeps a deposit on 'In use' when the row has no vault id to correlate", () => {
+    render(
+      <ActivityRowV3
+        row={{ ...baseRow, vaultId: null }}
+        activeVaultIds={new Set<string>()}
+      />,
+    );
+
+    expect(screen.getByText("In use")).toBeInTheDocument();
+  });
+
+  it("shows 'Done' for a Withdraw row whatever the active vault set holds", () => {
+    render(
+      <ActivityRowV3
+        row={{ ...baseRow, type: "Withdraw" }}
+        activeVaultIds={new Set(["0xvault1"])}
+      />,
+    );
+
+    expect(screen.getByText("Done")).toBeInTheDocument();
+    expect(screen.queryByText("In use")).not.toBeInTheDocument();
   });
 
   it("shows 'Done' for a settled borrow / repay", () => {

--- a/services/vault/src/components/pages/__tests__/Activity.test.tsx
+++ b/services/vault/src/components/pages/__tests__/Activity.test.tsx
@@ -56,6 +56,13 @@ vi.mock("@/hooks/usePendingDeposits", () => ({
   },
 }));
 
+// The USD sub-line's price source imports the built wallet-connector bundle
+// (for its network enum), which vitest cannot evaluate here, and prices are not
+// what the wallet gating in this suite checks.
+vi.mock("@/hooks/usePrices", () => ({
+  usePrices: () => ({ prices: {} }),
+}));
+
 vi.mock("@/context/ProtocolParamsContext", () => ({
   ProtocolParamsProvider: ({ children }: { children: React.ReactNode }) =>
     children,

--- a/services/vault/src/components/pages/__tests__/Activity.test.tsx
+++ b/services/vault/src/components/pages/__tests__/Activity.test.tsx
@@ -57,10 +57,17 @@ vi.mock("@/hooks/usePendingDeposits", () => ({
 }));
 
 // The USD sub-line's price source imports the built wallet-connector bundle
-// (for its network enum), which vitest cannot evaluate here, and prices are not
-// what the wallet gating in this suite checks.
+// (for its network enum), which vitest cannot evaluate here, and the live
+// deposit status reads vaults through react-query — neither belongs to the
+// wallet gating this suite checks. An undefined vault read is also what the
+// page sees before the query resolves, so the rows keep their type-derived
+// status.
 vi.mock("@/hooks/usePrices", () => ({
   usePrices: () => ({ prices: {} }),
+}));
+
+vi.mock("@/hooks/useVaults", () => ({
+  useVaults: () => ({ data: undefined }),
 }));
 
 vi.mock("@/context/ProtocolParamsContext", () => ({

--- a/services/vault/src/dev/demoDeposit.ts
+++ b/services/vault/src/dev/demoDeposit.ts
@@ -567,7 +567,11 @@ function demoActivityLog(
 }
 
 function demoBtcAmount(amount: string) {
-  return { value: amount, symbol: VAULT_COLLATERAL_ASSET.symbol };
+  return {
+    value: amount,
+    symbol: VAULT_COLLATERAL_ASSET.symbol,
+    numeric: Number(amount),
+  };
 }
 
 /** Borrow / repay / liquidation rows are denominated in the panel's selected
@@ -579,10 +583,15 @@ export function activityScenarios(
   const debtIcon = getCurrencyIconWithFallback(undefined, symbol);
   /** Borrow / repay rows are denominated in the debt asset, so the panel's
    *  amount drives them directly. */
-  const demoDebtAmount = (amount: string) => ({ value: amount, symbol });
+  const demoDebtAmount = (amount: string) => ({
+    value: amount,
+    symbol,
+    numeric: Number(amount),
+  });
   const demoLiquidationDebtAmount = () => ({
     value: DEMO_LIQUIDATION_DEBT_AMOUNT,
     symbol,
+    numeric: Number(DEMO_LIQUIDATION_DEBT_AMOUNT),
   });
 
   return [

--- a/services/vault/src/services/activity/__tests__/fetchActivities.test.ts
+++ b/services/vault/src/services/activity/__tests__/fetchActivities.test.ts
@@ -943,7 +943,7 @@ describe("fetchUserActivities refunded deposits", () => {
     const row = asStandard(result[0]);
     expect(row.type).toBe("Deposit");
     expect(row.isExpired).toBe(true);
-    expect(row.amount).toEqual({ value: "1", symbol: "sBTC" });
+    expect(row.amount).toEqual({ value: "1", symbol: "sBTC", numeric: 1 });
     expect(row.tokenIcon).toBe("/images/btc.svg");
     // Refunded deposit links to the original BTC peg-in tx (via vault.peginTxHash)
     // for parity with normal Deposit rows.

--- a/services/vault/src/services/activity/pendingActivities.ts
+++ b/services/vault/src/services/activity/pendingActivities.ts
@@ -38,6 +38,11 @@ function convertPendingPeginToActivity(
     amount: {
       value: pending.amount,
       symbol: btcConfig.coinSymbol,
+      // localStorage holds the amount as the user-facing BTC string, so it is
+      // already unscaled. A malformed entry stays unpriced.
+      numeric: Number.isFinite(Number(pending.amount))
+        ? Number(pending.amount)
+        : undefined,
     },
     chain: "BTC",
     transactionHash: pending.peginTxHash,

--- a/services/vault/src/services/activity/projection.ts
+++ b/services/vault/src/services/activity/projection.ts
@@ -169,6 +169,15 @@ export function formatAmount(amount: string, decimals: number): string {
 }
 
 /**
+ * The amount as a plain number, for the row's USD sub-line only. `formatUnits`
+ * keeps full precision; the `Number` cast is display-grade and never feeds a
+ * signed value.
+ */
+export function toNumericAmount(amount: string, decimals: number): number {
+  return Number(formatUnits(BigInt(amount), decimals));
+}
+
+/**
  * Caller-injected dependencies. The hook layer reads these from the AaveConfig
  * context provider (which already loads them once at app startup), keeping
  * this service free of global registry / network dependencies for non-
@@ -214,6 +223,7 @@ export function projectRefundedDeposit(
     amount: {
       value: formatAmount(item.amount, VAULT_COLLATERAL_ASSET.decimals),
       symbol: VAULT_COLLATERAL_ASSET.symbol,
+      numeric: toNumericAmount(item.amount, VAULT_COLLATERAL_ASSET.decimals),
     },
     chain,
     transactionHash,
@@ -239,10 +249,16 @@ export function projectStandardRow(
           ? formatAmount(item.amount, reserve.decimals)
           : item.amount,
         symbol: reserve?.symbol ?? "—",
+        // Without the reserve the token's decimals are unknown, so the raw
+        // amount cannot be scaled — leave it unpriced.
+        numeric: reserve
+          ? toNumericAmount(item.amount, reserve.decimals)
+          : undefined,
       }
     : {
         value: formatAmount(item.amount, VAULT_COLLATERAL_ASSET.decimals),
         symbol: VAULT_COLLATERAL_ASSET.symbol,
+        numeric: toNumericAmount(item.amount, VAULT_COLLATERAL_ASSET.decimals),
       };
 
   const tokenIcon = isPositionScoped

--- a/services/vault/src/types/activityLog.ts
+++ b/services/vault/src/types/activityLog.ts
@@ -39,6 +39,14 @@ export interface ActivityAmount {
   value: string;
   /** Token symbol (e.g., "USDC", "BTC") */
   symbol: string;
+  /**
+   * The same amount as a plain number, used only to derive the row's USD
+   * sub-line (amount × current price). Absent where the source has no
+   * unambiguous numeric amount — those rows render no sub-line rather than a
+   * `$0` / `NaN` one. Never use it for a signed value: `value` is what the
+   * user sees and the projection formats it independently.
+   */
+  numeric?: number;
 }
 
 /**


### PR DESCRIPTION
Closes #2114
Closes #2116

The last two follow-ups from the v3 Activity page (#2059). One commit each.

## Read this first — the USD value uses the CURRENT price

An activity row's USD sub-line is `amount × today's price`, not the price at the time of the transaction. The activity projection has no historical-price plumbing and no other surface in the app has any either, so a deposit made at $60k BTC shows its value at today's BTC price. Everything else in this PR is independent of that decision — if it is the wrong trade-off, the first commit is the one to hold back.

## Commit 1 — per-row USD value (#2114)

`ActivityAmount` now also carries the amount as a plain number alongside the preformatted display string, set wherever the source knows it unambiguously: the indexer projection (BTC collateral and, when the reserve is known, the borrow/repay asset), the localStorage pending peg-in, and the god-mode demo rows. A borrow/repay row with no resolved reserve has unknown decimals, so it stays unpriced.

`ActivityRowV3` turns that number into the sub-line with the existing `formatUsdValue` helper, priced from `usePrices()` — the same Chainlink read the dashboard, deposit form and vault list already use (`prices` covers BTC/sBTC, ETH/WETH, USDC, USDT, DAI, vBTC). Prices are fetched once for the whole list in `ActivityListWithRefund` and passed down, so no hook is instantiated per row.

A row that cannot be priced renders **no** sub-line — never `$0 USD` or `NaN`. That covers an unknown symbol, a missing numeric amount, and a non-positive product.

## Commit 2 — live "In use" vs settled for deposits (#2116)

The status column derived "In use" from the row *type*, so a withdrawn deposit still claimed its collateral was locked. The row now correlates the deposit against current vault state:

- **Join key: `ActivityLog.vaultId` → `Vault.id`.** `ActivityLog` documents `vaultId` as the only field safe to correlate with vault-keyed state — an indexed row's `id` is its event (`txHash-logIndex-type`), not its vault. It is the same key the expired-deposit refund action already matches on.
- **ACTIVE means in use.** `useVaults(ethAddress)` returns every vault of the depositor with its status (the query is cursor-paginated to completion and filters no status), so a vault that has left `ContractStatus.ACTIVE` — redeemed, withdrawn, liquidated, expired — is no longer holding collateral and the row reads "Done".
- **No new network.** That hook shares its query key with the deposit lifecycle `ActivityListWithRefund` already mounts, so it reads the same cache.
- **No wrong flash.** The active-id set is `undefined` until the vault read resolves; an undefined set — or a row with no vault id to correlate — keeps the existing type-derived label. Pending and expired still take precedence over both branches.

## Figma verification

Read live from *TBV v.3 Premium Design* (`NgDfn7fVnkQZP0XH9Uki63`), not from the local snapshot docs.

| Node | What it dictated |
| --- | --- |
| `13164:77269` + `13164:77644` (Activity, "After deposit" section, Dashboard page — dark and light) | The populated Activity frames. Every row carries a USD sub-line under its amount, on BTC rows **and** stable-side borrow/repay rows alike, so both get the treatment. |
| `13164:77311` (a row's amount + USD pair) | Sub-line format `$<value> USD` in *Typography/Desktop/caption* — Px Grotesk 12px, line-height 1.4, letter-spacing 0.4px, `text/secondary`. Implemented as `text-xs leading-[1.4] tracking-[0.4px] text-accent-secondary` with `formatUsdValue`. |
| `489:3270` (`Activity Currency`, BTC/USDC × Default/Liquidated) | Icon + amount only — the sub-line lives at row level, not in this component. Confirms the amount cell is where it belongs. |

### Conflicts resolved in Figma's favour, and one deliberately not

- **Three of the four node ids on the tracker no longer exist** (`10051-26752`, `10088-74585`, `10088-76983`). `10044-13346` still exists but is now the *empty-state* Activity frame. The populated frames are the two listed above — and #2114's own text points at the same "after deposit" frame.
- **Figma's current Activity row is a different layout from the shipped one:** transaction type + asset symbol at the left with a status *chip* (`Failed` / `Refund`) beside it, then the explorer link, then the time, then a right-aligned amount with the USD sub-line under it — and settled rows dimmed. There is no status-dot column at all.
  - For the USD sub-line I followed Figma's typography and format exactly but kept it under the amount **in the shipped 5-column row**. Re-cutting the row into Figma's layout is neither issue's scope; it wants its own ticket.
  - Because Figma no longer has a status column, it dictates no label for a settled deposit. Rather than invent one I reused the existing `COPY.activity.statusDone` — "Done", green dot, the same label every other settled action already shows. Worth a look: if the intent is distinct wording ("Withdrawn", "Settled"), it is a one-line copy change.
- **Figma also shows USD sub-lines on liquidation child rows.** Those render through `LiquidationGroupCardV3` / `LiquidationChildRow`, outside #2114's named files, so they are untouched. Follow-up if wanted.
- No feature flag anywhere — `ENABLE_V3_UI` was retired in #2184.

## Verification

- `tsc --noEmit -p tsconfig.lib.json` — clean.
- `eslint` on every touched path — clean.
- `nx build vault` — passes.
- `vitest run` — full vault suite green: 293 files, 3396 tests, 0 failures.
- Two page-level suites needed the new hooks stubbed: `Activity.test.tsx` and `router.test.tsx` render the Activity page without a `QueryClientProvider`, and `usePrices` reaches the built wallet-connector bundle that vitest cannot transform. Both now stub `usePrices` / `useVaults`, the same way that file already stubs the deposit-lifecycle graph.
- Activity row tests extended in place (`ActivityRowV3.test.tsx`): USD sub-line from amount × price; a stable-side row priced from its own symbol; no sub-line for an unpriced symbol, a missing numeric amount, or a zero amount; deposit with a live vault reads "In use"; deposit whose vault left the set reads "Done"; unresolved vault read and a row with no vault id both hold the type-derived label.
