### PR TITLE
feat(ledger-vault, vault): typed device errors, signing cancel, no ve…

### DIFF
--- a/packages/babylon-ledger-vault-signer/src/__tests__/e2e/peginFixture.ts
+++ b/packages/babylon-ledger-vault-signer/src/__tests__/e2e/peginFixture.ts
@@ -269,9 +269,9 @@ export function vaultHashlock(root: Uint8Array, htlcVout: number): Buffer {
  * pass {@link PrePeginPsbtFixture.txidInternal}. `prepeginTxid` is DISPLAY
  * order: the seam converts display → internal exactly like wallet-connector's
  * provider, and the wire carries the internal-order bytes the firmware compares
- * against the PSBT. `vaultCoreVersion` is 2: the device-supported tx-graph
- * version gate — the TLV's structure/version constants (both 1) are pinned
- * inside the encoder.
+ * against the PSBT. `vaultCoreVersion` is 2 — the graph version the fixture
+ * PSBTs were built under; the TLV's structure/version constants (both 1) are
+ * pinned inside the encoder.
  */
 export function buildDepositTerms(prepeginTxidInternal: Buffer): DepositTerms {
   return {

--- a/packages/babylon-ledger-vault-signer/src/__tests__/envelope.test.ts
+++ b/packages/babylon-ledger-vault-signer/src/__tests__/envelope.test.ts
@@ -57,7 +57,7 @@ describe("assertDepositTermsDeviceCompatible", () => {
 
   it("throws the shape the SDK matches on — name AND reason", () => {
     try {
-      assertDepositTermsDeviceCompatible(makeTerms({ vaultCoreVersion: 1 }));
+      assertDepositTermsDeviceCompatible(makeTerms({ protocolFeeRate: 0n }));
       expect.unreachable("should have thrown");
     } catch (error) {
       expect(error).toBeInstanceOf(DepositTermsRejectedError);
@@ -66,16 +66,12 @@ describe("assertDepositTermsDeviceCompatible", () => {
     }
   });
 
-  it("refuses any tx-graph version but v2 before any device I/O", () => {
-    // The intent TLV carries no version field, so a mismatched graph (v1 or a
-    // future v3) LOADS on-device and only fails at PSBT time, i.e. after the
-    // depositor has physically approved. Exact match, not a floor.
-    expect(() => assertDepositTermsDeviceCompatible(makeTerms({ vaultCoreVersion: 1 }))).toThrow(
-      /vaultCoreVersion 1 is not 2/,
-    );
-    expect(() => assertDepositTermsDeviceCompatible(makeTerms({ vaultCoreVersion: 3 }))).toThrow(
-      /vaultCoreVersion 3 is not 2/,
-    );
+  it("does not gate on the tx-graph version — that axis belongs to the WASM capability gate", () => {
+    // 2026-08-23 decision: unconstructable versions never get here, and a
+    // device-incompatible shape fails closed on-device.
+    for (const vaultCoreVersion of [1, 2, 3, 4]) {
+      expect(() => assertDepositTermsDeviceCompatible(makeTerms({ vaultCoreVersion }))).not.toThrow();
+    }
   });
 
   it("accepts multiple vault groups — v0.9.3 auto-detects the group by htlc_vout", () => {

--- a/packages/babylon-ledger-vault-signer/src/deviceCaps.ts
+++ b/packages/babylon-ledger-vault-signer/src/deviceCaps.ts
@@ -68,12 +68,3 @@ export const DEVICE_MIN_DEPOSITOR_CLAIM_VALUE_SATS = DEVICE_VAULT_DUST_LIMIT_SAT
  * into the protocol.
  */
 export const DEVICE_PEGIN_AMOUNT_DUST_MULTIPLE = 2n;
-
-/**
- * The ONLY tx-graph version this firmware can complete. The intent TLV
- * carries no core-version field, so the device cannot reject a mismatched
- * graph at load — the intent approves on-screen and signing fails at PSBT
- * time. Any other version (v1 or a future v3) must be refused before device
- * I/O, hence an exact match, not a floor.
- */
-export const DEVICE_SUPPORTED_VAULT_CORE_VERSION = 2;

--- a/packages/babylon-ledger-vault-signer/src/envelope.ts
+++ b/packages/babylon-ledger-vault-signer/src/envelope.ts
@@ -17,7 +17,6 @@ import {
   DEVICE_PEGIN_AMOUNT_DUST_MULTIPLE,
   DEVICE_PEGIN_CSV_TIMELOCK_MAX_BLOCKS,
   DEVICE_REFUND_TIMELOCK_MAX_BLOCKS,
-  DEVICE_SUPPORTED_VAULT_CORE_VERSION,
   DEVICE_TIMELOCK_MIN_BLOCKS,
   DEVICE_VAULT_DUST_LIMIT_SATS,
 } from "./deviceCaps";
@@ -37,16 +36,8 @@ function requireIntInRange(field: string, value: number, lo: number, hi: number)
  * @throws {DepositTermsRejectedError} on the first violation
  */
 export function assertDepositTermsDeviceCompatible(terms: DepositTerms): void {
-  // The firmware hardcodes one PSBT shape and the intent TLV carries no
-  // version field, so ANY mismatched graph (v1 or a future v3) loads fine and
-  // only fails at PSBT time — after the user has physically approved.
-  if (terms.vaultCoreVersion !== DEVICE_SUPPORTED_VAULT_CORE_VERSION) {
-    throw new DepositTermsRejectedError(
-      `${RANGE_MSG}: vaultCoreVersion ${terms.vaultCoreVersion} is not ` +
-        `${DEVICE_SUPPORTED_VAULT_CORE_VERSION}; this device only supports ` +
-        `tx-graph v${DEVICE_SUPPORTED_VAULT_CORE_VERSION} deposits.`,
-    );
-  }
+  // No tx-graph version check (2026-08-23 decision): the WASM capability gate
+  // stops unconstructable versions upstream; bad shapes fail closed on-device.
 
   // The >= 1 floor is enforced by both the contract and the device
   // (vault_tlv.c:73 rejects rate == 0).

--- a/packages/babylon-ledger-vault-signer/src/index.ts
+++ b/packages/babylon-ledger-vault-signer/src/index.ts
@@ -59,6 +59,7 @@ export { buildPopPsbtHex, type BuildPopPsbtParams } from "./popPsbt";
 export {
   SW_BAD_STATE,
   SW_CAP_EXCEEDED,
+  SW_CLA_NOT_SUPPORTED,
   type Apdu,
   type AppIdentity,
   type RawApduResponse,

--- a/packages/babylon-ledger-vault-signer/src/rawApdu.ts
+++ b/packages/babylon-ledger-vault-signer/src/rawApdu.ts
@@ -56,7 +56,7 @@ const SW_USER_REFUSED = new Set([0x5501, 0x6985]);
 const SW_DEVICE_LOCKED = new Set([0x5515, 0x6982, 0x5303]);
 
 /** CLA not supported — what the dashboard or a wrong app returns. */
-const SW_CLA_NOT_SUPPORTED = 0x6e00;
+export const SW_CLA_NOT_SUPPORTED = 0x6e00;
 
 /** SW_BAD_STATE — the loaded intent/root is gone (`fw:sw.h` via `base:src/boilerplate/sw.h:80` @ e400d8d8). */
 export const SW_BAD_STATE = 0xb007;

--- a/packages/babylon-wallet-connector/src/core/wallets/btc/ledger-vault/__tests__/provider.test.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/ledger-vault/__tests__/provider.test.ts
@@ -464,11 +464,6 @@ describe("LedgerVaultProvider", () => {
       return provider;
     }
 
-    /** The resendOnceOnIncorrectData the Nth device call received. */
-    function resendFlagOfCall(index: number): boolean | undefined {
-      return signMock.signPreparedVaultPsbt.mock.calls[index]?.[2]?.resendOnceOnIncorrectData;
-    }
-
     it("signs under the loaded intent and keeps it loaded for further PSBTs", async () => {
       const provider = await approved();
 
@@ -668,6 +663,7 @@ describe("LedgerVaultProvider", () => {
       await expect(
         p.signPsbt(keyPathPsbtHex([bip86Script(await changeXOnlyHex())]), { autoFinalized: false }),
       ).rejects.toMatchObject({
+        code: ERROR_CODES.DEVICE_CEREMONY_INVALID,
         message: expect.stringMatching(/holds no approved intent/),
       });
     });
@@ -686,35 +682,58 @@ describe("LedgerVaultProvider", () => {
       const provider = await approved();
       signMock.signPreparedVaultPsbt.mockRejectedValueOnce(new LedgerDeviceError(0xb007, "SW_BAD_STATE"));
 
-      await expect(provider.signPsbt(PSBT_A)).rejects.toThrow(/no longer holds the approved intent/);
-      await expect(provider.signPsbt(PSBT_A)).rejects.toThrow(/no approved intent/);
+      await expect(provider.signPsbt(PSBT_A)).rejects.toMatchObject({
+        code: ERROR_CODES.DEVICE_CEREMONY_INVALID,
+        message: expect.stringMatching(/no longer holds the approved intent/),
+      });
+      await expect(provider.signPsbt(PSBT_A)).rejects.toMatchObject({
+        code: ERROR_CODES.DEVICE_CEREMONY_INVALID,
+        message: expect.stringMatching(/no approved intent/),
+      });
 
       await provider.deriveContextHash("app", "aa".repeat(32));
       await provider.approveDepositTerms(TERMS);
       await expect(provider.signPsbt(PSBT_A)).resolves.toBe(`signed:${PSBT_A}`);
     });
 
-    it("an abandonment keeps the intent and arms the one-shot 0x6A80 recovery", async () => {
+    it("an aborted sign classifies as the user's cancel and forces the full re-ceremony", async () => {
+      // Keep-intent retries risk SW_CAP_EXCEEDED (caps commit pre-yield):
+      // the mirror drops and only a re-ceremony recovers.
       const provider = await approved();
       signMock.signPreparedVaultPsbt.mockRejectedValueOnce(new LedgerSignPsbtAbortedError(0, true));
 
-      await expect(provider.signPsbt(PSBT_A)).rejects.toMatchObject({ code: ERROR_CODES.WALLET_NOT_CONNECTED });
-      // No re-ceremony needed; the retry passes the recovery flag, and a
-      // successful sign disarms it for the call after.
+      await expect(provider.signPsbt(PSBT_A)).rejects.toMatchObject({ code: ERROR_CODES.CONNECTION_REJECTED });
+      await expect(provider.signPsbt(PSBT_A)).rejects.toMatchObject({ code: ERROR_CODES.DEVICE_CEREMONY_INVALID });
+
+      await provider.deriveContextHash("app", "aa".repeat(32));
+      await provider.approveDepositTerms(TERMS);
       await expect(provider.signPsbt(PSBT_A)).resolves.toBe(`signed:${PSBT_A}`);
-      await provider.signPsbt(PSBT_B);
-      expect(resendFlagOfCall(0)).toBe(false);
-      expect(resendFlagOfCall(1)).toBe(true);
-      expect(resendFlagOfCall(2)).toBe(false);
     });
 
-    it("a pre-send abort does not arm the recovery — no dispatcher was interrupted", async () => {
+    it("cancelSigning between batch elements stops the batch as a cancellation", async () => {
+      // The between-elements window has its own abort check; a same-generation
+      // abort there must classify as the user's cancel, mirror idle.
+      const provider = await approved();
+      signMock.signPreparedVaultPsbt.mockImplementationOnce(async (_send, prepared: { originalPsbtHex: string }) => {
+        provider.cancelSigning();
+        return { signedPsbtHex: `signed:${prepared.originalPsbtHex}`, yields: [] };
+      });
+
+      await expect(provider.signPsbts([PSBT_A, PSBT_B])).rejects.toMatchObject({
+        code: ERROR_CODES.CONNECTION_REJECTED,
+        message: expect.stringMatching(/after 1 of 2/),
+      });
+      await expect(provider.signPsbt(PSBT_A)).rejects.toMatchObject({
+        code: ERROR_CODES.DEVICE_CEREMONY_INVALID,
+      });
+    });
+
+    it("a pre-send abort takes the same cancel classification and reset", async () => {
       const provider = await approved();
       signMock.signPreparedVaultPsbt.mockRejectedValueOnce(new LedgerSignPsbtAbortedError(0, false));
 
-      await expect(provider.signPsbt(PSBT_A)).rejects.toMatchObject({ code: ERROR_CODES.WALLET_NOT_CONNECTED });
-      await provider.signPsbt(PSBT_A);
-      expect(resendFlagOfCall(1)).toBe(false);
+      await expect(provider.signPsbt(PSBT_A)).rejects.toMatchObject({ code: ERROR_CODES.CONNECTION_REJECTED });
+      await expect(provider.signPsbt(PSBT_A)).rejects.toMatchObject({ code: ERROR_CODES.DEVICE_CEREMONY_INVALID });
     });
 
     it("signPsbts signs a whole batch in order under one intent", async () => {
@@ -810,6 +829,55 @@ describe("LedgerVaultProvider", () => {
           }),
       );
     }
+
+    it("cancelSigning settles the in-flight ceremony as a user cancellation and drops the mirror", async () => {
+      // No teardown → classifies as the user's act, not a disconnect; caps may
+      // be consumed pre-yield, so retry must re-run the full ceremony.
+      const provider = await approved();
+      hangUntilAborted();
+      const inFlight = provider.signPsbt(PSBT_A);
+      inFlight.catch(() => {});
+      await vi.waitFor(() => expect(signMock.signPreparedVaultPsbt).toHaveBeenCalledTimes(1));
+
+      provider.cancelSigning();
+
+      await expect(inFlight).rejects.toMatchObject({
+        code: ERROR_CODES.CONNECTION_REJECTED,
+        message: expect.stringMatching(/cancelled/i),
+      });
+      await expect(provider.signPsbt(PSBT_A)).rejects.toMatchObject({
+        code: ERROR_CODES.DEVICE_CEREMONY_INVALID,
+        message: expect.stringMatching(/no approved intent/),
+      });
+    });
+
+    it("cancelSigning with nothing in flight is a no-op and keeps the loaded intent", async () => {
+      const provider = await approved();
+
+      expect(() => provider.cancelSigning()).not.toThrow();
+
+      await expect(provider.signPsbt(PSBT_A)).resolves.toBe(`signed:${PSBT_A}`);
+    });
+
+    it("cancelSigning during the PoP also drops the mirror — uniform conservative policy", async () => {
+      // An interrupted dispatcher is tx-type-agnostic; PoP takes the same reset.
+      const provider = await approved();
+      hangUntilAborted();
+      const pop = provider.signMessage("hello", "bip322-simple");
+      pop.catch(() => {});
+      await vi.waitFor(() => expect(signMock.signPreparedVaultPsbt).toHaveBeenCalledTimes(1));
+
+      provider.cancelSigning();
+
+      await expect(pop).rejects.toMatchObject({
+        code: ERROR_CODES.CONNECTION_REJECTED,
+        message: expect.stringMatching(/cancelled/i),
+      });
+      await expect(provider.signPsbt(PSBT_A)).rejects.toMatchObject({
+        code: ERROR_CODES.DEVICE_CEREMONY_INVALID,
+        message: expect.stringMatching(/no approved intent/),
+      });
+    });
 
     it("admits one device ceremony at a time", async () => {
       const provider = await approved();
@@ -913,19 +981,6 @@ describe("LedgerVaultProvider", () => {
       await expect(provider.signPsbt(PSBT_B)).rejects.toThrow(/already signed/);
     });
 
-    it("a fresh derive disarms the resend-once recovery", async () => {
-      const provider = await approved();
-      signMock.signPreparedVaultPsbt.mockRejectedValueOnce(new LedgerSignPsbtAbortedError(0, true));
-      await expect(provider.signPsbt(PSBT_A)).rejects.toMatchObject({ code: ERROR_CODES.WALLET_NOT_CONNECTED });
-
-      await provider.deriveContextHash("app", "aa".repeat(32));
-      await provider.approveDepositTerms(TERMS);
-      await provider.signPsbt(PSBT_A);
-
-      // The armed flag died with the old intent — the fresh sign must not resend.
-      expect(resendFlagOfCall(1)).toBe(false);
-    });
-
     it("a fresh approval resets the replay guard — the device counters were reset too", async () => {
       const provider = await approved();
       await provider.signPsbt(PSBT_A);
@@ -989,15 +1044,29 @@ describe("LedgerVaultProvider", () => {
   });
 
   it("runs the envelope gate before any device I/O", async () => {
-    // A v1 intent loads fine on-device and only fails at PSBT time — after the
-    // depositor has physically approved. Nothing may reach the device.
+    // An out-of-envelope intent dies on-device with an opaque status word
+    // and a nullified session. Nothing may reach the device.
     const provider = await derived();
     h.sent.length = 0;
 
-    await expect(provider.approveDepositTerms({ ...TERMS, vaultCoreVersion: 1 })).rejects.toThrow(
-      /vaultCoreVersion 1 is not 2/,
-    );
+    await expect(provider.approveDepositTerms({ ...TERMS, protocolFeeRate: 0n })).rejects.toThrow(/protocolFeeRate/);
     expect(h.sent).toHaveLength(0);
+  });
+
+  it("classifies both approve-time state conflicts as DEVICE_CEREMONY_INVALID", async () => {
+    // The UX routes restart-from-derivation on this code, not on message text.
+    const loaded = await derived();
+    await loaded.approveDepositTerms(TERMS);
+    await expect(loaded.approveDepositTerms({ ...TERMS, prepeginTxid: "2".repeat(64) })).rejects.toMatchObject({
+      code: ERROR_CODES.DEVICE_CEREMONY_INVALID,
+      message: expect.stringMatching(/different approved intent/),
+    });
+
+    const idle = await connected(); // connected, never derived
+    await expect(idle.approveDepositTerms(TERMS)).rejects.toMatchObject({
+      code: ERROR_CODES.DEVICE_CEREMONY_INVALID,
+      message: expect.stringMatching(/no freshly derived context root/),
+    });
   });
 
   it("refuses to approve before a context root is derived on this connection", async () => {
@@ -1426,7 +1495,12 @@ describe("LedgerVaultProvider", () => {
 
   it.each([
     ["a device decline", new LedgerUserRefusedError(0x6985), ERROR_CODES.CONNECTION_REJECTED],
-    ["a locked device", new LedgerDeviceLockedError(0x5515), ERROR_CODES.CONNECTION_FAILED],
+    ["a locked device", new LedgerDeviceLockedError(0x5515), ERROR_CODES.DEVICE_LOCKED],
+    [
+      "the wrong running app",
+      new LedgerDeviceError(0x6e00, "The running app does not handle vault instructions — open the Babylon Vault app"),
+      ERROR_CODES.DEVICE_WRONG_APP,
+    ],
     [
       "a generic device rejection",
       new LedgerDeviceError(0x6f42, "The device rejected the request"),

--- a/packages/babylon-wallet-connector/src/core/wallets/btc/ledger-vault/provider.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/ledger-vault/provider.ts
@@ -9,8 +9,8 @@ import {
   createDmkRawApduSender,
   DepositTermsRejectedError,
   deriveChangeXOnlyHex,
-  deriveReceiveXOnlyHex,
   deriveContextHash,
+  deriveReceiveXOnlyHex,
   disconnectDmkSession,
   encodeIntentGroup,
   encodeIntentScalars,
@@ -31,6 +31,7 @@ import {
   signPreparedVaultPsbt,
   SW_BAD_STATE,
   SW_CAP_EXCEEDED,
+  SW_CLA_NOT_SUPPORTED,
   type ApduSender,
   type DefaultTaprootWalletPolicy,
   type DepositTerms,
@@ -167,8 +168,6 @@ export class LedgerVaultProvider implements IBTCProvider {
   private rawSend: RawApduSender | undefined;
   /** Request-identity keys ({@link signingRequestKey}) signed under the CURRENT loaded intent. */
   private signedFingerprints = new Set<string>();
-  /** A host abandonment interrupted the dispatcher — the next sign resends once on 0x6A80. */
-  private loopAbandoned = false;
   /**
    * ONE in-flight device ceremony (derive/approve/sign) at a time — a
    * concurrent APDU would be eaten with 0x6A80 and desync the interrupt loop.
@@ -332,7 +331,6 @@ export class LedgerVaultProvider implements IBTCProvider {
     this.pubkeyHexPromise = undefined;
     this.policyContextPromise = undefined;
     this.signedFingerprints = new Set();
-    this.loopAbandoned = false;
     // Release the ceremony lock and stop an in-flight signing loop NOW — the
     // stale call's finally only releases its own token, and its rejection
     // commits nothing (the generation just changed).
@@ -383,11 +381,7 @@ export class LedgerVaultProvider implements IBTCProvider {
         // but only at SIGN_PSBT — by then approveDepositTerms has already spent
         // the intent ceremony. This guards a host-side desync (depositorPath vs
         // accountPath, coin type, a refactor of either getter), not a device fault.
-        const derivedXOnlyHex = deriveReceiveXOnlyHex(
-          accountXpub,
-          toNetwork(this.network).bip32,
-          ADDRESS_INDEX,
-        );
+        const derivedXOnlyHex = deriveReceiveXOnlyHex(accountXpub, toNetwork(this.network).bip32, ADDRESS_INDEX);
         if (derivedXOnlyHex !== depositorXOnlyHex) {
           throw new WalletError({
             code: ERROR_CODES.CONNECTION_FAILED,
@@ -472,7 +466,6 @@ export class LedgerVaultProvider implements IBTCProvider {
     // old intent's dedup state dies with it — clear the sign bookkeeping too.
     this.deviceState = { phase: "idle" };
     this.signedFingerprints = new Set();
-    this.loopAbandoned = false;
 
     const generation = this.connectionGeneration;
     const root = await deriveContextHash(this.requireSender(), {
@@ -599,7 +592,7 @@ export class LedgerVaultProvider implements IBTCProvider {
     if (this.deviceState.phase === "intent-loaded") {
       if (this.deviceState.termsKey === key) return;
       throw new WalletError({
-        code: ERROR_CODES.WALLET_NOT_CONNECTED,
+        code: ERROR_CODES.DEVICE_CEREMONY_INVALID,
         message:
           `${WALLET_PROVIDER_NAME} already holds a different approved intent ` +
           `on this connection — the device admits one ceremony per ` +
@@ -611,7 +604,7 @@ export class LedgerVaultProvider implements IBTCProvider {
     // the device) would die at the first APDU with SW_BAD_STATE.
     if (this.deviceState.phase === "idle") {
       throw new WalletError({
-        code: ERROR_CODES.WALLET_NOT_CONNECTED,
+        code: ERROR_CODES.DEVICE_CEREMONY_INVALID,
         message:
           `${WALLET_PROVIDER_NAME} has no freshly derived context root on ` +
           `this connection — the device requires DERIVE_CONTEXT_HASH before ` +
@@ -630,7 +623,6 @@ export class LedgerVaultProvider implements IBTCProvider {
     // fresh, so the same PSBT bytes are legitimately signable again. (The
     // byte-equal re-approval no-op above returns earlier and keeps both.)
     this.signedFingerprints = new Set();
-    this.loopAbandoned = false;
   };
 
   /**
@@ -701,12 +693,19 @@ export class LedgerVaultProvider implements IBTCProvider {
         }
         const signed: string[] = [];
         for (const one of staged) {
-          // A cancel landing BETWEEN elements must stop the batch — inside an
-          // element the loop's own signal checks cover it.
+          // Abort between elements: same generation = user's cancelSigning,
+          // changed = teardown/disconnect. In-element aborts settle in the loop.
           if (controller.signal.aborted) {
+            const cancelled = ctx.generation === this.connectionGeneration;
+            if (cancelled) {
+              this.deviceState = { phase: "idle" };
+              this.signedFingerprints = new Set();
+            }
             throw new WalletError({
-              code: ERROR_CODES.WALLET_NOT_CONNECTED,
-              message: `${WALLET_PROVIDER_NAME} stopped signing (disconnected) after ${signed.length} of ${psbtsHexes.length} PSBT(s).`,
+              code: cancelled ? ERROR_CODES.CONNECTION_REJECTED : ERROR_CODES.WALLET_NOT_CONNECTED,
+              message: cancelled
+                ? `Signing cancelled after ${signed.length} of ${psbtsHexes.length} PSBT(s) — the ceremony restarts from the device approval screens on retry.`
+                : `${WALLET_PROVIDER_NAME} stopped signing (disconnected) after ${signed.length} of ${psbtsHexes.length} PSBT(s).`,
               wallet: WALLET_PROVIDER_NAME,
             });
           }
@@ -716,6 +715,16 @@ export class LedgerVaultProvider implements IBTCProvider {
         return signed;
       }),
     );
+
+  /**
+   * User cancel of the in-flight ceremony: aborts WITHOUT teardown, settling
+   * as CONNECTION_REJECTED at the next exchange boundary — possibly only after
+   * the user acts on the device, so callers hold a "cancel requested" state
+   * until the sign promise settles. No-op when idle.
+   */
+  cancelSigning = (): void => {
+    this.signAbortController?.abort();
+  };
 
   /**
    * ONE AbortController per public sign call (plan D1) — it spans a whole
@@ -754,7 +763,7 @@ export class LedgerVaultProvider implements IBTCProvider {
     this.assertSameConnection(generation);
     if (requireIntent && this.deviceState.phase !== "intent-loaded") {
       throw new WalletError({
-        code: ERROR_CODES.WALLET_NOT_CONNECTED,
+        code: ERROR_CODES.DEVICE_CEREMONY_INVALID,
         message:
           `${WALLET_PROVIDER_NAME} holds no approved intent on this ` +
           `connection — signing requires DERIVE_CONTEXT_HASH and an approved ` +
@@ -877,25 +886,21 @@ export class LedgerVaultProvider implements IBTCProvider {
         signal: controller.signal,
         appIdentity:
           session.appName !== undefined ? { appName: session.appName, appVersion: session.appVersion } : undefined,
-        resendOnceOnIncorrectData: this.loopAbandoned,
       });
       this.assertSameConnection(generation);
       // Success never consumes the intent: further (different) PSBTs sign
       // under the same approval; this one never again.
       this.signedFingerprints.add(fingerprintKey);
-      this.loopAbandoned = false;
       return result.signedPsbtHex;
     } catch (error) {
       const walletError = this.classifySignFailure(error, generation, label);
-      // Mirror reset is signPsbt-only (a PoP failure never invalidates the
-      // device's vault context). Skip it for the two classifications that
-      // commit nothing: a stale rejection and an abandonment.
+      // Mirror reset is signPsbt-only (PoP failures don't invalidate the vault
+      // context); stale rejections and cancels were already handled in classify.
       if (generation === this.connectionGeneration && !isLedgerSignPsbtAbortedError(error)) {
         // Pessimistically assume the device dropped the intent (error-path
         // invalidation is mixed in firmware — never assume survival).
         this.deviceState = { phase: "idle" };
         this.signedFingerprints = new Set();
-        this.loopAbandoned = false;
       }
       throw walletError;
     }
@@ -904,8 +909,8 @@ export class LedgerVaultProvider implements IBTCProvider {
   /**
    * Classify one device-ceremony failure, for every SIGN_PSBT caller: a
    * disconnect must surface as WALLET_NOT_CONNECTED, never as a generic
-   * UNKNOWN_ERROR. Touches only {@link loopAbandoned} — the intent mirror is
-   * the caller's to reset, since PoP must never touch it.
+   * UNKNOWN_ERROR. Mirror resets are the caller's, except the user-cancel
+   * branch, which resets here so PoP cancels take the same re-ceremony path.
    */
   private classifySignFailure(error: unknown, generation: number, label: string): WalletError {
     // A stale rejection must not touch the new connection's state.
@@ -920,15 +925,14 @@ export class LedgerVaultProvider implements IBTCProvider {
       );
     }
     if (isLedgerSignPsbtAbortedError(error)) {
-      // The intent MAY survive an abandonment (hint only) — keep the mirror.
-      // Arm the one-shot 0x6A80 recovery only if a dispatcher is actually
-      // mid-interruption. NB: unreachable while teardown (the only abort
-      // source) bumps the generation first; goes live with #2110's cancel.
-      if (error.dispatcherInterrupted) this.loopAbandoned = true;
+      // Same-generation abort = user's cancelSigning; caps commit pre-yield, so
+      // idle + full re-ceremony (device aftermath: LedgerSignPsbtAbortedError doc).
+      this.deviceState = { phase: "idle" };
+      this.signedFingerprints = new Set();
       return new WalletError(
         {
-          code: ERROR_CODES.WALLET_NOT_CONNECTED,
-          message: `${label === "signPsbt" ? "" : `${label}: `}${WALLET_PROVIDER_NAME} stopped signing (disconnected); reconnect and retry.`,
+          code: ERROR_CODES.CONNECTION_REJECTED,
+          message: `${label === "signPsbt" ? "" : `${label}: `}Signing cancelled — the ceremony restarts from the device approval screens on retry.`,
           wallet: WALLET_PROVIDER_NAME,
         },
         { cause: error },
@@ -1003,7 +1007,6 @@ export class LedgerVaultProvider implements IBTCProvider {
               ctx.session.appName !== undefined
                 ? { appName: ctx.session.appName, appVersion: ctx.session.appVersion }
                 : undefined,
-            resendOnceOnIncorrectData: this.loopAbandoned,
           });
         } catch (error) {
           throw this.classifySignFailure(error, ctx.generation, "signMessage");
@@ -1024,8 +1027,6 @@ export class LedgerVaultProvider implements IBTCProvider {
             wallet: WALLET_PROVIDER_NAME,
           });
         }
-        // The loop ran to completion, so no dispatcher is mid-interruption.
-        this.loopAbandoned = false;
         return `0x${BIP322_P2TR_WITNESS_PREFIX_HEX}${Buffer.from(yielded.signature).toString("hex")}`;
       }),
     );
@@ -1065,17 +1066,18 @@ function toStagingWalletError(error: unknown, context: string): WalletError {
  */
 /**
  * Sign-seam failure mapping: the two "intent gone" status words and the
- * signer's own typed sign errors get the stable restart-from-derivation
- * suffix #2110's UX routes on; everything else reuses the shared mapper.
- * The ceremony sender keeps verbatim messages — derive/approve failures are
- * not phase-wise "restart from derivation" beyond what their own copy says.
+ * signer's own typed sign errors carry DEVICE_CEREMONY_INVALID — the typed
+ * signal #2110's UX routes restart-from-derivation on (the message suffix
+ * stays for humans, never for routing). Everything else reuses the shared
+ * mapper. The ceremony sender keeps verbatim messages — derive/approve
+ * failures are not phase-wise "restart from derivation" beyond their copy.
  */
 function toSignFailureWalletError(error: unknown, label: string): WalletError {
   const prefix = label === "signPsbt" ? "" : `${label}: `;
   if (isLedgerDeviceError(error) && (error.statusWord === SW_BAD_STATE || error.statusWord === SW_CAP_EXCEEDED)) {
     return new WalletError(
       {
-        code: ERROR_CODES.UNKNOWN_ERROR,
+        code: ERROR_CODES.DEVICE_CEREMONY_INVALID,
         message: `${prefix}The device no longer holds the approved intent (${error.message}) — restart the flow from derivation.`,
         wallet: WALLET_PROVIDER_NAME,
       },
@@ -1089,7 +1091,7 @@ function toSignFailureWalletError(error: unknown, label: string): WalletError {
   ) {
     return new WalletError(
       {
-        code: ERROR_CODES.UNKNOWN_ERROR,
+        code: ERROR_CODES.DEVICE_CEREMONY_INVALID,
         message: `${prefix}${error.message} — restart the flow from derivation.`,
         wallet: WALLET_PROVIDER_NAME,
       },
@@ -1124,7 +1126,13 @@ function toSignerWalletError(error: unknown): WalletError | undefined {
   }
   if (isLedgerDeviceLockedError(error)) {
     return new WalletError(
-      { code: ERROR_CODES.CONNECTION_FAILED, message: error.message, wallet: WALLET_PROVIDER_NAME },
+      { code: ERROR_CODES.DEVICE_LOCKED, message: error.message, wallet: WALLET_PROVIDER_NAME },
+      { cause: error },
+    );
+  }
+  if (isLedgerDeviceError(error) && error.statusWord === SW_CLA_NOT_SUPPORTED) {
+    return new WalletError(
+      { code: ERROR_CODES.DEVICE_WRONG_APP, message: error.message, wallet: WALLET_PROVIDER_NAME },
       { cause: error },
     );
   }

--- a/packages/babylon-wallet-connector/src/error/codes.ts
+++ b/packages/babylon-wallet-connector/src/error/codes.ts
@@ -39,6 +39,9 @@ export const ERROR_CODES = {
   // ===== QR/Hardware Wallet =====
   QR_READ_ERROR: "QR_READ_ERROR", // QR read failed
   QR_SCAN_ERROR: "QR_SCAN_ERROR", // QR scan failed
+  DEVICE_CEREMONY_INVALID: "DEVICE_CEREMONY_INVALID", // Device ceremony state unusable — restart from derivation
+  DEVICE_LOCKED: "DEVICE_LOCKED", // Hardware device is PIN-locked
+  DEVICE_WRONG_APP: "DEVICE_WRONG_APP", // Wrong app open on the hardware device
 
   // ===== Inscriptions/Network =====
   INSCRIPTIONS_UNSUPPORTED_NETWORK: "INSCRIPTIONS_UNSUPPORTED_NETWORK", // Inscriptions unsupported

--- a/services/vault/src/components/deposit/PayoutSignModal/__tests__/usePayoutSigningState.test.tsx
+++ b/services/vault/src/components/deposit/PayoutSignModal/__tests__/usePayoutSigningState.test.tsx
@@ -789,7 +789,44 @@ describe("usePayoutSigningState", () => {
       expect(result.current.canCancel).toBe(false);
     });
 
-    it("handleCancel calls the provider's cancelSigning, aborts the in-flight signal, and sets cancelRequested", async () => {
+    it("cancels the provider that started the sign, not a wallet swapped in mid-prompt", async () => {
+      const { cancelSigning } = connectCancellableWallet();
+      const pending = armPendingSdkCall();
+      const { result, rerender } = renderHookWithProps();
+
+      let signPromise!: Promise<void>;
+      act(() => {
+        signPromise = result.current.handleSign();
+      });
+      await waitFor(() => expect(result.current.canCancel).toBe(true));
+
+      // Swap the connected wallet while the device prompt is still open.
+      const replacementCancelSigning = vi.fn();
+      mockBtcConnector!.connectedWallet!.provider = {
+        signPsbt: vi.fn(),
+        cancelSigning: replacementCancelSigning,
+      };
+      rerender();
+
+      // The affordance tracks the running ceremony, not the live connector.
+      expect(result.current.canCancel).toBe(true);
+
+      act(() => {
+        result.current.handleCancel();
+      });
+
+      expect(cancelSigning).toHaveBeenCalledTimes(1);
+      expect(replacementCancelSigning).not.toHaveBeenCalled();
+
+      await act(async () => {
+        pending.reject(signingCancelledError());
+        await signPromise;
+      });
+    });
+
+    // Shared setup for the cancel-request tests below: start a sign on a
+    // cancellable wallet, request the cancel, hand back a settle helper.
+    async function startSignAndRequestCancel() {
       const { cancelSigning } = connectCancellableWallet();
       const pending = armPendingSdkCall();
       const { result } = renderHookWithProps();
@@ -804,16 +841,49 @@ describe("usePayoutSigningState", () => {
         result.current.handleCancel();
       });
 
+      const settleAsCancelRejection = async () => {
+        await act(async () => {
+          pending.reject(signingCancelledError());
+          await signPromise;
+        });
+      };
+      return { result, cancelSigning, pending, settleAsCancelRejection };
+    }
+
+    it("handleCancel invokes the provider's cancelSigning once", async () => {
+      const { cancelSigning, settleAsCancelRejection } =
+        await startSignAndRequestCancel();
+
       expect(cancelSigning).toHaveBeenCalledTimes(1);
+
+      await settleAsCancelRejection();
+    });
+
+    it("handleCancel aborts the in-flight signal so VP polling stops now", async () => {
+      const { pending, settleAsCancelRejection } =
+        await startSignAndRequestCancel();
+
       expect(pending.signal?.aborted).toBe(true);
+
+      await settleAsCancelRejection();
+    });
+
+    it("handleCancel sets cancelRequested", async () => {
+      const { result, settleAsCancelRejection } =
+        await startSignAndRequestCancel();
+
       expect(result.current.cancelRequested).toBe(true);
-      // The cancel is a request: the sign has not settled yet.
+
+      await settleAsCancelRejection();
+    });
+
+    it("keeps the sign pending after handleCancel — a cancel is a request, not a settle", async () => {
+      const { result, settleAsCancelRejection } =
+        await startSignAndRequestCancel();
+
       expect(result.current.signing).toBe(true);
 
-      await act(async () => {
-        pending.reject(signingCancelledError());
-        await signPromise;
-      });
+      await settleAsCancelRejection();
     });
 
     it("resets to idle with no error when a requested cancel settles as the provider's signing-cancelled rejection", async () => {

--- a/services/vault/src/components/deposit/PayoutSignModal/__tests__/usePayoutSigningState.test.tsx
+++ b/services/vault/src/components/deposit/PayoutSignModal/__tests__/usePayoutSigningState.test.tsx
@@ -705,6 +705,220 @@ describe("usePayoutSigningState", () => {
     });
   });
 
+  describe("device-sign cancellation", () => {
+    // Ledger-shaped provider: the only BTC provider exposing cancelSigning.
+    // No approveDepositTerms on purpose — the cancel seam is orthogonal to
+    // the approval rebuild, so these tests stay on the software-wallet path.
+    function connectCancellableWallet() {
+      const cancelSigning = vi.fn();
+      mockBtcConnector = {
+        connectedWallet: {
+          account: { address: "tb1test" },
+          provider: { signPsbt: vi.fn(), cancelSigning },
+        },
+      };
+      return { cancelSigning };
+    }
+
+    // Holds the SDK call open so cancel/settle ordering is test-controlled.
+    function armPendingSdkCall() {
+      const pending: {
+        resolve: () => void;
+        reject: (err: unknown) => void;
+        signal: AbortSignal | undefined;
+      } = { resolve: () => {}, reject: () => {}, signal: undefined };
+      mockSignAndSubmitPayouts.mockImplementation(
+        ({ signal }: { signal: AbortSignal }) => {
+          pending.signal = signal;
+          return new Promise<void>((resolve, reject) => {
+            pending.resolve = resolve;
+            pending.reject = reject;
+          });
+        },
+      );
+      return pending;
+    }
+
+    // What the Ledger provider rejects with when a requested cancel settles
+    // at the next device exchange boundary (WalletError, typed code).
+    function signingCancelledError() {
+      return Object.assign(
+        new Error(
+          "Signing cancelled after 0 of 3 PSBT(s) — the ceremony restarts from the device approval screens on retry.",
+        ),
+        { code: "CONNECTION_REJECTED" },
+      );
+    }
+
+    it("reports canCancel false while signing when the provider lacks cancelSigning", async () => {
+      // setupHappyPath connects the plain signPsbt-only software wallet.
+      const pending = armPendingSdkCall();
+      const { result } = renderHookWithProps();
+
+      let signPromise!: Promise<void>;
+      act(() => {
+        signPromise = result.current.handleSign();
+      });
+      await waitFor(() => expect(result.current.signing).toBe(true));
+
+      expect(result.current.canCancel).toBe(false);
+
+      await act(async () => {
+        pending.resolve();
+        await signPromise;
+      });
+    });
+
+    it("reports canCancel true only while a sign is in flight on a provider with cancelSigning", async () => {
+      connectCancellableWallet();
+      const pending = armPendingSdkCall();
+      const { result } = renderHookWithProps();
+
+      expect(result.current.canCancel).toBe(false);
+
+      let signPromise!: Promise<void>;
+      act(() => {
+        signPromise = result.current.handleSign();
+      });
+      await waitFor(() => expect(result.current.canCancel).toBe(true));
+
+      await act(async () => {
+        pending.resolve();
+        await signPromise;
+      });
+      expect(result.current.canCancel).toBe(false);
+    });
+
+    it("handleCancel calls the provider's cancelSigning, aborts the in-flight signal, and sets cancelRequested", async () => {
+      const { cancelSigning } = connectCancellableWallet();
+      const pending = armPendingSdkCall();
+      const { result } = renderHookWithProps();
+
+      let signPromise!: Promise<void>;
+      act(() => {
+        signPromise = result.current.handleSign();
+      });
+      await waitFor(() => expect(result.current.canCancel).toBe(true));
+
+      act(() => {
+        result.current.handleCancel();
+      });
+
+      expect(cancelSigning).toHaveBeenCalledTimes(1);
+      expect(pending.signal?.aborted).toBe(true);
+      expect(result.current.cancelRequested).toBe(true);
+      // The cancel is a request: the sign has not settled yet.
+      expect(result.current.signing).toBe(true);
+
+      await act(async () => {
+        pending.reject(signingCancelledError());
+        await signPromise;
+      });
+    });
+
+    it("resets to idle with no error when a requested cancel settles as the provider's signing-cancelled rejection", async () => {
+      connectCancellableWallet();
+      const pending = armPendingSdkCall();
+      const { result } = renderHookWithProps();
+
+      let signPromise!: Promise<void>;
+      act(() => {
+        signPromise = result.current.handleSign();
+      });
+      await waitFor(() => expect(result.current.canCancel).toBe(true));
+
+      act(() => {
+        result.current.handleCancel();
+      });
+      await act(async () => {
+        pending.reject(signingCancelledError());
+        await signPromise;
+      });
+
+      // A self-requested cancel is not an error — back to the pre-sign state.
+      expect(result.current.error).toBeNull();
+      expect(result.current.signing).toBe(false);
+      expect(result.current.cancelRequested).toBe(false);
+      expect(result.current.isComplete).toBe(false);
+      expect(onSuccess).not.toHaveBeenCalled();
+      expect(mockLoggerError).not.toHaveBeenCalled();
+    });
+
+    it("still surfaces a device rejection as an error when no cancel was requested", async () => {
+      connectCancellableWallet();
+      const pending = armPendingSdkCall();
+      const { result } = renderHookWithProps();
+
+      let signPromise!: Promise<void>;
+      act(() => {
+        signPromise = result.current.handleSign();
+      });
+      await waitFor(() => expect(result.current.signing).toBe(true));
+
+      await act(async () => {
+        pending.reject(signingCancelledError());
+        await signPromise;
+      });
+
+      // The user rejected on the device without asking us to cancel — they
+      // are still here, so show them why nothing was signed.
+      expect(result.current.error?.title).toBe("Sign Error");
+      expect(result.current.signing).toBe(false);
+    });
+
+    it("surfaces an unrelated failure after a requested cancel and clears cancelRequested", async () => {
+      connectCancellableWallet();
+      const pending = armPendingSdkCall();
+      const { result } = renderHookWithProps();
+
+      let signPromise!: Promise<void>;
+      act(() => {
+        signPromise = result.current.handleSign();
+      });
+      await waitFor(() => expect(result.current.canCancel).toBe(true));
+
+      act(() => {
+        result.current.handleCancel();
+      });
+      await act(async () => {
+        pending.reject(new Error("VP unreachable"));
+        await signPromise;
+      });
+
+      expect(result.current.error).toEqual({
+        title: "Sign Error",
+        message: "VP unreachable",
+      });
+      expect(result.current.cancelRequested).toBe(false);
+      expect(result.current.signing).toBe(false);
+    });
+
+    it("clears cancelRequested when the sign settles successfully after a late cancel", async () => {
+      connectCancellableWallet();
+      const pending = armPendingSdkCall();
+      const { result } = renderHookWithProps();
+
+      let signPromise!: Promise<void>;
+      act(() => {
+        signPromise = result.current.handleSign();
+      });
+      await waitFor(() => expect(result.current.canCancel).toBe(true));
+
+      act(() => {
+        result.current.handleCancel();
+      });
+      await act(async () => {
+        pending.resolve();
+        await signPromise;
+      });
+
+      // The cancel came too late — the sign completed. The request must be
+      // consumed so the modal cannot wedge on the disabled cancel button.
+      expect(result.current.cancelRequested).toBe(false);
+      expect(result.current.isComplete).toBe(true);
+    });
+  });
+
   describe("deposit-terms approval capability forwarding through wallet wrappers", () => {
     // A real depositor-approval wallet (e.g. Ledger) implements
     // approveDepositTerms as a class-prototype method, not an own/instance

--- a/services/vault/src/components/deposit/PayoutSignModal/usePayoutSigningState.ts
+++ b/services/vault/src/components/deposit/PayoutSignModal/usePayoutSigningState.ts
@@ -81,8 +81,8 @@ export interface UsePayoutSigningStateResult {
   handleSign: () => Promise<void>;
   /**
    * True while the in-flight sign can be cancelled: signing is active AND the
-   * connected BTC provider exposes `cancelSigning` (only the Ledger provider
-   * does — always capability-probed, never assumed).
+   * provider that started the sign exposes `cancelSigning` (only the Ledger
+   * provider does — always capability-probed, never assumed).
    */
   canCancel: boolean;
   /** True from {@link handleCancel} until the in-flight sign settles. */
@@ -152,6 +152,10 @@ export function usePayoutSigningState({
   // `signing === false`. Flip the ref before the first await, clear it in
   // `finally`, and always check this before the state.
   const inFlightRef = useRef(false);
+
+  // Provider that STARTED the in-flight sign. Cancellation binds to it so a
+  // wallet swapped in mid-prompt cannot orphan the original ceremony.
+  const signingProviderRef = useRef<unknown>(null);
 
   const claimersDoneRef = useRef(false);
 
@@ -272,6 +276,7 @@ export function usePayoutSigningState({
         return;
       }
 
+      signingProviderRef.current = btcWalletProvider;
       setSigning(true);
       setError(null);
       // Start on the auth-anchor step — the first thing the flow does is
@@ -433,6 +438,7 @@ export function usePayoutSigningState({
       }
     } finally {
       inFlightRef.current = false;
+      signingProviderRef.current = null;
       // Every settle path (success, any error, guard return) consumes a
       // pending cancel request so the modal can't wedge on a disabled button.
       cancelRequestedRef.current = false;
@@ -455,18 +461,23 @@ export function usePayoutSigningState({
     onSuccess,
   ]);
 
-  // Capability probe on every render: only the Ledger vault provider exposes
-  // cancelSigning, and the affordance is only honest while a sign is running.
-  const connectedProvider = btcConnector?.connectedWallet?.provider as
-    | { cancelSigning?: unknown }
-    | undefined;
+  // Capability probe: only the Ledger vault provider exposes cancelSigning.
+  // Reads the provider that started the sign, not the live connector — a
+  // wallet swapped in mid-prompt must not retarget the affordance. The ref is
+  // only ever set/cleared together with the `signing` state, so this render
+  // read stays in sync.
+  const signingProvider = signingProviderRef.current as {
+    cancelSigning?: unknown;
+  } | null;
   const canCancel =
-    signing && typeof connectedProvider?.cancelSigning === "function";
+    signing && typeof signingProvider?.cancelSigning === "function";
 
   const handleCancel = useCallback(() => {
-    const provider = btcConnector?.connectedWallet?.provider as
-      | { cancelSigning?: () => void }
-      | undefined;
+    // Cancel the ceremony on the provider that started it — never the
+    // connector's current provider.
+    const provider = signingProviderRef.current as {
+      cancelSigning?: () => void;
+    } | null;
     if (!inFlightRef.current || cancelRequestedRef.current) return;
     if (typeof provider?.cancelSigning !== "function") return;
     cancelRequestedRef.current = true;
@@ -476,7 +487,7 @@ export function usePayoutSigningState({
     // acts on the device. Abort our own signal too so VP polling stops now.
     provider.cancelSigning();
     abortRef.current?.abort();
-  }, [btcConnector?.connectedWallet?.provider]);
+  }, []);
 
   return {
     signing,

--- a/services/vault/src/components/deposit/PayoutSignModal/usePayoutSigningState.ts
+++ b/services/vault/src/components/deposit/PayoutSignModal/usePayoutSigningState.ts
@@ -46,6 +46,7 @@ import {
   verifyBtcWalletLiveness,
 } from "../../../utils/btc";
 import { formatPayoutSignatureError } from "../../../utils/errors/formatting";
+import { isUserCancellation } from "../../../utils/errors/userCancellation";
 import { isVaultLifecycleStateError } from "../../../utils/errors/vaultLifecycleStateError";
 
 export interface SigningError {
@@ -78,6 +79,20 @@ export interface UsePayoutSigningStateResult {
   isComplete: boolean;
   /** Handler to initiate signing */
   handleSign: () => Promise<void>;
+  /**
+   * True while the in-flight sign can be cancelled: signing is active AND the
+   * connected BTC provider exposes `cancelSigning` (only the Ledger provider
+   * does — always capability-probed, never assumed).
+   */
+  canCancel: boolean;
+  /** True from {@link handleCancel} until the in-flight sign settles. */
+  cancelRequested: boolean;
+  /**
+   * Requests cancellation of the in-flight sign. This does NOT settle it:
+   * the provider aborts at its next device exchange boundary, which may be
+   * only after the user finishes or rejects on the physical device.
+   */
+  handleCancel: () => void;
 }
 
 function normalizeScriptPubKeyHex(scriptPubKey: string): string {
@@ -99,6 +114,10 @@ export function usePayoutSigningState({
   });
   const [error, setError] = useState<SigningError | null>(null);
   const [errorTerminal, setErrorTerminal] = useState(false);
+  const [cancelRequested, setCancelRequested] = useState(false);
+  // Ref mirror so the settle paths inside handleSign read the live value —
+  // the state itself is stale inside the long-lived async closure.
+  const cancelRequestedRef = useRef(false);
 
   const { findProvider } = useVaultProviders(activity.applicationEntryPoint);
   const btcConnector = useChainConnector("BTC");
@@ -374,7 +393,16 @@ export function usePayoutSigningState({
         setIsComplete(true);
         onSuccess();
       } catch (err) {
+        // Read before the finally consumes it: was this settle preceded by
+        // the user's own cancel request?
+        const selfCancelRequested = cancelRequestedRef.current;
         if (err instanceof Error && err.name === "AbortError") {
+          setSigning(false);
+          return;
+        }
+        // A self-requested cancel settling as the wallet's user-cancel
+        // rejection is not an error — return to the pre-sign idle state.
+        if (selfCancelRequested && isUserCancellation(err)) {
           setSigning(false);
           return;
         }
@@ -405,6 +433,10 @@ export function usePayoutSigningState({
       }
     } finally {
       inFlightRef.current = false;
+      // Every settle path (success, any error, guard return) consumes a
+      // pending cancel request so the modal can't wedge on a disabled button.
+      cancelRequestedRef.current = false;
+      setCancelRequested(false);
     }
   }, [
     signing,
@@ -423,5 +455,38 @@ export function usePayoutSigningState({
     onSuccess,
   ]);
 
-  return { signing, progress, error, errorTerminal, isComplete, handleSign };
+  // Capability probe on every render: only the Ledger vault provider exposes
+  // cancelSigning, and the affordance is only honest while a sign is running.
+  const connectedProvider = btcConnector?.connectedWallet?.provider as
+    | { cancelSigning?: unknown }
+    | undefined;
+  const canCancel =
+    signing && typeof connectedProvider?.cancelSigning === "function";
+
+  const handleCancel = useCallback(() => {
+    const provider = btcConnector?.connectedWallet?.provider as
+      | { cancelSigning?: () => void }
+      | undefined;
+    if (!inFlightRef.current || cancelRequestedRef.current) return;
+    if (typeof provider?.cancelSigning !== "function") return;
+    cancelRequestedRef.current = true;
+    setCancelRequested(true);
+    // A REQUEST, not a settle: the provider aborts at its next device
+    // exchange boundary, so the sign promise stays pending until the user
+    // acts on the device. Abort our own signal too so VP polling stops now.
+    provider.cancelSigning();
+    abortRef.current?.abort();
+  }, [btcConnector?.connectedWallet?.provider]);
+
+  return {
+    signing,
+    progress,
+    error,
+    errorTerminal,
+    isComplete,
+    handleSign,
+    canCancel,
+    cancelRequested,
+    handleCancel,
+  };
 }

--- a/services/vault/src/components/simple/DepositProgressView/DepositProgressView.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/DepositProgressView.tsx
@@ -147,6 +147,20 @@ export interface DepositProgressViewProps {
    * gates on. Omit pre-sign (no registered version yet) → latest params.
    */
   offchainParamsVersion?: number;
+  /**
+   * True while an in-flight device signing ceremony can be cancelled
+   * (capability-probed by the caller; only the Ledger provider supports it).
+   * Defaults false so every other flow renders exactly as before.
+   */
+  canCancelSigning?: boolean;
+  /**
+   * True after the user requested a cancel and the sign has not settled yet —
+   * the device settles the in-flight signature only once the user acts on it,
+   * so the UI parks on a disabled button plus a finish-on-device notice.
+   */
+  cancelSigningRequested?: boolean;
+  /** Requests cancellation of the in-flight device signing ceremony. */
+  onCancelSigning?: () => void;
 }
 
 /**
@@ -248,6 +262,9 @@ export function DepositProgressView(props: DepositProgressViewProps) {
     offchainParamsVersion,
     started = true,
     onSign,
+    canCancelSigning = false,
+    cancelSigningRequested = false,
+    onCancelSigning,
   } = props;
 
   // Every flow that renders this view requires the BTC wallet, so surface a
@@ -305,6 +322,18 @@ export function DepositProgressView(props: DepositProgressViewProps) {
   // the primary CTA becomes an unlock action (matching the navbar and deposit
   // form) instead of starting a flow that would only stall at the signing call.
   const showUnlockCta = !started && walletLocked;
+
+  // Cancel affordance only while a device sign is actually in flight; when
+  // false (every non-Ledger flow) the button behaves exactly as before.
+  const showCancelSigning =
+    started &&
+    !showUnlockCta &&
+    isProcessing &&
+    canCancelSigning &&
+    !error &&
+    !isComplete &&
+    !isTerminalSuccess &&
+    onCancelSigning !== undefined;
 
   // On completion, advance past the last row so every circle renders as ✓.
   // The pre-entry state (`!started`) keeps the REAL step: work already done
@@ -438,13 +467,21 @@ export function DepositProgressView(props: DepositProgressViewProps) {
             <Callout variant="success">{terminalMessage}</Callout>
           )}
 
+          {showCancelSigning && cancelSigningRequested && (
+            <Callout variant="info">
+              {COPY.deposit.progress.cancelRequestedNotice}
+            </Callout>
+          )}
+
           <Button
             disabled={
               showUnlockCta
                 ? isUnlocking
-                : started
-                  ? !canClose && !isTerminalSuccess
-                  : false
+                : showCancelSigning
+                  ? cancelSigningRequested
+                  : started
+                    ? !canClose && !isTerminalSuccess
+                    : false
             }
             variant="contained"
             color="secondary"
@@ -452,11 +489,13 @@ export function DepositProgressView(props: DepositProgressViewProps) {
             onClick={
               showUnlockCta
                 ? unlock
-                : !started
-                  ? onSign
-                  : error && onRetry
-                    ? onRetry
-                    : onClose
+                : showCancelSigning
+                  ? onCancelSigning
+                  : !started
+                    ? onSign
+                    : error && onRetry
+                      ? onRetry
+                      : onClose
             }
           >
             {showUnlockCta ? (
@@ -467,6 +506,8 @@ export function DepositProgressView(props: DepositProgressViewProps) {
               )
             ) : !started ? (
               COPY.deposit.progress.buttons.signTransaction
+            ) : showCancelSigning ? (
+              COPY.deposit.progress.buttons.cancelSigning
             ) : canContinueInBackground ? (
               COPY.deposit.progress.buttons.closeContinueLater
             ) : error ? (

--- a/services/vault/src/components/simple/DepositProgressView/__tests__/DepositProgressView.test.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/__tests__/DepositProgressView.test.tsx
@@ -1028,6 +1028,99 @@ describe("DepositProgressView", () => {
       ).not.toBeInTheDocument();
     });
   });
+  describe("device signing cancellation", () => {
+    it("keeps the processing button disabled with the signing label when cancellation is unavailable", () => {
+      // Pin: without canCancelSigning the processing state renders exactly as
+      // it always has — no cancel affordance, button disabled.
+      render(
+        <DepositProgressView
+          {...baseProps}
+          currentStep={DepositFlowStep.SIGN_DEPOSITOR_GRAPH}
+          isProcessing
+          canClose={false}
+        />,
+      );
+
+      expect(
+        screen.getByRole("button", {
+          name: COPY.deposit.progress.buttons.sign,
+        }),
+      ).toBeDisabled();
+      expect(
+        screen.queryByText(COPY.deposit.progress.buttons.cancelSigning),
+      ).not.toBeInTheDocument();
+    });
+
+    it("enables a Cancel signing button while processing when cancellation is available", () => {
+      const onCancelSigning = vi.fn();
+      render(
+        <DepositProgressView
+          {...baseProps}
+          currentStep={DepositFlowStep.SIGN_DEPOSITOR_GRAPH}
+          isProcessing
+          canClose={false}
+          canCancelSigning
+          onCancelSigning={onCancelSigning}
+        />,
+      );
+
+      const button = screen.getByRole("button", {
+        name: COPY.deposit.progress.buttons.cancelSigning,
+      });
+      expect(button).toBeEnabled();
+      // No notice until the user actually requests the cancel.
+      expect(
+        screen.queryByText(COPY.deposit.progress.cancelRequestedNotice),
+      ).not.toBeInTheDocument();
+
+      fireEvent.click(button);
+      expect(onCancelSigning).toHaveBeenCalledTimes(1);
+    });
+
+    it("disables the button and shows the finish-on-device notice once cancellation is requested", () => {
+      render(
+        <DepositProgressView
+          {...baseProps}
+          currentStep={DepositFlowStep.SIGN_DEPOSITOR_GRAPH}
+          isProcessing
+          canClose={false}
+          canCancelSigning
+          cancelSigningRequested
+          onCancelSigning={vi.fn()}
+        />,
+      );
+
+      expect(
+        screen.getByRole("button", {
+          name: COPY.deposit.progress.buttons.cancelSigning,
+        }),
+      ).toBeDisabled();
+      expect(
+        screen.getByText(COPY.deposit.progress.cancelRequestedNotice),
+      ).toBeInTheDocument();
+    });
+
+    it("offers no cancel affordance outside the processing state", () => {
+      render(
+        <DepositProgressView
+          {...baseProps}
+          currentStep={DepositFlowStep.SIGN_DEPOSITOR_GRAPH}
+          canCancelSigning
+          onCancelSigning={vi.fn()}
+        />,
+      );
+
+      expect(
+        screen.getByRole("button", {
+          name: COPY.deposit.progress.buttons.sign,
+        }),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByText(COPY.deposit.progress.buttons.cancelSigning),
+      ).not.toBeInTheDocument();
+    });
+  });
+
   describe("Ethereum confirmation panel", () => {
     it("renders the live counter under the ETH registration step while the gate holds", () => {
       render(

--- a/services/vault/src/components/simple/DepositSignContent.tsx
+++ b/services/vault/src/components/simple/DepositSignContent.tsx
@@ -60,6 +60,9 @@ export function DepositSignContent({
     perVaultSteps,
     btcConfirmationDetail,
     ethConfirmationDetail,
+    canCancelDeviceSign,
+    deviceCancelRequested,
+    cancelDeviceSign,
   } = useDepositFlow({
     vaultAmounts,
     ...flowParams,
@@ -210,6 +213,9 @@ export function DepositSignContent({
         onSign={handleSign}
         btcConfirmationDetail={btcConfirmationDetail}
         ethConfirmationDetail={ethConfirmationDetail}
+        canCancelSigning={canCancelDeviceSign}
+        cancelSigningRequested={deviceCancelRequested}
+        onCancelSigning={cancelDeviceSign}
       />
     </>
   );

--- a/services/vault/src/components/simple/ResumeDepositContent.tsx
+++ b/services/vault/src/components/simple/ResumeDepositContent.tsx
@@ -105,15 +105,47 @@ export function ResumeSignContent({
   onClose,
   onSuccess,
 }: ResumeSignContentProps) {
-  const { signing, progress, error, errorTerminal, isComplete, handleSign } =
-    usePayoutSigningState({
-      activity,
-      btcPublicKey,
-      depositorEthAddress,
-      onSuccess,
-    });
+  const {
+    signing,
+    progress,
+    error,
+    errorTerminal,
+    isComplete,
+    handleSign,
+    canCancel,
+    cancelRequested,
+    handleCancel,
+  } = usePayoutSigningState({
+    activity,
+    btcPublicKey,
+    depositorEthAddress,
+    onSuccess,
+  });
 
   useRunOnce(handleSign);
+
+  // A self-requested cancel settles QUIETLY in the hook (idle, no error, not
+  // complete). Left alone, that state renders a disabled Sign button with no
+  // retry seam, so route it into the view's pre-sign entry state instead —
+  // its CTA re-runs the full ceremony, matching the WOTS re-offer pattern.
+  const [reofferAfterCancel, setReofferAfterCancel] = useState(false);
+  const sawCancelRequestRef = useRef(false);
+  useEffect(() => {
+    if (cancelRequested) {
+      sawCancelRequestRef.current = true;
+      return;
+    }
+    if (!sawCancelRequestRef.current || signing) return;
+    // The requested cancel has settled (the hook consumes the request on
+    // every settle path); only the quiet outcome becomes a re-offer.
+    sawCancelRequestRef.current = false;
+    if (!error && !isComplete) setReofferAfterCancel(true);
+  }, [cancelRequested, signing, error, isComplete]);
+
+  const handleResign = useCallback(() => {
+    setReofferAfterCancel(false);
+    void handleSign();
+  }, [handleSign]);
 
   // Once signing is done the deposit waits on the vault provider. Track the
   // live contract status so the "Awaiting vault provider verification" wait has
@@ -187,6 +219,11 @@ export function ResumeSignContent({
       // rejected the terms) re-runs the whole chain-read chain and fails
       // identically — no Retry CTA, same seam as the activation branch.
       onRetry={error && !errorTerminal ? handleSign : undefined}
+      started={!reofferAfterCancel}
+      onSign={handleResign}
+      canCancelSigning={canCancel}
+      cancelSigningRequested={cancelRequested}
+      onCancelSigning={handleCancel}
     />
   );
 }

--- a/services/vault/src/components/simple/__tests__/DepositSignContent.test.tsx
+++ b/services/vault/src/components/simple/__tests__/DepositSignContent.test.tsx
@@ -9,6 +9,12 @@ import type { DepositProgressViewProps } from "../DepositProgressView";
 import { DepositSignContent } from "../DepositSignContent";
 
 const mockExecuteDeposit = vi.hoisted(() => vi.fn());
+const mockCancelDeviceSign = vi.hoisted(() => vi.fn());
+// Mutable so tests can drive the flow's cancel seam through the static mock.
+const deviceCancelState = vi.hoisted(() => ({
+  canCancel: false,
+  requested: false,
+}));
 // Captures the latest `onSign` handed to DepositProgressView so a test can
 // invoke it twice synchronously — the real double-click race that happens
 // before the `started` re-render flips the button out of the pre-sign state.
@@ -29,6 +35,9 @@ vi.mock("@/hooks/deposit/useDepositFlow", () => ({
     payoutSigningProgress: null,
     peginSigningProgress: null,
     btcConfirmationDetail: null,
+    canCancelDeviceSign: deviceCancelState.canCancel,
+    deviceCancelRequested: deviceCancelState.requested,
+    cancelDeviceSign: mockCancelDeviceSign,
   }),
 }));
 
@@ -92,6 +101,22 @@ describe("DepositSignContent", () => {
     vi.clearAllMocks();
     signHolder.onSign = null;
     lastProgressProps.current = {};
+    deviceCancelState.canCancel = false;
+    deviceCancelState.requested = false;
+  });
+
+  it("plumbs the flow's device-cancel seam into DepositProgressView", () => {
+    mockExecuteDeposit.mockResolvedValue(null);
+    deviceCancelState.canCancel = true;
+    deviceCancelState.requested = true;
+
+    renderContent();
+
+    expect(lastProgressProps.current.canCancelSigning).toBe(true);
+    expect(lastProgressProps.current.cancelSigningRequested).toBe(true);
+    expect(lastProgressProps.current.onCancelSigning).toBe(
+      mockCancelDeviceSign,
+    );
   });
 
   it("renders DepositProgressView in the pre-sign state and only starts the flow on Sign Transaction", () => {

--- a/services/vault/src/components/simple/__tests__/ResumeDepositContent.test.tsx
+++ b/services/vault/src/components/simple/__tests__/ResumeDepositContent.test.tsx
@@ -137,6 +137,9 @@ vi.mock("@/components/deposit/PayoutSignModal/usePayoutSigningState", () => ({
     errorTerminal: false,
     isComplete: false,
     handleSign: vi.fn(),
+    canCancel: false,
+    cancelRequested: false,
+    handleCancel: vi.fn(),
   })),
 }));
 
@@ -216,6 +219,9 @@ vi.mock("../DepositProgressView", () => ({
     wotsApprovalHint,
     started,
     onSign,
+    canCancelSigning,
+    cancelSigningRequested,
+    onCancelSigning,
   }: {
     currentStep?: string;
     error?: { title: string; body: string } | null;
@@ -227,6 +233,9 @@ vi.mock("../DepositProgressView", () => ({
     wotsApprovalHint?: string | null;
     started?: boolean;
     onSign?: () => void;
+    canCancelSigning?: boolean;
+    cancelSigningRequested?: boolean;
+    onCancelSigning?: () => void;
   }) => (
     <div data-testid="progress-view">
       {/* Mirrors the real prop default so views that never pass it read as
@@ -244,6 +253,17 @@ vi.mock("../DepositProgressView", () => ({
       <span data-testid="processing">{String(!!isProcessing)}</span>
       <span data-testid="terminal">{terminalMessage ?? ""}</span>
       <span data-testid="background">{String(!!canContinueInBackground)}</span>
+      <span data-testid="can-cancel">{String(!!canCancelSigning)}</span>
+      <span data-testid="cancel-requested">
+        {String(!!cancelSigningRequested)}
+      </span>
+      <button
+        type="button"
+        data-testid="cancel-signing"
+        onClick={onCancelSigning}
+      >
+        cancel
+      </button>
     </div>
   ),
 }));
@@ -678,6 +698,9 @@ describe("ResumeSignContent — reactive verification terminal", () => {
       errorTerminal: false,
       isComplete: true,
       handleSign: vi.fn(),
+      canCancel: false,
+      cancelRequested: false,
+      handleCancel: vi.fn(),
     });
   });
 
@@ -739,6 +762,9 @@ describe("ResumeSignContent — reactive verification terminal", () => {
       errorTerminal: true,
       isComplete: false,
       handleSign: vi.fn(),
+      canCancel: false,
+      cancelRequested: false,
+      handleCancel: vi.fn(),
     });
 
     const { getByTestId } = renderSign();
@@ -757,11 +783,81 @@ describe("ResumeSignContent — reactive verification terminal", () => {
       errorTerminal: false,
       isComplete: false,
       handleSign: vi.fn(),
+      canCancel: false,
+      cancelRequested: false,
+      handleCancel: vi.fn(),
     });
 
     const { getByTestId } = renderSign();
 
     expect(getByTestId("has-retry").textContent).toBe("true");
+  });
+
+  it("plumbs the hook's device-cancel seam into DepositProgressView", () => {
+    const handleCancel = vi.fn();
+    vi.mocked(usePayoutSigningState).mockReturnValue({
+      signing: true,
+      progress: { phase: "claimers", completed: 0, total: 3 },
+      error: null,
+      errorTerminal: false,
+      isComplete: false,
+      handleSign: vi.fn(),
+      canCancel: true,
+      cancelRequested: true,
+      handleCancel,
+    });
+
+    const { getByTestId } = renderSign();
+
+    expect(getByTestId("can-cancel").textContent).toBe("true");
+    expect(getByTestId("cancel-requested").textContent).toBe("true");
+    fireEvent.click(getByTestId("cancel-signing"));
+    expect(handleCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-enters the pre-sign entry state after a self-requested cancel settles quietly", () => {
+    // The hook's quiet reset (signing false, NO error) must not strand the
+    // modal on a disabled Sign button: the view's pre-sign entry state is the
+    // re-offer seam, and its CTA re-runs the full ceremony via handleSign.
+    const handleSign = vi.fn();
+    const midCancel = {
+      signing: true,
+      progress: { phase: "graph", completed: 0, total: 1 },
+      error: null,
+      errorTerminal: false,
+      isComplete: false,
+      handleSign,
+      canCancel: true,
+      cancelRequested: true,
+      handleCancel: vi.fn(),
+    } as const;
+    vi.mocked(usePayoutSigningState).mockReturnValue({ ...midCancel });
+
+    const { getByTestId, rerender } = renderSign();
+    expect(getByTestId("started").textContent).toBe("true");
+
+    // The cancel settles quietly: idle, no error, not complete.
+    vi.mocked(usePayoutSigningState).mockReturnValue({
+      ...midCancel,
+      signing: false,
+      canCancel: false,
+      cancelRequested: false,
+    });
+    rerender(
+      <ResumeSignContent
+        activity={baseActivity}
+        btcPublicKey="0xbtcpub"
+        depositorEthAddress={"0xdepositor" as never}
+        onClose={vi.fn()}
+        onSuccess={vi.fn()}
+      />,
+    );
+
+    expect(getByTestId("started").textContent).toBe("false");
+    // useRunOnce auto-fires handleSign at mount; the CTA must add a fresh run.
+    const callsBeforeClick = handleSign.mock.calls.length;
+    fireEvent.click(getByTestId("sign"));
+    expect(handleSign.mock.calls.length).toBe(callsBeforeClick + 1);
   });
 });
 

--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -58,6 +58,17 @@ const WRONG_WALLET_BODY =
 // Shared by formatPayoutSignatureError's Error and non-Error fallbacks so the
 // generic payout-signing title can't drift between the two.
 const PAYOUT_SIGNING_ERROR_TITLE = "Payout signing error";
+// Device-state copy shared by deposit.errors and payoutSignatureErrors so the
+// two can't drift; wording warns that retry re-runs the device approval screens.
+const DEVICE_CEREMONY_INVALID_TITLE = "Device approval needed again";
+const DEVICE_CEREMONY_INVALID_BODY =
+  "Your signing device no longer holds this deposit's approval. Try again to restart from the device approval screens.";
+const DEVICE_LOCKED_TITLE = "Signing device locked";
+const DEVICE_LOCKED_BODY =
+  "Your signing device is locked. Unlock it with your PIN and try again.";
+const DEVICE_WRONG_APP_TITLE = "Wrong app on device";
+const DEVICE_WRONG_APP_BODY =
+  "A different app is open on your signing device. Open the Babylon Vault app on the device and try again.";
 // Action-required labels shared between the in-app badges
 // (`pegin.actionRequiredBadges`) and the browser-notification titles so the two
 // surfaces can't drift.
@@ -402,7 +413,14 @@ export const COPY = {
         done: "Done",
         sign: "Sign",
         signTransaction: SIGN_TRANSACTION_LABEL,
+        // Hardware-wallet flows only: shown while an in-flight device signing
+        // ceremony can be cancelled.
+        cancelSigning: "Cancel signing",
       },
+      // Cancelling is a request, not an immediate stop: the device settles the
+      // in-flight signature only once the user acts on it.
+      cancelRequestedNotice:
+        "Cancellation requested — finish or reject the request on your signing device to continue.",
     },
     btcConfirmation: {
       estRemaining: "Est. remaining",
@@ -921,6 +939,20 @@ export const COPY = {
         title: "Wallet action not supported",
         body: "Your connected wallet can't perform an action this deposit requires. Please reconnect with a supported wallet and try again.",
       },
+      // Typed device-state codes from the hardware-wallet provider; wording
+      // shared with payoutSignatureErrors via the DEVICE_* constants above.
+      deviceCeremonyInvalid: {
+        title: DEVICE_CEREMONY_INVALID_TITLE,
+        body: DEVICE_CEREMONY_INVALID_BODY,
+      },
+      deviceLocked: {
+        title: DEVICE_LOCKED_TITLE,
+        body: DEVICE_LOCKED_BODY,
+      },
+      deviceWrongApp: {
+        title: DEVICE_WRONG_APP_TITLE,
+        body: DEVICE_WRONG_APP_BODY,
+      },
       // Vault-provider JSON-RPC error copy, consumed by `mapVpRpcError`
       // (utils/errors/formatting.ts). Title + message are both user-facing.
       vp: {
@@ -1062,6 +1094,20 @@ export const COPY = {
         title: "Wallet action not supported",
         message:
           "Your connected wallet can't perform an action this deposit requires, and the deposit can only continue with the wallet that created it. Try again after updating the app or that wallet, or contact support.",
+      },
+      // Typed device-state codes from the hardware-wallet provider; wording
+      // shared with deposit.errors via the DEVICE_* constants above.
+      deviceCeremonyInvalid: {
+        title: DEVICE_CEREMONY_INVALID_TITLE,
+        message: DEVICE_CEREMONY_INVALID_BODY,
+      },
+      deviceLocked: {
+        title: DEVICE_LOCKED_TITLE,
+        message: DEVICE_LOCKED_BODY,
+      },
+      deviceWrongApp: {
+        title: DEVICE_WRONG_APP_TITLE,
+        message: DEVICE_WRONG_APP_BODY,
       },
       unexpected: {
         title: PAYOUT_SIGNING_ERROR_TITLE,

--- a/services/vault/src/hooks/deposit/__tests__/useDepositFlow.test.tsx
+++ b/services/vault/src/hooks/deposit/__tests__/useDepositFlow.test.tsx
@@ -1606,7 +1606,60 @@ describe("useDepositFlow", () => {
       });
     });
 
-    it("cancelDeviceSign forwards to the provider and the settled rejection surfaces as the signing-rejected copy", async () => {
+    it("cancels the provider that started the sign, not a wallet swapped in mid-prompt", async () => {
+      const { preparePeginTransaction } = vi.mocked(
+        await import("@/services/vault/vaultTransactionService"),
+      );
+      const { wallet, settle, cancelSigning } = pendingSignWallet(true);
+      vi.mocked(preparePeginTransaction).mockImplementation(async (w) => {
+        await w.signPsbt("psbt0", {});
+        return MOCK_BATCH_RESULT as any;
+      });
+
+      const { result, rerender } = renderHook(
+        (props: { btcWalletProvider: unknown }) =>
+          useDepositFlow({
+            ...MOCK_PARAMS,
+            btcWalletProvider: props.btcWalletProvider as any,
+          }),
+        { initialProps: { btcWalletProvider: wallet as unknown } },
+      );
+
+      let flowPromise!: Promise<unknown>;
+      act(() => {
+        flowPromise = result.current.executeDeposit();
+      });
+      await waitFor(() =>
+        expect(result.current.canCancelDeviceSign).toBe(true),
+      );
+
+      // Swap the connected wallet while the device prompt is still open.
+      const replacementCancelSigning = vi.fn();
+      rerender({
+        btcWalletProvider: {
+          ...MOCK_BTC_WALLET,
+          cancelSigning: replacementCancelSigning,
+        },
+      });
+
+      // The affordance tracks the running ceremony, not the live prop.
+      expect(result.current.canCancelDeviceSign).toBe(true);
+
+      act(() => {
+        result.current.cancelDeviceSign();
+      });
+      expect(cancelSigning).toHaveBeenCalledTimes(1);
+      expect(replacementCancelSigning).not.toHaveBeenCalled();
+
+      await act(async () => {
+        settle.reject(signingCancelledError());
+        await flowPromise;
+      });
+    });
+
+    // Shared setup for the cancel-request tests below: start a flow with a
+    // held-open signPsbt, request the device cancel, hand back a settle helper.
+    async function startSignAndRequestCancel() {
       const { preparePeginTransaction } = vi.mocked(
         await import("@/services/vault/vaultTransactionService"),
       );
@@ -1631,19 +1684,45 @@ describe("useDepositFlow", () => {
       act(() => {
         result.current.cancelDeviceSign();
       });
-      expect(cancelSigning).toHaveBeenCalledTimes(1);
-      expect(result.current.deviceCancelRequested).toBe(true);
 
-      let resolved: unknown;
-      await act(async () => {
-        settle.reject(signingCancelledError());
-        resolved = await flowPromise;
-      });
+      const settleAsCancelRejection = async () => {
+        let resolved: unknown;
+        await act(async () => {
+          settle.reject(signingCancelledError());
+          resolved = await flowPromise;
+        });
+        return resolved;
+      };
+      return { result, cancelSigning, settleAsCancelRejection };
+    }
+
+    it("cancelDeviceSign forwards to the provider's cancelSigning once", async () => {
+      const { cancelSigning, settleAsCancelRejection } =
+        await startSignAndRequestCancel();
+
+      expect(cancelSigning).toHaveBeenCalledTimes(1);
+
+      await settleAsCancelRejection();
+    });
+
+    it("surfaces the cancel-settled rejection as the signing-rejected copy", async () => {
+      const { result, settleAsCancelRejection } =
+        await startSignAndRequestCancel();
 
       // The flow controller was NOT aborted: the rejection reaches the normal
       // error path (an aborted flow would have swallowed it silently).
+      const resolved = await settleAsCancelRejection();
       expect(resolved).toBeNull();
       expect(result.current.error).toEqual(DEPOSIT_ERRORS.signingRejected);
+    });
+
+    it("sets deviceCancelRequested on request and clears it when the cancelled sign settles", async () => {
+      const { result, settleAsCancelRejection } =
+        await startSignAndRequestCancel();
+
+      expect(result.current.deviceCancelRequested).toBe(true);
+
+      await settleAsCancelRejection();
       expect(result.current.deviceCancelRequested).toBe(false);
     });
 

--- a/services/vault/src/hooks/deposit/__tests__/useDepositFlow.test.tsx
+++ b/services/vault/src/hooks/deposit/__tests__/useDepositFlow.test.tsx
@@ -1511,6 +1511,329 @@ describe("useDepositFlow", () => {
     });
   });
 
+  describe("Device-sign cancellation", () => {
+    // Only signPsbt/signPsbts/signMessage go through the Ledger provider's
+    // abortable loop, so the cancel affordance must track exactly those
+    // windows — never derive/approve ceremonies or non-wallet waits.
+
+    /** Wallet whose signPsbt stays pending until the test settles it. */
+    function pendingSignWallet(withCancel: boolean) {
+      const settle: {
+        resolve: (v: string) => void;
+        reject: (e: unknown) => void;
+      } = { resolve: () => {}, reject: () => {} };
+      const signPsbt = vi.fn(
+        () =>
+          new Promise<string>((resolve, reject) => {
+            settle.resolve = resolve;
+            settle.reject = reject;
+          }),
+      );
+      const cancelSigning = vi.fn();
+      const wallet = {
+        ...MOCK_BTC_WALLET,
+        signPsbt,
+        ...(withCancel ? { cancelSigning } : {}),
+      };
+      return { wallet, settle, cancelSigning };
+    }
+
+    /** What the Ledger provider rejects with when a requested cancel settles. */
+    function signingCancelledError() {
+      return Object.assign(
+        new Error(
+          "Signing cancelled after 0 of 1 PSBT(s) — the ceremony restarts from the device approval screens on retry.",
+        ),
+        { code: "CONNECTION_REJECTED" },
+      );
+    }
+
+    it("exposes canCancelDeviceSign only while a pre-pegin signPsbt is in flight on a provider with cancelSigning", async () => {
+      const { preparePeginTransaction } = vi.mocked(
+        await import("@/services/vault/vaultTransactionService"),
+      );
+      const { wallet, settle } = pendingSignWallet(true);
+      vi.mocked(preparePeginTransaction).mockImplementation(async (w) => {
+        await w.signPsbt("psbt0", {});
+        return MOCK_BATCH_RESULT as any;
+      });
+
+      const { result } = renderHook(() =>
+        useDepositFlow({ ...MOCK_PARAMS, btcWalletProvider: wallet as any }),
+      );
+      expect(result.current.canCancelDeviceSign).toBe(false);
+
+      let flowPromise!: Promise<unknown>;
+      act(() => {
+        flowPromise = result.current.executeDeposit();
+      });
+      await waitFor(() =>
+        expect(result.current.canCancelDeviceSign).toBe(true),
+      );
+
+      await act(async () => {
+        settle.resolve("mockSignedPsbtHex");
+        await flowPromise;
+      });
+      expect(result.current.canCancelDeviceSign).toBe(false);
+    });
+
+    it("keeps canCancelDeviceSign false for providers without cancelSigning", async () => {
+      const { preparePeginTransaction } = vi.mocked(
+        await import("@/services/vault/vaultTransactionService"),
+      );
+      const { wallet, settle } = pendingSignWallet(false);
+      vi.mocked(preparePeginTransaction).mockImplementation(async (w) => {
+        await w.signPsbt("psbt0", {});
+        return MOCK_BATCH_RESULT as any;
+      });
+
+      const { result } = renderHook(() =>
+        useDepositFlow({ ...MOCK_PARAMS, btcWalletProvider: wallet as any }),
+      );
+
+      let flowPromise!: Promise<unknown>;
+      act(() => {
+        flowPromise = result.current.executeDeposit();
+      });
+      await waitFor(() => expect(wallet.signPsbt).toHaveBeenCalled());
+
+      expect(result.current.canCancelDeviceSign).toBe(false);
+
+      await act(async () => {
+        settle.resolve("mockSignedPsbtHex");
+        await flowPromise;
+      });
+    });
+
+    it("cancelDeviceSign forwards to the provider and the settled rejection surfaces as the signing-rejected copy", async () => {
+      const { preparePeginTransaction } = vi.mocked(
+        await import("@/services/vault/vaultTransactionService"),
+      );
+      const { wallet, settle, cancelSigning } = pendingSignWallet(true);
+      vi.mocked(preparePeginTransaction).mockImplementation(async (w) => {
+        await w.signPsbt("psbt0", {});
+        return MOCK_BATCH_RESULT as any;
+      });
+
+      const { result } = renderHook(() =>
+        useDepositFlow({ ...MOCK_PARAMS, btcWalletProvider: wallet as any }),
+      );
+
+      let flowPromise!: Promise<unknown>;
+      act(() => {
+        flowPromise = result.current.executeDeposit();
+      });
+      await waitFor(() =>
+        expect(result.current.canCancelDeviceSign).toBe(true),
+      );
+
+      act(() => {
+        result.current.cancelDeviceSign();
+      });
+      expect(cancelSigning).toHaveBeenCalledTimes(1);
+      expect(result.current.deviceCancelRequested).toBe(true);
+
+      let resolved: unknown;
+      await act(async () => {
+        settle.reject(signingCancelledError());
+        resolved = await flowPromise;
+      });
+
+      // The flow controller was NOT aborted: the rejection reaches the normal
+      // error path (an aborted flow would have swallowed it silently).
+      expect(resolved).toBeNull();
+      expect(result.current.error).toEqual(DEPOSIT_ERRORS.signingRejected);
+      expect(result.current.deviceCancelRequested).toBe(false);
+    });
+
+    it("clears deviceCancelRequested when the sign settles successfully after a late cancel", async () => {
+      const { preparePeginTransaction } = vi.mocked(
+        await import("@/services/vault/vaultTransactionService"),
+      );
+      const { wallet, settle } = pendingSignWallet(true);
+      vi.mocked(preparePeginTransaction).mockImplementation(async (w) => {
+        await w.signPsbt("psbt0", {});
+        return MOCK_BATCH_RESULT as any;
+      });
+
+      const { result } = renderHook(() =>
+        useDepositFlow({ ...MOCK_PARAMS, btcWalletProvider: wallet as any }),
+      );
+
+      let flowPromise!: Promise<unknown>;
+      act(() => {
+        flowPromise = result.current.executeDeposit();
+      });
+      await waitFor(() =>
+        expect(result.current.canCancelDeviceSign).toBe(true),
+      );
+
+      act(() => {
+        result.current.cancelDeviceSign();
+      });
+
+      let resolved: unknown;
+      await act(async () => {
+        settle.resolve("mockSignedPsbtHex");
+        resolved = await flowPromise;
+      });
+
+      expect(resolved).not.toBeNull();
+      expect(result.current.error).toBeNull();
+      expect(result.current.deviceCancelRequested).toBe(false);
+    });
+
+    it("covers the batch signPsbts window", async () => {
+      const { preparePeginTransaction } = vi.mocked(
+        await import("@/services/vault/vaultTransactionService"),
+      );
+      const settle: { resolve: (v: string[]) => void } = { resolve: () => {} };
+      const signPsbts = vi.fn(
+        () =>
+          new Promise<string[]>((resolve) => {
+            settle.resolve = resolve;
+          }),
+      );
+      const wallet = {
+        ...MOCK_BTC_WALLET,
+        signPsbts,
+        cancelSigning: vi.fn(),
+      };
+      vi.mocked(preparePeginTransaction).mockImplementation(async (w) => {
+        await w.signPsbts!(["psbt0", "psbt1"], [{}, {}]);
+        return MOCK_BATCH_RESULT as any;
+      });
+
+      const { result } = renderHook(() =>
+        useDepositFlow({ ...MOCK_PARAMS, btcWalletProvider: wallet as any }),
+      );
+
+      let flowPromise!: Promise<unknown>;
+      act(() => {
+        flowPromise = result.current.executeDeposit();
+      });
+      await waitFor(() =>
+        expect(result.current.canCancelDeviceSign).toBe(true),
+      );
+
+      await act(async () => {
+        settle.resolve(["signed0", "signed1"]);
+        await flowPromise;
+      });
+      expect(result.current.canCancelDeviceSign).toBe(false);
+    });
+
+    it("covers the proof-of-possession window", async () => {
+      const { signProofOfPossession } = vi.mocked(
+        await import("../depositFlowSteps"),
+      );
+      const settle: { resolve: (v: unknown) => void } = { resolve: () => {} };
+      vi.mocked(signProofOfPossession).mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            settle.resolve = resolve as (v: unknown) => void;
+          }) as any,
+      );
+      const wallet = { ...MOCK_BTC_WALLET, cancelSigning: vi.fn() };
+
+      const { result } = renderHook(() =>
+        useDepositFlow({ ...MOCK_PARAMS, btcWalletProvider: wallet as any }),
+      );
+
+      let flowPromise!: Promise<unknown>;
+      act(() => {
+        flowPromise = result.current.executeDeposit();
+      });
+      await waitFor(() =>
+        expect(result.current.canCancelDeviceSign).toBe(true),
+      );
+
+      await act(async () => {
+        settle.resolve({
+          btcPopSignature: "0xMockPopSignature",
+          depositorEthAddress: "0xEthAddress123",
+          depositorBtcPubkey: MOCK_DEPOSITOR_PUBKEY,
+        });
+        await flowPromise;
+      });
+      expect(result.current.canCancelDeviceSign).toBe(false);
+    });
+
+    it("covers the Pre-PegIn broadcast signature window", async () => {
+      const { broadcastPrePeginTransaction } = vi.mocked(
+        await import("@/services/vault/vaultPeginBroadcastService"),
+      );
+      const { wallet, settle } = pendingSignWallet(true);
+      vi.mocked(broadcastPrePeginTransaction).mockImplementation(
+        async ({ btcWalletProvider }) => {
+          await btcWalletProvider.signPsbt("fundedPrePegin");
+          return "mockBroadcastTxId";
+        },
+      );
+
+      const { result } = renderHook(() =>
+        useDepositFlow({ ...MOCK_PARAMS, btcWalletProvider: wallet as any }),
+      );
+
+      let flowPromise!: Promise<unknown>;
+      act(() => {
+        flowPromise = result.current.executeDeposit();
+      });
+      await waitFor(() =>
+        expect(result.current.canCancelDeviceSign).toBe(true),
+      );
+
+      await act(async () => {
+        settle.resolve("signedFundedPrePegin");
+        await flowPromise;
+      });
+      expect(result.current.canCancelDeviceSign).toBe(false);
+    });
+
+    it("covers the post-broadcast depositor-graph window", async () => {
+      const { signAndSubmitPayouts } = vi.mocked(
+        await import("../depositFlowSteps"),
+      );
+      // Only the FIRST graph sign is held open — the flow runs one payout
+      // round per vault, and a still-pending second round would hang the test.
+      const settle: { resolve: (v: string) => void } = { resolve: () => {} };
+      const signPsbt = vi
+        .fn()
+        .mockImplementationOnce(
+          () =>
+            new Promise<string>((resolve) => {
+              settle.resolve = resolve;
+            }),
+        )
+        .mockResolvedValue("mockSignedPsbtHex");
+      const wallet = { ...MOCK_BTC_WALLET, signPsbt, cancelSigning: vi.fn() };
+      vi.mocked(signAndSubmitPayouts).mockImplementation(
+        async ({ btcWallet }) => {
+          await btcWallet.signPsbt("graphPsbt");
+        },
+      );
+
+      const { result } = renderHook(() =>
+        useDepositFlow({ ...MOCK_PARAMS, btcWalletProvider: wallet as any }),
+      );
+
+      let flowPromise!: Promise<unknown>;
+      act(() => {
+        flowPromise = result.current.executeDeposit();
+      });
+      await waitFor(() =>
+        expect(result.current.canCancelDeviceSign).toBe(true),
+      );
+
+      await act(async () => {
+        settle.resolve("signedGraphPsbt");
+        await flowPromise;
+      });
+      expect(result.current.canCancelDeviceSign).toBe(false);
+    });
+  });
+
   describe("Soft warnings", () => {
     it("populates lastWarnings when addPendingPegin throws on persist failure", async () => {
       const { addPendingPegin } = vi.mocked(

--- a/services/vault/src/hooks/deposit/useDepositFlow.ts
+++ b/services/vault/src/hooks/deposit/useDepositFlow.ts
@@ -191,6 +191,20 @@ export interface UseDepositFlowReturn {
    * that window — the flow is only here for ~1.6 min per deposit.
    */
   ethConfirmationDetail: RegistrationDepthProgress | null;
+  /**
+   * True while a cancellable device signature (signPsbt/signPsbts/signMessage)
+   * is in flight AND the connected provider exposes `cancelSigning` (only the
+   * Ledger provider does — always capability-probed).
+   */
+  canCancelDeviceSign: boolean;
+  /** True from {@link cancelDeviceSign} until the in-flight signature settles. */
+  deviceCancelRequested: boolean;
+  /**
+   * Requests cancellation of the in-flight device signature. Does NOT settle
+   * it: the provider aborts at its next device exchange boundary, which may be
+   * only after the user finishes or rejects on the physical device.
+   */
+  cancelDeviceSign: () => void;
 }
 
 export interface PeginCreationResult {
@@ -287,6 +301,31 @@ export function useDepositFlow(
     useState<RegistrationDepthProgress | null>(null);
 
   const payoutClaimersDoneRef = useRef(false);
+
+  // Cancellable device-sign window (#2110 T3): only signPsbt/signPsbts/
+  // signMessage run through the Ledger provider's abortable loop, so the flag
+  // tracks exactly those calls — never derive/approve ceremonies or waits.
+  const [deviceSignActive, setDeviceSignActive] = useState(false);
+  const [deviceCancelRequested, setDeviceCancelRequested] = useState(false);
+  // Ref mirror so cancelDeviceSign reads the live value synchronously.
+  const deviceSignActiveRef = useRef(false);
+
+  const runCancellableSign = useCallback(
+    async <T>(sign: () => Promise<T>): Promise<T> => {
+      deviceSignActiveRef.current = true;
+      setDeviceSignActive(true);
+      try {
+        return await sign();
+      } finally {
+        deviceSignActiveRef.current = false;
+        setDeviceSignActive(false);
+        // Either outcome consumes a pending cancel request — the UI must
+        // never wedge on the disabled cancel button after a settle.
+        setDeviceCancelRequested(false);
+      }
+    },
+    [],
+  );
 
   // Abort controller for cancelling the flow
   const abortControllerRef = useRef<AbortController | null>(null);
@@ -465,7 +504,9 @@ export function useDepositFlow(
           opts,
         ) => {
           advanceStep(DepositFlowStep.SIGN_PEGIN_BTC);
-          const signed = await confirmedBtcWallet.signPsbt(psbtHex, opts);
+          const signed = await runCancellableSign(() =>
+            confirmedBtcWallet.signPsbt(psbtHex, opts),
+          );
           setPeginSigningProgress((prev) =>
             prev
               ? { ...prev, completed: Math.min(prev.completed + 1, prev.total) }
@@ -480,7 +521,9 @@ export function useDepositFlow(
         ) => {
           advanceStep(DepositFlowStep.SIGN_PEGIN_BTC);
           setPeginSigningProgress({ completed: 0, total: psbtHexes.length });
-          const signed = await confirmedBtcWallet.signPsbts!(psbtHexes, opts);
+          const signed = await runCancellableSign(() =>
+            confirmedBtcWallet.signPsbts!(psbtHexes, opts),
+          );
           setPeginSigningProgress({
             completed: psbtHexes.length,
             total: psbtHexes.length,
@@ -593,9 +636,10 @@ export function useDepositFlow(
         // 3b. Sign PoP during SIGN_POP so the wallet popup is associated
         // with this step, not the following SUBMIT_PEGIN.
         advanceStep(DepositFlowStep.SIGN_POP);
-        const popSignature = await signProofOfPossession(
-          confirmedBtcWallet,
-          walletClient,
+        // Wrapped as a whole: the BIP-322 signMessage inside is the
+        // cancellable device call, and its prep reads are cached/fast.
+        const popSignature = await runCancellableSign(() =>
+          signProofOfPossession(confirmedBtcWallet, walletClient),
         );
 
         // Guard: the BTC pubkey used for WOTS derivation (in preparePegin)
@@ -861,7 +905,7 @@ export function useDepositFlow(
             unsignedTxHex: batchResult.fundedPrePeginTxHex,
             btcWalletProvider: {
               signPsbt: (psbtHex: string) =>
-                confirmedBtcWallet.signPsbt(psbtHex),
+                runCancellableSign(() => confirmedBtcWallet.signPsbt(psbtHex)),
               deriveContextHash: (appName: string, context: string) =>
                 confirmedBtcWallet.deriveContextHash(appName, context),
               // Object spread drops prototype methods — see forwardDepositApproval.
@@ -1017,7 +1061,9 @@ export function useDepositFlow(
             }
             setIsWaiting(false);
             try {
-              return await confirmedBtcWallet.signPsbt(psbtHex, opts);
+              return await runCancellableSign(() =>
+                confirmedBtcWallet.signPsbt(psbtHex, opts),
+              );
             } finally {
               setIsWaiting(true);
               if (payoutClaimersDoneRef.current) {
@@ -1042,7 +1088,9 @@ export function useDepositFlow(
                   }
                   setIsWaiting(false);
                   try {
-                    return await confirmedBtcWallet.signPsbts!(psbtHexes, opts);
+                    return await runCancellableSign(() =>
+                      confirmedBtcWallet.signPsbts!(psbtHexes, opts),
+                    );
                   } finally {
                     setIsWaiting(true);
                     if (payoutClaimersDoneRef.current) {
@@ -1394,6 +1442,7 @@ export function useDepositFlow(
       }
     }, [
       advanceStep,
+      runCancellableSign,
       gate,
       vaultAmounts,
       mempoolFeeRate,
@@ -1419,6 +1468,24 @@ export function useDepositFlow(
       queryClient,
     ]);
 
+  const cancelDeviceSign = useCallback(() => {
+    const provider = btcWalletProvider as
+      | (BitcoinWallet & { cancelSigning?: () => void })
+      | null;
+    if (!deviceSignActiveRef.current) return;
+    if (typeof provider?.cancelSigning !== "function") return;
+    setDeviceCancelRequested(true);
+    // Device-only cancel (aborting the flow controller reads as a closed modal).
+    // Settles like an on-device reject: pre-broadcast = "Signing rejected"
+    // callout; post-broadcast payout stage = per-vault warning, loop continues.
+    provider.cancelSigning();
+  }, [btcWalletProvider]);
+
+  const canCancelDeviceSign =
+    deviceSignActive &&
+    typeof (btcWalletProvider as { cancelSigning?: unknown } | null)
+      ?.cancelSigning === "function";
+
   return {
     executeDeposit,
     abort,
@@ -1434,5 +1501,8 @@ export function useDepositFlow(
     perVaultSteps,
     btcConfirmationDetail,
     ethConfirmationDetail,
+    canCancelDeviceSign,
+    deviceCancelRequested,
+    cancelDeviceSign,
   };
 }

--- a/services/vault/src/hooks/deposit/useDepositFlow.ts
+++ b/services/vault/src/hooks/deposit/useDepositFlow.ts
@@ -193,8 +193,8 @@ export interface UseDepositFlowReturn {
   ethConfirmationDetail: RegistrationDepthProgress | null;
   /**
    * True while a cancellable device signature (signPsbt/signPsbts/signMessage)
-   * is in flight AND the connected provider exposes `cancelSigning` (only the
-   * Ledger provider does — always capability-probed).
+   * is in flight AND the provider that started it exposes `cancelSigning`
+   * (only the Ledger provider does — always capability-probed).
    */
   canCancelDeviceSign: boolean;
   /** True from {@link cancelDeviceSign} until the in-flight signature settles. */
@@ -309,14 +309,19 @@ export function useDepositFlow(
   const [deviceCancelRequested, setDeviceCancelRequested] = useState(false);
   // Ref mirror so cancelDeviceSign reads the live value synchronously.
   const deviceSignActiveRef = useRef(false);
+  // Provider that STARTED the in-flight sign. Cancellation binds to it so a
+  // wallet swapped in mid-prompt cannot orphan the original ceremony.
+  const deviceSignProviderRef = useRef<unknown>(null);
 
   const runCancellableSign = useCallback(
-    async <T>(sign: () => Promise<T>): Promise<T> => {
+    async <T>(signingProvider: unknown, sign: () => Promise<T>): Promise<T> => {
+      deviceSignProviderRef.current = signingProvider;
       deviceSignActiveRef.current = true;
       setDeviceSignActive(true);
       try {
         return await sign();
       } finally {
+        deviceSignProviderRef.current = null;
         deviceSignActiveRef.current = false;
         setDeviceSignActive(false);
         // Either outcome consumes a pending cancel request — the UI must
@@ -504,7 +509,7 @@ export function useDepositFlow(
           opts,
         ) => {
           advanceStep(DepositFlowStep.SIGN_PEGIN_BTC);
-          const signed = await runCancellableSign(() =>
+          const signed = await runCancellableSign(confirmedBtcWallet, () =>
             confirmedBtcWallet.signPsbt(psbtHex, opts),
           );
           setPeginSigningProgress((prev) =>
@@ -521,7 +526,7 @@ export function useDepositFlow(
         ) => {
           advanceStep(DepositFlowStep.SIGN_PEGIN_BTC);
           setPeginSigningProgress({ completed: 0, total: psbtHexes.length });
-          const signed = await runCancellableSign(() =>
+          const signed = await runCancellableSign(confirmedBtcWallet, () =>
             confirmedBtcWallet.signPsbts!(psbtHexes, opts),
           );
           setPeginSigningProgress({
@@ -638,7 +643,7 @@ export function useDepositFlow(
         advanceStep(DepositFlowStep.SIGN_POP);
         // Wrapped as a whole: the BIP-322 signMessage inside is the
         // cancellable device call, and its prep reads are cached/fast.
-        const popSignature = await runCancellableSign(() =>
+        const popSignature = await runCancellableSign(confirmedBtcWallet, () =>
           signProofOfPossession(confirmedBtcWallet, walletClient),
         );
 
@@ -905,7 +910,9 @@ export function useDepositFlow(
             unsignedTxHex: batchResult.fundedPrePeginTxHex,
             btcWalletProvider: {
               signPsbt: (psbtHex: string) =>
-                runCancellableSign(() => confirmedBtcWallet.signPsbt(psbtHex)),
+                runCancellableSign(confirmedBtcWallet, () =>
+                  confirmedBtcWallet.signPsbt(psbtHex),
+                ),
               deriveContextHash: (appName: string, context: string) =>
                 confirmedBtcWallet.deriveContextHash(appName, context),
               // Object spread drops prototype methods — see forwardDepositApproval.
@@ -1061,7 +1068,7 @@ export function useDepositFlow(
             }
             setIsWaiting(false);
             try {
-              return await runCancellableSign(() =>
+              return await runCancellableSign(confirmedBtcWallet, () =>
                 confirmedBtcWallet.signPsbt(psbtHex, opts),
               );
             } finally {
@@ -1088,7 +1095,7 @@ export function useDepositFlow(
                   }
                   setIsWaiting(false);
                   try {
-                    return await runCancellableSign(() =>
+                    return await runCancellableSign(confirmedBtcWallet, () =>
                       confirmedBtcWallet.signPsbts!(psbtHexes, opts),
                     );
                   } finally {
@@ -1469,9 +1476,11 @@ export function useDepositFlow(
     ]);
 
   const cancelDeviceSign = useCallback(() => {
-    const provider = btcWalletProvider as
-      | (BitcoinWallet & { cancelSigning?: () => void })
-      | null;
+    // Cancel the ceremony on the provider that started it — never the live
+    // prop, which a mid-prompt wallet swap can replace.
+    const provider = deviceSignProviderRef.current as {
+      cancelSigning?: () => void;
+    } | null;
     if (!deviceSignActiveRef.current) return;
     if (typeof provider?.cancelSigning !== "function") return;
     setDeviceCancelRequested(true);
@@ -1479,11 +1488,13 @@ export function useDepositFlow(
     // Settles like an on-device reject: pre-broadcast = "Signing rejected"
     // callout; post-broadcast payout stage = per-vault warning, loop continues.
     provider.cancelSigning();
-  }, [btcWalletProvider]);
+  }, []);
 
+  // The ref is only ever set/cleared together with the `deviceSignActive`
+  // state, so this render read stays in sync.
   const canCancelDeviceSign =
     deviceSignActive &&
-    typeof (btcWalletProvider as { cancelSigning?: unknown } | null)
+    typeof (deviceSignProviderRef.current as { cancelSigning?: unknown } | null)
       ?.cancelSigning === "function";
 
   return {

--- a/services/vault/src/utils/errors/__tests__/depositErrors.test.ts
+++ b/services/vault/src/utils/errors/__tests__/depositErrors.test.ts
@@ -329,7 +329,7 @@ describe("mapDepositError", () => {
     expect(mapDepositError(wrapped)).toEqual(ERRORS.walletMethodNotSupported);
   });
 
-  it("maps each typed device-state code to its dedicated copy", () => {
+  it("maps DEVICE_CEREMONY_INVALID to its dedicated copy", () => {
     expect(
       mapDepositError(
         new FakeWalletError(
@@ -338,11 +338,17 @@ describe("mapDepositError", () => {
         ),
       ),
     ).toEqual(ERRORS.deviceCeremonyInvalid);
+  });
+
+  it("maps DEVICE_LOCKED to its dedicated copy", () => {
     expect(
       mapDepositError(
         new FakeWalletError("DEVICE_LOCKED", "Device is locked (0x5515)"),
       ),
     ).toEqual(ERRORS.deviceLocked);
+  });
+
+  it("maps DEVICE_WRONG_APP to its dedicated copy", () => {
     expect(
       mapDepositError(
         new FakeWalletError(

--- a/services/vault/src/utils/errors/__tests__/depositErrors.test.ts
+++ b/services/vault/src/utils/errors/__tests__/depositErrors.test.ts
@@ -329,6 +329,73 @@ describe("mapDepositError", () => {
     expect(mapDepositError(wrapped)).toEqual(ERRORS.walletMethodNotSupported);
   });
 
+  it("maps each typed device-state code to its dedicated copy", () => {
+    expect(
+      mapDepositError(
+        new FakeWalletError(
+          "DEVICE_CEREMONY_INVALID",
+          "Ledger Vault holds no approved intent on this connection — restart the flow from derivation.",
+        ),
+      ),
+    ).toEqual(ERRORS.deviceCeremonyInvalid);
+    expect(
+      mapDepositError(
+        new FakeWalletError("DEVICE_LOCKED", "Device is locked (0x5515)"),
+      ),
+    ).toEqual(ERRORS.deviceLocked);
+    expect(
+      mapDepositError(
+        new FakeWalletError(
+          "DEVICE_WRONG_APP",
+          "The running app does not handle vault instructions — open the Babylon Vault app",
+        ),
+      ),
+    ).toEqual(ERRORS.deviceWrongApp);
+  });
+
+  it("lets a top-frame device code win over an inner unsupported-method cause", () => {
+    // The provider's typed device error can wrap lower-level causes; the
+    // outer, more specific frame must not be shadowed by the walking
+    // unsupported-method bucket.
+    const err = Object.assign(
+      new FakeWalletError(
+        "DEVICE_CEREMONY_INVALID",
+        "restart the flow from derivation.",
+      ),
+      {
+        cause: new FakeWalletError(
+          "WALLET_METHOD_NOT_SUPPORTED",
+          "no deriveContextHash",
+        ),
+      },
+    );
+    expect(mapDepositError(err)).toEqual(ERRORS.deviceCeremonyInvalid);
+  });
+
+  it("lets a top-frame unsupported-method code win over an inner device cause", () => {
+    const err = Object.assign(
+      new FakeWalletError(
+        "WALLET_METHOD_NOT_SUPPORTED",
+        "no deriveContextHash",
+      ),
+      { cause: new FakeWalletError("DEVICE_LOCKED", "Device is locked") },
+    );
+    expect(mapDepositError(err)).toEqual(ERRORS.walletMethodNotSupported);
+  });
+
+  it("finds DEVICE_CEREMONY_INVALID through a broadcast wrapper's cause chain", () => {
+    // Without the typed bucket, the wrapper's "broadcast" wording would claim
+    // this as "Broadcast failed" — misleading for a device-state error.
+    const inner = new FakeWalletError(
+      "DEVICE_CEREMONY_INVALID",
+      "The device no longer holds the approved intent (SW_BAD_STATE) — restart the flow from derivation.",
+    );
+    const wrapped = new Error("Failed to broadcast Pre-PegIn transaction", {
+      cause: inner,
+    });
+    expect(mapDepositError(wrapped)).toEqual(ERRORS.deviceCeremonyInvalid);
+  });
+
   it("keeps the VP mapping when a JsonRpcError carries an unrelated unsupported-method cause", () => {
     // Precedence: typed classifications run before the cause walk, so the
     // meaningful outer VP error must win over the nested code.

--- a/services/vault/src/utils/errors/__tests__/formatting.test.ts
+++ b/services/vault/src/utils/errors/__tests__/formatting.test.ts
@@ -890,9 +890,7 @@ describe("Error Formatting", () => {
       );
     });
 
-    it("maps each typed device-state code to its dedicated payout copy", () => {
-      // Today these fall to PSE.unexpected with the real message dropped to
-      // diagnostics — the typed buckets must claim them first.
+    it("maps DEVICE_CEREMONY_INVALID to its dedicated payout copy", () => {
       expect(
         formatPayoutSignatureError(
           new FakeWalletError(
@@ -901,11 +899,17 @@ describe("Error Formatting", () => {
           ),
         ),
       ).toEqual(COPY.deposit.payoutSignatureErrors.deviceCeremonyInvalid);
+    });
+
+    it("maps DEVICE_LOCKED to its dedicated payout copy", () => {
       expect(
         formatPayoutSignatureError(
           new FakeWalletError("DEVICE_LOCKED", "Device is locked (0x5515)"),
         ),
       ).toEqual(COPY.deposit.payoutSignatureErrors.deviceLocked);
+    });
+
+    it("maps DEVICE_WRONG_APP to its dedicated payout copy", () => {
       expect(
         formatPayoutSignatureError(
           new FakeWalletError(
@@ -936,29 +940,58 @@ describe("Error Formatting", () => {
 
     // Same convention as the guards above: a connector-side rename must fail
     // here, not silently disable the mapping.
-    it("inlined DEVICE_* codes match wallet-connector source", () => {
+    it("inlined DEVICE_CEREMONY_INVALID code matches wallet-connector source", () => {
       const codesPath = resolve(
         __dirname,
         "../../../../../../packages/babylon-wallet-connector/src/error/codes.ts",
       );
       const source = readFileSync(codesPath, "utf8");
-      for (const [code, copy] of [
-        [
-          "DEVICE_CEREMONY_INVALID",
-          COPY.deposit.payoutSignatureErrors.deviceCeremonyInvalid,
-        ],
-        ["DEVICE_LOCKED", COPY.deposit.payoutSignatureErrors.deviceLocked],
-        ["DEVICE_WRONG_APP", COPY.deposit.payoutSignatureErrors.deviceWrongApp],
-      ] as const) {
-        const match = source.match(new RegExp(`${code}:\\s*"([^"]+)"`));
-        expect(match).not.toBeNull();
-        expect(match?.[1]).toBe(code);
-        expect(
-          formatPayoutSignatureError(
-            new FakeWalletError(match![1], "device error"),
-          ),
-        ).toEqual(copy);
-      }
+      const match = source.match(/DEVICE_CEREMONY_INVALID:\s*"([^"]+)"/);
+
+      expect(match).not.toBeNull();
+      expect(match?.[1]).toBe("DEVICE_CEREMONY_INVALID");
+
+      expect(
+        formatPayoutSignatureError(
+          new FakeWalletError(match![1], "device error"),
+        ),
+      ).toEqual(COPY.deposit.payoutSignatureErrors.deviceCeremonyInvalid);
+    });
+
+    it("inlined DEVICE_LOCKED code matches wallet-connector source", () => {
+      const codesPath = resolve(
+        __dirname,
+        "../../../../../../packages/babylon-wallet-connector/src/error/codes.ts",
+      );
+      const source = readFileSync(codesPath, "utf8");
+      const match = source.match(/DEVICE_LOCKED:\s*"([^"]+)"/);
+
+      expect(match).not.toBeNull();
+      expect(match?.[1]).toBe("DEVICE_LOCKED");
+
+      expect(
+        formatPayoutSignatureError(
+          new FakeWalletError(match![1], "device error"),
+        ),
+      ).toEqual(COPY.deposit.payoutSignatureErrors.deviceLocked);
+    });
+
+    it("inlined DEVICE_WRONG_APP code matches wallet-connector source", () => {
+      const codesPath = resolve(
+        __dirname,
+        "../../../../../../packages/babylon-wallet-connector/src/error/codes.ts",
+      );
+      const source = readFileSync(codesPath, "utf8");
+      const match = source.match(/DEVICE_WRONG_APP:\s*"([^"]+)"/);
+
+      expect(match).not.toBeNull();
+      expect(match?.[1]).toBe("DEVICE_WRONG_APP");
+
+      expect(
+        formatPayoutSignatureError(
+          new FakeWalletError(match![1], "device error"),
+        ),
+      ).toEqual(COPY.deposit.payoutSignatureErrors.deviceWrongApp);
     });
 
     it("finds DEVICE_CEREMONY_INVALID nested in a wrapper's cause chain", () => {

--- a/services/vault/src/utils/errors/__tests__/formatting.test.ts
+++ b/services/vault/src/utils/errors/__tests__/formatting.test.ts
@@ -890,6 +890,88 @@ describe("Error Formatting", () => {
       );
     });
 
+    it("maps each typed device-state code to its dedicated payout copy", () => {
+      // Today these fall to PSE.unexpected with the real message dropped to
+      // diagnostics — the typed buckets must claim them first.
+      expect(
+        formatPayoutSignatureError(
+          new FakeWalletError(
+            "DEVICE_CEREMONY_INVALID",
+            "The device no longer holds the approved intent (SW_BAD_STATE) — restart the flow from derivation.",
+          ),
+        ),
+      ).toEqual(COPY.deposit.payoutSignatureErrors.deviceCeremonyInvalid);
+      expect(
+        formatPayoutSignatureError(
+          new FakeWalletError("DEVICE_LOCKED", "Device is locked (0x5515)"),
+        ),
+      ).toEqual(COPY.deposit.payoutSignatureErrors.deviceLocked);
+      expect(
+        formatPayoutSignatureError(
+          new FakeWalletError(
+            "DEVICE_WRONG_APP",
+            "The running app does not handle vault instructions — open the Babylon Vault app",
+          ),
+        ),
+      ).toEqual(COPY.deposit.payoutSignatureErrors.deviceWrongApp);
+    });
+
+    it("lets a top-frame device code win over an inner unsupported-method cause", () => {
+      const err = Object.assign(
+        new FakeWalletError(
+          "DEVICE_CEREMONY_INVALID",
+          "restart the flow from derivation.",
+        ),
+        {
+          cause: new FakeWalletError(
+            "WALLET_METHOD_NOT_SUPPORTED",
+            "no deriveContextHash",
+          ),
+        },
+      );
+      expect(formatPayoutSignatureError(err)).toEqual(
+        COPY.deposit.payoutSignatureErrors.deviceCeremonyInvalid,
+      );
+    });
+
+    // Same convention as the guards above: a connector-side rename must fail
+    // here, not silently disable the mapping.
+    it("inlined DEVICE_* codes match wallet-connector source", () => {
+      const codesPath = resolve(
+        __dirname,
+        "../../../../../../packages/babylon-wallet-connector/src/error/codes.ts",
+      );
+      const source = readFileSync(codesPath, "utf8");
+      for (const [code, copy] of [
+        [
+          "DEVICE_CEREMONY_INVALID",
+          COPY.deposit.payoutSignatureErrors.deviceCeremonyInvalid,
+        ],
+        ["DEVICE_LOCKED", COPY.deposit.payoutSignatureErrors.deviceLocked],
+        ["DEVICE_WRONG_APP", COPY.deposit.payoutSignatureErrors.deviceWrongApp],
+      ] as const) {
+        const match = source.match(new RegExp(`${code}:\\s*"([^"]+)"`));
+        expect(match).not.toBeNull();
+        expect(match?.[1]).toBe(code);
+        expect(
+          formatPayoutSignatureError(
+            new FakeWalletError(match![1], "device error"),
+          ),
+        ).toEqual(copy);
+      }
+    });
+
+    it("finds DEVICE_CEREMONY_INVALID nested in a wrapper's cause chain", () => {
+      const inner = new FakeWalletError(
+        "DEVICE_CEREMONY_INVALID",
+        "signPsbts[1]: The device no longer holds the approved intent — restart the flow from derivation.",
+      );
+      const wrapped = new Error("payout signing failed", { cause: inner });
+      expect(formatPayoutSignatureError(wrapped)).toEqual(
+        COPY.deposit.payoutSignatureErrors.deviceCeremonyInvalid,
+      );
+    });
+
     it("lets a typed top-frame rejection win over an inner unsupported-method cause", () => {
       // Outer frame is EIP-1193 4001; the inner cause carries the
       // unsupported-method code. The rejection is the accurate reading.

--- a/services/vault/src/utils/errors/depositErrors.ts
+++ b/services/vault/src/utils/errors/depositErrors.ts
@@ -54,6 +54,9 @@ import { COPY } from "@/copy";
 
 import { isDepositorWalletMismatchError } from "./depositorWalletMismatch";
 import {
+  DEVICE_CEREMONY_INVALID_CODE,
+  DEVICE_LOCKED_CODE,
+  DEVICE_WRONG_APP_CODE,
   deviceErrorCodeOfFrame,
   isDeviceCeremonyInvalidError,
   isDeviceLockedError,
@@ -189,11 +192,11 @@ export function mapDepositError(err: unknown): DepositErrorContent {
   // 3g'. Top-frame device code — before both cause walks, so an outer device
   // error is never shadowed by an inner cause (same contract as step 2).
   switch (deviceErrorCodeOfFrame(err)) {
-    case "DEVICE_CEREMONY_INVALID":
+    case DEVICE_CEREMONY_INVALID_CODE:
       return ERRORS.deviceCeremonyInvalid;
-    case "DEVICE_LOCKED":
+    case DEVICE_LOCKED_CODE:
       return ERRORS.deviceLocked;
-    case "DEVICE_WRONG_APP":
+    case DEVICE_WRONG_APP_CODE:
       return ERRORS.deviceWrongApp;
   }
 

--- a/services/vault/src/utils/errors/depositErrors.ts
+++ b/services/vault/src/utils/errors/depositErrors.ts
@@ -54,6 +54,12 @@ import { COPY } from "@/copy";
 
 import { isDepositorWalletMismatchError } from "./depositorWalletMismatch";
 import {
+  deviceErrorCodeOfFrame,
+  isDeviceCeremonyInvalidError,
+  isDeviceLockedError,
+  isDeviceWrongAppError,
+} from "./deviceErrors";
+import {
   classifyError,
   formatErrorDiagnostics,
   mapVpRpcError,
@@ -180,12 +186,35 @@ export function mapDepositError(err: unknown): DepositErrorContent {
     return ERRORS.wrongDepositorWallet;
   }
 
+  // 3g'. Top-frame device code — before both cause walks, so an outer device
+  // error is never shadowed by an inner cause (same contract as step 2).
+  switch (deviceErrorCodeOfFrame(err)) {
+    case "DEVICE_CEREMONY_INVALID":
+      return ERRORS.deviceCeremonyInvalid;
+    case "DEVICE_LOCKED":
+      return ERRORS.deviceLocked;
+    case "DEVICE_WRONG_APP":
+      return ERRORS.deviceWrongApp;
+  }
+
   // 3g. Wallet lacks a required method. Cause-walking, so it must run AFTER
   // every typed bucket above — an inner unsupported-method code must never
   // override a meaningful outer wallet/VP/contract error (step 2 already
   // claimed any typed top-frame rejection).
   if (isWalletMethodNotSupported(err)) {
     return ERRORS.walletMethodNotSupported;
+  }
+
+  // 3h. Device codes nested in a cause chain — must beat the message buckets
+  // (a broadcast wrapper's wording would otherwise claim them).
+  if (isDeviceCeremonyInvalidError(err)) {
+    return ERRORS.deviceCeremonyInvalid;
+  }
+  if (isDeviceLockedError(err)) {
+    return ERRORS.deviceLocked;
+  }
+  if (isDeviceWrongAppError(err)) {
+    return ERRORS.deviceWrongApp;
   }
 
   const msg = lowerMessage(err);

--- a/services/vault/src/utils/errors/deviceErrors.ts
+++ b/services/vault/src/utils/errors/deviceErrors.ts
@@ -1,0 +1,61 @@
+/**
+ * Typed hardware-device error codes from the wallet connector. Inlined like
+ * userCancellation.ts (drift-guarded in formatting.test.ts); nothing here may
+ * import from formatting.ts or depositErrors.ts.
+ */
+
+/** Device ceremony state unusable — the flow must restart from derivation. */
+export const DEVICE_CEREMONY_INVALID_CODE = "DEVICE_CEREMONY_INVALID";
+/** Hardware device is PIN-locked. */
+export const DEVICE_LOCKED_CODE = "DEVICE_LOCKED";
+/** Wrong app open on the hardware device. */
+export const DEVICE_WRONG_APP_CODE = "DEVICE_WRONG_APP";
+
+/** How far to walk a `cause` chain before giving up. */
+const MAX_CAUSE_DEPTH = 10;
+
+const DEVICE_CODES = [
+  DEVICE_CEREMONY_INVALID_CODE,
+  DEVICE_LOCKED_CODE,
+  DEVICE_WRONG_APP_CODE,
+] as const;
+
+export type DeviceErrorCode = (typeof DEVICE_CODES)[number];
+
+/**
+ * Device code on THIS frame only (no cause walk) — runs before the walking
+ * buckets so an outer device error is never shadowed by an inner code.
+ */
+export function deviceErrorCodeOfFrame(
+  frame: unknown,
+): DeviceErrorCode | undefined {
+  if (!frame || typeof frame !== "object") return undefined;
+  const { code } = frame as { code?: unknown };
+  return DEVICE_CODES.find((c) => c === code);
+}
+
+/**
+ * True when the error or its cause chain carries the code. Cause-walking:
+ * callers must run it AFTER their typed top-frame buckets.
+ */
+function chainCarriesCode(error: unknown, code: string): boolean {
+  let cur: unknown = error;
+  for (let depth = 0; depth <= MAX_CAUSE_DEPTH && cur != null; depth++) {
+    if (typeof cur !== "object") return false;
+    if ((cur as { code?: unknown }).code === code) return true;
+    cur = (cur as { cause?: unknown }).cause;
+  }
+  return false;
+}
+
+export function isDeviceCeremonyInvalidError(error: unknown): boolean {
+  return chainCarriesCode(error, DEVICE_CEREMONY_INVALID_CODE);
+}
+
+export function isDeviceLockedError(error: unknown): boolean {
+  return chainCarriesCode(error, DEVICE_LOCKED_CODE);
+}
+
+export function isDeviceWrongAppError(error: unknown): boolean {
+  return chainCarriesCode(error, DEVICE_WRONG_APP_CODE);
+}

--- a/services/vault/src/utils/errors/formatting.ts
+++ b/services/vault/src/utils/errors/formatting.ts
@@ -15,6 +15,9 @@ import { COPY } from "@/copy";
 
 import { isDepositorWalletMismatchError } from "./depositorWalletMismatch";
 import {
+  DEVICE_CEREMONY_INVALID_CODE,
+  DEVICE_LOCKED_CODE,
+  DEVICE_WRONG_APP_CODE,
   deviceErrorCodeOfFrame,
   isDeviceCeremonyInvalidError,
   isDeviceLockedError,
@@ -542,11 +545,11 @@ export function formatPayoutSignatureError(error: unknown): {
   // Top-frame device code — before both cause walks, so an outer device error
   // is never shadowed by an inner cause (same contract as the rejection bucket).
   switch (deviceErrorCodeOfFrame(error)) {
-    case "DEVICE_CEREMONY_INVALID":
+    case DEVICE_CEREMONY_INVALID_CODE:
       return PSE.deviceCeremonyInvalid;
-    case "DEVICE_LOCKED":
+    case DEVICE_LOCKED_CODE:
       return PSE.deviceLocked;
-    case "DEVICE_WRONG_APP":
+    case DEVICE_WRONG_APP_CODE:
       return PSE.deviceWrongApp;
   }
 

--- a/services/vault/src/utils/errors/formatting.ts
+++ b/services/vault/src/utils/errors/formatting.ts
@@ -15,6 +15,12 @@ import { COPY } from "@/copy";
 
 import { isDepositorWalletMismatchError } from "./depositorWalletMismatch";
 import {
+  deviceErrorCodeOfFrame,
+  isDeviceCeremonyInvalidError,
+  isDeviceLockedError,
+  isDeviceWrongAppError,
+} from "./deviceErrors";
+import {
   isTypedUserRejectionFrame,
   isUserCancellationFrame,
 } from "./userCancellation";
@@ -533,11 +539,34 @@ export function formatPayoutSignatureError(error: unknown): {
     return PSE.wrongDepositorWallet;
   }
 
+  // Top-frame device code — before both cause walks, so an outer device error
+  // is never shadowed by an inner cause (same contract as the rejection bucket).
+  switch (deviceErrorCodeOfFrame(error)) {
+    case "DEVICE_CEREMONY_INVALID":
+      return PSE.deviceCeremonyInvalid;
+    case "DEVICE_LOCKED":
+      return PSE.deviceLocked;
+    case "DEVICE_WRONG_APP":
+      return PSE.deviceWrongApp;
+  }
+
   // Cause-walking, so it must run AFTER every typed bucket above — an inner
   // unsupported-method code must never override a meaningful outer error.
   // Resume-specific copy: an in-flight deposit cannot switch wallets.
   if (isWalletMethodNotSupported(error)) {
     return PSE.walletMethodNotSupported;
+  }
+
+  // Device codes nested in a cause chain — without these they fall to
+  // PSE.unexpected with the real message dropped to diagnostics.
+  if (isDeviceCeremonyInvalidError(error)) {
+    return PSE.deviceCeremonyInvalid;
+  }
+  if (isDeviceLockedError(error)) {
+    return PSE.deviceLocked;
+  }
+  if (isDeviceWrongAppError(error)) {
+    return PSE.deviceWrongApp;
   }
 
   if (error instanceof Error) {


### PR DESCRIPTION
Ledger failures surfaced as raw text or generic fallbacks, a started
ceremony could not be backed out of, and the envelope's tx-graph pin would
have blocked v3 deposits the device signs fine. Errors now carry typed codes
mapped to real copy, cancelSigning() backs out safely (retry re-runs the
full ceremony), and version gating is left to the WASM capability gate.