### PR TITLE
fix(vault): stop the collateral stat column collapsing under its label

### DIFF
--- a/services/vault/src/components/simple/PositionStatCards.tsx
+++ b/services/vault/src/components/simple/PositionStatCards.tsx
@@ -42,7 +42,7 @@ function StatMeter({
         aria-valuemin={0}
         aria-valuemax={100}
         aria-valuenow={Math.round(clamped * 100)}
-        className="h-1 w-[68px] overflow-hidden rounded-full bg-secondary-strokeLight"
+        className="h-1 w-[68px] overflow-hidden rounded-full bg-secondary-strokeLight xl:max-[1439px]:w-[48px]"
       >
         <div
           className="h-full rounded-full bg-secondary-main"
@@ -59,9 +59,9 @@ function StatMeter({
 function StatSection({ card }: { card: PositionStatCard }) {
   const hasAction = card.actionLabel != null && card.onAction != null;
   return (
-    <div className="flex flex-[1_0_0] items-center justify-between gap-4">
+    <div className="flex flex-[1_0_0] items-center justify-between gap-4 xl:max-[1439px]:gap-2">
       <div className="flex flex-col gap-3">
-        <div className="flex items-center gap-1 whitespace-nowrap text-sm leading-[1.43] tracking-[0.17px] text-accent-secondary">
+        <div className="flex items-center gap-1 text-sm leading-[1.43] tracking-[0.17px] text-accent-secondary xl:whitespace-nowrap">
           {card.tooltip ? (
             <Hint
               tooltip={card.tooltip}
@@ -74,7 +74,7 @@ function StatSection({ card }: { card: PositionStatCard }) {
           )}
         </div>
 
-        <span className="flex items-center gap-2 whitespace-nowrap text-xl leading-[1.6] tracking-[0.15px] text-accent-primary">
+        <span className="flex items-center gap-2 text-xl leading-[1.6] tracking-[0.15px] text-accent-primary xl:whitespace-nowrap">
           {card.valueNode ?? card.value}
         </span>
 
@@ -85,7 +85,7 @@ function StatSection({ card }: { card: PositionStatCard }) {
             ariaLabel={card.label}
           />
         ) : card.caption ? (
-          <span className="whitespace-nowrap text-sm leading-[1.43] tracking-[0.17px] text-accent-secondary">
+          <span className="text-sm leading-[1.43] tracking-[0.17px] text-accent-secondary xl:whitespace-nowrap">
             {card.caption}
           </span>
         ) : null}
@@ -97,7 +97,7 @@ function StatSection({ card }: { card: PositionStatCard }) {
           onClick={() => card.onAction?.()}
           disabled={card.actionDisabled}
           data-testid={card.actionTestId}
-          className="flex h-10 w-[120px] shrink-0 items-center justify-center rounded-lg bg-secondary-strokeLight text-base leading-[1.5] tracking-[0.15px] text-accent-primary transition-[filter] enabled:hover:brightness-110 disabled:cursor-not-allowed disabled:text-accent-disabled"
+          className="flex h-10 w-[120px] shrink-0 items-center justify-center rounded-lg bg-secondary-strokeLight text-base leading-[1.5] tracking-[0.15px] text-accent-primary transition-[filter] enabled:hover:brightness-110 disabled:cursor-not-allowed disabled:text-accent-disabled xl:max-[1439px]:w-[100px]"
         >
           {card.actionLabel}
         </button>
@@ -109,7 +109,7 @@ function StatSection({ card }: { card: PositionStatCard }) {
 export function PositionStatCards({ cards }: { cards: PositionStatCard[] }) {
   return (
     <div className="rounded-lg bg-secondary-highlight p-6">
-      <div className="flex flex-col gap-6 xl:flex-row xl:items-stretch">
+      <div className="flex flex-col gap-6 xl:flex-row xl:items-stretch xl:max-[1439px]:gap-4">
         {cards.map((card, index) => (
           <Fragment key={card.label}>
             {index > 0 && (

--- a/services/vault/src/components/simple/PositionStatCards.tsx
+++ b/services/vault/src/components/simple/PositionStatCards.tsx
@@ -59,9 +59,9 @@ function StatMeter({
 function StatSection({ card }: { card: PositionStatCard }) {
   const hasAction = card.actionLabel != null && card.onAction != null;
   return (
-    <div className="flex flex-1 items-center justify-between gap-4">
+    <div className="flex flex-[1_0_0] items-center justify-between gap-4">
       <div className="flex flex-col gap-3">
-        <div className="flex items-center gap-1 text-sm leading-[1.43] tracking-[0.17px] text-accent-secondary">
+        <div className="flex items-center gap-1 whitespace-nowrap text-sm leading-[1.43] tracking-[0.17px] text-accent-secondary">
           {card.tooltip ? (
             <Hint
               tooltip={card.tooltip}
@@ -74,7 +74,7 @@ function StatSection({ card }: { card: PositionStatCard }) {
           )}
         </div>
 
-        <span className="flex items-center gap-2 text-xl leading-[1.6] tracking-[0.15px] text-accent-primary">
+        <span className="flex items-center gap-2 whitespace-nowrap text-xl leading-[1.6] tracking-[0.15px] text-accent-primary">
           {card.valueNode ?? card.value}
         </span>
 
@@ -85,7 +85,7 @@ function StatSection({ card }: { card: PositionStatCard }) {
             ariaLabel={card.label}
           />
         ) : card.caption ? (
-          <span className="text-sm leading-[1.43] tracking-[0.17px] text-accent-secondary">
+          <span className="whitespace-nowrap text-sm leading-[1.43] tracking-[0.17px] text-accent-secondary">
             {card.caption}
           </span>
         ) : null}

--- a/services/vault/src/components/simple/__tests__/PositionStatCards.test.tsx
+++ b/services/vault/src/components/simple/__tests__/PositionStatCards.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { PositionStatCards, type PositionStatCard } from "../PositionStatCards";
+
+const cards: PositionStatCard[] = [
+  {
+    label: "Total collateral value",
+    value: "$10,000",
+    caption: "0.5 BTC",
+    actionLabel: "Deposit",
+    onAction: () => {},
+  },
+  {
+    label: "Available to borrow",
+    value: "$5,000",
+    meter: { percent: 0.75, label: "75% remaining" },
+    actionLabel: "Borrow",
+    onAction: () => {},
+  },
+];
+
+describe("PositionStatCards", () => {
+  it("forces the three-column row and single-line labels from xl (1280px) up, not just at 1440px", () => {
+    render(<PositionStatCards cards={cards} />);
+
+    const row = screen.getByText("$10,000").closest("div.flex.flex-col.gap-6");
+    expect(row).toHaveClass("xl:flex-row");
+    expect(row).toHaveClass("xl:items-stretch");
+
+    const label = screen.getByText("Total collateral value");
+    expect(label).toHaveClass("xl:whitespace-nowrap");
+
+    const value = screen.getByText("$10,000");
+    expect(value).toHaveClass("xl:whitespace-nowrap");
+
+    const caption = screen.getByText("0.5 BTC");
+    expect(caption).toHaveClass("xl:whitespace-nowrap");
+  });
+
+  it("below xl, labels are free to wrap instead of forcing the row to overflow", () => {
+    // Regression guard for PR #2296: shrink-0 + unconditional nowrap forced
+    // the row wider than its content and clipped the Repay button.
+    render(<PositionStatCards cards={cards} />);
+
+    const label = screen.getByText("Total collateral value");
+    expect(label).not.toHaveClass("whitespace-nowrap");
+  });
+
+  it("compresses gaps, the action button, and the meter bar only in the 1280-1439px band, so the row fits between the sidebar and 1440px without clipping", () => {
+    render(<PositionStatCards cards={cards} />);
+
+    const row = screen.getByText("$10,000").closest("div.flex.flex-col.gap-6");
+    expect(row).toHaveClass("xl:max-[1439px]:gap-4");
+    // Figma-true gap-6 stays the base value, so it's back in effect at 1440+
+    // without needing a separate min-[1440px] override.
+    expect(row).toHaveClass("gap-6");
+
+    const depositButton = screen.getByRole("button", { name: "Deposit" });
+    expect(depositButton).toHaveClass("xl:max-[1439px]:w-[100px]");
+    expect(depositButton).toHaveClass("w-[120px]");
+
+    const meterBar = screen.getByRole("progressbar", {
+      name: "Available to borrow",
+    });
+    expect(meterBar).toHaveClass("xl:max-[1439px]:w-[48px]");
+    expect(meterBar).toHaveClass("w-[68px]");
+  });
+});


### PR DESCRIPTION
## What

On the Overview Position panel, the "Total collateral value" label wrapped onto three lines with the info icon floating mid-wrap, because the first column got squeezed.

## Root cause

The columns used `flex-1` (shrink allowed) with unconstrained text. With wrapping allowed, a flex item's automatic minimum width collapses to its narrowest word, so the column with the longest label plus the info icon was the one that gave way. The design (Figma `10094-26791`, Stats instance) specifies `flex: 1 0 0` on all three columns and `whitespace-nowrap` on every label, value, and caption.

## Change

`PositionStatCards.tsx`: `flex-1` → `flex-[1_0_0]` on the column container, and `whitespace-nowrap` on the label row, value, and caption — matching the frame exactly. One file, no behaviour change.