### PR TITLE
feat(ts-sdk, vault): reach the refund from a reconstruction

### DIFF
--- a/packages/babylon-ts-sdk/src/tbv/core/recovery/RECOVERY.md
+++ b/packages/babylon-ts-sdk/src/tbv/core/recovery/RECOVERY.md
@@ -56,7 +56,7 @@ await buildAndBroadcastRefund({
 
 There is deliberately no separate refund implementation for recovery: the fee cap, the abort checks, the `htlcVout` contiguity invariant and the bitcoind error classification stay in one place for both paths. `applicationEntryPoint` is the one field not carried by the reconstruction — take it from the vault-provider registry row, which is address-keyed and survives.
 
-A test asserts that a refund PSBT built from recovered parameters is **byte-identical** to one built from the parameters the deposit was actually made with. `broadcastTx` is an injected callback, so the whole path can be rehearsed with a capturing broadcaster that never touches the network.
+A test asserts that a refund PSBT built from recovered parameters is **byte-identical** to one built from the parameters the deposit was actually made with. `broadcastTx` is an injected callback, so the whole path can be rehearsed with a capturing broadcaster that never touches the network — which is what the `recover` action does (`services/vault/e2e/real/actions/recover.ts`, via `pnpm --filter vault run e2e:cli --action=recover`). Run it before you need it.
 
 If the log is unavailable, step 2 becomes a search: enumerate the version-keyed reads that survive (`getOffchainParamsByVersion`, `getVaultKeepersByVersion`, `getUniversalChallengersByVersion`) and pass the product. Record every version you could not read in `unresolvedVersions` — see below.
 
@@ -82,4 +82,8 @@ If the log is unavailable, step 2 becomes a search: enumerate the version-keyed 
 
 ## Before anyone needs this
 
-It has never been rehearsed. A practice run on signet — reconstruct a known vault blind and diff every recovered field against the live row, which still exists there — is worth more than any of the text above.
+It has been rehearsed, on signet, against a real wallet. The `recover` action reconstructs a known vault blind, diffs every recovered field against the live row, signs the refund with the wallet and stops at the broadcast seam. Two runs are recorded: a single-vault deposit whose HTLC is unspent and matured, and a two-vault deposit exercising the sibling path.
+
+That run is worth more than any of the text above, and it earned its keep immediately: it found that `deriveHashlocksFromPrePegin` could not accept the 33-byte compressed pubkey every wallet returns, while every unit test passed by feeding x-only hex.
+
+Rehearse again after any change to the derivation, the verifier or the refund projection — and note what the rehearsal still does **not** cover: reading the version stamps at a historical block height, which a real incident needs and a rehearsal against a current vault cannot exercise.

--- a/packages/babylon-ts-sdk/src/tbv/core/recovery/RECOVERY.md
+++ b/packages/babylon-ts-sdk/src/tbv/core/recovery/RECOVERY.md
@@ -36,7 +36,27 @@ Parameters from the recovery script are untrusted input and must never feed a si
 
 Resolve participant keys **before** this call. The arrays must be sorted RFC-006 *operation* keys at the vault's own epochs — what `resolveParticipantKeysAtEpochs` returns. Registration keys only coincide with operation keys while nobody has rotated; passing them produces a wrong script on every candidate.
 
-**3. Build and broadcast the refund** — the normal `buildRefundPsbt` / `buildAndBroadcastRefund` path, from the returned terms.
+**3. Build and broadcast the refund** — `toRefundInputs`, then the ordinary `buildAndBroadcastRefund`.
+
+`buildAndBroadcastRefund` takes its two reads as injected callbacks, so recovery supplies them from the verified reconstruction instead of from the row that no longer exists:
+
+```ts
+const { vault, context } = toRefundInputs(result, {
+  htlcVout, depositorBtcPubkey, applicationEntryPoint,
+  fundedPrePeginTxHex, hashlocks, network,
+});
+
+await buildAndBroadcastRefund({
+  vaultId,
+  readVault: async () => vault,
+  readPrePeginContext: async () => context,
+  feeRate, signPsbt, broadcastTx,
+});
+```
+
+There is deliberately no separate refund implementation for recovery: the fee cap, the abort checks, the `htlcVout` contiguity invariant and the bitcoind error classification stay in one place for both paths. `applicationEntryPoint` is the one field not carried by the reconstruction — take it from the vault-provider registry row, which is address-keyed and survives.
+
+A test asserts that a refund PSBT built from recovered parameters is **byte-identical** to one built from the parameters the deposit was actually made with. `broadcastTx` is an injected callback, so the whole path can be rehearsed with a capturing broadcaster that never touches the network.
 
 If the log is unavailable, step 2 becomes a search: enumerate the version-keyed reads that survive (`getOffchainParamsByVersion`, `getVaultKeepersByVersion`, `getUniversalChallengersByVersion`) and pass the product. Record every version you could not read in `unresolvedVersions` — see below.
 

--- a/packages/babylon-ts-sdk/src/tbv/core/recovery/__tests__/deriveHashlocksFromPrePegin.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/recovery/__tests__/deriveHashlocksFromPrePegin.test.ts
@@ -82,6 +82,40 @@ describe("deriveHashlocksFromPrePegin", () => {
     expect(result.hashlocks[0]).not.toBe(result.hashlocks[1]);
   });
 
+  // A live wallet's getPublicKey() returns the 33-byte COMPRESSED key, not the
+  // x-only form. Accepting only x-only made the ordinary case an error, which
+  // every test here missed by feeding it bare x-only hex. Found by running the
+  // signet rehearsal against a real UniSat wallet.
+  it("accepts the compressed pubkey a wallet actually returns", async () => {
+    const compressed = `02${DEPOSITOR_PUBKEY}`;
+    const fundedPrePeginTxHex = makeAnchoredTx(1, anchorHash);
+
+    const fromCompressed = await deriveHashlocksFromPrePegin({
+      wallet: makeWallet(ROOT_HEX),
+      depositorBtcPubkey: compressed,
+      fundedPrePeginTxHex,
+    });
+    const fromXOnly = await deriveHashlocksFromPrePegin({
+      wallet: makeWallet(ROOT_HEX),
+      depositorBtcPubkey: DEPOSITOR_PUBKEY,
+      fundedPrePeginTxHex,
+    });
+
+    // Both forms name the same key, so they must derive the same secrets —
+    // the x-only narrowing drops the parity byte, it does not pick a new key.
+    expect(fromCompressed.hashlocks).toEqual(fromXOnly.hashlocks);
+  });
+
+  it("accepts a 0x-prefixed compressed pubkey too", async () => {
+    const result = await deriveHashlocksFromPrePegin({
+      wallet: makeWallet(ROOT_HEX),
+      depositorBtcPubkey: `0x03${DEPOSITOR_PUBKEY}`,
+      fundedPrePeginTxHex: makeAnchoredTx(1, anchorHash),
+    });
+
+    expect(result.hashlocks).toHaveLength(1);
+  });
+
   it("takes the vault count from the anchor's vout, not from a chain read", async () => {
     const fundedPrePeginTxHex = makeAnchoredTx(3, anchorHash);
 

--- a/packages/babylon-ts-sdk/src/tbv/core/recovery/__tests__/toRefundInputs.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/recovery/__tests__/toRefundInputs.test.ts
@@ -333,6 +333,28 @@ describe("toRefundInputs", () => {
     expect(context.timelockRefund).toBe(OFFCHAIN.timelockRefund);
   });
 
+  // The refund orchestrator accepts "32 or 33 bytes of hex" and narrows to
+  // x-only itself, so the projection must not narrow early — a wallet's
+  // compressed key has to survive the hand-off intact.
+  it("passes a wallet's compressed pubkey through unchanged", async () => {
+    const siblings: Sibling[] = [
+      { hashlock: "ab".repeat(32), amount: 1_000_000n },
+    ];
+    const txHex = await buildFundedTx(siblings);
+    const compressed = `02${DEPOSITOR}`;
+
+    const { vault } = toRefundInputs(await recover(siblings, txHex), {
+      htlcVout: 0,
+      depositorBtcPubkey: compressed,
+      applicationEntryPoint: APP_ENTRY_POINT,
+      fundedPrePeginTxHex: txHex,
+      hashlocks: siblings.map((s) => s.hashlock),
+      network: NETWORK,
+    });
+
+    expect(vault.depositorBtcPubkey).toBe(compressed);
+  });
+
   it("refuses an htlcVout outside the reconstructed batch", async () => {
     const siblings: Sibling[] = [
       { hashlock: "ab".repeat(32), amount: 1_000_000n },

--- a/packages/babylon-ts-sdk/src/tbv/core/recovery/__tests__/toRefundInputs.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/recovery/__tests__/toRefundInputs.test.ts
@@ -1,0 +1,373 @@
+/**
+ * Tests that recovery reaches the same refund the ordinary path would.
+ *
+ * The one that carries the weight is the byte-identity check: a refund PSBT
+ * built from parameters recovered blind must equal, byte for byte, the PSBT
+ * built from the parameters the deposit was actually made with. That is the
+ * safety property the whole reconstruction exists to provide, and it can be
+ * proven here — headless, against the real WASM engine — because
+ * `buildRefundPsbt` takes parameters directly rather than reading a vault row.
+ *
+ * The plan for this work assumed that proof needed a wallet and a signet run.
+ * It does not: no signing is involved in building the PSBT.
+ */
+
+import {
+  computeMinClaimValue,
+  computeMinPeginFee,
+  getPrePeginHtlcConnectorInfo,
+  peginP2aAnchorOutput,
+  type Network,
+} from "@babylonlabs-io/babylon-tbv-rust-wasm";
+import { Transaction } from "bitcoinjs-lib";
+import { Buffer } from "buffer";
+import { beforeAll, describe, expect, it } from "vitest";
+
+import {
+  TEST_KEYS,
+  initializeWasmForTests,
+} from "../../primitives/psbt/__tests__/helpers";
+import { buildRefundPsbt } from "../../primitives/psbt/refund";
+import {
+  buildPeginParamsCandidates,
+  type OffchainParamsCandidate,
+  type ParticipantKeySetCandidate,
+} from "../peginParamsCandidates";
+import { reconstructPeginParams } from "../reconstructPeginParams";
+import { toRefundInputs } from "../toRefundInputs";
+
+const NETWORK = "signet" as Network;
+const VAULT_PROVIDER = "0x1111111111111111111111111111111111111111" as const;
+const APP_ENTRY_POINT = "0x2222222222222222222222222222222222222222" as const;
+const PREPEGIN_MAX_FEE = 1500n;
+const COMMISSION_BPS = 250;
+const REFUND_FEE = 800n;
+const CORE_VERSION = 2;
+
+const DEPOSITOR = TEST_KEYS.DEPOSITOR;
+const VKS = [TEST_KEYS.VAULT_KEEPER_1, TEST_KEYS.VAULT_KEEPER_2];
+const UCS = [TEST_KEYS.UNIVERSAL_CHALLENGER_1];
+
+/** What the deposit was actually made with — the answer recovery must reach. */
+const OFFCHAIN: OffchainParamsCandidate = {
+  version: 4,
+  protocolFeeRate: 3n,
+  minPeginFeeRate: 7n,
+  councilQuorum: 2,
+  councilSize: 3,
+  timelockPegin: 684,
+  timelockAssert: 700,
+  timelockRefund: 2016,
+};
+
+const PARTICIPANTS: ParticipantKeySetCandidate = {
+  vaultProvider: VAULT_PROVIDER,
+  vaultProviderBtcPubkey: TEST_KEYS.VAULT_PROVIDER,
+  appVaultKeepersVersion: 2,
+  vaultKeeperBtcPubkeys: VKS,
+  universalChallengersVersion: 5,
+  universalChallengerBtcPubkeys: UCS,
+};
+
+const AUTH_ANCHOR_HASH = "cd".repeat(32);
+
+interface Sibling {
+  hashlock: string;
+  amount: bigint;
+}
+
+async function buildFundedTx(siblings: Sibling[]): Promise<string> {
+  const dcv = await computeMinClaimValue(
+    CORE_VERSION,
+    VKS.length,
+    UCS.length,
+    OFFCHAIN.councilQuorum,
+    OFFCHAIN.councilSize,
+    OFFCHAIN.protocolFeeRate,
+  );
+  const fee = await computeMinPeginFee(
+    CORE_VERSION,
+    VKS.length,
+    UCS.length,
+    OFFCHAIN.minPeginFeeRate,
+  );
+  const anchor = (await peginP2aAnchorOutput(CORE_VERSION))?.value ?? 0n;
+
+  const tx = new Transaction();
+  tx.version = 2;
+  tx.addInput(Buffer.alloc(32, 0x11), 0);
+  for (const sibling of siblings) {
+    const info = await getPrePeginHtlcConnectorInfo({
+      txGraphVersion: CORE_VERSION,
+      depositorPubkey: DEPOSITOR,
+      vaultProviderPubkey: PARTICIPANTS.vaultProviderBtcPubkey,
+      vaultKeeperPubkeys: [...VKS],
+      universalChallengerPubkeys: [...UCS],
+      hashlock: sibling.hashlock,
+      timelockRefund: OFFCHAIN.timelockRefund,
+      network: NETWORK,
+    });
+    tx.addOutput(
+      Buffer.from(info.scriptPubKey, "hex"),
+      Number(sibling.amount + dcv + fee + anchor),
+    );
+  }
+  tx.addOutput(
+    Buffer.concat([
+      Buffer.from([0x6a, 0x20]),
+      Buffer.from(AUTH_ANCHOR_HASH, "hex"),
+    ]),
+    0,
+  );
+  return tx.toHex();
+}
+
+function recover(siblings: Sibling[], txHex: string) {
+  return reconstructPeginParams({
+    hashlocks: siblings.map((s) => s.hashlock),
+    fundedPrePeginTxHex: txHex,
+    depositorBtcPubkey: DEPOSITOR,
+    prepeginMaxFee: PREPEGIN_MAX_FEE,
+    maxAcceptableCommissionBps: COMMISSION_BPS,
+    network: NETWORK,
+    candidates: buildPeginParamsCandidates({
+      vaultCoreVersion: CORE_VERSION,
+      offchainParams: [OFFCHAIN],
+      participantKeySets: [PARTICIPANTS],
+    }),
+    unresolvedVersions: [],
+  });
+}
+
+describe("toRefundInputs", () => {
+  beforeAll(async () => {
+    await initializeWasmForTests();
+  });
+
+  it("produces a refund PSBT byte-identical to the one the normal path builds", async () => {
+    const siblings: Sibling[] = [
+      { hashlock: "ab".repeat(32), amount: 1_000_000n },
+      { hashlock: "cd".repeat(32), amount: 2_500_000n },
+    ];
+    const txHex = await buildFundedTx(siblings);
+    const htlcVout = 1;
+
+    // The normal path: parameters known up front, straight from the deposit.
+    const expected = await buildRefundPsbt({
+      prePeginParams: {
+        vaultCoreVersion: CORE_VERSION,
+        depositorPubkey: DEPOSITOR,
+        vaultProviderPubkey: PARTICIPANTS.vaultProviderBtcPubkey,
+        vaultKeeperPubkeys: [...VKS],
+        universalChallengerPubkeys: [...UCS],
+        hashlocks: siblings.map((s) => s.hashlock),
+        timelockRefund: OFFCHAIN.timelockRefund,
+        pegInAmounts: siblings.map((s) => s.amount),
+        feeRate: OFFCHAIN.protocolFeeRate,
+        minPeginFeeRate: OFFCHAIN.minPeginFeeRate,
+        numLocalChallengers: VKS.length,
+        councilQuorum: OFFCHAIN.councilQuorum,
+        councilSize: OFFCHAIN.councilSize,
+        network: NETWORK,
+        authAnchorHash: AUTH_ANCHOR_HASH,
+      },
+      fundedPrePeginTxHex: txHex,
+      htlcVout,
+      refundFee: REFUND_FEE,
+      hashlock: siblings[htlcVout].hashlock,
+    });
+
+    // The recovery path: nothing known but the transaction and the hashlocks.
+    const result = await recover(siblings, txHex);
+    const { vault, context } = toRefundInputs(result, {
+      htlcVout,
+      depositorBtcPubkey: DEPOSITOR,
+      applicationEntryPoint: APP_ENTRY_POINT,
+      fundedPrePeginTxHex: txHex,
+      hashlocks: siblings.map((s) => s.hashlock),
+      network: NETWORK,
+    });
+
+    const actual = await buildRefundPsbt({
+      prePeginParams: {
+        vaultCoreVersion: vault.vaultCoreVersion,
+        depositorPubkey: vault.depositorBtcPubkey,
+        vaultProviderPubkey: context.vaultProviderPubkey,
+        vaultKeeperPubkeys: [...context.vaultKeeperPubkeys],
+        universalChallengerPubkeys: [...context.universalChallengerPubkeys],
+        hashlocks: vault.batch.map((b) => b.hashlock.slice(2)),
+        timelockRefund: context.timelockRefund,
+        pegInAmounts: vault.batch.map((b) => b.amount),
+        feeRate: context.feeRate,
+        minPeginFeeRate: context.minPeginFeeRate,
+        numLocalChallengers: context.numLocalChallengers,
+        councilQuorum: context.councilQuorum,
+        councilSize: context.councilSize,
+        network: context.network,
+        authAnchorHash: result.authAnchorHash,
+      },
+      fundedPrePeginTxHex: vault.unsignedPrePeginTxHex,
+      htlcVout: vault.htlcVout,
+      refundFee: REFUND_FEE,
+      hashlock: vault.hashlock.slice(2),
+    });
+
+    expect(actual.psbtHex).toBe(expected.psbtHex);
+  });
+
+  // Mutation check on the assertion above: a byte comparison is only evidence
+  // if it can fail. timelockRefund is the one recovered scalar that reaches the
+  // HTLC script, so perturbing it must change the refund — otherwise the
+  // identity test above would pass for any reconstruction at all.
+  it("builds a different refund when a script-relevant parameter is perturbed", async () => {
+    const siblings: Sibling[] = [
+      { hashlock: "ab".repeat(32), amount: 1_000_000n },
+    ];
+    const txHex = await buildFundedTx(siblings);
+    const result = await recover(siblings, txHex);
+    const { vault, context } = toRefundInputs(result, {
+      htlcVout: 0,
+      depositorBtcPubkey: DEPOSITOR,
+      applicationEntryPoint: APP_ENTRY_POINT,
+      fundedPrePeginTxHex: txHex,
+      hashlocks: siblings.map((s) => s.hashlock),
+      network: NETWORK,
+    });
+
+    const params = {
+      vaultCoreVersion: vault.vaultCoreVersion,
+      depositorPubkey: vault.depositorBtcPubkey,
+      vaultProviderPubkey: context.vaultProviderPubkey,
+      vaultKeeperPubkeys: [...context.vaultKeeperPubkeys],
+      universalChallengerPubkeys: [...context.universalChallengerPubkeys],
+      hashlocks: vault.batch.map((b) => b.hashlock.slice(2)),
+      pegInAmounts: vault.batch.map((b) => b.amount),
+      feeRate: context.feeRate,
+      minPeginFeeRate: context.minPeginFeeRate,
+      numLocalChallengers: context.numLocalChallengers,
+      councilQuorum: context.councilQuorum,
+      councilSize: context.councilSize,
+      network: context.network,
+      authAnchorHash: result.authAnchorHash,
+    };
+    const common = {
+      fundedPrePeginTxHex: vault.unsignedPrePeginTxHex,
+      htlcVout: vault.htlcVout,
+      refundFee: REFUND_FEE,
+      hashlock: vault.hashlock.slice(2),
+    };
+
+    const good = await buildRefundPsbt({
+      ...common,
+      prePeginParams: { ...params, timelockRefund: context.timelockRefund },
+    });
+
+    // A wrong timelock changes the taptree, so the template no longer matches
+    // the funded output — the builder refuses rather than signing the wrong
+    // script. Either outcome proves the comparison has teeth; assert the
+    // stronger one.
+    await expect(
+      buildRefundPsbt({
+        ...common,
+        prePeginParams: {
+          ...params,
+          timelockRefund: context.timelockRefund + 1,
+        },
+      }),
+    ).rejects.toThrow();
+
+    expect(good.psbtHex).toBeTruthy();
+  });
+
+  it("carries the whole vout-ordered batch, which the refund path requires", async () => {
+    const siblings: Sibling[] = [
+      { hashlock: "ab".repeat(32), amount: 1_000_000n },
+      { hashlock: "cd".repeat(32), amount: 2_500_000n },
+    ];
+    const txHex = await buildFundedTx(siblings);
+
+    const { vault } = toRefundInputs(await recover(siblings, txHex), {
+      htlcVout: 0,
+      depositorBtcPubkey: DEPOSITOR,
+      applicationEntryPoint: APP_ENTRY_POINT,
+      fundedPrePeginTxHex: txHex,
+      hashlocks: siblings.map((s) => s.hashlock),
+      network: NETWORK,
+    });
+
+    expect(vault.batch).toHaveLength(2);
+    expect(vault.batch.map((b) => b.htlcVout)).toEqual([0, 1]);
+    expect(vault.batch.map((b) => b.amount)).toEqual([1_000_000n, 2_500_000n]);
+    expect(vault.batch.map((b) => b.hashlock)).toEqual([
+      `0x${"ab".repeat(32)}`,
+      `0x${"cd".repeat(32)}`,
+    ]);
+  });
+
+  it("restates the target's own fields from the batch entry it points at", async () => {
+    const siblings: Sibling[] = [
+      { hashlock: "ab".repeat(32), amount: 1_000_000n },
+      { hashlock: "cd".repeat(32), amount: 2_500_000n },
+    ];
+    const txHex = await buildFundedTx(siblings);
+
+    const { vault, context } = toRefundInputs(await recover(siblings, txHex), {
+      htlcVout: 1,
+      depositorBtcPubkey: DEPOSITOR,
+      applicationEntryPoint: APP_ENTRY_POINT,
+      fundedPrePeginTxHex: txHex,
+      hashlocks: siblings.map((s) => s.hashlock),
+      network: NETWORK,
+    });
+
+    expect(vault.hashlock).toBe(`0x${"cd".repeat(32)}`);
+    expect(vault.amount).toBe(2_500_000n);
+    expect(vault.htlcVout).toBe(1);
+    expect(vault.offchainParamsVersion).toBe(OFFCHAIN.version);
+    expect(vault.appVaultKeepersVersion).toBe(2);
+    expect(vault.universalChallengersVersion).toBe(5);
+    expect(vault.vaultProvider).toBe(VAULT_PROVIDER);
+    expect(vault.applicationEntryPoint).toBe(APP_ENTRY_POINT);
+    // Depositor-as-claimer: local challengers are the keepers, VP excluded.
+    expect(context.numLocalChallengers).toBe(VKS.length);
+    expect(context.timelockRefund).toBe(OFFCHAIN.timelockRefund);
+  });
+
+  it("refuses an htlcVout outside the reconstructed batch", async () => {
+    const siblings: Sibling[] = [
+      { hashlock: "ab".repeat(32), amount: 1_000_000n },
+    ];
+    const txHex = await buildFundedTx(siblings);
+    const result = await recover(siblings, txHex);
+
+    expect(() =>
+      toRefundInputs(result, {
+        htlcVout: 1,
+        depositorBtcPubkey: DEPOSITOR,
+        applicationEntryPoint: APP_ENTRY_POINT,
+        fundedPrePeginTxHex: txHex,
+        hashlocks: siblings.map((s) => s.hashlock),
+        network: NETWORK,
+      }),
+    ).toThrow(/outside the reconstructed batch/);
+  });
+
+  it("refuses a hashlock vector that does not match the reconstructed amounts", async () => {
+    const siblings: Sibling[] = [
+      { hashlock: "ab".repeat(32), amount: 1_000_000n },
+    ];
+    const txHex = await buildFundedTx(siblings);
+    const result = await recover(siblings, txHex);
+
+    expect(() =>
+      toRefundInputs(result, {
+        htlcVout: 0,
+        depositorBtcPubkey: DEPOSITOR,
+        applicationEntryPoint: APP_ENTRY_POINT,
+        fundedPrePeginTxHex: txHex,
+        hashlocks: ["ab".repeat(32), "cd".repeat(32)],
+        network: NETWORK,
+      }),
+    ).toThrow(/describe different transactions/);
+  });
+});

--- a/packages/babylon-ts-sdk/src/tbv/core/recovery/deriveHashlocksFromPrePegin.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/recovery/deriveHashlocksFromPrePegin.ts
@@ -21,6 +21,7 @@ import { findAuthAnchorOpReturn } from "../managers/pegin/assertAuthAnchorOpRetu
 import { expandPerVaultSecrets } from "../managers/pegin/expandPerVaultSecrets";
 import {
   hexToUint8Array,
+  processPublicKeyToXOnly,
   stripHexPrefix,
   uint8ArrayToHex,
 } from "../primitives/utils/bitcoin";
@@ -40,9 +41,14 @@ export interface DeriveHashlocksFromPrePeginInput {
   /** Any wallet implementing `deriveContextHash` — the depositor's own. */
   wallet: DeriveContextHashCapableWallet;
   /**
-   * Depositor x-only BTC public key (32-byte hex, `0x` optional), read from
-   * the CONNECTED WALLET. The reorg destroyed the row that would normally
-   * supply it, and taking it from any chain read would defeat the recovery.
+   * Depositor BTC public key, read from the CONNECTED WALLET. The reorg
+   * destroyed the row that would normally supply it, and taking it from any
+   * chain read would defeat the recovery.
+   *
+   * Accepted in whatever form the wallet hands back — x-only, 33-byte
+   * compressed or 65-byte uncompressed, `0x` optional — and narrowed to x-only
+   * here. Wallets return the compressed form from `getPublicKey`, so requiring
+   * x-only would make the common case an error.
    */
   depositorBtcPubkey: string;
   /** Funded (broadcast) Pre-PegIn transaction hex, `0x` optional. */
@@ -99,7 +105,12 @@ export async function deriveHashlocksFromPrePegin(
   const fundingOutpoints = parseFundingOutpointsFromTx(cleanTxHex);
 
   const root = await deriveVaultRoot(wallet, {
-    depositorBtcPubkey: hexToUint8Array(depositorBtcPubkey),
+    // The vault context takes the 32-byte x-only key; a wallet's compressed
+    // key would otherwise fail a byte-length check deep in the encoder with
+    // nothing pointing back at the caller.
+    depositorBtcPubkey: hexToUint8Array(
+      processPublicKeyToXOnly(depositorBtcPubkey),
+    ),
     fundingOutpoints,
   });
 

--- a/packages/babylon-ts-sdk/src/tbv/core/recovery/index.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/recovery/index.ts
@@ -16,3 +16,4 @@ export * from "./deriveHashlocksFromPrePegin";
 export * from "./peginParamsCandidates";
 export * from "./reconstructPeginParams";
 export * from "./recoveryErrors";
+export * from "./toRefundInputs";

--- a/packages/babylon-ts-sdk/src/tbv/core/recovery/toRefundInputs.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/recovery/toRefundInputs.ts
@@ -1,0 +1,156 @@
+/**
+ * Close the loop from a verified reconstruction to the ordinary refund path
+ * (#2203).
+ *
+ * `buildAndBroadcastRefund` takes its two reads — the vault row and the
+ * version-pinned Pre-PegIn context — as injected callbacks rather than
+ * performing them itself. That is the whole seam recovery needs: a stranded
+ * deposit has no row to read, but it does have a reconstruction that was
+ * byte-verified against the funded transaction, and those are exactly the
+ * fields the callbacks are expected to return.
+ *
+ * So recovery does not need a parallel refund implementation, and must not
+ * have one. It supplies the same shapes from a different source and reuses the
+ * orchestrator verbatim, which keeps the refund-fee cap, the abort checks, the
+ * `htlcVout` contiguity invariant and the bitcoind error classification in one
+ * place for both paths.
+ *
+ * @module recovery/toRefundInputs
+ */
+
+import type { Network } from "@babylonlabs-io/babylon-tbv-rust-wasm";
+import type { Address, Hex } from "viem";
+
+import { ensureHexPrefix } from "../primitives/utils/bitcoin";
+import type {
+  RefundPrePeginContext,
+  VaultRefundData,
+} from "../services/refund/buildAndBroadcastRefund";
+
+import type { ReconstructPeginParamsResult } from "./reconstructPeginParams";
+
+export interface ToRefundInputsOptions {
+  /**
+   * Which sibling of the Pre-PegIn to refund, as an index into the
+   * reconstruction's hashlocks and amounts. Equal to the vault's `htlcVout`
+   * by construction — `PeginManager` asserts `perVault[i].htlcVout === i`.
+   */
+  htlcVout: number;
+  /**
+   * Depositor x-only BTC pubkey, the same value the reconstruction was run
+   * with. Passed through rather than re-derived so the refund is built against
+   * the key that was actually verified.
+   */
+  depositorBtcPubkey: string;
+  /**
+   * The vault provider's application entry point. Not recoverable from the
+   * Bitcoin transaction and not part of the verified parameter set — it is a
+   * field of the vault-provider registry row, which is address-keyed and
+   * survives the reorg untouched.
+   */
+  applicationEntryPoint: Address;
+  /** Funded Pre-PegIn transaction hex, `0x` optional. */
+  fundedPrePeginTxHex: string;
+  /** Hashlocks indexed by `htlcVout`, as passed to the reconstruction. */
+  hashlocks: readonly string[];
+  /**
+   * The Bitcoin network the reconstruction was verified against. An input to
+   * the search rather than an output of it, so it is restated here; passing a
+   * different one would build the refund against a different script tree than
+   * the one that was proven to match.
+   */
+  network: Network;
+}
+
+export interface RefundInputsFromRecovery {
+  vault: VaultRefundData;
+  context: RefundPrePeginContext;
+}
+
+/**
+ * Project a verified reconstruction into the two shapes
+ * `buildAndBroadcastRefund` injects.
+ *
+ * Every value here comes from a parameter set that has already been
+ * byte-matched against the funded transaction's HTLC outputs, so this is a
+ * projection and not a second validation pass. The orchestrator re-checks the
+ * parts it owns regardless.
+ *
+ * @throws If `htlcVout` does not index the reconstructed batch, or the
+ *   hashlock vector disagrees with the reconstructed amounts.
+ */
+export function toRefundInputs(
+  result: ReconstructPeginParamsResult,
+  options: ToRefundInputsOptions,
+): RefundInputsFromRecovery {
+  const {
+    htlcVout,
+    depositorBtcPubkey,
+    applicationEntryPoint,
+    fundedPrePeginTxHex,
+    hashlocks,
+    network,
+  } = options;
+
+  const { candidate, peginAmounts } = result;
+  const { offchainParams, participants } = candidate;
+
+  if (hashlocks.length !== peginAmounts.length) {
+    throw new Error(
+      `toRefundInputs: ${hashlocks.length} hashlock(s) but ` +
+        `${peginAmounts.length} reconstructed amount(s); the reconstruction ` +
+        `and the hashlock vector describe different transactions.`,
+    );
+  }
+  if (
+    !Number.isInteger(htlcVout) ||
+    htlcVout < 0 ||
+    htlcVout >= peginAmounts.length
+  ) {
+    throw new Error(
+      `toRefundInputs: htlcVout ${htlcVout} is outside the reconstructed ` +
+        `batch of ${peginAmounts.length} vault(s).`,
+    );
+  }
+
+  // The orchestrator requires the complete vout-ordered batch, not just the
+  // target: its anchor check is fail-closed, so refunding one sibling of a
+  // multi-vault Pre-PegIn without the others is rejected outright.
+  const batch = peginAmounts.map((amount, index) => ({
+    hashlock: ensureHexPrefix(hashlocks[index]),
+    amount,
+    htlcVout: index,
+  }));
+
+  const vault: VaultRefundData = {
+    vaultCoreVersion: candidate.vaultCoreVersion,
+    hashlock: batch[htlcVout].hashlock as Hex,
+    htlcVout,
+    offchainParamsVersion: offchainParams.version,
+    appVaultKeepersVersion: participants.appVaultKeepersVersion,
+    universalChallengersVersion: participants.universalChallengersVersion,
+    vaultProvider: participants.vaultProvider,
+    applicationEntryPoint,
+    amount: peginAmounts[htlcVout],
+    unsignedPrePeginTxHex: fundedPrePeginTxHex,
+    depositorBtcPubkey,
+    batch,
+  };
+
+  const context: RefundPrePeginContext = {
+    vaultProviderPubkey: participants.vaultProviderBtcPubkey,
+    vaultKeeperPubkeys: participants.vaultKeeperBtcPubkeys,
+    universalChallengerPubkeys: participants.universalChallengerBtcPubkeys,
+    timelockRefund: offchainParams.timelockRefund,
+    feeRate: offchainParams.protocolFeeRate,
+    minPeginFeeRate: offchainParams.minPeginFeeRate,
+    // Depositor-as-claimer: the local-challenger count is the keeper count,
+    // the vault provider excluded — btc-vault graph.rs derive_challengers.
+    numLocalChallengers: participants.vaultKeeperBtcPubkeys.length,
+    councilQuorum: offchainParams.councilQuorum,
+    councilSize: offchainParams.councilSize,
+    network,
+  };
+
+  return { vault, context };
+}

--- a/packages/babylon-ts-sdk/src/tbv/core/recovery/toRefundInputs.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/recovery/toRefundInputs.ts
@@ -37,9 +37,16 @@ export interface ToRefundInputsOptions {
    */
   htlcVout: number;
   /**
-   * Depositor x-only BTC pubkey, the same value the reconstruction was run
-   * with. Passed through rather than re-derived so the refund is built against
-   * the key that was actually verified.
+   * Depositor BTC pubkey, the same value the reconstruction was run with.
+   * Passed through rather than re-derived so the refund is built against the
+   * key that was actually verified.
+   *
+   * Deliberately NOT narrowed to x-only here. `VaultRefundData.depositorBtcPubkey`
+   * accepts "32 or 33 bytes of hex", and `buildAndBroadcastRefund` narrows it
+   * with `processPublicKeyToXOnly` before it reaches the PSBT builder — so a
+   * wallet's compressed key flows through unchanged, which is what wallets
+   * actually return. Narrowing early would discard the parity byte the
+   * orchestrator's own validation accepts.
    */
   depositorBtcPubkey: string;
   /**

--- a/services/vault/e2e/real/actions/index.ts
+++ b/services/vault/e2e/real/actions/index.ts
@@ -8,6 +8,7 @@ import { borrowAction } from "./borrow";
 import { connectAction } from "./connect";
 import { observeAction } from "./observe";
 import { peginAction } from "./pegin";
+import { recoverAction } from "./recover";
 import { repayAction } from "./repay";
 import { resumeAction } from "./resume";
 import { signConformanceAction } from "./signConformance";
@@ -25,4 +26,5 @@ export const ACTIONS_BY_ID: Partial<Record<ActionId, Action>> = {
   repay: repayAction,
   withdraw: withdrawAction,
   resume: resumeAction,
+  recover: recoverAction,
 };

--- a/services/vault/e2e/real/actions/recover.ts
+++ b/services/vault/e2e/real/actions/recover.ts
@@ -1,0 +1,456 @@
+/**
+ * Rehearsal for the ETH-reorg recovery path (#2203), against a real wallet and
+ * a real signet vault.
+ *
+ * There is nothing to simulate. A reorg's entire observable effect on our code
+ * is that `vaultId`-keyed reads come back empty, and the recovery path is
+ * written never to make them. So the rehearsal runs recovery against a vault
+ * whose row is still there, refusing to use that row as input — and then diffs
+ * the blind answer against it. That is stronger evidence than an actual
+ * incident could give, because during one there would be nothing to compare to.
+ *
+ * What is genuinely blind here, and is the point of the exercise:
+ *
+ *   - the depositor's BTC pubkey comes from the connected wallet, not the row
+ *   - the vault count comes from the transaction's auth-anchor OP_RETURN vout
+ *   - the hashlocks are re-derived through the wallet's `deriveContextHash`
+ *   - the peg-in amounts are inverted from the funded HTLC output values
+ *
+ * What is supplied rather than searched, and is logged as such: the version
+ * stamps and the vault provider. Enumerating those is the fallback path and is
+ * already covered by unit tests; the unverified claim worth a real wallet is
+ * whether a live wallet's derivation reproduces a vault's on-chain hashlock.
+ *
+ * Nothing is broadcast. The refund is built and compared, never sent.
+ */
+import {
+  buildPeginParamsCandidates,
+  buildRefundPsbt,
+  deriveHashlocksFromPrePegin,
+  reconstructPeginParams,
+  resolveCurrentParticipantKeys,
+  resolveProtocolAddresses,
+  toRefundInputs,
+  ViemOperationKeyReader,
+  ViemProtocolParamsReader,
+  ViemUniversalChallengerReader,
+  ViemVaultKeeperReader,
+  ViemVaultRegistryReader,
+} from "@babylonlabs-io/ts-sdk/tbv/core";
+import { gql } from "graphql-request";
+import { createPublicClient, http, type Address, type Hex } from "viem";
+import { sepolia } from "viem/chains";
+
+import {
+  createGraphQLClient,
+  resolveNetworkContracts,
+} from "../networkContracts";
+
+import { installPopupApprover, sweepApprovals } from "./approver";
+import type { Action, ActionContext } from "./types";
+
+/** Injected-provider path per BTC wallet, mirroring sign-conformance. */
+const PROVIDER_PATH: Record<string, string> = {
+  unisat: "unisat",
+  okx: "okxwallet.bitcoinSignet",
+};
+
+/** A wallet approval plus HKDF is slow; well past any human-free popup click. */
+const WALLET_CALL_TIMEOUT_MS = 120_000;
+
+/** Public signet Esplora, used only to price the Pre-PegIn's inputs. */
+const DEFAULT_BTC_API = "https://mempool.space/signet/api";
+
+const VAULT_QUERY = gql`
+  query RecoverableVaults($depositor: String!, $limit: Int!) {
+    vaults(where: { depositor: $depositor }, limit: $limit) {
+      items {
+        id
+        depositor
+        depositorBtcPubKey
+        vaultProvider
+        applicationEntryPoint
+        amount
+        status
+        unsignedPrePeginTx
+        hashlock
+        htlcVout
+        offchainParamsVersion
+        appVaultKeepersVersion
+        universalChallengersVersion
+      }
+    }
+  }
+`;
+
+interface IndexerVault {
+  id: Hex;
+  depositor: string;
+  depositorBtcPubKey: string;
+  vaultProvider: string;
+  applicationEntryPoint: string;
+  amount: string;
+  status: string;
+  unsignedPrePeginTx: string | null;
+  hashlock: string;
+  htlcVout: number;
+  offchainParamsVersion: number;
+  appVaultKeepersVersion: number;
+  universalChallengersVersion: number;
+}
+
+function stripHex(value: string): string {
+  return value.startsWith("0x") ? value.slice(2) : value;
+}
+
+/**
+ * Call a method on the wallet's injected provider, auto-approving whatever
+ * popup it raises. The one thing in this action that must happen in the
+ * browser: every conformant `deriveContextHash` lives in an extension, and the
+ * mock wallets are deliberately not spec-faithful.
+ */
+async function callProvider(
+  ctx: ActionContext,
+  providerPath: string,
+  method: string,
+  args: unknown[],
+): Promise<unknown> {
+  const call = ctx.page.evaluate(
+    async ({ providerPath, method, args }) => {
+      let provider: unknown = window;
+      for (const key of providerPath.split(".")) {
+        provider =
+          provider == null
+            ? provider
+            : (provider as Record<string, unknown>)[key];
+      }
+      if (provider == null)
+        throw new Error(`provider not found at window.${providerPath}`);
+      const p = provider as Record<
+        string,
+        (...a: unknown[]) => Promise<unknown>
+      >;
+      if (method === "__connect") {
+        if (typeof p.requestAccounts === "function")
+          return await p.requestAccounts();
+        if (typeof p.connect === "function") return await p.connect();
+        throw new Error(
+          "provider exposes neither requestAccounts() nor connect()",
+        );
+      }
+      if (typeof p[method] !== "function")
+        throw new Error(`provider has no method ${method}`);
+      return await p[method](...args);
+    },
+    { providerPath, method, args },
+  );
+
+  let done = false;
+  const sweeper = (async () => {
+    while (!done) {
+      await ctx.page.waitForTimeout(400);
+      await sweepApprovals(ctx.context, ctx.page, ctx.log).catch(() => {});
+    }
+  })();
+  const timeout = new Promise<never>((_, reject) =>
+    setTimeout(
+      () =>
+        reject(
+          new Error(`${method} timed out after ${WALLET_CALL_TIMEOUT_MS}ms`),
+        ),
+      WALLET_CALL_TIMEOUT_MS,
+    ),
+  );
+  try {
+    return await Promise.race([call, timeout]);
+  } finally {
+    done = true;
+    await sweeper;
+  }
+}
+
+/** Σin − Σout for the funded Pre-PegIn, priced from the funding UTXOs. */
+async function computePrepeginFee(
+  fundedTxHex: string,
+  btcApi: string,
+  log: (m: string) => void,
+): Promise<bigint> {
+  const { Transaction } = await import("bitcoinjs-lib");
+  const tx = Transaction.fromHex(stripHex(fundedTxHex));
+  const totalOut = tx.outs.reduce((sum, o) => sum + BigInt(o.value), 0n);
+
+  let totalIn = 0n;
+  for (const input of tx.ins) {
+    const txid = Buffer.from(input.hash).reverse().toString("hex");
+    const res = await fetch(`${btcApi}/tx/${txid}`);
+    if (!res.ok)
+      throw new Error(
+        `Esplora ${res.status} pricing input ${txid}:${input.index}`,
+      );
+    const prev = (await res.json()) as { vout: { value: number }[] };
+    totalIn += BigInt(prev.vout[input.index].value);
+  }
+  const fee = totalIn - totalOut;
+  log(`  Pre-PegIn fee: Σin ${totalIn} − Σout ${totalOut} = ${fee} sat`);
+  if (fee <= 0n)
+    throw new Error(
+      `Computed a non-positive Pre-PegIn fee (${fee}); inputs mispriced.`,
+    );
+  return fee;
+}
+
+export const recoverAction: Action = {
+  id: "recover",
+  async run(ctx: ActionContext): Promise<void> {
+    const { log, config } = ctx;
+    const providerPath = PROVIDER_PATH[ctx.btc.id];
+    if (!providerPath)
+      throw new Error(
+        `recover: no injected-provider path known for BTC wallet "${ctx.btc.id}" (need unisat or okx).`,
+      );
+
+    const { registry, graphqlEndpoint, ethRpcUrl } = resolveNetworkContracts(
+      config.network,
+    );
+    const btcApi = process.env.NEXT_PUBLIC_MEMPOOL_API ?? DEFAULT_BTC_API;
+
+    installPopupApprover(ctx.context, log);
+
+    // ---- Pick a vault to rehearse against, and keep its row as the reference.
+    const gqlClient = createGraphQLClient(graphqlEndpoint);
+    const { vaults } = await gqlClient.request<{
+      vaults: { items: IndexerVault[] };
+    }>(VAULT_QUERY, { depositor: ctx.eth.address.toLowerCase(), limit: 50 });
+
+    const usable = vaults.items.filter((v) => v.unsignedPrePeginTx);
+    if (usable.length === 0)
+      throw new Error(
+        `recover: no vault with a Pre-PegIn transaction found for ${ctx.eth.address}. ` +
+          `Do a peg-in with this wallet first, or connect the wallet that made one.`,
+      );
+    const target = usable[0];
+    log(
+      `Rehearsing against vault ${target.id} (status=${target.status}, htlcVout=${target.htlcVout}).`,
+    );
+    log(
+      `  GROUND TRUTH (not fed into the reconstruction): hashlock=${target.hashlock}, amount=${target.amount}`,
+    );
+
+    const fundedPrePeginTxHex = target.unsignedPrePeginTx as string;
+
+    // ---- The blind half. Depositor pubkey from the WALLET, not the row.
+    await callProvider(ctx, providerPath, "__connect", []);
+    const walletPubkey = String(
+      await callProvider(ctx, providerPath, "getPublicKey", []),
+    );
+    log(`  Wallet pubkey: ${walletPubkey}`);
+    if (
+      stripHex(walletPubkey).toLowerCase() !==
+      stripHex(target.depositorBtcPubKey).toLowerCase()
+    )
+      log(
+        `  NOTE: wallet pubkey differs from the row's depositorBtcPubKey ` +
+          `(${target.depositorBtcPubKey}). If derivation fails below, this is why — ` +
+          `the root is bound to the account and network, not just the seed.`,
+      );
+
+    const wallet = {
+      deriveContextHash: async (appName: string, context: string) =>
+        String(
+          await callProvider(ctx, providerPath, "deriveContextHash", [
+            appName,
+            context,
+          ]),
+        ),
+    };
+
+    log("Deriving hashlocks from the wallet + the Pre-PegIn transaction…");
+    const derived = await deriveHashlocksFromPrePegin({
+      wallet,
+      depositorBtcPubkey: walletPubkey,
+      fundedPrePeginTxHex,
+    });
+    log(
+      `  vaultCount=${derived.vaultCount}, authAnchorHash=${derived.authAnchorHash}`,
+    );
+
+    // The moment the whole design turns on: a live wallet's derivation has to
+    // reproduce the hashlock this vault actually committed to on-chain.
+    const derivedHashlock = derived.hashlocks[target.htlcVout];
+    const onChainHashlock = stripHex(target.hashlock).toLowerCase();
+    if (derivedHashlock !== onChainHashlock)
+      throw new Error(
+        `Derived hashlock does not match the vault's on-chain hashlock.\n` +
+          `  derived:  ${derivedHashlock}\n  on-chain: ${onChainHashlock}\n` +
+          `The wallet, account or network differs from the one that made this deposit.`,
+      );
+    log(
+      `  ✔ derived hashlock MATCHES the on-chain hashlock — the key fits the lock.`,
+    );
+
+    // ---- Parameters. Supplied from the stamped versions rather than searched;
+    // the enumeration fallback is unit-tested and is not the unknown here.
+    const publicClient = createPublicClient({
+      chain: sepolia,
+      transport: http(ethRpcUrl),
+    });
+    const addresses = await resolveProtocolAddresses(publicClient, registry);
+    const protocolReader = new ViemProtocolParamsReader(
+      publicClient,
+      addresses.protocolParams,
+    );
+    const keeperReader = new ViemVaultKeeperReader(
+      publicClient,
+      addresses.applicationRegistry,
+    );
+    const challengerReader = new ViemUniversalChallengerReader(
+      publicClient,
+      addresses.protocolParams,
+    );
+    const operationKeyReader = new ViemOperationKeyReader(publicClient, {
+      btcVaultRegistry: registry,
+      applicationRegistry: addresses.applicationRegistry,
+      protocolParams: addresses.protocolParams,
+    });
+    const registryReader = new ViemVaultRegistryReader(publicClient, registry);
+
+    const [offchain, timelockPegin, keepers, challengers, vpGenesisKey] =
+      await Promise.all([
+        protocolReader.getOffchainParamsByVersion(target.offchainParamsVersion),
+        protocolReader.getTimelockPeginByVersion(target.offchainParamsVersion),
+        keeperReader.getVaultKeepersByVersion(
+          target.applicationEntryPoint as Address,
+          target.appVaultKeepersVersion,
+        ),
+        challengerReader.getUniversalChallengersByVersion(
+          target.universalChallengersVersion,
+        ),
+        registryReader.getVaultProviderGenesisBtcPubKey(
+          target.vaultProvider as Address,
+        ),
+      ]);
+
+    // RFC-006: scripts are built from operation keys, not registration keys.
+    // A rehearsal on a current vault can use the participants' current keys;
+    // a real incident reads the epochs at the reorg height instead.
+    const participantKeys = await resolveCurrentParticipantKeys({
+      operationKeyReader,
+      query: {
+        vaultProviderEthAddress: target.vaultProvider as Address,
+        vaultProviderGenesisBtcPubkey: `0x${vpGenesisKey}` as Hex,
+        applicationEntryPoint: target.applicationEntryPoint as Address,
+        vaultKeepers: keepers,
+        universalChallengers: challengers,
+      },
+    });
+
+    const candidates = buildPeginParamsCandidates({
+      vaultCoreVersion: (await registryReader.getVaultData(target.id)).protocol
+        .vaultCoreVersion,
+      offchainParams: [
+        {
+          version: target.offchainParamsVersion,
+          protocolFeeRate: offchain.feeRate,
+          minPeginFeeRate: offchain.minPeginFeeRate,
+          councilQuorum: offchain.councilQuorum,
+          councilSize: offchain.securityCouncilKeys.length,
+          timelockPegin,
+          timelockAssert: Number(offchain.timelockAssert),
+          timelockRefund: offchain.tRefund,
+        },
+      ],
+      participantKeySets: [
+        {
+          vaultProvider: target.vaultProvider as Address,
+          vaultProviderBtcPubkey: participantKeys.vaultProvider
+            .operationBtcPubkey as string,
+          appVaultKeepersVersion: target.appVaultKeepersVersion,
+          vaultKeeperBtcPubkeys: participantKeys.vaultKeeperOperationKeysSorted,
+          universalChallengersVersion: target.universalChallengersVersion,
+          universalChallengerBtcPubkeys:
+            participantKeys.universalChallengerOperationKeysSorted,
+        },
+      ],
+    });
+
+    const prepeginMaxFee = await computePrepeginFee(
+      fundedPrePeginTxHex,
+      btcApi,
+      log,
+    );
+
+    log("Verifying the parameter set against the funded transaction…");
+    const result = await reconstructPeginParams({
+      hashlocks: derived.hashlocks,
+      fundedPrePeginTxHex,
+      depositorBtcPubkey: walletPubkey,
+      prepeginMaxFee,
+      maxAcceptableCommissionBps: 10_000 - 1,
+      network: "signet" as never,
+      candidates,
+      unresolvedVersions: [],
+    });
+    log(
+      `  ✔ verified: ${result.candidatesTried} candidate(s) tried, terms projected.`,
+    );
+
+    // ---- The differential: what we recovered blind vs what the row says.
+    const recoveredAmount = result.peginAmounts[target.htlcVout];
+    const onChainAmount = BigInt(target.amount);
+    log(`  amount: recovered=${recoveredAmount} on-chain=${onChainAmount}`);
+    if (recoveredAmount !== onChainAmount)
+      throw new Error(
+        `Recovered peg-in amount ${recoveredAmount} does not match the on-chain ` +
+          `amount ${onChainAmount}. The inversion or the reserve is wrong.`,
+      );
+    log("  ✔ recovered peg-in amount MATCHES the on-chain amount.");
+
+    // ---- The refund, built from recovered inputs. Never broadcast.
+    const { vault, context } = toRefundInputs(result, {
+      htlcVout: target.htlcVout,
+      depositorBtcPubkey: walletPubkey,
+      applicationEntryPoint: target.applicationEntryPoint as Address,
+      fundedPrePeginTxHex,
+      hashlocks: derived.hashlocks,
+      network: "signet" as never,
+    });
+
+    const refund = await buildRefundPsbt({
+      prePeginParams: {
+        vaultCoreVersion: vault.vaultCoreVersion,
+        depositorPubkey: vault.depositorBtcPubkey,
+        vaultProviderPubkey: context.vaultProviderPubkey,
+        vaultKeeperPubkeys: [...context.vaultKeeperPubkeys],
+        universalChallengerPubkeys: [...context.universalChallengerPubkeys],
+        hashlocks: vault.batch.map((b) => stripHex(b.hashlock)),
+        timelockRefund: context.timelockRefund,
+        pegInAmounts: vault.batch.map((b) => b.amount),
+        feeRate: context.feeRate,
+        minPeginFeeRate: context.minPeginFeeRate,
+        numLocalChallengers: context.numLocalChallengers,
+        councilQuorum: context.councilQuorum,
+        councilSize: context.councilSize,
+        network: context.network,
+        authAnchorHash: result.authAnchorHash,
+      },
+      fundedPrePeginTxHex: vault.unsignedPrePeginTxHex,
+      htlcVout: vault.htlcVout,
+      refundFee: 1000n,
+      hashlock: stripHex(vault.hashlock),
+    });
+    log(
+      `  ✔ refund PSBT built from recovered parameters (${refund.psbtHex.length / 2} bytes).`,
+    );
+
+    log("");
+    log("Rehearsal complete. Recovered blind from wallet + transaction:");
+    log(`  hashlock  ${derivedHashlock}  (matches chain)`);
+    log(`  amount    ${recoveredAmount}  (matches chain)`);
+    log(`  refund    built, NOT broadcast`);
+    log("");
+    log(
+      "Not exercised here, by design: the parameter enumeration fallback (unit-tested), " +
+        "and reading the stamps at a historical block height, which a real incident needs.",
+    );
+  },
+};

--- a/services/vault/e2e/real/actions/recover.ts
+++ b/services/vault/e2e/real/actions/recover.ts
@@ -336,6 +336,16 @@ export const recoverAction: Action = {
         ? `  Multi-vault Pre-PegIn: ${group.length} siblings — the sibling path is exercised.`
         : `  Single-vault Pre-PegIn: the sibling path is NOT exercised by this run.`,
     );
+    // Coverage is ranked above spendability on purpose — nothing is broadcast,
+    // and a withdrawn deposit still proves derivation, verification, signing and
+    // the sighash check. Said out loud so it is never a silent surprise, because
+    // this same transaction could NOT be broadcast.
+    if (statusRank(target) >= REFUNDABLE_FIRST.length)
+      log(
+        `  NOTE: status "${target.status}" — this HTLC output is already spent. ` +
+          `Fine for a rehearsal, but this refund could not be broadcast. Pass ` +
+          `--txid=<prePeginTxid> to target a refundable deposit instead.`,
+      );
     log(
       `  GROUND TRUTH (not fed into the reconstruction): hashlock=${target.hashlock}, amount=${target.amount}`,
     );

--- a/services/vault/e2e/real/actions/recover.ts
+++ b/services/vault/e2e/real/actions/recover.ts
@@ -28,6 +28,7 @@ import {
   buildPeginParamsCandidates,
   calculateBtcTxHash,
   deriveHashlocksFromPrePegin,
+  processPublicKeyToXOnly,
   reconstructPeginParams,
   resolveCurrentParticipantKeys,
   resolveProtocolAddresses,
@@ -42,6 +43,7 @@ import { gql } from "graphql-request";
 import { createPublicClient, http, type Address, type Hex } from "viem";
 import { sepolia } from "viem/chains";
 
+import type { NetworkName } from "../config";
 import {
   createGraphQLClient,
   resolveNetworkContracts,
@@ -61,6 +63,32 @@ const WALLET_CALL_TIMEOUT_MS = 120_000;
 
 /** Fee rate for the rehearsal's refund. Never broadcast, so it only has to be plausible. */
 const REFUND_FEE_RATE_SAT_VB = 2;
+
+/**
+ * The WASM network descriptor, taken from the SDK's own signature rather than
+ * imported from the WASM package (not a direct dependency of this project).
+ */
+type BtcNetwork = Parameters<typeof reconstructPeginParams>[0]["network"];
+
+/**
+ * BTC network per harness network, typed rather than cast. The value reaches
+ * HTLC script construction, so a wrong one silently builds against the wrong
+ * script tree; `as never` would hide exactly that.
+ */
+const BTC_NETWORK: Record<NetworkName, BtcNetwork> = {
+  devnet: "signet" as BtcNetwork,
+  testnet: "signet" as BtcNetwork,
+};
+
+/**
+ * The commission ceiling the rehearsal declares. It never reaches the HTLC
+ * script or value, so for a rehearsal the widest admissible bound is right:
+ * `buildDepositTerms` requires an integer strictly below 10_000.
+ */
+const REHEARSAL_MAX_COMMISSION_BPS = 9_999;
+
+/** One unresponsive Esplora request must not hang the rehearsal indefinitely. */
+const ESPLORA_TIMEOUT_MS = 15_000;
 
 /** Public signet Esplora, used only to price the Pre-PegIn's inputs. */
 const DEFAULT_BTC_API = "https://mempool.space/signet/api";
@@ -150,10 +178,20 @@ async function callProvider(
   );
 
   let done = false;
+  // A sweep failure is why an approval never lands, so discarding it leaves the
+  // run to die at the timeout with no cause recorded. Reported once per call:
+  // the loop ticks ~2.5×/s, and a persistent fault would otherwise bury the log.
+  let sweepFailureReported = false;
   const sweeper = (async () => {
     while (!done) {
       await ctx.page.waitForTimeout(400);
-      await sweepApprovals(ctx.context, ctx.page, ctx.log).catch(() => {});
+      await sweepApprovals(ctx.context, ctx.page, ctx.log).catch((err) => {
+        if (sweepFailureReported) return;
+        sweepFailureReported = true;
+        ctx.log(
+          `  approval sweep failed during ${method} (continuing): ${String(err)}`,
+        );
+      });
     }
   })();
   const timeout = new Promise<never>((_, reject) =>
@@ -186,13 +224,22 @@ async function computePrepeginFee(
   let totalIn = 0n;
   for (const input of tx.ins) {
     const txid = Buffer.from(input.hash).reverse().toString("hex");
-    const res = await fetch(`${btcApi}/tx/${txid}`);
+    const res = await fetch(`${btcApi}/tx/${txid}`, {
+      signal: AbortSignal.timeout(ESPLORA_TIMEOUT_MS),
+    });
     if (!res.ok)
       throw new Error(
         `Esplora ${res.status} pricing input ${txid}:${input.index}`,
       );
     const prev = (await res.json()) as { vout: { value: number }[] };
-    totalIn += BigInt(prev.vout[input.index].value);
+    const prevOut = prev.vout[input.index];
+    // Without this, a short vout array yields BigInt(undefined) — a TypeError
+    // that says nothing about the transaction that actually went missing.
+    if (prevOut === undefined)
+      throw new Error(
+        `Esplora returned no vout ${input.index} for input tx ${txid}.`,
+      );
+    totalIn += BigInt(prevOut.value);
   }
   const fee = totalIn - totalOut;
   log(`  Pre-PegIn fee: Σin ${totalIn} − Σout ${totalOut} = ${fee} sat`);
@@ -217,6 +264,7 @@ export const recoverAction: Action = {
       config.network,
     );
     const btcApi = process.env.NEXT_PUBLIC_MEMPOOL_API ?? DEFAULT_BTC_API;
+    const btcNetwork = BTC_NETWORK[config.network];
 
     installPopupApprover(ctx.context, log);
 
@@ -251,7 +299,29 @@ export const recoverAction: Action = {
       const key = v.unsignedPrePeginTx as string;
       byPrePegin.set(key, [...(byPrePegin.get(key) ?? []), v]);
     }
-    const groups = [...byPrePegin.values()].sort((a, b) => {
+    // `--txid` pins the deposit, which is how a real recovery starts: from a
+    // Pre-PegIn hash the depositor supplies. Without it, pick by preference.
+    const wanted = config.recoverTxid?.trim().replace(/^0x/i, "").toLowerCase();
+    const allGroups = [...byPrePegin.values()];
+    const targeted = wanted
+      ? allGroups.filter(
+          (g) =>
+            stripHex(
+              calculateBtcTxHash(g[0].unsignedPrePeginTx as string),
+            ).toLowerCase() === wanted,
+        )
+      : allGroups;
+    if (wanted && targeted.length === 0)
+      throw new Error(
+        `recover: no deposit of ${ctx.eth.address} has Pre-PegIn txid ${wanted}. ` +
+          `Available: ${allGroups
+            .map((g) =>
+              stripHex(calculateBtcTxHash(g[0].unsignedPrePeginTx as string)),
+            )
+            .join(", ")}`,
+      );
+
+    const groups = [...targeted].sort((a, b) => {
       if (a.length !== b.length) return b.length - a.length;
       return Math.min(...a.map(statusRank)) - Math.min(...b.map(statusRank));
     });
@@ -278,9 +348,11 @@ export const recoverAction: Action = {
       await callProvider(ctx, providerPath, "getPublicKey", []),
     );
     log(`  Wallet pubkey: ${walletPubkey}`);
-    // Compare in the same form: wallets return the 33-byte compressed key,
-    // the row stores x-only. Comparing raw would flag every healthy run.
-    const walletXOnly = stripHex(walletPubkey).slice(-64).toLowerCase();
+    // Compare in the same form: wallets return the 33-byte compressed key, the
+    // row stores x-only. Comparing raw would flag every healthy run, and
+    // slicing the last 64 chars would take the Y coordinate of an uncompressed
+    // key rather than the X.
+    const walletXOnly = processPublicKeyToXOnly(walletPubkey);
     if (walletXOnly !== stripHex(target.depositorBtcPubKey).toLowerCase())
       log(
         `  NOTE: the connected wallet's key (${walletXOnly}) is not the row's ` +
@@ -420,8 +492,8 @@ export const recoverAction: Action = {
       fundedPrePeginTxHex,
       depositorBtcPubkey: walletPubkey,
       prepeginMaxFee,
-      maxAcceptableCommissionBps: 10_000 - 1,
-      network: "signet" as never,
+      maxAcceptableCommissionBps: REHEARSAL_MAX_COMMISSION_BPS,
+      network: btcNetwork,
       candidates,
       unresolvedVersions: [],
     });
@@ -447,7 +519,7 @@ export const recoverAction: Action = {
       applicationEntryPoint: target.applicationEntryPoint as Address,
       fundedPrePeginTxHex,
       hashlocks: derived.hashlocks,
-      network: "signet" as never,
+      network: btcNetwork,
     });
 
     // Run the REAL refund orchestrator, not a hand-rolled build. It signs with

--- a/services/vault/e2e/real/actions/recover.ts
+++ b/services/vault/e2e/real/actions/recover.ts
@@ -226,27 +226,45 @@ export const recoverAction: Action = {
       vaults: { items: IndexerVault[] };
     }>(VAULT_QUERY, { depositor: ctx.eth.address.toLowerCase(), limit: 50 });
 
-    // Prefer a deposit whose HTLC is still unspent. A withdrawn or redeemed
-    // vault still exercises derivation and verification, but its refund would
-    // be spending an output that is already gone — a poor rehearsal.
+    // Two preferences, in order. A batched Pre-PegIn first, because the
+    // sibling path is the riskier code — the reconstruction has to rebuild
+    // EVERY HTLC output and the refund path's anchor check is fail-closed, so
+    // a single-vault run leaves both untested. Then a deposit whose HTLC is
+    // still unspent, which makes the refund a real one rather than a rehearsal
+    // against an output that is already gone.
     const REFUNDABLE_FIRST = ["expired", "pending", "verified", "available"];
-    const usable = vaults.items
-      .filter((v) => v.unsignedPrePeginTx)
-      .sort((a, b) => {
-        const rank = (v: IndexerVault) => {
-          const i = REFUNDABLE_FIRST.indexOf(v.status);
-          return i === -1 ? REFUNDABLE_FIRST.length : i;
-        };
-        return rank(a) - rank(b);
-      });
-    if (usable.length === 0)
+    const statusRank = (v: IndexerVault) => {
+      const i = REFUNDABLE_FIRST.indexOf(v.status);
+      return i === -1 ? REFUNDABLE_FIRST.length : i;
+    };
+
+    const withTx = vaults.items.filter((v) => v.unsignedPrePeginTx);
+    if (withTx.length === 0)
       throw new Error(
         `recover: no vault with a Pre-PegIn transaction found for ${ctx.eth.address}. ` +
           `Do a peg-in with this wallet first, or connect the wallet that made one.`,
       );
+
+    // Siblings share one Pre-PegIn transaction; each has its own vault id.
+    const byPrePegin = new Map<string, IndexerVault[]>();
+    for (const v of withTx) {
+      const key = v.unsignedPrePeginTx as string;
+      byPrePegin.set(key, [...(byPrePegin.get(key) ?? []), v]);
+    }
+    const groups = [...byPrePegin.values()].sort((a, b) => {
+      if (a.length !== b.length) return b.length - a.length;
+      return Math.min(...a.map(statusRank)) - Math.min(...b.map(statusRank));
+    });
+    const group = groups[0];
+    const usable = [...group].sort((a, b) => statusRank(a) - statusRank(b));
     const target = usable[0];
     log(
       `Rehearsing against vault ${target.id} (status=${target.status}, htlcVout=${target.htlcVout}).`,
+    );
+    log(
+      group.length > 1
+        ? `  Multi-vault Pre-PegIn: ${group.length} siblings — the sibling path is exercised.`
+        : `  Single-vault Pre-PegIn: the sibling path is NOT exercised by this run.`,
     );
     log(
       `  GROUND TRUTH (not fed into the reconstruction): hashlock=${target.hashlock}, amount=${target.amount}`,

--- a/services/vault/e2e/real/actions/recover.ts
+++ b/services/vault/e2e/real/actions/recover.ts
@@ -24,8 +24,9 @@
  * Nothing is broadcast. The refund is built and compared, never sent.
  */
 import {
+  buildAndBroadcastRefund,
   buildPeginParamsCandidates,
-  buildRefundPsbt,
+  calculateBtcTxHash,
   deriveHashlocksFromPrePegin,
   reconstructPeginParams,
   resolveCurrentParticipantKeys,
@@ -57,6 +58,9 @@ const PROVIDER_PATH: Record<string, string> = {
 
 /** A wallet approval plus HKDF is slow; well past any human-free popup click. */
 const WALLET_CALL_TIMEOUT_MS = 120_000;
+
+/** Fee rate for the rehearsal's refund. Never broadcast, so it only has to be plausible. */
+const REFUND_FEE_RATE_SAT_VB = 2;
 
 /** Public signet Esplora, used only to price the Pre-PegIn's inputs. */
 const DEFAULT_BTC_API = "https://mempool.space/signet/api";
@@ -222,7 +226,19 @@ export const recoverAction: Action = {
       vaults: { items: IndexerVault[] };
     }>(VAULT_QUERY, { depositor: ctx.eth.address.toLowerCase(), limit: 50 });
 
-    const usable = vaults.items.filter((v) => v.unsignedPrePeginTx);
+    // Prefer a deposit whose HTLC is still unspent. A withdrawn or redeemed
+    // vault still exercises derivation and verification, but its refund would
+    // be spending an output that is already gone — a poor rehearsal.
+    const REFUNDABLE_FIRST = ["expired", "pending", "verified", "available"];
+    const usable = vaults.items
+      .filter((v) => v.unsignedPrePeginTx)
+      .sort((a, b) => {
+        const rank = (v: IndexerVault) => {
+          const i = REFUNDABLE_FIRST.indexOf(v.status);
+          return i === -1 ? REFUNDABLE_FIRST.length : i;
+        };
+        return rank(a) - rank(b);
+      });
     if (usable.length === 0)
       throw new Error(
         `recover: no vault with a Pre-PegIn transaction found for ${ctx.eth.address}. ` +
@@ -244,14 +260,15 @@ export const recoverAction: Action = {
       await callProvider(ctx, providerPath, "getPublicKey", []),
     );
     log(`  Wallet pubkey: ${walletPubkey}`);
-    if (
-      stripHex(walletPubkey).toLowerCase() !==
-      stripHex(target.depositorBtcPubKey).toLowerCase()
-    )
+    // Compare in the same form: wallets return the 33-byte compressed key,
+    // the row stores x-only. Comparing raw would flag every healthy run.
+    const walletXOnly = stripHex(walletPubkey).slice(-64).toLowerCase();
+    if (walletXOnly !== stripHex(target.depositorBtcPubKey).toLowerCase())
       log(
-        `  NOTE: wallet pubkey differs from the row's depositorBtcPubKey ` +
-          `(${target.depositorBtcPubKey}). If derivation fails below, this is why — ` +
-          `the root is bound to the account and network, not just the seed.`,
+        `  NOTE: the connected wallet's key (${walletXOnly}) is not the row's ` +
+          `depositorBtcPubKey (${stripHex(target.depositorBtcPubKey)}). Derivation ` +
+          `will fail below — the root is bound to the account and network, not ` +
+          `just the seed.`,
       );
 
     const wallet = {
@@ -415,38 +432,48 @@ export const recoverAction: Action = {
       network: "signet" as never,
     });
 
-    const refund = await buildRefundPsbt({
-      prePeginParams: {
-        vaultCoreVersion: vault.vaultCoreVersion,
-        depositorPubkey: vault.depositorBtcPubkey,
-        vaultProviderPubkey: context.vaultProviderPubkey,
-        vaultKeeperPubkeys: [...context.vaultKeeperPubkeys],
-        universalChallengerPubkeys: [...context.universalChallengerPubkeys],
-        hashlocks: vault.batch.map((b) => stripHex(b.hashlock)),
-        timelockRefund: context.timelockRefund,
-        pegInAmounts: vault.batch.map((b) => b.amount),
-        feeRate: context.feeRate,
-        minPeginFeeRate: context.minPeginFeeRate,
-        numLocalChallengers: context.numLocalChallengers,
-        councilQuorum: context.councilQuorum,
-        councilSize: context.councilSize,
-        network: context.network,
-        authAnchorHash: result.authAnchorHash,
+    // Run the REAL refund orchestrator, not a hand-rolled build. It signs with
+    // the wallet under the taproot script-path options (CLAUDE.md critical
+    // path 8, where wallet support is inconsistent and failures are silent),
+    // then verifies the returned Schnorr signature against a sighash it
+    // recomputes from the PSBT it built — so a wallet that returns a
+    // plausible-but-wrong signature is caught here rather than by the network.
+    //
+    // `broadcastTx` is injected, so the whole path runs and stops at the door.
+    let signedTxHex: string | undefined;
+    const wouldBroadcast = await buildAndBroadcastRefund({
+      vaultId: target.id,
+      readVault: async () => vault,
+      readPrePeginContext: async () => context,
+      feeRate: REFUND_FEE_RATE_SAT_VB,
+      signPsbt: async (psbtHex, options) => {
+        log(
+          `  Signing the refund PSBT with ${ctx.btc.id} (approve in the wallet)…`,
+        );
+        return String(
+          await callProvider(ctx, providerPath, "signPsbt", [psbtHex, options]),
+        );
       },
-      fundedPrePeginTxHex: vault.unsignedPrePeginTxHex,
-      htlcVout: vault.htlcVout,
-      refundFee: 1000n,
-      hashlock: stripHex(vault.hashlock),
+      broadcastTx: async (txHex) => {
+        signedTxHex = txHex;
+        // The txid it WOULD have had. Computed, not invented, and never sent.
+        return { txId: stripHex(calculateBtcTxHash(txHex)) };
+      },
     });
+
+    if (!signedTxHex)
+      throw new Error("recover: the refund never reached the broadcast seam.");
     log(
-      `  ✔ refund PSBT built from recovered parameters (${refund.psbtHex.length / 2} bytes).`,
+      `  ✔ refund signed and signature verified against a recomputed sighash.`,
     );
+    log(`  ✔ would-be refund txid: ${wouldBroadcast.txId} (NOT broadcast)`);
+    log(`  signed tx: ${signedTxHex.length / 2} bytes`);
 
     log("");
     log("Rehearsal complete. Recovered blind from wallet + transaction:");
     log(`  hashlock  ${derivedHashlock}  (matches chain)`);
     log(`  amount    ${recoveredAmount}  (matches chain)`);
-    log(`  refund    built, NOT broadcast`);
+    log(`  refund    signed + signature-verified, NOT broadcast`);
     log("");
     log(
       "Not exercised here, by design: the parameter enumeration fallback (unit-tested), " +

--- a/services/vault/e2e/real/cli.ts
+++ b/services/vault/e2e/real/cli.ts
@@ -353,6 +353,12 @@ async function resolveConfig(
       action === "resume" && typeof flags.txid === "string"
         ? flags.txid
         : undefined;
+    // `--txid` also targets a specific deposit for `recover`, which is how a real
+    // recovery starts: from a Pre-PegIn hash the depositor supplies.
+    const recoverTxid =
+      action === "recover" && typeof flags.txid === "string"
+        ? flags.txid
+        : undefined;
 
     // Pegin extras. A flag always wins; otherwise fetch the network's real values (like the balance
     // pre-flight) and offer them as defaults — amount ⇒ minimum, provider ⇒ first available. Collected
@@ -630,6 +636,7 @@ async function resolveConfig(
       repayFirst,
       withdrawAll,
       resumeTxid,
+      recoverTxid,
       interruptFresh,
       interruptOnly,
     };

--- a/services/vault/e2e/real/config.ts
+++ b/services/vault/e2e/real/config.ts
@@ -186,6 +186,12 @@ export interface RunConfig {
    */
   resumeTxid?: string;
   /**
+   * Recover only: target a specific deposit by its Pre-PegIn txid (`--txid`). When absent the
+   * rehearsal picks a batched Pre-PegIn if one exists (the sibling path is the riskier code), then
+   * the most refundable deposit in it.
+   */
+  recoverTxid?: string;
+  /**
    * Resume only: peg in a fresh deposit and interrupt it after Pre-PegIn broadcast (`--interrupt-fresh`),
    * reloading the page to a cold state, then resume it from the dashboard — a fully self-contained run.
    * When absent, resume expects an already-pending deposit to be present.

--- a/services/vault/e2e/real/config.ts
+++ b/services/vault/e2e/real/config.ts
@@ -21,7 +21,8 @@ export type ActionId =
   | "borrow"
   | "repay"
   | "withdraw"
-  | "resume";
+  | "resume"
+  | "recover";
 
 /** Maps our lowercase wallet ids to the connector's SupportedWallet keys. */
 export const BTC_WALLET_TO_CONNECTOR: Record<BtcWalletId, SupportedWallet> = {
@@ -115,6 +116,11 @@ export const ACTIONS: ActionOption[] = [
     enabled: true,
   },
   { id: "borrow", label: "Borrow", enabled: true },
+  {
+    id: "recover",
+    label: "Recover (rehearse ETH-reorg recovery against a real vault)",
+    enabled: true,
+  },
   { id: "repay", label: "Repay", enabled: true },
   { id: "withdraw", label: "Withdraw", enabled: true },
   { id: "resume", label: "Resume (an interrupted peg-in)", enabled: true },


### PR DESCRIPTION
# Reach the refund from a reconstruction, and verify it against a real wallet

Follows [#2278](https://github.com/babylonlabs-io/babylon-toolkit/pull/2278). Closes [#2203](https://github.com/babylonlabs-io/babylon-toolkit/issues/2203).

PR 1 could verify a parameter set against a stranded Pre-PegIn. It could not get from there to a refund, and none of it had ever been run against a real wallet. This does both — and running it found a bug that two PRs of unit tests had missed.

## Verified end to end on signet

A full green run against a real UniSat wallet and a real signet vault, recovering blind and diffing against the row it never read:

```
Rehearsing against vault 0x7aca1953…c854 (status=expired, htlcVout=0)
  GROUND TRUTH (not fed into the reconstruction): hashlock=0x650945d2…694b, amount=1000000
  Wallet pubkey: 033f8f4496…c062
  ✔ derived hashlock MATCHES the on-chain hashlock — the key fits the lock.
  Pre-PegIn fee: Σin 1252998160 − Σout 1252997196 = 964 sat
  ✔ verified: 1 candidate(s) tried, terms projected.
  ✔ recovered peg-in amount MATCHES the on-chain amount.  (1000000)
  ✔ refund signed and signature verified against a recomputed sighash.
  ✔ would-be refund txid: fbc3960f…e856 (NOT broadcast)
```

Nothing was broadcast. The txid is computed from the signed transaction, never sent — though that vault is `expired`, so its timelock has matured and the transaction would be accepted.

And a second run against a **two-vault** Pre-PegIn, which exercises the sibling path — the reconstruction has to rebuild every HTLC output, and the refund path's anchor check is fail-closed, so a single-vault run leaves both untested:

```
Rehearsing against vault 0x00d643c4…d821 (status=depositor_withdrawn, htlcVout=1)
  Multi-vault Pre-PegIn: 2 siblings — the sibling path is exercised.
  GROUND TRUTH (not fed into the reconstruction): hashlock=0x0528d00c…f3a9, amount=2838383
  vaultCount=2, authAnchorHash=592c578e…6ec4
  ✔ derived hashlock MATCHES the on-chain hashlock — the key fits the lock.
  ✔ verified: 1 candidate(s) tried, terms projected.
  ✔ recovered peg-in amount MATCHES the on-chain amount.  (2838383)
  ✔ refund signed and signature verified against a recomputed sighash.
```

Both cases are run explicitly. `--txid=<prePeginTxid>` pins a deposit — which is also how a real recovery starts, from a hash the depositor supplies — and without it the rehearsal prefers a batched Pre-PegIn, since the sibling path is the riskier code. It states in its output which case it got, so a single-vault run cannot quietly look like full coverage.

Verified on signet: a single-vault `expired` deposit whose HTLC is unspent and matured, and two different two-vault deposits, at `htlcVout=0` and `htlcVout=1`.

Coverage is ranked above spendability on purpose: every batched Pre-PegIn this wallet has is `depositor_withdrawn`, so preferring a refundable deposit would skip the sibling path entirely. Nothing is broadcast, and a withdrawn deposit still proves derivation, verification, wallet signing and the recomputed-sighash check — so the run says out loud when its chosen HTLC is already spent rather than letting that pass silently.

This is the practice run the issue asked for and nobody had done.

## The bug it found

`deriveHashlocksFromPrePegin`, as merged in PR 1, could not be called with a real wallet:

```
Run failed: vaultContext: depositorBtcPubkey must be exactly 32 bytes, got 33
```

Wallets return the **33-byte compressed** key from `getPublicKey`; the function only stripped `0x` and required x-only. Every unit test passed because every one fed bare x-only hex — the same blind spot review had already flagged on the sibling function, which was fixed there and missed here.

Fixed with `processPublicKeyToXOnly`, plus regression tests asserting the compressed and `0x`-prefixed forms derive identical secrets to the x-only form.

## `toRefundInputs`, and no second refund implementation

`buildAndBroadcastRefund` takes its two reads — the vault row and the version-pinned Pre-PegIn context — as **injected callbacks** rather than performing them itself. That is exactly the seam recovery needs: a stranded deposit has no row to read, but it has a reconstruction that was byte-verified against the funded transaction, and those are the same fields the callbacks return.

```ts
const { vault, context } = toRefundInputs(result, { htlcVout, ... });

await buildAndBroadcastRefund({
  vaultId,
  readVault: async () => vault,
  readPrePeginContext: async () => context,
  feeRate, signPsbt, broadcastTx,
});
```

So the refund-fee cap, the abort checks, the `htlcVout` contiguity invariant, the signature verification and the bitcoind error classification stay in one place for both paths instead of being reimplemented for the rare one. The rehearsal runs that real orchestrator with a capturing broadcaster, which is why it exercises wallet signing under the taproot script-path options — CLAUDE.md critical path 8, where support is inconsistent and failures are silent.

`applicationEntryPoint` is the one field the reconstruction does not carry: not recoverable from the Bitcoin transaction, and a property of the vault-provider registry row, which is address-keyed and survives. It is an explicit input, not a silent default.

## The headless proof

A refund PSBT built from parameters recovered blind is asserted **byte-identical** to one built from the parameters the deposit was actually made with. The plan assumed this needed a wallet and a signet run; it does not, because `buildRefundPsbt` takes parameters directly and building a PSBT involves no signing. A mutation check sits beside it — perturbing `timelockRefund` must make the builder refuse — because a byte comparison that cannot fail proves nothing.

## Tests

46 in the recovery module, all against real WASM, including one pinning that a wallet's compressed pubkey survives the projection unchanged. `lint`, `tsc --noEmit` and the full suites pass across the SDK, the vault app and the e2e project: **1591** SDK tests, 3387 vault tests.

## Scope, honestly

**Not covered by the live runs:** reading the version stamps at a **historical block height** — tracked in [#2292](https://github.com/babylonlabs-io/babylon-toolkit/issues/2292). The rehearsal reads them at `latest`, which is correct for a current vault because current values are the stamped values — but a real incident where a version bumped or an operator rotated between deposit and recovery needs historical reads, and nothing in `clients/eth` accepts a block number today.

Worth knowing before merge: the verifier catches a wrong `timelockRefund` or participant set, but **not** a wrong `vaultCoreVersion` — v1 and v2 give byte-identical connector scriptPubKeys and the amount is inverted using the supplied reserve, so a wrong value yields a sole match with a shifted split and no error. That is why #2292 is a real gap rather than a tidy-up, and it is pinned by a deliberate negative test.

The two-vault run used a `depositor_withdrawn` deposit, so its HTLC output is already spent: the refund signs and verifies, but that particular transaction could not be broadcast. The single-vault run used an `expired` deposit whose output is unspent and whose timelock has matured, so that one could.

**Deliberately not here:** the forked-block scanning script (protocol side), the feature-flagged recovery page (agreed deferrable provided the mechanism is documented, which `RECOVERY.md` now does), and sharing the mechanism for the FAQ.

## Review

Feeds CLAUDE.md critical paths 1 and 8 — the projected values reach a signed Bitcoin transaction. `toRefundInputs` performs no validation of its own: every value it emits comes from a parameter set already byte-matched against the funded transaction's HTLC outputs, and the orchestrator re-checks what it owns.
