### PR TITLE
fix(vault): move the max-vaults notice below the Position section

### DIFF
--- a/services/vault/src/components/simple/DashboardPage.tsx
+++ b/services/vault/src/components/simple/DashboardPage.tsx
@@ -209,8 +209,9 @@ export function DashboardPage() {
       ? formatBasisPointsAsPercent(collateralFactorBps)
       : COPY.common.emptyValue;
 
-  // The cascade banner sits between the Position and Risk sections (Figma
-  // 10204-45310).
+  // The cascade banner and the max-vaults notice share the same slot between
+  // the Position and Risk sections — same "Notifications" instance in both
+  // the default and critical states (Figma 10094-26791, 10204-45310).
   const cascadeBanner = liquidationNotificationsEnabled ? (
     <PositionNotificationBanner
       connectedAddress={address}
@@ -235,18 +236,12 @@ export function DashboardPage() {
   return (
     <Container className={`${PAGE_CONTENT_CLASS} pb-6`}>
       <div className="space-y-10">
-        {/* Notifications sit above Overview per Figma (frame 6508-114810). The
-            critical top banner, the max-vaults notice, and the cascade banner
-            share this slot. */}
+        {/* Full-bleed alert bar above the header/sidebar row, not part of this
+            column — it portals into RootLayout's top-banner slot (Figma frame
+            10204-45613; see CriticalLiquidationTopBanner). */}
         {liquidationNotificationsEnabled && (
           <CriticalLiquidationTopBanner result={criticalBannerResult} />
         )}
-
-        {/* "Maximum vaults reached" is a value-protection capacity fact shown
-            ALWAYS (independent of the liquidation-notifications flag and of BTC
-            price), and decoupled from the cascade banner so a stale-price or
-            all-pending position still surfaces it. */}
-        <MaxVaultsNotification connectedAddress={address} />
 
         <OverviewSection
           totalCollateralValue={totalCollateralValue}
@@ -263,6 +258,12 @@ export function DashboardPage() {
           canBorrow={canBorrow}
           canRepay={hasLoans}
         />
+
+        {/* "Maximum vaults reached" is a value-protection capacity fact shown
+            ALWAYS (independent of the liquidation-notifications flag and of BTC
+            price), and decoupled from the cascade banner so a stale-price or
+            all-pending position still surfaces it. */}
+        <MaxVaultsNotification connectedAddress={address} />
 
         {cascadeBanner}
 

--- a/services/vault/src/components/simple/__tests__/DashboardPage.test.tsx
+++ b/services/vault/src/components/simple/__tests__/DashboardPage.test.tsx
@@ -121,6 +121,15 @@ describe("DashboardPage composition", () => {
     expect(screen.getByTestId("critical-banner")).toBeInTheDocument();
     expect(screen.getByTestId("position-banner")).toBeInTheDocument();
     expect(screen.getByText(COPY.risk.title)).toBeInTheDocument();
+
+    // Figma (10094-26791, 10204-45310): the max-vaults notice and the cascade
+    // banner share the slot below Position, not above it.
+    const overview = screen.getByTestId("overview-section");
+    const maxVaults = screen.getByTestId("max-vaults");
+    expect(
+      overview.compareDocumentPosition(maxVaults) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
   });
 });
 


### PR DESCRIPTION
## What

On the Overview page, the "Maximum vaults reached" notice rendered above the Position section while the other notification cards render below it. This moves `MaxVaultsNotification` into the shared below-Position slot, between the Position stats and the cascade banner.

## Why this placement

Figma frame `10094-26791` shows the Notifications instance (`10182:57535`) rendering the max-vaults content directly below the Position block, and frame `10204-45310` shows the identically-positioned instance rendering the cascade (critical-state) content — the two banners are one design slot with alternate content, not two stacked positions. The previous top placement cited frame `6508-114810`, which is superseded; the stale comment is replaced with the current frame references.

`CriticalLiquidationTopBanner` intentionally stays at page top: per frame `10204-45310` it is a full-bleed bar spanning above the sidebar and header (y=0, full page width), and the component portals into the root-layout slot above the content row (`10204-45613`). It is not part of the Position column.

## Changes

- `DashboardPage.tsx`: render order is now Position → max-vaults notice → cascade banner → Risk. Render conditions are unchanged (the notice stays always-on, independent of the liquidation-notifications flag).
- `DashboardPage.test.tsx`: a DOM-order assertion locks the notice below the Position section so the regression cannot return silently.

Layout move only — no styling, copy, or behaviour changes.
