### PR TITLE
feat(ts-sdk): verify P2WPKH depositor signatures host-side

### DIFF
--- a/packages/babylon-ts-sdk/docs/api/managers.md
+++ b/packages/babylon-ts-sdk/docs/api/managers.md
@@ -382,9 +382,9 @@ wallet to the connected ETH account for this chain and vault
 registry. The returned [PopSignature](#popsignature) can be reused across
 every register call in the same session.
 
-A one-item (P2TR) witness is verified against the depositor key before
-it is returned — see verifyPopWitness. Two-item (P2WPKH)
-witnesses are not yet verified host-side.
+The witness is verified against the depositor key before it is
+returned — Schnorr for one-item (P2TR), ECDSA over the BIP-322
+P2WPKH virtual transaction for two-item — see verifyPopWitness.
 
 ###### Returns
 
@@ -392,8 +392,8 @@ witnesses are not yet verified host-side.
 
 ###### Throws
 
-If the wallet returns a malformed witness or a P2TR signature
-        that does not verify.
+If the wallet returns a malformed witness or a signature that
+        does not verify.
 
 ##### getNetwork()
 

--- a/packages/babylon-ts-sdk/docs/api/primitives.md
+++ b/packages/babylon-ts-sdk/docs/api/primitives.md
@@ -2505,10 +2505,14 @@ function assertReturnedKeyPathSignatures(params): number;
 
 Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/verifyKeyPathSchnorrSignature.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/verifyKeyPathSchnorrSignature.ts)
 
-Verify every key-path-eligible input of the REQUESTED PSBT against what the
-wallet RETURNED: `tapKeySig`, or the single finalized witness item for wallets
-that auto-finalize — and when both are present they must be the same bytes.
-Script-path inputs are skipped (they have their own check).
+Verify every key-path-eligible and P2WPKH input of the REQUESTED PSBT
+against what the wallet RETURNED. Key-path: `tapKeySig`, or the single
+finalized witness item for wallets that auto-finalize — and when both are
+present they must be the same bytes. P2WPKH: `partialSig`, or the finalized
+2-item witness, verified as ECDSA over the BIP-143 sighash
+(assertReturnedP2wpkhSignature); a failure throws but the input is
+NOT counted. Script-path and unknown script types are skipped (they have
+their own checks).
 
 #### Parameters
 
@@ -2520,16 +2524,16 @@ Script-path inputs are skipped (they have their own check).
 
 `number`
 
-How many inputs were actually verified. 0 means NO input was
-         key-path eligible — a caller that knows every input is taproot
-         key-path must assert this equals its input count, or a P2WPKH
-         depositor would read "nothing verified" as "all verified".
+How many inputs were verified KEY-PATH. A caller that knows every
+         input is taproot key-path (e.g. an approval wallet) must assert
+         this equals its input count — P2WPKH inputs never count toward it,
+         so that gate stays exact.
 
 #### Throws
 
 If the input counts differ, an eligible input carries no signature, a
-        finalized witness disagrees with its `tapKeySig`, or any signature
-        does not verify.
+        finalized witness disagrees with its `tapKeySig`/`partialSig`, or any
+        signature does not verify.
 
 ***
 

--- a/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/__tests__/bip322P2wpkhVectors.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/__tests__/bip322P2wpkhVectors.ts
@@ -1,0 +1,52 @@
+/**
+ * BIP-322 official P2WPKH "simple" test vectors, pinned from
+ * `bitcoin/bips` `bip-0322/basic-test-vectors.json` at commit
+ * d77863fb9e9be7829ad8bb51694b9ba80a786766 ("BIP-0322: update test
+ * vectors", 2026-05-06). The base64 `bip322_signatures` entries (after
+ * stripping the file's `smp` variant marker) decode to consensus
+ * witnesses `[DER sig ‖ 0x01, 33-byte compressed pubkey]`; the fields
+ * below are those decoded bytes as hex.
+ *
+ * Signer: private key L3VFeEujGtevx9w18HD1fhRbCH67Az2dpCymeRE1SoPK6XQtaN2k
+ * for address bc1q9vza2e8x573nczrlzms0wvx3gsqjx7vavgkx0l — public BIP
+ * test material, not real key material.
+ */
+
+/** 33-byte compressed pubkey shared by every vector (hash160 = the address's witness program). */
+export const BIP322_P2WPKH_PUBKEY_HEX =
+  "02c7f12003196442943d8588e01aee840423cc54fc1521526a3b85c2b0cbd58872";
+
+/** x-only form of {@link BIP322_P2WPKH_PUBKEY_HEX}, as a depositor key would be normalized. */
+export const BIP322_P2WPKH_PUBKEY_XONLY_HEX =
+  "c7f12003196442943d8588e01aee840423cc54fc1521526a3b85c2b0cbd58872";
+
+/**
+ * Encoded signatures (DER ‖ 0x01 sighash byte) per message. Each message
+ * carries the file's two variants: a 71-byte and a 72-byte encoding.
+ */
+export const BIP322_P2WPKH_SIGNATURES: ReadonlyArray<{
+  readonly message: string;
+  readonly encodedSignatureHexes: readonly [string, string];
+}> = [
+  {
+    message: "",
+    encodedSignatureHexes: [
+      "30440220336801010aaf657d79662cac98a990a43ac6f376af2c84f8f76401ccb9d0231602201693a4e683db4a91944ca5cb11527840366daf583a2c695fccf8e93483b52e3401",
+      "3045022100f909d50e28612d21b6fcae4851cbc51429140639e9bef452f13b0f16b37a7d1902202d65f173d52e93e88db731623694afe970d4d69dcbb22fc50bfa831dc9d560cc01",
+    ],
+  },
+  {
+    message: "Hello World",
+    encodedSignatureHexes: [
+      "304402206517c8637a7bfc3a154edcba6196d64bbd5b73955cb7da7d1626bcdde466c364022022bf10d19fc0bb69b4596e306b362acaa835293cf693bb176f7324b531f5afec01",
+      "3045022100ecf2ca796ab7dde538a26bfb09a6c487a7b3fff33f397db6a20eb9af77c0ee8c022062e67e44c8070f49c3a37f5940a8850842daf7cca35e6af61a6c7c91f1e1a1a301",
+    ],
+  },
+];
+
+/**
+ * The "Hello World" 71-byte-signature vector as a full consensus-encoded
+ * two-item witness (`0x02 ‖ 0x47 ‖ sig ‖ 0x21 ‖ pubkey`), for callers
+ * that consume the raw witness (e.g. `verifyPopWitness`).
+ */
+export const BIP322_P2WPKH_HELLO_WORLD_WITNESS_HEX = `0247${BIP322_P2WPKH_SIGNATURES[1].encodedSignatureHexes[0]}21${BIP322_P2WPKH_PUBKEY_HEX}`;

--- a/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/__tests__/bip322Verify.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/__tests__/bip322Verify.test.ts
@@ -1,23 +1,35 @@
 /**
- * Golden-vector test for BIP-322 simple verify.
+ * Golden-vector tests for BIP-322 simple verify.
  *
- * The signature + message + pubkey are emitted by the Rust reference
- * in `btc-vault/crates/btc-auth/src/server_identity.rs`. The signer
- * seed is 7 and the payload is produced by
+ * P2TR: the signature + message + pubkey are emitted by the Rust
+ * reference in `btc-vault/crates/btc-auth/src/server_identity.rs`.
+ * The signer seed is 7 and the payload is produced by
  * `build_server_identity_payload` with a seed-42 ephemeral pubkey
  * and expires_at = 1_700_000_000. These were generated end-to-end
  * by the Rust production path, not constructed ad-hoc — so if this
  * test passes, the TypeScript implementation byte-exactly matches
  * what a real VP would sign.
  *
- * Canonical hex lives in `./goldenVectors.ts` so that all
- * server-identity tests share one source of truth and can't drift.
+ * P2WPKH: the vectors are BIP-322's official ones, pinned in
+ * `./bip322P2wpkhVectors.ts`.
+ *
+ * Canonical hex lives in `./goldenVectors.ts` / `./bip322P2wpkhVectors.ts`
+ * so the suites share one source of truth and can't drift.
  */
 
+import { Buffer } from "buffer";
+
+import * as ecc from "@bitcoin-js/tiny-secp256k1-asmjs";
+import { sha256 } from "@noble/hashes/sha2.js";
+import { script as bscript, payments, Transaction } from "bitcoinjs-lib";
 import { describe, expect, it } from "vitest";
 
-import { verifyBip322Simple } from "../bip322Verify";
+import { verifyBip322P2wpkhSimple, verifyBip322Simple } from "../bip322Verify";
 import { encodeServerIdentityPayload } from "../cbor";
+import {
+  BIP322_P2WPKH_PUBKEY_HEX,
+  BIP322_P2WPKH_SIGNATURES,
+} from "./bip322P2wpkhVectors";
 import {
   GOLDEN_EPHEMERAL_PUBKEY_COMPRESSED,
   GOLDEN_EXPIRES_AT,
@@ -131,5 +143,155 @@ describe("verifyBip322Simple — end-to-end via encodeServerIdentityPayload", ()
         false,
       );
     }
+  });
+});
+
+const VECTOR_PUBKEY = fromHex(BIP322_P2WPKH_PUBKEY_HEX);
+const utf8 = (s: string) => new TextEncoder().encode(s);
+
+// In-test BIP-322 P2WPKH signer for cases the official vectors can't cover
+// (wrong hashtype, short DER encoding). Reconstructs to_spend/to_sign per the
+// BIP-322 spec ("simple" format); the official-vector tests above anchor that
+// the production verifier follows the same construction.
+const TEST_PRIV = Buffer.alloc(32, 0);
+TEST_PRIV[31] = 1; // privkey 1 → pubkey G; public test material.
+const TEST_PUB = Buffer.from(ecc.pointFromScalar(TEST_PRIV, true)!);
+
+function bip322P2wpkhSighash(
+  messageBytes: Uint8Array,
+  pubkey: Buffer,
+  hashType: number,
+): Buffer {
+  const th = Buffer.from(sha256(utf8("BIP0322-signed-message")));
+  const messageHash = Buffer.from(
+    sha256(Buffer.concat([th, th, Buffer.from(messageBytes)])),
+  );
+  const p2wpkh = payments.p2wpkh({ pubkey });
+  const toSpend = new Transaction();
+  toSpend.version = 0;
+  toSpend.locktime = 0;
+  toSpend.addInput(
+    Buffer.alloc(32, 0),
+    0xffffffff,
+    0,
+    Buffer.concat([Buffer.from([0x00, 0x20]), messageHash]),
+  );
+  toSpend.addOutput(p2wpkh.output!, 0);
+  const toSign = new Transaction();
+  toSign.version = 0;
+  toSign.locktime = 0;
+  toSign.addInput(toSpend.getHash(), 0, 0);
+  toSign.addOutput(Buffer.from([0x6a]), 0);
+  const scriptCode = payments.p2pkh({ hash: p2wpkh.hash! }).output!;
+  return toSign.hashForWitnessV0(0, scriptCode, 0, hashType);
+}
+
+describe("verifyBip322P2wpkhSimple — BIP-322 official P2WPKH vectors", () => {
+  it("accepts every official vector (both messages, 71- and 72-byte encodings)", () => {
+    for (const { message, encodedSignatureHexes } of BIP322_P2WPKH_SIGNATURES) {
+      for (const sigHex of encodedSignatureHexes) {
+        expect(
+          verifyBip322P2wpkhSimple(
+            utf8(message),
+            VECTOR_PUBKEY,
+            fromHex(sigHex),
+          ),
+        ).toBe(true);
+      }
+    }
+  });
+
+  it("rejects a tampered signature byte", () => {
+    const sig = fromHex(BIP322_P2WPKH_SIGNATURES[1].encodedSignatureHexes[0]);
+    sig[10] ^= 0x01; // inside the DER r value
+    expect(
+      verifyBip322P2wpkhSimple(utf8("Hello World"), VECTOR_PUBKEY, sig),
+    ).toBe(false);
+  });
+
+  it("rejects the right signature under a different pubkey", () => {
+    expect(
+      verifyBip322P2wpkhSimple(
+        utf8("Hello World"),
+        TEST_PUB, // valid compressed point, not the vector signer
+        fromHex(BIP322_P2WPKH_SIGNATURES[1].encodedSignatureHexes[0]),
+      ),
+    ).toBe(false);
+  });
+
+  it("rejects the wrong message", () => {
+    expect(
+      verifyBip322P2wpkhSimple(
+        utf8("Hello World!"),
+        VECTOR_PUBKEY,
+        fromHex(BIP322_P2WPKH_SIGNATURES[1].encodedSignatureHexes[0]),
+      ),
+    ).toBe(false);
+  });
+
+  it("rejects a trailing hashtype byte that is not SIGHASH_ALL", () => {
+    for (const hashType of [0x00, 0x02, 0x03, 0x81]) {
+      const sig = fromHex(BIP322_P2WPKH_SIGNATURES[1].encodedSignatureHexes[0]);
+      sig[sig.length - 1] = hashType;
+      expect(
+        verifyBip322P2wpkhSimple(utf8("Hello World"), VECTOR_PUBKEY, sig),
+      ).toBe(false);
+    }
+  });
+
+  it("rejects a cryptographically valid SIGHASH_NONE signature (gate, not sig failure)", () => {
+    // Signed over the real NONE sighash: without the explicit SIGHASH_ALL
+    // gate (bip322 crate 0.0.10 verify.rs:156-161) this would verify.
+    const message = utf8("sighash gate");
+    const sighashNone = bip322P2wpkhSighash(message, TEST_PUB, 0x02);
+    const encoded = bscript.signature.encode(
+      Buffer.from(ecc.sign(sighashNone, TEST_PRIV)),
+      0x02,
+    );
+    expect(verifyBip322P2wpkhSimple(message, TEST_PUB, encoded)).toBe(false);
+  });
+
+  it("rejects an encoded signature shorter than 71 bytes even when cryptographically valid", () => {
+    // vaultd's verifier accepts ONLY 71/72-byte encodings (bip322 crate
+    // 0.0.10 verify.rs:141-153), so a short-DER signature would fail
+    // ingestion permanently — the host gate must reject it too. Grind the
+    // sign entropy until r or s DER-encodes one byte short.
+    const message = utf8("short der");
+    const sighash = bip322P2wpkhSighash(message, TEST_PUB, 0x01);
+    let shortEncoded: Buffer | undefined;
+    for (let i = 0; i < 5000 && !shortEncoded; i++) {
+      const entropy = Buffer.alloc(32, 0);
+      entropy.writeUInt32LE(i, 0);
+      const candidate = bscript.signature.encode(
+        Buffer.from(ecc.sign(sighash, TEST_PRIV, entropy)),
+        0x01,
+      );
+      if (candidate.length < 71) shortEncoded = candidate;
+    }
+    expect(shortEncoded).toBeDefined();
+    // Sanity: the short signature IS valid ECDSA for this sighash.
+    expect(
+      ecc.verify(
+        sighash,
+        TEST_PUB,
+        bscript.signature.decode(shortEncoded!).signature,
+        true,
+      ),
+    ).toBe(true);
+    expect(verifyBip322P2wpkhSimple(message, TEST_PUB, shortEncoded!)).toBe(
+      false,
+    );
+  });
+
+  it("rejects a pubkey that is not on the curve or not 33 bytes", () => {
+    const sig = fromHex(BIP322_P2WPKH_SIGNATURES[0].encodedSignatureHexes[0]);
+    const notAPoint = Buffer.concat([
+      Buffer.from([0x02]),
+      Buffer.alloc(32, 0xff), // x ≥ field prime — no point has this encoding
+    ]);
+    expect(verifyBip322P2wpkhSimple(utf8(""), notAPoint, sig)).toBe(false);
+    expect(
+      verifyBip322P2wpkhSimple(utf8(""), VECTOR_PUBKEY.subarray(1), sig),
+    ).toBe(false);
   });
 });

--- a/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/bip322Verify.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/bip322Verify.ts
@@ -69,6 +69,21 @@ const P2WPKH_ENCODED_SIG_MAX = 72;
 // plain `0` everywhere.
 const ZERO_SATS = 0;
 
+// Wire fields of the virtual to_spend/to_sign transactions (`bip322`
+// crate 0.0.10 `util.rs:18-85`).
+const BIP322_TX_VERSION = 0;
+const BIP322_TX_LOCKTIME = 0;
+const BIP322_INPUT_SEQUENCE = 0;
+/** to_spend prevout: all-zero 32-byte txid at index 0xFFFFFFFF (`util.rs:18-85`). */
+const TO_SPEND_PREVOUT_TXID_BYTES = 32;
+const TO_SPEND_PREVOUT_INDEX = 0xffffffff;
+/** to_sign spends to_spend's only output (`util.rs:18-85`). */
+const TO_SPEND_OUTPUT_INDEX = 0;
+const OP_0 = 0x00;
+/** Direct push of the 32-byte tagged message hash. */
+const OP_PUSHBYTES_32 = 0x20;
+const OP_RETURN = 0x6a;
+
 /**
  * BIP-340 tagged hash: `SHA256( SHA256(tag) || SHA256(tag) || data )`.
  * Used for both BIP-322 message hashing and BIP-341 tap-tweak.
@@ -112,27 +127,30 @@ function buildToSignTransaction(
   const messageHash = taggedHash(BIP322_TAG, messageBytes);
 
   const toSpend = new Transaction();
-  toSpend.version = 0;
-  toSpend.locktime = 0;
-  // scriptSig: OP_0 (0x00) + OP_PUSHBYTES_32 (0x20) + message_hash (32B)
+  toSpend.version = BIP322_TX_VERSION;
+  toSpend.locktime = BIP322_TX_LOCKTIME;
   const scriptSig = Buffer.concat([
-    Buffer.from([0x00, 0x20]),
+    Buffer.from([OP_0, OP_PUSHBYTES_32]),
     Buffer.from(messageHash),
   ]);
   toSpend.addInput(
-    Buffer.alloc(32, 0), // prev_txid = 0x0000...0000
-    0xffffffff, // prev_vout = 0xFFFFFFFF
-    0, // sequence = 0
+    Buffer.alloc(TO_SPEND_PREVOUT_TXID_BYTES, 0),
+    TO_SPEND_PREVOUT_INDEX,
+    BIP322_INPUT_SEQUENCE,
     scriptSig,
   );
   toSpend.addOutput(scriptPubKey, ZERO_SATS);
 
   const toSign = new Transaction();
-  toSign.version = 0;
-  toSign.locktime = 0;
+  toSign.version = BIP322_TX_VERSION;
+  toSign.locktime = BIP322_TX_LOCKTIME;
   // Bitcoin txid in natural-byte (little-endian) form.
-  toSign.addInput(toSpend.getHash(), 0, 0);
-  toSign.addOutput(Buffer.from([0x6a]), ZERO_SATS); // OP_RETURN
+  toSign.addInput(
+    toSpend.getHash(),
+    TO_SPEND_OUTPUT_INDEX,
+    BIP322_INPUT_SEQUENCE,
+  );
+  toSign.addOutput(Buffer.from([OP_RETURN]), ZERO_SATS);
 
   return toSign;
 }

--- a/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/bip322Verify.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/bip322Verify.ts
@@ -1,10 +1,10 @@
 /**
- * BIP-322 "simple" signature verification for P2TR key-path.
+ * BIP-322 "simple" signature verification for P2TR key-path and P2WPKH.
  *
  * Mirrors the Rust reference in
- * `btc-vault/crates/btc-signer/src/message.rs::verify_bip322_message`
- * (which delegates to `rust-bitcoin::bip322::verify_simple` for a
- * P2TR key-path-only address with no merkle root).
+ * `btc-vault/crates/btc-signer/src/message.rs` (`verify_bip322_message`
+ * and the P2WPKH arm of `verify_pop_witness`, both of which delegate to
+ * the `bip322` crate 0.0.10's `verify_simple`).
  *
  * The algorithm:
  *
@@ -14,30 +14,30 @@
  *
  *   2. Build a virtual "to_spend" transaction with one input (prevout
  *      all-zero txid + 0xFFFFFFFF vout, scriptSig = `OP_0 PUSH32 m_hash`,
- *      sequence = 0) and one output (value 0, scriptPubKey = P2TR for
- *      the signer's x-only pubkey).
+ *      sequence = 0) and one output (value 0, scriptPubKey = the signer's
+ *      address: P2TR key-path-only, or P2WPKH of the compressed pubkey).
  *
  *   3. Build a "to_sign" transaction that spends to_spend[0] and has a
  *      single `OP_RETURN` output (value 0).
  *
- *   4. Compute the BIP-341 taproot sighash of to_sign input 0 with the
- *      caller's `hashType` (SIGHASH_DEFAULT 0x00 unless the witness item
- *      carried a trailing SIGHASH_ALL 0x01 byte).
+ *   4. Compute the sighash of to_sign input 0: BIP-341 taproot for P2TR
+ *      (SIGHASH_DEFAULT 0x00 unless the witness item carried a trailing
+ *      SIGHASH_ALL 0x01 byte), BIP-143 with the standard P2WPKH
+ *      scriptCode for P2WPKH (SIGHASH_ALL only).
  *
- *   5. Verify the 64-byte Schnorr signature against the **tweaked**
- *      output key `Q = P + tap_tweak(P) * G`, where `tap_tweak(P) =
- *      hash_TapTweak(serialize_x_only(P))` (no merkle root — key-path
- *      only).
+ *   5. Verify the signature: Schnorr against the **tweaked** output key
+ *      `Q = P + tap_tweak(P) * G` for P2TR (no merkle root — key-path
+ *      only), ECDSA against the compressed pubkey for P2WPKH.
  *
  * `bitcoinjs-lib` handles (2)–(4); `tiny-secp256k1-asmjs` provides
- * the tweak and Schnorr verify. Pulling in a full BIP-322 library
- * would add a peer dep for what amounts to ~40 lines of glue.
+ * the tweak and the Schnorr/ECDSA verifies. Pulling in a full BIP-322
+ * library would add a peer dep for what amounts to ~40 lines of glue.
  *
  * @module tbv/core/clients/vault-provider/auth/bip322Verify
  */
 
 import * as ecc from "@bitcoin-js/tiny-secp256k1-asmjs";
-import { payments, Transaction } from "bitcoinjs-lib";
+import { script as bscript, payments, Transaction } from "bitcoinjs-lib";
 
 import { sha256 } from "@noble/hashes/sha2.js";
 import { Buffer } from "buffer";
@@ -50,6 +50,24 @@ const TAPTWEAK_TAG = "TapTweak";
 
 const X_ONLY_PUBKEY_SIZE = 32;
 const SCHNORR_SIG_SIZE = 64;
+/** SEC1 compressed pubkey: 0x02/0x03 prefix + 32-byte x coordinate. */
+const COMPRESSED_PUBKEY_SIZE = 33;
+/**
+ * vaultd's P2WPKH BIP-322 verifier accepts ONLY 71/72-byte encoded
+ * signatures — DER (70/71B) + sighash byte (`bip322` crate 0.0.10
+ * `verify.rs:141-153`). A shorter (short-DER) signature fails ingestion
+ * permanently, so this gate must be exactly as strict.
+ */
+const P2WPKH_ENCODED_SIG_MIN = 71;
+const P2WPKH_ENCODED_SIG_MAX = 72;
+
+// NOTE: bitcoinjs-lib v6.x's `Transaction.addOutput` and its sighash
+// methods are typed for `Satoshi` (a UInt53 number), not `bigint`.
+// Passing `BigInt(0)` triggers a typeforce assertion in `addOutput`
+// ("Expected property '1' of type Satoshi, got BigInt 0") which the
+// verifiers' try/catch silently turns into `verify -> false`. Use
+// plain `0` everywhere.
+const ZERO_SATS = 0;
 
 /**
  * BIP-340 tagged hash: `SHA256( SHA256(tag) || SHA256(tag) || data )`.
@@ -80,6 +98,43 @@ function tweakXOnlyKey(xOnly: Uint8Array): Uint8Array | null {
   const tweak = taggedHash(TAPTWEAK_TAG, xOnly);
   const tweaked = ecc.xOnlyPointAddTweak(xOnly, tweak);
   return tweaked ? tweaked.xOnlyPubkey : null;
+}
+
+/**
+ * Build the BIP-322 virtual `to_sign` transaction for a signer
+ * scriptPubKey (steps 1–3 above; `bip322` crate 0.0.10 `util.rs:18-85`:
+ * both txs version 0, locktime 0, sequence 0, all values 0).
+ */
+function buildToSignTransaction(
+  messageBytes: Uint8Array,
+  scriptPubKey: Buffer,
+): Transaction {
+  const messageHash = taggedHash(BIP322_TAG, messageBytes);
+
+  const toSpend = new Transaction();
+  toSpend.version = 0;
+  toSpend.locktime = 0;
+  // scriptSig: OP_0 (0x00) + OP_PUSHBYTES_32 (0x20) + message_hash (32B)
+  const scriptSig = Buffer.concat([
+    Buffer.from([0x00, 0x20]),
+    Buffer.from(messageHash),
+  ]);
+  toSpend.addInput(
+    Buffer.alloc(32, 0), // prev_txid = 0x0000...0000
+    0xffffffff, // prev_vout = 0xFFFFFFFF
+    0, // sequence = 0
+    scriptSig,
+  );
+  toSpend.addOutput(scriptPubKey, ZERO_SATS);
+
+  const toSign = new Transaction();
+  toSign.version = 0;
+  toSign.locktime = 0;
+  // Bitcoin txid in natural-byte (little-endian) form.
+  toSign.addInput(toSpend.getHash(), 0, 0);
+  toSign.addOutput(Buffer.from([0x6a]), ZERO_SATS); // OP_RETURN
+
+  return toSign;
 }
 
 /**
@@ -127,10 +182,7 @@ export function verifyBip322Simple(
   // treated as a verification failure rather than propagated — a
   // verifier MUST return a boolean, not raise.
   try {
-    // Step 1: BIP-322 tagged hash of the message.
-    const messageHash = taggedHash(BIP322_TAG, messageBytes);
-
-    // Step 2: scriptPubKey for the signer's P2TR key-path-only address.
+    // scriptPubKey for the signer's P2TR key-path-only address.
     // bitcoinjs-lib's `payments.p2tr({ internalPubkey })` computes the
     // tweak and produces the `OP_1 <tweaked_xonly>` output script.
     const p2tr = payments.p2tr({
@@ -139,41 +191,9 @@ export function verifyBip322Simple(
     if (!p2tr.output) return false;
     const scriptPubKey = p2tr.output;
 
-    // Step 3: build to_spend virtual tx.
-    //
-    // NOTE: bitcoinjs-lib v6.x's `Transaction.addOutput` and
-    // `hashForWitnessV1` are typed for `Satoshi` (a UInt53 number),
-    // not `bigint`. Passing `BigInt(0)` triggers a typeforce
-    // assertion in `addOutput` ("Expected property '1' of type
-    // Satoshi, got BigInt 0") which our outer try/catch silently
-    // turns into `verify -> false`. Use plain `0` everywhere.
-    const ZERO_SATS = 0;
-    const toSpend = new Transaction();
-    toSpend.version = 0;
-    toSpend.locktime = 0;
-    // scriptSig: OP_0 (0x00) + OP_PUSHBYTES_32 (0x20) + message_hash (32B)
-    const scriptSig = Buffer.concat([
-      Buffer.from([0x00, 0x20]),
-      Buffer.from(messageHash),
-    ]);
-    toSpend.addInput(
-      Buffer.alloc(32, 0), // prev_txid = 0x0000...0000
-      0xffffffff, // prev_vout = 0xFFFFFFFF
-      0, // sequence = 0
-      scriptSig,
-    );
-    toSpend.addOutput(scriptPubKey, ZERO_SATS);
+    const toSign = buildToSignTransaction(messageBytes, scriptPubKey);
 
-    // Step 4: build to_sign virtual tx spending to_spend[0].
-    const toSign = new Transaction();
-    toSign.version = 0;
-    toSign.locktime = 0;
-    // Bitcoin txid in natural-byte (little-endian) form.
-    const toSpendTxid = toSpend.getHash();
-    toSign.addInput(toSpendTxid, 0, 0);
-    toSign.addOutput(Buffer.from([0x6a]), ZERO_SATS); // OP_RETURN
-
-    // Step 5: taproot sighash for to_sign input 0.
+    // Taproot sighash for to_sign input 0.
     const sighash = toSign.hashForWitnessV1(
       0,
       [scriptPubKey],
@@ -181,11 +201,77 @@ export function verifyBip322Simple(
       hashType,
     );
 
-    // Step 6: tweak the x-only pubkey (no merkle root) and verify Schnorr.
+    // Tweak the x-only pubkey (no merkle root) and verify Schnorr.
     const tweakedXOnly = tweakXOnlyKey(xOnlyPubkey);
     if (!tweakedXOnly) return false;
 
     return ecc.verifySchnorr(sighash, tweakedXOnly, signature);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Verify a BIP-322 "simple" P2WPKH signature over an arbitrary byte
+ * message, mirroring the verifier vaultd runs on a two-item PoP witness
+ * (`bip322` crate 0.0.10 `verify.rs:102-186 verify_full_p2wpkh`).
+ *
+ * @internal Consumed by `verifyPopWitness` for Native SegWit software
+ * wallets, and exposed so the BIP-322 official-vector test suite can pin
+ * the verifier independently.
+ *
+ * @param compressedPubkey - 33-byte SEC1 compressed pubkey of the signer
+ *                           (witness item 1). The address is derived from
+ *                           it; network affects only bech32 encoding, not
+ *                           script or sighash (`message.rs:125-127`).
+ * @param encodedSignature - Witness item 0: DER signature with trailing
+ *                           sighash byte, 71 or 72 bytes, SIGHASH_ALL only
+ *                           (`verify.rs:141-161`).
+ * @returns `true` if the signature verifies against the P2WPKH address of
+ *          `compressedPubkey`; `false` otherwise.
+ */
+export function verifyBip322P2wpkhSimple(
+  messageBytes: Uint8Array,
+  compressedPubkey: Uint8Array,
+  encodedSignature: Uint8Array,
+): boolean {
+  if (compressedPubkey.length !== COMPRESSED_PUBKEY_SIZE) return false;
+  if (
+    encodedSignature.length < P2WPKH_ENCODED_SIG_MIN ||
+    encodedSignature.length > P2WPKH_ENCODED_SIG_MAX
+  ) {
+    return false;
+  }
+  // Any exception below (strict-DER decode, malformed pubkey) is a
+  // verification failure, not an error — a verifier returns a boolean.
+  try {
+    // Full curve-point parse, as `PublicKey::from_slice` (`verify.rs:82-83`).
+    if (!ecc.isPointCompressed(compressedPubkey)) return false;
+
+    // Strict DER decode, then SIGHASH_ALL only — deliberately NARROWER than
+    // `verify.rs:156-161` (its from_consensus maps more bytes to All); host-stricter is safe.
+    const { signature, hashType } = bscript.signature.decode(
+      Buffer.from(encodedSignature),
+    );
+    if (hashType !== Transaction.SIGHASH_ALL) return false;
+
+    // scriptPubKey = OP_0 PUSH20 hash160(pubkey) (`message.rs:127 Address::p2wpkh`).
+    const p2wpkh = payments.p2wpkh({ pubkey: Buffer.from(compressedPubkey) });
+    if (!p2wpkh.output || !p2wpkh.hash) return false;
+
+    const toSign = buildToSignTransaction(messageBytes, p2wpkh.output);
+
+    // BIP-143 sighash with the standard P2WPKH scriptCode
+    // `OP_DUP OP_HASH160 <20B> OP_EQUALVERIFY OP_CHECKSIG` and value 0
+    // (`verify.rs:163-173 p2wpkh_signature_hash`; scriptCode template per
+    // bitcoinjs-lib's own P2WPKH signer, `src/psbt.js:1245-1255`).
+    const scriptCode = payments.p2pkh({ hash: p2wpkh.hash }).output;
+    if (!scriptCode) return false;
+    const sighash = toSign.hashForWitnessV0(0, scriptCode, ZERO_SATS, hashType);
+
+    // strict=true rejects high-S, as libsecp256k1's verify does
+    // (`verify.rs:180-182`; secp256k1 crate `ecdsa/mod.rs:194`).
+    return ecc.verify(sighash, compressedPubkey, signature, true);
   } catch {
     return false;
   }

--- a/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts
@@ -1209,10 +1209,10 @@ export class PeginManager {
       returnedPsbtHex: signedPsbtHex,
     });
 
-    // Far-side check of the key-path signatures (CLAUDE.md §8: never trust the
-    // wallet's success/finalization). Covers taproot-funded inputs only —
-    // P2WPKH/P2WSH funding (non-taproot software-wallet accounts) is skipped
-    // by isKeyPathEligible and stays unverified here.
+    // Far-side check of the returned signatures (CLAUDE.md §8: never trust
+    // the wallet's success/finalization). Taproot key-path inputs are
+    // Schnorr-verified and counted; P2WPKH funding is ECDSA-verified
+    // (throwing on failure) without counting; P2WSH stays skipped.
     const verifiedInputs = assertReturnedKeyPathSignatures({
       requestedPsbtHex,
       returnedPsbtHex: signedPsbtHex,
@@ -1786,12 +1786,12 @@ export class PeginManager {
    * registry. The returned {@link PopSignature} can be reused across
    * every register call in the same session.
    *
-   * A one-item (P2TR) witness is verified against the depositor key before
-   * it is returned — see {@link verifyPopWitness}. Two-item (P2WPKH)
-   * witnesses are not yet verified host-side.
+   * The witness is verified against the depositor key before it is
+   * returned — Schnorr for one-item (P2TR), ECDSA over the BIP-322
+   * P2WPKH virtual transaction for two-item — see {@link verifyPopWitness}.
    *
-   * @throws If the wallet returns a malformed witness or a P2TR signature
-   *         that does not verify.
+   * @throws If the wallet returns a malformed witness or a signature that
+   *         does not verify.
    */
   async signProofOfPossession(): Promise<PopSignature> {
     if (!this.config.ethWallet.account) {
@@ -1813,8 +1813,8 @@ export class PeginManager {
 
     const btcPopSignature = normalizePopSignature(raw);
     // Fail before the Ethereum registration: vaultd rejects a bad PoP permanently.
-    // The verdict is informational — a P2WPKH witness can only be pubkey-checked,
-    // and both outcomes are acceptable here; anything worse already threw.
+    // The verdict is informational — both shapes are fully verified, and
+    // anything invalid already threw.
     verifyPopWitness(
       new TextEncoder().encode(popMessage),
       depositorBtcPubkey,

--- a/packages/babylon-ts-sdk/src/tbv/core/managers/__tests__/PeginManager.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/__tests__/PeginManager.test.ts
@@ -972,10 +972,18 @@ describe("PeginManager", () => {
   });
 
   describe("signProofOfPossession", () => {
-    // varint(2) ‖ varint(71) ‖ 71B DER sig ‖ varint(33) ‖ 33B pubkey — the
-    // two-item P2WPKH shape. The embedded pubkey must be the depositor's
-    // (verifyPopWitness mirrors vaultd's WitnessPubkeyMismatch check).
-    const P2WPKH_POP_WITNESS_HEX = `02${"47"}${"11".repeat(71)}${"21"}${"02" + TEST_KEYS.DEPOSITOR}`;
+    // A REAL two-item P2WPKH witness for the PoP message the manager under
+    // test builds — `verifyPopWitness` now cryptographically verifies it
+    // (vaultd's message.rs:107-133), so injected fixtures must be valid.
+    async function realPopWitnessHex(
+      ethWallet: MockEthereumWallet,
+    ): Promise<string> {
+      const popMessage = `${ethWallet.account!.address.toLowerCase()}:${TEST_CHAIN.id}:pegin:${TEST_CONTRACT_ADDRESS.toLowerCase()}`;
+      const signed = await new MockBitcoinWallet({
+        publicKeyHex: TEST_KEYS.DEPOSITOR,
+      }).signMessage(popMessage, "bip322-simple");
+      return signed.slice(2);
+    }
 
     it("returns signature bound to connected ETH and BTC identities", async () => {
       const btcWallet = new MockBitcoinWallet({
@@ -1028,10 +1036,11 @@ describe("PeginManager", () => {
       const btcWallet = new MockBitcoinWallet({
         publicKeyHex: TEST_KEYS.DEPOSITOR,
       });
-      vi.spyOn(btcWallet, "signMessage").mockResolvedValueOnce(
-        `0x${P2WPKH_POP_WITNESS_HEX.toUpperCase()}`,
-      );
       const ethWallet = new MockEthereumWallet();
+      const witnessHex = await realPopWitnessHex(ethWallet);
+      vi.spyOn(btcWallet, "signMessage").mockResolvedValueOnce(
+        `0x${witnessHex.toUpperCase()}`,
+      );
 
       const manager = new PeginManager({
         btcNetwork: "signet",
@@ -1044,7 +1053,7 @@ describe("PeginManager", () => {
       });
 
       const pop = await manager.signProofOfPossession();
-      expect(pop.btcPopSignature).toBe(`0x${P2WPKH_POP_WITNESS_HEX}`);
+      expect(pop.btcPopSignature).toBe(`0x${witnessHex}`);
     });
 
     it("rejects wallet output that is not a decodable witness", async () => {
@@ -1094,14 +1103,15 @@ describe("PeginManager", () => {
       );
     });
 
-    it("lets a two-item (P2WPKH) PoP witness through", async () => {
+    it("verifies a two-item (P2WPKH) PoP witness and lets it through", async () => {
       const btcWallet = new MockBitcoinWallet({
         publicKeyHex: TEST_KEYS.DEPOSITOR,
       });
-      vi.spyOn(btcWallet, "signMessage").mockResolvedValueOnce(
-        `0x${P2WPKH_POP_WITNESS_HEX}`,
-      );
       const ethWallet = new MockEthereumWallet();
+      const witnessHex = await realPopWitnessHex(ethWallet);
+      vi.spyOn(btcWallet, "signMessage").mockResolvedValueOnce(
+        `0x${witnessHex}`,
+      );
 
       const manager = new PeginManager({
         btcNetwork: "signet",
@@ -1114,7 +1124,35 @@ describe("PeginManager", () => {
       });
 
       const pop = await manager.signProofOfPossession();
-      expect(pop.btcPopSignature).toBe(`0x${P2WPKH_POP_WITNESS_HEX}`);
+      expect(pop.btcPopSignature).toBe(`0x${witnessHex}`);
+    });
+
+    it("throws when the wallet returns a P2WPKH PoP whose signature does not verify", async () => {
+      const btcWallet = new MockBitcoinWallet({
+        publicKeyHex: TEST_KEYS.DEPOSITOR,
+      });
+      const ethWallet = new MockEthereumWallet();
+      // Flip a hex digit inside the DER r value (offset 20 of the witness).
+      const witnessHex = await realPopWitnessHex(ethWallet);
+      const tampered =
+        witnessHex.slice(0, 20) +
+        (witnessHex[20] === "0" ? "1" : "0") +
+        witnessHex.slice(21);
+      vi.spyOn(btcWallet, "signMessage").mockResolvedValueOnce(`0x${tampered}`);
+
+      const manager = new PeginManager({
+        btcNetwork: "signet",
+        btcWallet,
+        ethWallet: ethWallet as any,
+        ethChain: TEST_CHAIN,
+        publicClient: TEST_PUBLIC_CLIENT,
+        vaultContracts: { btcVaultRegistry: TEST_CONTRACT_ADDRESS },
+        mempoolApiUrl: MEMPOOL_API_URLS.signet,
+      });
+
+      await expect(manager.signProofOfPossession()).rejects.toThrow(
+        /proof of possession signature does not verify/,
+      );
     });
 
     it("rejects an empty signature from the wallet", async () => {
@@ -1182,10 +1220,9 @@ describe("PeginManager", () => {
       const btcWallet = new MockBitcoinWallet({
         publicKeyHex: TEST_KEYS.DEPOSITOR,
       });
-      vi.spyOn(btcWallet, "signMessage").mockResolvedValueOnce(
-        P2WPKH_POP_WITNESS_HEX,
-      );
       const ethWallet = new MockEthereumWallet();
+      const witnessHex = await realPopWitnessHex(ethWallet);
+      vi.spyOn(btcWallet, "signMessage").mockResolvedValueOnce(witnessHex);
 
       const manager = new PeginManager({
         btcNetwork: "signet",
@@ -1198,7 +1235,7 @@ describe("PeginManager", () => {
       });
 
       const pop = await manager.signProofOfPossession();
-      expect(pop.btcPopSignature).toBe(`0x${P2WPKH_POP_WITNESS_HEX}`);
+      expect(pop.btcPopSignature).toBe(`0x${witnessHex}`);
     });
 
     it("accepts a compressed sec1 pubkey and drops the prefix byte", async () => {

--- a/packages/babylon-ts-sdk/src/tbv/core/managers/pegin/__tests__/verifyPopWitness.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/pegin/__tests__/verifyPopWitness.test.ts
@@ -3,13 +3,18 @@
  *
  * The P2TR cases reuse the BIP-322 golden vector emitted by the Rust
  * reference (`btc-vault/crates/btc-auth/src/server_identity.rs`, signer
- * seed 7) so a passing test proves the witness path feeds the verifier
- * exactly what a real signer produced.
+ * seed 7); the P2WPKH cases use BIP-322's official test vectors — so a
+ * passing test proves the witness path feeds the verifiers exactly what
+ * a real signer produced.
  */
 
 import { Buffer } from "buffer";
 import { describe, expect, it } from "vitest";
 
+import {
+  BIP322_P2WPKH_HELLO_WORLD_WITNESS_HEX,
+  BIP322_P2WPKH_PUBKEY_XONLY_HEX,
+} from "../../../clients/vault-provider/auth/__tests__/bip322P2wpkhVectors";
 import {
   GOLDEN_PAYLOAD_HEX,
   GOLDEN_SIGNATURE_HEX,
@@ -19,11 +24,9 @@ import { verifyPopWitness } from "../verifyPopWitness";
 
 const fromHex = (h: string) => Uint8Array.from(Buffer.from(h, "hex"));
 
-/** varint(2) ‖ varint(71) ‖ 71B DER sig ‖ varint(33) ‖ 33B compressed pubkey. */
-/** Two-item P2WPKH witness: [DER sig(71B), compressed pubkey] with the given x-only key. */
-function p2wpkhWitness(xOnlyHex: string): `0x${string}` {
-  return `0x02${"47"}${"11".repeat(71)}${"21"}${"02" + xOnlyHex}`;
-}
+const HELLO_WORLD = new TextEncoder().encode("Hello World");
+const HELLO_WORLD_WITNESS =
+  `0x${BIP322_P2WPKH_HELLO_WORLD_WITNESS_HEX}` as const;
 
 describe("verifyPopWitness", () => {
   it("verifies a one-item P2TR witness (0x01 0x40 ‖ sig) against the BIP-322 golden vector", () => {
@@ -113,25 +116,48 @@ describe("verifyPopWitness", () => {
     ).toThrow(/bare 64-char x-only hex/);
   });
 
-  it("passes a two-item P2WPKH witness with the depositor's pubkey through unverified (sig verify: #2284)", () => {
+  it("verifies a two-item P2WPKH witness against the BIP-322 official vector", () => {
     expect(
       verifyPopWitness(
-        fromHex(GOLDEN_PAYLOAD_HEX),
-        GOLDEN_SIGNING_KEY_XONLY,
-        p2wpkhWitness(GOLDEN_SIGNING_KEY_XONLY),
+        HELLO_WORLD,
+        BIP322_P2WPKH_PUBKEY_XONLY_HEX,
+        HELLO_WORLD_WITNESS,
       ),
-    ).toEqual({ kind: "p2wpkh-unverified" });
+    ).toEqual({ kind: "p2wpkh-verified" });
   });
 
-  it("rejects a two-item witness whose embedded pubkey is not the depositor's", () => {
-    // Mirrors vaultd's WitnessPubkeyMismatch — the wrong-account signature
-    // must fail here, not as a permanent InvalidDepositorPop after registration.
+  it("throws when the P2WPKH signature does not verify", () => {
+    // Flip one byte inside the DER r value (witness hex offset: 2-item
+    // marker + length byte + DER header land the r bytes well past index 8).
+    const tampered =
+      HELLO_WORLD_WITNESS.slice(0, 20) +
+      (HELLO_WORLD_WITNESS[20] === "0" ? "1" : "0") +
+      HELLO_WORLD_WITNESS.slice(21);
     expect(() =>
       verifyPopWitness(
-        fromHex(GOLDEN_PAYLOAD_HEX),
-        GOLDEN_SIGNING_KEY_XONLY,
-        p2wpkhWitness("22".repeat(32)),
+        HELLO_WORLD,
+        BIP322_P2WPKH_PUBKEY_XONLY_HEX,
+        tampered as `0x${string}`,
       ),
+    ).toThrow(/proof of possession signature does not verify/);
+  });
+
+  it("throws when the message differs from the one signed", () => {
+    expect(() =>
+      verifyPopWitness(
+        new TextEncoder().encode("Hello World!"),
+        BIP322_P2WPKH_PUBKEY_XONLY_HEX,
+        HELLO_WORLD_WITNESS,
+      ),
+    ).toThrow(/proof of possession signature does not verify/);
+  });
+
+  it("rejects a valid witness whose embedded pubkey is not the depositor's", () => {
+    // Mirrors vaultd's WitnessPubkeyMismatch (message.rs:117-123): a VALID
+    // signature from the wrong account must surface as the pubkey-mismatch
+    // failure, not as an invalid signature.
+    expect(() =>
+      verifyPopWitness(HELLO_WORLD, "22".repeat(32), HELLO_WORLD_WITNESS),
     ).toThrow(/does not match the depositor key/);
   });
 
@@ -145,6 +171,15 @@ describe("verifyPopWitness", () => {
         badWitness,
       ),
     ).toThrow(/not a compressed public key/);
+  });
+
+  it("rejects a two-item witness whose pubkey is not a point on secp256k1", () => {
+    // Correct shape (33 bytes, 0x02 prefix) but x ≥ the field prime —
+    // vaultd rejects it at CompressedPublicKey::from_slice (message.rs:111-116).
+    const notAPoint: `0x${string}` = `0x02${"47"}${"11".repeat(71)}${"21"}${"02" + "ff".repeat(32)}`;
+    expect(() =>
+      verifyPopWitness(fromHex(GOLDEN_PAYLOAD_HEX), "ff".repeat(32), notAPoint),
+    ).toThrow(/not a valid secp256k1 point/);
   });
 
   it("throws on a witness with any other item count or a truncated item", () => {

--- a/packages/babylon-ts-sdk/src/tbv/core/managers/pegin/verifyPopWitness.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/pegin/verifyPopWitness.ts
@@ -34,6 +34,10 @@ const P2TR_WITNESS_ITEMS = 1;
 const P2WPKH_WITNESS_ITEMS = 2;
 /** SEC1 compressed pubkey: 0x02/0x03 prefix + 32-byte x coordinate. */
 const COMPRESSED_PUBKEY_BYTES = 33;
+/** SEC1 prefix bytes: 0x02 even Y, 0x03 odd Y; the x coordinate follows. */
+const SEC1_EVEN_Y_PREFIX = 0x02;
+const SEC1_ODD_Y_PREFIX = 0x03;
+const SEC1_PREFIX_BYTES = 1;
 const SCHNORR_SIG_BYTES = 64;
 /** BIP-341 hash types: 0x00 default (64-byte sig), 0x01 ALL (65-byte sig with trailing type byte). */
 const SIGHASH_DEFAULT = 0x00;
@@ -128,7 +132,7 @@ export function verifyPopWitness(
     const [encodedSignature, pubkey] = items;
     if (
       pubkey.length !== COMPRESSED_PUBKEY_BYTES ||
-      (pubkey[0] !== 0x02 && pubkey[0] !== 0x03)
+      (pubkey[0] !== SEC1_EVEN_Y_PREFIX && pubkey[0] !== SEC1_ODD_Y_PREFIX)
     ) {
       throw new Error(
         `proof of possession P2WPKH witness item 1 is not a compressed public key ` +
@@ -145,7 +149,9 @@ export function verifyPopWitness(
     // Pubkey compare (message.rs:117-123, WitnessPubkeyMismatch): witness
     // item 1 must be the depositor's compressed key — a wrong-account
     // signature fails HERE, not as a generic invalid signature.
-    const witnessXOnlyHex = Buffer.from(pubkey.subarray(1)).toString("hex");
+    const witnessXOnlyHex = Buffer.from(
+      pubkey.subarray(SEC1_PREFIX_BYTES),
+    ).toString("hex");
     if (witnessXOnlyHex !== depositorXOnlyHex.toLowerCase()) {
       throw new Error(
         `proof of possession witness pubkey does not match the depositor key: ` +

--- a/packages/babylon-ts-sdk/src/tbv/core/managers/pegin/verifyPopWitness.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/pegin/verifyPopWitness.ts
@@ -12,18 +12,23 @@
  *
  * P2TR is verified with the package's existing BIP-322 verifier (64-byte
  * SIGHASH_DEFAULT or 65-byte SIGHASH_ALL, matching what the `bip322` crate
- * 0.0.10 accepts in `verify.rs:213-236`). P2WPKH witnesses pass through
- * UNVERIFIED for now (follow-up: a P2WPKH BIP-322 verifier mirroring
- * `message.rs:107-133`); the verdict says so.
+ * 0.0.10 accepts in `verify.rs:213-236`). P2WPKH mirrors the 2-item arm of
+ * `message.rs:107-133`: parse the compressed pubkey, require its x-only
+ * form to equal the depositor key, then BIP-322-verify the witness against
+ * that pubkey's P2WPKH address.
  *
  * @module managers/pegin/verifyPopWitness
  */
 
+import * as ecc from "@bitcoin-js/tiny-secp256k1-asmjs";
 import { Buffer } from "buffer";
-import { decodeWitnessStack } from "../../utils/witness/witnessStack";
 import type { Hex } from "viem";
+import { decodeWitnessStack } from "../../utils/witness/witnessStack";
 
-import { verifyBip322Simple } from "../../clients/vault-provider/auth/bip322Verify";
+import {
+  verifyBip322P2wpkhSimple,
+  verifyBip322Simple,
+} from "../../clients/vault-provider/auth/bip322Verify";
 
 const P2TR_WITNESS_ITEMS = 1;
 const P2WPKH_WITNESS_ITEMS = 2;
@@ -40,7 +45,7 @@ const WITNESS_BODY_HEX = /^(?:[0-9a-f]{2})+$/;
 
 export type PopWitnessVerdict =
   | { readonly kind: "p2tr-verified" }
-  | { readonly kind: "p2wpkh-unverified" };
+  | { readonly kind: "p2wpkh-verified" };
 
 function decodeWitnessItems(witnessHex: Hex): Uint8Array[] {
   const body = witnessHex.slice(2);
@@ -57,16 +62,17 @@ function decodeWitnessItems(witnessHex: Hex): Uint8Array[] {
 }
 
 /**
- * Decode a consensus-encoded PoP witness and, for the P2TR shape, verify the
- * Schnorr signature against the depositor's key.
+ * Decode a consensus-encoded PoP witness and verify it against the
+ * depositor's key: Schnorr for the P2TR shape, ECDSA over the BIP-322
+ * P2WPKH virtual transaction for the two-item shape.
  *
  * @param messageBytes     - Bytes of the PoP message that was signed.
  * @param depositorXOnlyHex - Depositor x-only pubkey, bare 64-char hex
  *                            (enforced, not assumed).
  * @param witnessHex       - 0x-prefixed consensus-encoded witness.
  * @throws If the witness is malformed, has an unsupported item count, the
- *         depositor key is not bare x-only hex, or the P2TR signature does
- *         not verify.
+ *         depositor key is not bare x-only hex, the witness pubkey is not
+ *         the depositor's, or the signature does not verify.
  */
 export function verifyPopWitness(
   messageBytes: Uint8Array,
@@ -114,17 +120,12 @@ export function verifyPopWitness(
   }
 
   if (items.length === P2WPKH_WITNESS_ITEMS) {
-    // Signature verification is deferred (#2284), but vaultd's FIRST check is
-    // a plain pubkey compare (btc-vault crates/btc-signer/src/message.rs:110-123,
-    // WitnessPubkeyMismatch): witness item 1 must be the depositor's compressed
-    // key. Mirror it here — it needs no crypto and catches a wrong-account
-    // signature before it becomes a permanent InvalidDepositorPop.
     if (!X_ONLY_PUBKEY_HEX.test(depositorXOnlyHex)) {
       throw new Error(
         `depositor public key must be bare 64-char x-only hex, got "${depositorXOnlyHex}"`,
       );
     }
-    const pubkey = items[1];
+    const [encodedSignature, pubkey] = items;
     if (
       pubkey.length !== COMPRESSED_PUBKEY_BYTES ||
       (pubkey[0] !== 0x02 && pubkey[0] !== 0x03)
@@ -134,6 +135,16 @@ export function verifyPopWitness(
           `(${pubkey.length} bytes, prefix 0x${pubkey[0]?.toString(16) ?? "none"})`,
       );
     }
+    // Full curve-point parse, as vaultd's CompressedPublicKey::from_slice
+    // (message.rs:111-116) — before the key compare, matching its order.
+    if (!ecc.isPointCompressed(pubkey)) {
+      throw new Error(
+        "proof of possession P2WPKH witness pubkey is not a valid secp256k1 point",
+      );
+    }
+    // Pubkey compare (message.rs:117-123, WitnessPubkeyMismatch): witness
+    // item 1 must be the depositor's compressed key — a wrong-account
+    // signature fails HERE, not as a generic invalid signature.
     const witnessXOnlyHex = Buffer.from(pubkey.subarray(1)).toString("hex");
     if (witnessXOnlyHex !== depositorXOnlyHex.toLowerCase()) {
       throw new Error(
@@ -141,7 +152,14 @@ export function verifyPopWitness(
           `witness carries ${witnessXOnlyHex}, expected ${depositorXOnlyHex}`,
       );
     }
-    return { kind: "p2wpkh-unverified" };
+    // BIP-322 simple verification against the P2WPKH address of the witness
+    // pubkey (message.rs:125-133; network affects only bech32 encoding).
+    if (!verifyBip322P2wpkhSimple(messageBytes, pubkey, encodedSignature)) {
+      throw new Error(
+        "proof of possession signature does not verify against the depositor key",
+      );
+    }
+    return { kind: "p2wpkh-verified" };
   }
 
   throw new Error(

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/__tests__/verifyKeyPathSchnorrSignature.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/__tests__/verifyKeyPathSchnorrSignature.test.ts
@@ -12,8 +12,10 @@
 import { Buffer } from "buffer";
 
 import * as ecc from "@bitcoin-js/tiny-secp256k1-asmjs";
+import { sha256 } from "@noble/hashes/sha2.js";
 import {
   crypto as bcrypto,
+  script as bscript,
   initEccLib,
   payments,
   Psbt,
@@ -327,5 +329,377 @@ describe("assertReturnedKeyPathSignatures", () => {
         returnedPsbtHex: req.toHex(),
       }),
     ).not.toThrow();
+  });
+});
+
+// ── P2WPKH (Native SegWit funding) helpers ──
+// Signed in-test with the same key material; the verifier under test mirrors
+// btc-vault `crates/btc-wallet-remote/src/client.rs verify_finalized_p2wpkh_spend`.
+const P2WPKH_PAYMENT = payments.p2wpkh({ pubkey: PUB });
+const P2WPKH_SCRIPT = P2WPKH_PAYMENT.output!;
+
+function p2wpkhScriptCode(pubkey: Buffer): Buffer {
+  return payments.p2pkh({ hash: bcrypto.hash160(pubkey) }).output!;
+}
+
+function p2wpkhRequestedPsbt(values: number[] = [100_000, 50_000]): Psbt {
+  const psbt = new Psbt();
+  values.forEach((value, i) => {
+    psbt.addInput({
+      hash: Buffer.alloc(32, i + 1),
+      index: i,
+      witnessUtxo: { script: P2WPKH_SCRIPT, value },
+    });
+  });
+  psbt.addOutput({
+    script: Buffer.concat([Buffer.from([0x51, 0x20]), Buffer.alloc(32, 0xaa)]),
+    value: 140_000,
+  });
+  return psbt;
+}
+
+/** DER ‖ sighash-byte signature over the BIP-143 sighash of one input. */
+function signP2wpkh(
+  psbt: Psbt,
+  inputIndex: number,
+  overrides: { value?: number; hashType?: number; priv?: Buffer } = {},
+): Buffer {
+  const value =
+    overrides.value ?? psbt.data.inputs[inputIndex].witnessUtxo!.value;
+  const hashType = overrides.hashType ?? Transaction.SIGHASH_ALL;
+  const priv = overrides.priv ?? PRIV;
+  const tx = Transaction.fromBuffer(psbt.data.globalMap.unsignedTx.toBuffer());
+  const pub = Buffer.from(ecc.pointFromScalar(priv, true)!);
+  const sighash = tx.hashForWitnessV0(
+    inputIndex,
+    p2wpkhScriptCode(pub),
+    value,
+    hashType,
+  );
+  return Buffer.from(
+    bscript.signature.encode(Buffer.from(ecc.sign(sighash, priv)), hashType),
+  );
+}
+
+/** Consensus 2-item witness `[sig, pubkey]` (or another item list for tampering). */
+function p2wpkhWitness(items: Buffer[]): Buffer {
+  return Buffer.concat([
+    Buffer.from([items.length]),
+    ...items.map((item) => Buffer.concat([Buffer.from([item.length]), item])),
+  ]);
+}
+
+describe("assertReturnedKeyPathSignatures — P2WPKH inputs", () => {
+  it("verifies partialSig on every P2WPKH input (unfinalized return)", () => {
+    const req = p2wpkhRequestedPsbt();
+    const ret = Psbt.fromHex(req.toHex());
+    ret.updateInput(0, {
+      partialSig: [{ pubkey: PUB, signature: signP2wpkh(req, 0) }],
+    });
+    ret.updateInput(1, {
+      partialSig: [{ pubkey: PUB, signature: signP2wpkh(req, 1) }],
+    });
+    expect(
+      assertReturnedKeyPathSignatures({
+        requestedPsbtHex: req.toHex(),
+        returnedPsbtHex: ret.toHex(),
+      }),
+    ).toBe(0); // count stays key-path-only; P2WPKH failures throw instead
+  });
+
+  it("verifies the finalized 2-item witness when the wallet auto-finalized", () => {
+    const req = p2wpkhRequestedPsbt();
+    const ret = Psbt.fromHex(req.toHex());
+    ret.updateInput(0, {
+      finalScriptWitness: p2wpkhWitness([signP2wpkh(req, 0), PUB]),
+    });
+    ret.updateInput(1, {
+      finalScriptWitness: p2wpkhWitness([signP2wpkh(req, 1), PUB]),
+    });
+    expect(() =>
+      assertReturnedKeyPathSignatures({
+        requestedPsbtHex: req.toHex(),
+        returnedPsbtHex: ret.toHex(),
+      }),
+    ).not.toThrow();
+  });
+
+  it("throws when a P2WPKH input carries no signature", () => {
+    const req = p2wpkhRequestedPsbt();
+    const ret = Psbt.fromHex(req.toHex());
+    ret.updateInput(0, {
+      partialSig: [{ pubkey: PUB, signature: signP2wpkh(req, 0) }],
+    });
+    expect(() =>
+      assertReturnedKeyPathSignatures({
+        requestedPsbtHex: req.toHex(),
+        returnedPsbtHex: ret.toHex(),
+      }),
+    ).toThrow(/input 1 carries no P2WPKH signature/);
+  });
+
+  it("throws when the signature is tampered, naming the input", () => {
+    const req = p2wpkhRequestedPsbt();
+    const ret = Psbt.fromHex(req.toHex());
+    const sig = signP2wpkh(req, 0);
+    sig[10] ^= 0x01; // inside the DER r value
+    ret.updateInput(0, { partialSig: [{ pubkey: PUB, signature: sig }] });
+    ret.updateInput(1, {
+      partialSig: [{ pubkey: PUB, signature: signP2wpkh(req, 1) }],
+    });
+    expect(() =>
+      assertReturnedKeyPathSignatures({
+        requestedPsbtHex: req.toHex(),
+        returnedPsbtHex: ret.toHex(),
+      }),
+    ).toThrow(/input 0 does not verify/);
+  });
+
+  it("throws on a wrong prevout value (sighash mismatch)", () => {
+    const req = p2wpkhRequestedPsbt();
+    const ret = Psbt.fromHex(req.toHex());
+    ret.updateInput(0, {
+      partialSig: [
+        { pubkey: PUB, signature: signP2wpkh(req, 0, { value: 100_001 }) },
+      ],
+    });
+    ret.updateInput(1, {
+      partialSig: [{ pubkey: PUB, signature: signP2wpkh(req, 1) }],
+    });
+    expect(() =>
+      assertReturnedKeyPathSignatures({
+        requestedPsbtHex: req.toHex(),
+        returnedPsbtHex: ret.toHex(),
+      }),
+    ).toThrow(/input 0 does not verify/);
+  });
+
+  it("rejects a cryptographically valid SIGHASH_NONE signature, naming the input", () => {
+    // Without the SIGHASH_ALL-only gate (client.rs:981-987) this would verify.
+    const req = p2wpkhRequestedPsbt();
+    const ret = Psbt.fromHex(req.toHex());
+    ret.updateInput(0, {
+      partialSig: [
+        {
+          pubkey: PUB,
+          signature: signP2wpkh(req, 0, { hashType: Transaction.SIGHASH_NONE }),
+        },
+      ],
+    });
+    ret.updateInput(1, {
+      partialSig: [{ pubkey: PUB, signature: signP2wpkh(req, 1) }],
+    });
+    expect(() =>
+      assertReturnedKeyPathSignatures({
+        requestedPsbtHex: req.toHex(),
+        returnedPsbtHex: ret.toHex(),
+      }),
+    ).toThrow(/input 0.*SIGHASH_ALL/);
+  });
+
+  it("rejects corrupted DER and an undefined hashtype byte, naming the input", () => {
+    const req = p2wpkhRequestedPsbt();
+    const badDer = Psbt.fromHex(req.toHex());
+    const mangled = signP2wpkh(req, 0);
+    mangled[0] = 0x31; // DER sequence tag must be 0x30
+    // Direct assignment: bip174 refuses mangled DER via updateInput, but its
+    // PARSER doesn't validate signature bytes — a wallet can return this.
+    badDer.data.inputs[0].partialSig = [{ pubkey: PUB, signature: mangled }];
+    badDer.updateInput(1, {
+      partialSig: [{ pubkey: PUB, signature: signP2wpkh(req, 1) }],
+    });
+    expect(() =>
+      assertReturnedKeyPathSignatures({
+        requestedPsbtHex: req.toHex(),
+        returnedPsbtHex: badDer.toHex(),
+      }),
+    ).toThrow(/input 0/);
+
+    const badType = Psbt.fromHex(req.toHex());
+    const zeroType = signP2wpkh(req, 0);
+    zeroType[zeroType.length - 1] = 0x00; // not a defined sighash type
+    badType.data.inputs[0].partialSig = [{ pubkey: PUB, signature: zeroType }];
+    badType.updateInput(1, {
+      partialSig: [{ pubkey: PUB, signature: signP2wpkh(req, 1) }],
+    });
+    expect(() =>
+      assertReturnedKeyPathSignatures({
+        requestedPsbtHex: req.toHex(),
+        returnedPsbtHex: badType.toHex(),
+      }),
+    ).toThrow(/input 0/);
+  });
+
+  it("rejects a pubkey that does not hash to the prevout's witness program", () => {
+    const req = p2wpkhRequestedPsbt();
+    const ret = Psbt.fromHex(req.toHex());
+    const otherPriv = Buffer.alloc(32, 9);
+    const otherPub = Buffer.from(ecc.pointFromScalar(otherPriv, true)!);
+    ret.updateInput(0, {
+      finalScriptWitness: p2wpkhWitness([
+        signP2wpkh(req, 0, { priv: otherPriv }),
+        otherPub,
+      ]),
+    });
+    ret.updateInput(1, {
+      partialSig: [{ pubkey: PUB, signature: signP2wpkh(req, 1) }],
+    });
+    expect(() =>
+      assertReturnedKeyPathSignatures({
+        requestedPsbtHex: req.toHex(),
+        returnedPsbtHex: ret.toHex(),
+      }),
+    ).toThrow(/witness program/);
+  });
+
+  it("rejects a finalized witness with the wrong item count or a non-33-byte pubkey", () => {
+    const req = p2wpkhRequestedPsbt();
+    const sig = signP2wpkh(req, 0);
+    const threeItems = Psbt.fromHex(req.toHex());
+    threeItems.updateInput(0, {
+      finalScriptWitness: p2wpkhWitness([sig, PUB, Buffer.from([0x01])]),
+    });
+    threeItems.updateInput(1, {
+      partialSig: [{ pubkey: PUB, signature: signP2wpkh(req, 1) }],
+    });
+    expect(() =>
+      assertReturnedKeyPathSignatures({
+        requestedPsbtHex: req.toHex(),
+        returnedPsbtHex: threeItems.toHex(),
+      }),
+    ).toThrow(/exactly 2 items/);
+
+    const xOnlyPub = Psbt.fromHex(req.toHex());
+    xOnlyPub.updateInput(0, {
+      finalScriptWitness: p2wpkhWitness([sig, PUB.subarray(1)]),
+    });
+    xOnlyPub.updateInput(1, {
+      partialSig: [{ pubkey: PUB, signature: signP2wpkh(req, 1) }],
+    });
+    expect(() =>
+      assertReturnedKeyPathSignatures({
+        requestedPsbtHex: req.toHex(),
+        returnedPsbtHex: xOnlyPub.toHex(),
+      }),
+    ).toThrow(/33 bytes/);
+  });
+
+  it("throws when a finalized witness disagrees with the partialSig on the same input", () => {
+    // The consumers broadcast the witness bytes, so a valid partialSig must
+    // not launder a different witness signature past the check.
+    const req = p2wpkhRequestedPsbt();
+    const ret = Psbt.fromHex(req.toHex());
+    ret.updateInput(0, {
+      partialSig: [{ pubkey: PUB, signature: signP2wpkh(req, 0) }],
+      finalScriptWitness: p2wpkhWitness([signP2wpkh(req, 1), PUB]),
+    });
+    ret.updateInput(1, {
+      partialSig: [{ pubkey: PUB, signature: signP2wpkh(req, 1) }],
+    });
+    expect(() =>
+      assertReturnedKeyPathSignatures({
+        requestedPsbtHex: req.toHex(),
+        returnedPsbtHex: ret.toHex(),
+      }),
+    ).toThrow(/input 0.*does not match its partialSig/);
+  });
+
+  it("verifies a mixed PSBT and still counts only key-path inputs", () => {
+    const req = new Psbt();
+    req.addInput({
+      hash: Buffer.alloc(32, 1),
+      index: 0,
+      witnessUtxo: { script: P2TR, value: 100_000 },
+      tapInternalKey: X_ONLY,
+    });
+    req.addInput({
+      hash: Buffer.alloc(32, 2),
+      index: 1,
+      witnessUtxo: { script: P2WPKH_SCRIPT, value: 50_000 },
+    });
+    req.addOutput({
+      script: Buffer.concat([
+        Buffer.from([0x51, 0x20]),
+        Buffer.alloc(32, 0xaa),
+      ]),
+      value: 140_000,
+    });
+    const ret = Psbt.fromHex(req.toHex());
+    ret.updateInput(0, { tapKeySig: sign(req, 0) });
+    ret.updateInput(1, {
+      partialSig: [{ pubkey: PUB, signature: signP2wpkh(req, 1) }],
+    });
+    expect(
+      assertReturnedKeyPathSignatures({
+        requestedPsbtHex: req.toHex(),
+        returnedPsbtHex: ret.toHex(),
+      }),
+    ).toBe(1);
+  });
+
+  it("still skips genuinely unknown script types (P2WSH)", () => {
+    const req = new Psbt();
+    req.addInput({
+      hash: Buffer.alloc(32, 1),
+      index: 0,
+      witnessUtxo: {
+        script: Buffer.concat([
+          Buffer.from([0x00, 0x20]),
+          Buffer.alloc(32, 0x33),
+        ]),
+        value: 1_000,
+      },
+    });
+    req.addOutput({ script: Buffer.from([0x6a]), value: 0 });
+    expect(() =>
+      assertReturnedKeyPathSignatures({
+        requestedPsbtHex: req.toHex(),
+        returnedPsbtHex: req.toHex(),
+      }),
+    ).not.toThrow();
+  });
+
+  it("differential over varied keys and values: accepts honest signatures, rejects one-byte tampering", () => {
+    // CLAUDE.md §9: golden vectors plus varied inputs, not one pinned vector.
+    // Keys/values derive from a hash counter so failures are reproducible.
+    const utf8 = (s: string) => new TextEncoder().encode(s);
+    for (let i = 0; i < 6; i++) {
+      const priv = Buffer.from(sha256(utf8(`p2wpkh-differential-${i}`)));
+      const pub = Buffer.from(ecc.pointFromScalar(priv, true)!);
+      const value = 1_000 + (priv.readUInt32BE(0) % 5_000_000);
+      const script = payments.p2wpkh({ pubkey: pub }).output!;
+      const req = new Psbt();
+      req.addInput({
+        hash: Buffer.from(sha256(utf8(`prevout-${i}`))),
+        index: 0,
+        witnessUtxo: { script, value },
+      });
+      req.addOutput({ script: Buffer.from([0x6a]), value: 0 });
+      const sig = signP2wpkh(req, 0, { priv });
+
+      const honest = Psbt.fromHex(req.toHex());
+      honest.updateInput(0, {
+        finalScriptWitness: p2wpkhWitness([sig, pub]),
+      });
+      expect(() =>
+        assertReturnedKeyPathSignatures({
+          requestedPsbtHex: req.toHex(),
+          returnedPsbtHex: honest.toHex(),
+        }),
+      ).not.toThrow();
+
+      const tampered = Psbt.fromHex(req.toHex());
+      const badSig = Buffer.from(sig);
+      badSig[12 + (i % 8)] ^= 0x01;
+      tampered.updateInput(0, {
+        finalScriptWitness: p2wpkhWitness([badSig, pub]),
+      });
+      expect(() =>
+        assertReturnedKeyPathSignatures({
+          requestedPsbtHex: req.toHex(),
+          returnedPsbtHex: tampered.toHex(),
+        }),
+      ).toThrow(/input 0/);
+    }
   });
 });

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/__tests__/verifyKeyPathSchnorrSignature.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/__tests__/verifyKeyPathSchnorrSignature.test.ts
@@ -497,7 +497,7 @@ describe("assertReturnedKeyPathSignatures — P2WPKH inputs", () => {
     ).toThrow(/input 0.*SIGHASH_ALL/);
   });
 
-  it("rejects corrupted DER and an undefined hashtype byte, naming the input", () => {
+  it("rejects corrupted DER, naming the input", () => {
     const req = p2wpkhRequestedPsbt();
     const badDer = Psbt.fromHex(req.toHex());
     const mangled = signP2wpkh(req, 0);
@@ -514,10 +514,15 @@ describe("assertReturnedKeyPathSignatures — P2WPKH inputs", () => {
         returnedPsbtHex: badDer.toHex(),
       }),
     ).toThrow(/input 0/);
+  });
 
+  it("rejects an undefined sighash-type byte, naming the input", () => {
+    const req = p2wpkhRequestedPsbt();
     const badType = Psbt.fromHex(req.toHex());
     const zeroType = signP2wpkh(req, 0);
     zeroType[zeroType.length - 1] = 0x00; // not a defined sighash type
+    // Direct assignment: bip174 refuses mangled DER via updateInput, but its
+    // PARSER doesn't validate signature bytes — a wallet can return this.
     badType.data.inputs[0].partialSig = [{ pubkey: PUB, signature: zeroType }];
     badType.updateInput(1, {
       partialSig: [{ pubkey: PUB, signature: signP2wpkh(req, 1) }],
@@ -552,12 +557,15 @@ describe("assertReturnedKeyPathSignatures — P2WPKH inputs", () => {
     ).toThrow(/witness program/);
   });
 
-  it("rejects a finalized witness with the wrong item count or a non-33-byte pubkey", () => {
+  it("rejects a finalized witness with the wrong item count", () => {
     const req = p2wpkhRequestedPsbt();
-    const sig = signP2wpkh(req, 0);
     const threeItems = Psbt.fromHex(req.toHex());
     threeItems.updateInput(0, {
-      finalScriptWitness: p2wpkhWitness([sig, PUB, Buffer.from([0x01])]),
+      finalScriptWitness: p2wpkhWitness([
+        signP2wpkh(req, 0),
+        PUB,
+        Buffer.from([0x01]),
+      ]),
     });
     threeItems.updateInput(1, {
       partialSig: [{ pubkey: PUB, signature: signP2wpkh(req, 1) }],
@@ -568,10 +576,13 @@ describe("assertReturnedKeyPathSignatures — P2WPKH inputs", () => {
         returnedPsbtHex: threeItems.toHex(),
       }),
     ).toThrow(/exactly 2 items/);
+  });
 
+  it("rejects a finalized witness with a non-33-byte pubkey", () => {
+    const req = p2wpkhRequestedPsbt();
     const xOnlyPub = Psbt.fromHex(req.toHex());
     xOnlyPub.updateInput(0, {
-      finalScriptWitness: p2wpkhWitness([sig, PUB.subarray(1)]),
+      finalScriptWitness: p2wpkhWitness([signP2wpkh(req, 0), PUB.subarray(1)]),
     });
     xOnlyPub.updateInput(1, {
       partialSig: [{ pubkey: PUB, signature: signP2wpkh(req, 1) }],

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/verifyKeyPathSchnorrSignature.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/verifyKeyPathSchnorrSignature.ts
@@ -5,6 +5,10 @@
  * `crates/btc-wallet-remote/src/client.rs check_signatures_valid` (output key taken
  * from the prevout scriptPubKey, all prevouts committed). The wallet's
  * success/finalization is never trusted on its own (CLAUDE.md §8).
+ * `assertReturnedKeyPathSignatures` additionally dispatches P2WPKH-funded
+ * inputs to `verifyP2wpkhEcdsaSignature` (client.rs's
+ * `verify_finalized_p2wpkh_spend` sibling), so a Native SegWit software
+ * wallet's signatures no longer pass through unchecked.
  *
  * Why verify against the *requested* PSBT: `assertPsbtUnsignedTxMatches` pins
  * the unsigned transaction but deliberately skips per-input metadata, so a
@@ -20,8 +24,12 @@ import { Psbt, Transaction } from "bitcoinjs-lib";
 
 import { Buffer } from "buffer";
 
-import { hexToUint8Array, stripHexPrefix } from "../utils/bitcoin";
 import { decodeWitnessStack } from "../../utils/witness/witnessStack";
+import { hexToUint8Array, stripHexPrefix } from "../utils/bitcoin";
+import {
+  assertReturnedP2wpkhSignature,
+  isP2wpkhScript,
+} from "./verifyP2wpkhEcdsaSignature";
 
 const SCHNORR_SIG_BYTES = 64;
 const SIGHASH_DEFAULT = Transaction.SIGHASH_DEFAULT; // 0x00
@@ -194,18 +202,22 @@ export interface AssertReturnedKeyPathSignaturesParams {
 }
 
 /**
- * Verify every key-path-eligible input of the REQUESTED PSBT against what the
- * wallet RETURNED: `tapKeySig`, or the single finalized witness item for wallets
- * that auto-finalize — and when both are present they must be the same bytes.
- * Script-path inputs are skipped (they have their own check).
+ * Verify every key-path-eligible and P2WPKH input of the REQUESTED PSBT
+ * against what the wallet RETURNED. Key-path: `tapKeySig`, or the single
+ * finalized witness item for wallets that auto-finalize — and when both are
+ * present they must be the same bytes. P2WPKH: `partialSig`, or the finalized
+ * 2-item witness, verified as ECDSA over the BIP-143 sighash
+ * ({@link assertReturnedP2wpkhSignature}); a failure throws but the input is
+ * NOT counted. Script-path and unknown script types are skipped (they have
+ * their own checks).
  *
- * @returns How many inputs were actually verified. 0 means NO input was
- *          key-path eligible — a caller that knows every input is taproot
- *          key-path must assert this equals its input count, or a P2WPKH
- *          depositor would read "nothing verified" as "all verified".
+ * @returns How many inputs were verified KEY-PATH. A caller that knows every
+ *          input is taproot key-path (e.g. an approval wallet) must assert
+ *          this equals its input count — P2WPKH inputs never count toward it,
+ *          so that gate stays exact.
  * @throws If the input counts differ, an eligible input carries no signature, a
- *         finalized witness disagrees with its `tapKeySig`, or any signature
- *         does not verify.
+ *         finalized witness disagrees with its `tapKeySig`/`partialSig`, or any
+ *         signature does not verify.
  */
 export function assertReturnedKeyPathSignatures(
   params: AssertReturnedKeyPathSignaturesParams,
@@ -224,10 +236,22 @@ export function assertReturnedKeyPathSignatures(
 
   let verified = 0;
   requested.data.inputs.forEach((input, inputIndex) => {
-    if (!isKeyPathEligible(input)) return;
+    const returnedInput = returned.data.inputs[inputIndex];
+
+    if (!isKeyPathEligible(input)) {
+      // Native SegWit funding inputs get the ECDSA check; anything else
+      // (script-path, P2WSH, ...) is another verifier's job.
+      if (isP2wpkhScript(input.witnessUtxo?.script)) {
+        assertReturnedP2wpkhSignature({
+          requestedPsbtHex,
+          returnedInput,
+          inputIndex,
+        });
+      }
+      return;
+    }
     verified++;
 
-    const returnedInput = returned.data.inputs[inputIndex];
     const tapKeySig = returnedInput.tapKeySig;
     const witnessSig = returnedInput.finalScriptWitness
       ? singleWitnessItem(returnedInput.finalScriptWitness, inputIndex)

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/verifyP2wpkhEcdsaSignature.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/verifyP2wpkhEcdsaSignature.ts
@@ -1,0 +1,247 @@
+/**
+ * Far-side verification of P2WPKH ECDSA signatures a wallet returned, over
+ * the PSBT we requested (trusted prevouts) — the Native SegWit sibling of
+ * `verifyKeyPathSchnorrSignature`. Reference: btc-vault
+ * `crates/btc-wallet-remote/src/client.rs:945-1000
+ * verify_finalized_p2wpkh_spend`. The wallet's success/finalization is
+ * never trusted on its own (CLAUDE.md §8): prevout script and value come
+ * from the PSBT we built; only the signature bytes come from the wallet.
+ *
+ * @module tbv/core/primitives/psbt/verifyP2wpkhEcdsaSignature
+ */
+
+import * as ecc from "@bitcoin-js/tiny-secp256k1-asmjs";
+import {
+  crypto as bcrypto,
+  script as bscript,
+  payments,
+  Psbt,
+  Transaction,
+} from "bitcoinjs-lib";
+
+import { Buffer } from "buffer";
+
+import { decodeWitnessStack } from "../../utils/witness/witnessStack";
+
+// P2WPKH scriptPubKey is exactly `OP_0 OP_PUSHBYTES_20 <20-byte key hash>`
+// (BIP-141 witness program v0, 20 bytes).
+const P2WPKH_SCRIPT_LEN = 22;
+const OP_0 = 0x00;
+const OP_PUSHBYTES_20 = 0x14;
+const P2WPKH_PROGRAM_START = 2;
+
+/** SEC1 compressed pubkey (client.rs:959: "expected a 33-byte compressed key"). */
+const COMPRESSED_PUBKEY_BYTES = 33;
+/** Consensus P2WPKH witness: exactly [signature, pubkey] (client.rs:951-957). */
+const P2WPKH_WITNESS_ITEMS = 2;
+
+/** Only claim P2WPKH: 22-byte scriptPubKey starting `OP_0 PUSH20`. */
+export function isP2wpkhScript(
+  script: Uint8Array | undefined,
+): script is Uint8Array {
+  return (
+    script !== undefined &&
+    script.length === P2WPKH_SCRIPT_LEN &&
+    script[0] === OP_0 &&
+    script[1] === OP_PUSHBYTES_20
+  );
+}
+
+function bytesEqual(a: Uint8Array, b: Uint8Array): boolean {
+  return a.length === b.length && a.every((byte, i) => byte === b[i]);
+}
+
+/** The `[signature, pubkey]` pair of a finalized P2WPKH witness (client.rs:951-957). */
+function decodeP2wpkhWitness(
+  finalScriptWitness: Uint8Array,
+  inputIndex: number,
+): { signature: Uint8Array; pubkey: Uint8Array } {
+  const items = decodeWitnessStack(finalScriptWitness, "finalScriptWitness");
+  if (items.length !== P2WPKH_WITNESS_ITEMS) {
+    throw new Error(
+      `Returned PSBT input ${inputIndex}: a finalized P2WPKH witness must have ` +
+        `exactly 2 items [signature, pubkey], got ${items.length}.`,
+    );
+  }
+  return { signature: items[0], pubkey: items[1] };
+}
+
+export interface AssertReturnedP2wpkhSignatureParams {
+  /** Hex of the PSBT we built and sent (trusted prevout script/value). NOT the wallet's. */
+  requestedPsbtHex: string;
+  /** The wallet-returned PSBT input carrying the signature material. */
+  returnedInput: {
+    partialSig?: Array<{ pubkey: Uint8Array; signature: Uint8Array }>;
+    finalScriptWitness?: Uint8Array;
+  };
+  /** Index of the input the signature is for. */
+  inputIndex: number;
+}
+
+/**
+ * Assert that the returned input carries a valid P2WPKH ECDSA signature
+ * over the BIP-143 sighash of `requestedPsbtHex` input `inputIndex`:
+ * `partialSig` (BIP-174: the value is the exact witness-stack signature
+ * bytes, the key its pubkey), or the finalized 2-item witness — and when
+ * both are present they must be the same bytes.
+ *
+ * @throws If the requested input is not a P2WPKH spend, no signature was
+ *         returned, a finalized witness disagrees with its `partialSig`,
+ *         or any check of `verify_finalized_p2wpkh_spend` fails.
+ */
+export function assertReturnedP2wpkhSignature(
+  params: AssertReturnedP2wpkhSignatureParams,
+): void {
+  const { requestedPsbtHex, returnedInput, inputIndex } = params;
+
+  const partials = returnedInput.partialSig;
+  // Consensus allows exactly one signature in a P2WPKH witness, so a second
+  // partialSig entry is ambiguous tampering, not a fallback to pick from.
+  if (partials !== undefined && partials.length > 1) {
+    throw new Error(
+      `Returned PSBT input ${inputIndex}: a P2WPKH input must carry at most one ` +
+        `partial signature, got ${partials.length}.`,
+    );
+  }
+  const partial = partials?.[0];
+  const witness = returnedInput.finalScriptWitness
+    ? decodeP2wpkhWitness(returnedInput.finalScriptWitness, inputIndex)
+    : undefined;
+
+  // Both fields can be present, and the consumers broadcast the WITNESS
+  // bytes — so the two must agree, not just one of them verify (same
+  // rationale as the tapKeySig/witness agreement check).
+  if (
+    partial &&
+    witness &&
+    (!bytesEqual(partial.signature, witness.signature) ||
+      !bytesEqual(partial.pubkey, witness.pubkey))
+  ) {
+    throw new Error(
+      `Returned PSBT input ${inputIndex} finalized witness does not match its partialSig.`,
+    );
+  }
+
+  const material = partial ?? witness;
+  if (!material) {
+    throw new Error(
+      `Returned PSBT input ${inputIndex} carries no P2WPKH signature ` +
+        `(no partialSig, not finalized).`,
+    );
+  }
+
+  assertP2wpkhEcdsaSignature(
+    requestedPsbtHex,
+    material.signature,
+    material.pubkey,
+    inputIndex,
+  );
+}
+
+/**
+ * The crypto core, mirroring `verify_finalized_p2wpkh_spend` check by
+ * check: pubkey shape and curve membership, hash160(pubkey) == witness
+ * program, strict-DER + SIGHASH_ALL-only signature, ECDSA over the
+ * BIP-143 sighash recomputed from the REQUESTED prevout.
+ */
+function assertP2wpkhEcdsaSignature(
+  requestedPsbtHex: string,
+  encodedSignature: Uint8Array,
+  pubkey: Uint8Array,
+  inputIndex: number,
+): void {
+  const psbt = Psbt.fromHex(requestedPsbtHex);
+
+  if (inputIndex < 0 || inputIndex >= psbt.data.inputs.length) {
+    throw new Error(
+      `Input index ${inputIndex} out of range (${psbt.data.inputs.length} inputs).`,
+    );
+  }
+  const prevout = psbt.data.inputs[inputIndex].witnessUtxo;
+  if (!prevout || !isP2wpkhScript(prevout.script)) {
+    throw new Error(
+      `Input ${inputIndex} of the requested PSBT is not a P2WPKH input.`,
+    );
+  }
+
+  // Pubkey: exactly 33 bytes (client.rs:959-965) and a parseable curve
+  // point, as PublicKey::from_slice (client.rs:966-968).
+  if (pubkey.length !== COMPRESSED_PUBKEY_BYTES) {
+    throw new Error(
+      `Returned PSBT input ${inputIndex}: P2WPKH pubkey must be 33 bytes, ` +
+        `got ${pubkey.length}.`,
+    );
+  }
+  if (!ecc.isPointCompressed(pubkey)) {
+    throw new Error(
+      `Returned PSBT input ${inputIndex}: P2WPKH pubkey is not a valid secp256k1 point.`,
+    );
+  }
+
+  // hash160(pubkey) must equal the prevout's witness program — what
+  // consensus checks (client.rs:970-977).
+  const program = prevout.script.subarray(
+    P2WPKH_PROGRAM_START,
+    P2WPKH_SCRIPT_LEN,
+  );
+  if (!bytesEqual(bcrypto.hash160(Buffer.from(pubkey)), program)) {
+    throw new Error(
+      `Returned PSBT input ${inputIndex}: P2WPKH pubkey does not hash to the ` +
+        `prevout's witness program.`,
+    );
+  }
+
+  // Strict-DER decode with defined-hashtype gate — the accept set of
+  // ecdsa::Signature::from_slice / EcdsaSighashType::from_standard
+  // (client.rs:978-980) — then SIGHASH_ALL exactly (client.rs:981-987).
+  let decoded: { signature: Buffer; hashType: number };
+  try {
+    decoded = bscript.signature.decode(Buffer.from(encodedSignature));
+  } catch (e) {
+    throw new Error(
+      `Returned PSBT input ${inputIndex}: P2WPKH signature is not DER with a ` +
+        `defined sighash byte: ${e instanceof Error ? e.message : String(e)}`,
+    );
+  }
+  if (decoded.hashType !== Transaction.SIGHASH_ALL) {
+    throw new Error(
+      `Returned PSBT input ${inputIndex}: P2WPKH signature has sighash type ` +
+        `0x${decoded.hashType.toString(16)} (expected SIGHASH_ALL).`,
+    );
+  }
+
+  // BIP-143 sighash over the REQUESTED prevout value with the standard
+  // P2WPKH scriptCode built from the witness program (client.rs:988-991;
+  // scriptCode template per bitcoinjs-lib's own P2WPKH signer,
+  // `src/psbt.js:1245-1255`).
+  const scriptCode = payments.p2pkh({ hash: Buffer.from(program) }).output;
+  if (!scriptCode) {
+    throw new Error(
+      `Returned PSBT input ${inputIndex}: could not build the P2WPKH scriptCode.`,
+    );
+  }
+  const tx = Transaction.fromBuffer(psbt.data.globalMap.unsignedTx.toBuffer());
+  const sighash = tx.hashForWitnessV0(
+    inputIndex,
+    scriptCode,
+    prevout.value,
+    decoded.hashType,
+  );
+
+  // strict=true rejects high-S, as libsecp256k1's verify_ecdsa does
+  // (client.rs:992-999; secp256k1 crate `ecdsa/mod.rs:194`). ecc.verify
+  // throws on out-of-range r/s — that is a failed verification here.
+  let verifies = false;
+  try {
+    verifies = ecc.verify(sighash, pubkey, decoded.signature, true);
+  } catch {
+    verifies = false;
+  }
+  if (!verifies) {
+    throw new Error(
+      `P2WPKH signature for input ${inputIndex} does not verify against the ` +
+        `requested PSBT's prevout. The wallet may have signed a different ` +
+        `transaction or key.`,
+    );
+  }
+}

--- a/packages/babylon-ts-sdk/src/testing/MockBitcoinWallet.ts
+++ b/packages/babylon-ts-sdk/src/testing/MockBitcoinWallet.ts
@@ -10,6 +10,7 @@ import type {
   SignPsbtOptions,
 } from "../shared/wallets/interfaces/BitcoinWallet";
 import { uint8ArrayToHex } from "../tbv/core/primitives/utils/bitcoin";
+import { signBip322P2wpkhWitness } from "./signBip322P2wpkhWitness";
 
 /**
  * Configuration for MockBitcoinWallet.
@@ -19,6 +20,14 @@ export interface MockBitcoinWalletConfig {
   address?: string;
   network?: BitcoinNetwork;
   shouldFailSigning?: boolean;
+  /**
+   * 32-byte hex key `signMessage` signs BIP-322 proofs with. Defaults to
+   * the privkey-1 test key, whose x-only pubkey is the default
+   * `publicKeyHex` (the secp256k1 generator's x coordinate). PoP flows
+   * verify the witness against `publicKeyHex`, so keep the two consistent
+   * when overriding either. Test material only — never a real key.
+   */
+  privateKeyHex?: string;
   /**
    * Optional override for `deriveContextHash`. When omitted the mock
    * returns a deterministic 64-char lowercase hex string derived from
@@ -53,22 +62,18 @@ const defaultDeriveContextHash = async (
   return uint8ArrayToHex(sha256(buf));
 };
 
-/**
- * Shape of the mock BIP-322 witness: `varint(2) ‖ varint(71) ‖ DER sig ‖
- * varint(33) ‖ compressed pubkey` — the P2WPKH form, with the DER signature
- * at its maximum encoded length.
- */
-const MOCK_WITNESS_ITEM_COUNT = 2;
-const MOCK_WITNESS_DER_SIG_BYTES = 71;
-const MOCK_WITNESS_PUBKEY_BYTES = 33;
-const COMPRESSED_PUBKEY_EVEN_PREFIX = 0x02;
+/** Privkey 1 — the test key `signMessage` signs with by default. */
+const DEFAULT_PRIVATE_KEY_HEX = `${"00".repeat(31)}01`;
 
 const DEFAULT_CONFIG: Required<MockBitcoinWalletConfig> = {
+  // x-only pubkey of DEFAULT_PRIVATE_KEY_HEX (the secp256k1 generator's x
+  // coordinate), so the default wallet's PoP witnesses verify against it.
   publicKeyHex:
-    "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2",
+    "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
   address: "tb1pqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqkx6jks",
   network: BitcoinNetworks.SIGNET,
   shouldFailSigning: false,
+  privateKeyHex: DEFAULT_PRIVATE_KEY_HEX,
   deriveContextHash: defaultDeriveContextHash,
 };
 
@@ -85,6 +90,7 @@ export class MockBitcoinWallet implements BitcoinWallet {
       ...(config.shouldFailSigning !== undefined
         ? { shouldFailSigning: config.shouldFailSigning }
         : {}),
+      ...(config.privateKeyHex ? { privateKeyHex: config.privateKeyHex } : {}),
       ...(config.deriveContextHash
         ? { deriveContextHash: config.deriveContextHash }
         : {}),
@@ -127,7 +133,7 @@ export class MockBitcoinWallet implements BitcoinWallet {
 
   async signMessage(
     message: string,
-    type: "bip322-simple" | "ecdsa",
+    _type: "bip322-simple" | "ecdsa",
   ): Promise<string> {
     if (this.config.shouldFailSigning) {
       throw new Error("Mock signing failed");
@@ -137,35 +143,15 @@ export class MockBitcoinWallet implements BitcoinWallet {
       throw new Error("Invalid message: empty string");
     }
 
-    // The SDK decodes what a wallet returns (`verifyPopWitness`), so the mock
-    // has to emit a structurally valid two-item P2WPKH witness. The bytes are
-    // derived from the inputs so different messages still give different
-    // signatures; they are not a real signature and are never verified.
-    const digest = sha256(
-      new TextEncoder().encode(
-        `mock-signature-${type}-${message}-${this.config.publicKeyHex}`,
-      ),
+    // The SDK cryptographically verifies what a wallet returns
+    // (`verifyPopWitness`), so the mock signs a REAL BIP-322 P2WPKH witness
+    // with its private key. The type is not consulted: PoP flows only ever
+    // request "bip322-simple", and the interface tests assert shape only.
+    const witness = signBip322P2wpkhWitness(
+      new TextEncoder().encode(message),
+      Uint8Array.from(Buffer.from(this.config.privateKeyHex, "hex")),
     );
-    const derSignature = new Uint8Array(MOCK_WITNESS_DER_SIG_BYTES);
-    for (let i = 0; i < derSignature.length; i++) {
-      derSignature[i] = digest[i % digest.length];
-    }
-    // Witness item 1 must carry the wallet's own key — verifyPopWitness
-    // mirrors vaultd's WitnessPubkeyMismatch check. Length-aware: config may
-    // hold a compressed (66-char) or x-only (64-char) key.
-    const cleanKey = this.config.publicKeyHex.replace(/^0x/, "").toLowerCase();
-    const xOnlyHex = cleanKey.length === 66 ? cleanKey.slice(2) : cleanKey;
-    const xOnlyBytes = Uint8Array.from(Buffer.from(xOnlyHex, "hex"));
-    return `0x${uint8ArrayToHex(
-      Uint8Array.from([
-        MOCK_WITNESS_ITEM_COUNT,
-        MOCK_WITNESS_DER_SIG_BYTES,
-        ...derSignature,
-        MOCK_WITNESS_PUBKEY_BYTES,
-        COMPRESSED_PUBKEY_EVEN_PREFIX,
-        ...xOnlyBytes,
-      ]),
-    )}`;
+    return `0x${uint8ArrayToHex(witness)}`;
   }
 
   async getNetwork(): Promise<BitcoinNetwork> {

--- a/packages/babylon-ts-sdk/src/testing/MockBitcoinWallet.ts
+++ b/packages/babylon-ts-sdk/src/testing/MockBitcoinWallet.ts
@@ -1,3 +1,4 @@
+import * as ecc from "@bitcoin-js/tiny-secp256k1-asmjs";
 import { sha256 } from "@noble/hashes/sha2.js";
 import { Buffer } from "buffer";
 
@@ -9,7 +10,10 @@ import type {
   BitcoinWallet,
   SignPsbtOptions,
 } from "../shared/wallets/interfaces/BitcoinWallet";
-import { uint8ArrayToHex } from "../tbv/core/primitives/utils/bitcoin";
+import {
+  canonicalizeBtcPubkey,
+  uint8ArrayToHex,
+} from "../tbv/core/primitives/utils/bitcoin";
 import { signBip322P2wpkhWitness } from "./signBip322P2wpkhWitness";
 
 /**
@@ -24,8 +28,9 @@ export interface MockBitcoinWalletConfig {
    * 32-byte hex key `signMessage` signs BIP-322 proofs with. Defaults to
    * the privkey-1 test key, whose x-only pubkey is the default
    * `publicKeyHex` (the secp256k1 generator's x coordinate). PoP flows
-   * verify the witness against `publicKeyHex`, so keep the two consistent
-   * when overriding either. Test material only — never a real key.
+   * verify the witness against `publicKeyHex`: overriding only this key
+   * derives the matching `publicKeyHex`, and a divergent pair throws at
+   * sign time. Test material only — never a real key.
    */
   privateKeyHex?: string;
   /**
@@ -65,6 +70,15 @@ const defaultDeriveContextHash = async (
 /** Privkey 1 — the test key `signMessage` signs with by default. */
 const DEFAULT_PRIVATE_KEY_HEX = `${"00".repeat(31)}01`;
 
+/** Lowercase x-only pubkey of a 32-byte private key. */
+function xOnlyPubkeyHexOf(privateKeyHex: string): string {
+  return uint8ArrayToHex(
+    ecc.xOnlyPointFromScalar(
+      Uint8Array.from(Buffer.from(privateKeyHex, "hex")),
+    ),
+  );
+}
+
 const DEFAULT_CONFIG: Required<MockBitcoinWalletConfig> = {
   // x-only pubkey of DEFAULT_PRIVATE_KEY_HEX (the secp256k1 generator's x
   // coordinate), so the default wallet's PoP witnesses verify against it.
@@ -95,6 +109,11 @@ export class MockBitcoinWallet implements BitcoinWallet {
         ? { deriveContextHash: config.deriveContextHash }
         : {}),
     };
+    // A private-key override without a public key would otherwise sign
+    // against the DEFAULT pubkey — derive the matching one instead.
+    if (config.privateKeyHex && !config.publicKeyHex) {
+      this.config.publicKeyHex = xOnlyPubkeyHexOf(config.privateKeyHex);
+    }
   }
 
   async getPublicKeyHex(): Promise<string> {
@@ -141,6 +160,23 @@ export class MockBitcoinWallet implements BitcoinWallet {
 
     if (!message || message.length === 0) {
       throw new Error("Invalid message: empty string");
+    }
+
+    // PoP flows verify the witness against `publicKeyHex`, so a divergent
+    // key pair must fail loudly here, not as a confusing verify mismatch.
+    const signingXOnlyHex = xOnlyPubkeyHexOf(this.config.privateKeyHex);
+    let configuredXOnlyHex: string | undefined;
+    try {
+      configuredXOnlyHex = canonicalizeBtcPubkey(this.config.publicKeyHex);
+    } catch {
+      configuredXOnlyHex = undefined; // an unparseable key cannot match
+    }
+    if (configuredXOnlyHex !== signingXOnlyHex) {
+      throw new Error(
+        `MockBitcoinWallet.signMessage: privateKeyHex signs as x-only pubkey ` +
+          `${signingXOnlyHex}, but publicKeyHex is ${this.config.publicKeyHex}. ` +
+          `Pass a matching publicKeyHex/privateKeyHex pair.`,
+      );
     }
 
     // The SDK cryptographically verifies what a wallet returns

--- a/packages/babylon-ts-sdk/src/testing/__tests__/MockBitcoinWallet.test.ts
+++ b/packages/babylon-ts-sdk/src/testing/__tests__/MockBitcoinWallet.test.ts
@@ -1,0 +1,81 @@
+import type { Hex } from "viem";
+import { describe, expect, it } from "vitest";
+
+import { verifyPopWitness } from "../../tbv/core/managers/pegin/verifyPopWitness";
+import { MockBitcoinWallet } from "../MockBitcoinWallet";
+
+// Test scalar 2; its pubkey is 2·G, whose x-coordinate is below.
+const PRIVKEY_TWO_HEX = `${"00".repeat(31)}02`;
+const PUBKEY_TWO_XONLY_HEX =
+  "c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5";
+// Default pair: privkey 1 and the secp256k1 generator's x coordinate.
+const DEFAULT_XONLY_HEX =
+  "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798";
+
+describe("MockBitcoinWallet key consistency", () => {
+  it("derives publicKeyHex from privateKeyHex when only the private key is configured", async () => {
+    const wallet = new MockBitcoinWallet({ privateKeyHex: PRIVKEY_TWO_HEX });
+
+    expect(await wallet.getPublicKeyHex()).toBe(PUBKEY_TWO_XONLY_HEX);
+  });
+
+  it("signs a witness that verifies against the derived publicKeyHex", async () => {
+    const wallet = new MockBitcoinWallet({ privateKeyHex: PRIVKEY_TWO_HEX });
+    const message = "pop message";
+
+    const witness = await wallet.signMessage(message, "bip322-simple");
+
+    expect(
+      verifyPopWitness(
+        new TextEncoder().encode(message),
+        PUBKEY_TWO_XONLY_HEX,
+        witness as Hex,
+      ),
+    ).toEqual({ kind: "p2wpkh-verified" });
+  });
+
+  it("throws at sign time when publicKeyHex and privateKeyHex diverge, naming both keys", async () => {
+    const wallet = new MockBitcoinWallet({
+      privateKeyHex: PRIVKEY_TWO_HEX,
+      publicKeyHex: DEFAULT_XONLY_HEX,
+    });
+
+    const error: Error = await wallet
+      .signMessage("pop message", "bip322-simple")
+      .then(
+        () => {
+          throw new Error("expected signMessage to reject");
+        },
+        (e: Error) => e,
+      );
+    expect(error.message).toContain(PUBKEY_TWO_XONLY_HEX);
+    expect(error.message).toContain(DEFAULT_XONLY_HEX);
+    expect(error.message).toMatch(/matching/i);
+  });
+
+  it("accepts a publicKeyHex-only override at construction (suites that never sign)", async () => {
+    const overrideKey = "deadbeef".repeat(8);
+    const wallet = new MockBitcoinWallet({ publicKeyHex: overrideKey });
+
+    expect(await wallet.getPublicKeyHex()).toBe(overrideKey);
+  });
+
+  it("still signs when publicKeyHex is the compressed form of the signing key", async () => {
+    const wallet = new MockBitcoinWallet({
+      publicKeyHex: `02${DEFAULT_XONLY_HEX}`,
+    });
+
+    await expect(
+      wallet.signMessage("pop message", "bip322-simple"),
+    ).resolves.toMatch(/^0x[0-9a-f]+$/);
+  });
+
+  it("keeps the default pair working unchanged", async () => {
+    const wallet = new MockBitcoinWallet();
+
+    expect(await wallet.getPublicKeyHex()).toBe(DEFAULT_XONLY_HEX);
+    await expect(
+      wallet.signMessage("pop message", "bip322-simple"),
+    ).resolves.toMatch(/^0x[0-9a-f]+$/);
+  });
+});

--- a/packages/babylon-ts-sdk/src/testing/signBip322P2wpkhWitness.ts
+++ b/packages/babylon-ts-sdk/src/testing/signBip322P2wpkhWitness.ts
@@ -30,6 +30,26 @@ const ZERO_SATS = 0;
 const MIN_ENCODED_SIG_BYTES = 71;
 const MAX_SIGN_GRIND_ATTEMPTS = 100;
 
+// Wire fields of the virtual to_spend/to_sign transactions (`bip322`
+// crate 0.0.10 `util.rs:18-85`).
+const BIP322_TX_VERSION = 0;
+const BIP322_TX_LOCKTIME = 0;
+const BIP322_INPUT_SEQUENCE = 0;
+/** to_spend prevout: all-zero 32-byte txid at index 0xFFFFFFFF (`util.rs:18-85`). */
+const TO_SPEND_PREVOUT_TXID_BYTES = 32;
+const TO_SPEND_PREVOUT_INDEX = 0xffffffff;
+/** to_sign spends to_spend's only output (`util.rs:18-85`). */
+const TO_SPEND_OUTPUT_INDEX = 0;
+const OP_0 = 0x00;
+/** Direct push of the 32-byte tagged message hash. */
+const OP_PUSHBYTES_32 = 0x20;
+const OP_RETURN = 0x6a;
+/** Consensus P2WPKH witness: exactly [signature, pubkey]. */
+const P2WPKH_WITNESS_ITEMS = 2;
+/** Grinding: 32-byte extra-entropy buffer, attempt counter at offset 0. */
+const GRIND_ENTROPY_BYTES = 32;
+const GRIND_COUNTER_OFFSET = 0;
+
 /**
  * Sign `messageBytes` as a BIP-322 "simple" P2WPKH proof with `privateKey`
  * and return the consensus-encoded two-item witness
@@ -55,23 +75,29 @@ export function signBip322P2wpkhWitness(
     throw new Error("signBip322P2wpkhWitness: could not derive P2WPKH script");
   }
 
-  // to_spend / to_sign per bip322 crate util.rs:18-85 (version 0,
-  // locktime 0, sequence 0, all values 0, OP_RETURN spend output).
+  // to_spend / to_sign per bip322 crate util.rs:18-85.
   const toSpend = new Transaction();
-  toSpend.version = 0;
-  toSpend.locktime = 0;
+  toSpend.version = BIP322_TX_VERSION;
+  toSpend.locktime = BIP322_TX_LOCKTIME;
   toSpend.addInput(
-    Buffer.alloc(32, 0),
-    0xffffffff,
-    0,
-    Buffer.concat([Buffer.from([0x00, 0x20]), Buffer.from(messageHash)]),
+    Buffer.alloc(TO_SPEND_PREVOUT_TXID_BYTES, 0),
+    TO_SPEND_PREVOUT_INDEX,
+    BIP322_INPUT_SEQUENCE,
+    Buffer.concat([
+      Buffer.from([OP_0, OP_PUSHBYTES_32]),
+      Buffer.from(messageHash),
+    ]),
   );
   toSpend.addOutput(p2wpkh.output, ZERO_SATS);
   const toSign = new Transaction();
-  toSign.version = 0;
-  toSign.locktime = 0;
-  toSign.addInput(toSpend.getHash(), 0, 0);
-  toSign.addOutput(Buffer.from([0x6a]), ZERO_SATS); // OP_RETURN
+  toSign.version = BIP322_TX_VERSION;
+  toSign.locktime = BIP322_TX_LOCKTIME;
+  toSign.addInput(
+    toSpend.getHash(),
+    TO_SPEND_OUTPUT_INDEX,
+    BIP322_INPUT_SEQUENCE,
+  );
+  toSign.addOutput(Buffer.from([OP_RETURN]), ZERO_SATS);
 
   // BIP-143 sighash with the standard P2WPKH scriptCode, value 0
   // (bip322 crate verify.rs:163-173).
@@ -88,8 +114,8 @@ export function signBip322P2wpkhWitness(
 
   let encodedSignature: Buffer | undefined;
   for (let attempt = 0; attempt < MAX_SIGN_GRIND_ATTEMPTS; attempt++) {
-    const entropy = Buffer.alloc(32, 0);
-    entropy.writeUInt32LE(attempt, 0);
+    const entropy = Buffer.alloc(GRIND_ENTROPY_BYTES, 0);
+    entropy.writeUInt32LE(attempt, GRIND_COUNTER_OFFSET);
     // ecc.sign emits low-S (libsecp256k1), so 73-byte encodings can't occur.
     const candidate = bscript.signature.encode(
       Buffer.from(ecc.sign(sighash, privateKey, entropy)),
@@ -107,7 +133,7 @@ export function signBip322P2wpkhWitness(
   }
 
   return Uint8Array.from([
-    2, // witness item count
+    P2WPKH_WITNESS_ITEMS,
     encodedSignature.length,
     ...encodedSignature,
     pubkey.length,

--- a/packages/babylon-ts-sdk/src/testing/signBip322P2wpkhWitness.ts
+++ b/packages/babylon-ts-sdk/src/testing/signBip322P2wpkhWitness.ts
@@ -1,0 +1,116 @@
+/**
+ * Test-support BIP-322 "simple" P2WPKH signer.
+ *
+ * Produces the consensus-encoded two-item witness `[DER sig ‖ 0x01,
+ * compressed pubkey]` that a Native SegWit software wallet returns for
+ * `signMessage(..., "bip322-simple")`. The virtual to_spend/to_sign
+ * construction follows the `bip322` crate 0.0.10 (`util.rs:18-85`) — the
+ * same reference the production verifier
+ * (`tbv/core/clients/vault-provider/auth/bip322Verify.ts`) mirrors, and
+ * the BIP-322 official vectors pin.
+ *
+ * Test-only: never feed real key material to this module.
+ */
+
+import * as ecc from "@bitcoin-js/tiny-secp256k1-asmjs";
+import { sha256 } from "@noble/hashes/sha2.js";
+import { script as bscript, payments, Transaction } from "bitcoinjs-lib";
+import { Buffer } from "buffer";
+
+/** BIP-322 message tag (BIP-340 tagged-hash style). */
+const BIP322_TAG = "BIP0322-signed-message";
+const SIGHASH_ALL = 0x01;
+const ZERO_SATS = 0;
+/**
+ * vaultd accepts only 71/72-byte encoded signatures (`bip322` crate 0.0.10
+ * `verify.rs:141-153`); a short-DER signature (~0.8% of draws) is ground
+ * away by re-signing with fresh entropy. 100 attempts bounds the failure
+ * probability around 0.008^100.
+ */
+const MIN_ENCODED_SIG_BYTES = 71;
+const MAX_SIGN_GRIND_ATTEMPTS = 100;
+
+/**
+ * Sign `messageBytes` as a BIP-322 "simple" P2WPKH proof with `privateKey`
+ * and return the consensus-encoded two-item witness
+ * (`0x02 ‖ len ‖ sig ‖ 0x21 ‖ pubkey`).
+ */
+export function signBip322P2wpkhWitness(
+  messageBytes: Uint8Array,
+  privateKey: Uint8Array,
+): Uint8Array {
+  const pubkey = ecc.pointFromScalar(privateKey, true);
+  if (!pubkey) {
+    throw new Error("signBip322P2wpkhWitness: invalid private key");
+  }
+
+  // m_hash = SHA256( SHA256(tag) ‖ SHA256(tag) ‖ message )
+  const tagHash = sha256(new TextEncoder().encode(BIP322_TAG));
+  const messageHash = sha256(
+    Buffer.concat([tagHash, tagHash, Buffer.from(messageBytes)]),
+  );
+
+  const p2wpkh = payments.p2wpkh({ pubkey: Buffer.from(pubkey) });
+  if (!p2wpkh.output || !p2wpkh.hash) {
+    throw new Error("signBip322P2wpkhWitness: could not derive P2WPKH script");
+  }
+
+  // to_spend / to_sign per bip322 crate util.rs:18-85 (version 0,
+  // locktime 0, sequence 0, all values 0, OP_RETURN spend output).
+  const toSpend = new Transaction();
+  toSpend.version = 0;
+  toSpend.locktime = 0;
+  toSpend.addInput(
+    Buffer.alloc(32, 0),
+    0xffffffff,
+    0,
+    Buffer.concat([Buffer.from([0x00, 0x20]), Buffer.from(messageHash)]),
+  );
+  toSpend.addOutput(p2wpkh.output, ZERO_SATS);
+  const toSign = new Transaction();
+  toSign.version = 0;
+  toSign.locktime = 0;
+  toSign.addInput(toSpend.getHash(), 0, 0);
+  toSign.addOutput(Buffer.from([0x6a]), ZERO_SATS); // OP_RETURN
+
+  // BIP-143 sighash with the standard P2WPKH scriptCode, value 0
+  // (bip322 crate verify.rs:163-173).
+  const scriptCode = payments.p2pkh({ hash: p2wpkh.hash }).output;
+  if (!scriptCode) {
+    throw new Error("signBip322P2wpkhWitness: could not build scriptCode");
+  }
+  const sighash = toSign.hashForWitnessV0(
+    0,
+    scriptCode,
+    ZERO_SATS,
+    SIGHASH_ALL,
+  );
+
+  let encodedSignature: Buffer | undefined;
+  for (let attempt = 0; attempt < MAX_SIGN_GRIND_ATTEMPTS; attempt++) {
+    const entropy = Buffer.alloc(32, 0);
+    entropy.writeUInt32LE(attempt, 0);
+    // ecc.sign emits low-S (libsecp256k1), so 73-byte encodings can't occur.
+    const candidate = bscript.signature.encode(
+      Buffer.from(ecc.sign(sighash, privateKey, entropy)),
+      SIGHASH_ALL,
+    );
+    if (candidate.length >= MIN_ENCODED_SIG_BYTES) {
+      encodedSignature = candidate;
+      break;
+    }
+  }
+  if (!encodedSignature) {
+    throw new Error(
+      "signBip322P2wpkhWitness: could not grind a 71/72-byte signature",
+    );
+  }
+
+  return Uint8Array.from([
+    2, // witness item count
+    encodedSignature.length,
+    ...encodedSignature,
+    pubkey.length,
+    ...pubkey,
+  ]);
+}

--- a/services/vault/src/services/vault/vaultPeginBroadcastService.ts
+++ b/services/vault/src/services/vault/vaultPeginBroadcastService.ts
@@ -266,8 +266,9 @@ async function signAndFinalizePsbt(
     returnedPsbtHex: signedPsbtHex,
   });
 
-  // Never trust the wallet's finalization: verify the returned key-path
-  // signatures against the PSBT we asked it to sign before extracting.
+  // Never trust the wallet's finalization: verify the returned signatures
+  // against the PSBT we asked it to sign before extracting (key-path
+  // Schnorr counted; P2WPKH ECDSA verified-or-throw, not counted).
   const verifiedInputs = assertReturnedKeyPathSignatures({
     requestedPsbtHex: psbtHex,
     returnedPsbtHex: signedPsbtHex,


### PR DESCRIPTION
Closes #2284. Host-side verification for Native SegWit depositors: BIP-322
P2WPKH proof-of-possession witnesses (pubkey mismatch detected before
signature verify, mirroring vaultd's WitnessPubkeyMismatch) and finalized
P2WPKH Pre-PegIn inputs at both finalize sites. Every check cites its
oracle (btc-vault message.rs / client.rs, bip322 crate 0.0.10); goldens
are the official BIP-322 vectors pinned from bitcoin/bips@d77863fb.