### PR TITLE
fix(vault, ledger-vault): stop the payout loop on cancel; honest canc…

### DIFF
--- a/packages/babylon-ledger-vault-signer/src/__tests__/dmkRawApduSender.test.ts
+++ b/packages/babylon-ledger-vault-signer/src/__tests__/dmkRawApduSender.test.ts
@@ -1,9 +1,8 @@
 /**
  * Tests for the non-throwing DMK binding. The SIGN_PSBT loop reads 0xE000
- * (client command follows) as data, and 0x6A80 as data too so the loop's
- * single gated post-abandonment resend can see it (otherwise terminal) — a
- * sender that throws on either would kill the interrupt/continue protocol,
- * so pass-through on every status word is pinned here.
+ * (client command follows) as data and classifies terminal words itself — a
+ * sender that throws on any status word would kill the interrupt/continue
+ * protocol, so pass-through on every status word is pinned here.
  */
 
 import { describe, expect, it, vi } from "vitest";

--- a/packages/babylon-ledger-vault-signer/src/__tests__/envelope.test.ts
+++ b/packages/babylon-ledger-vault-signer/src/__tests__/envelope.test.ts
@@ -66,9 +66,11 @@ describe("assertDepositTermsDeviceCompatible", () => {
     }
   });
 
-  it("does not gate on the tx-graph version — that axis belongs to the WASM capability gate", () => {
-    // 2026-08-23 decision: unconstructable versions never get here, and a
-    // device-incompatible shape fails closed on-device.
+  it("does not gate on the tx-graph version — every reachable version is device-signable", () => {
+    // v3 is Core 2's Bitcoin tx shape byte-for-byte (btc-vault e1e50f66; SDK parity
+    // vector pegin.test.ts "builds the v3 Pre-PegIn byte-identical to the v2 vector");
+    // v1 is unreachable fresh (ProtocolParams setter rejects `newVersion <= prev`,
+    // no Ledger v1 vault exists); v4+ needs a new WASM release.
     for (const vaultCoreVersion of [1, 2, 3, 4]) {
       expect(() => assertDepositTermsDeviceCompatible(makeTerms({ vaultCoreVersion }))).not.toThrow();
     }

--- a/packages/babylon-ledger-vault-signer/src/__tests__/signPsbt.test.ts
+++ b/packages/babylon-ledger-vault-signer/src/__tests__/signPsbt.test.ts
@@ -161,9 +161,6 @@ describe("signVaultPsbt", () => {
     );
 
     expect(isLedgerSignPsbtAbortedError(outcome)).toBe(true);
-    if (!isLedgerSignPsbtAbortedError(outcome)) throw new Error("expected an aborted error");
-    // No dispatcher was interrupted — the caller must not arm resend-once.
-    expect(outcome.dispatcherInterrupted).toBe(false);
     expect(sent()).toBe(0);
   });
 
@@ -189,9 +186,6 @@ describe("signVaultPsbt", () => {
     );
 
     expect(isLedgerSignPsbtAbortedError(outcome)).toBe(true);
-    if (!isLedgerSignPsbtAbortedError(outcome)) throw new Error("expected an aborted error");
-    // The 0xE000 arrived, so a dispatcher is mid-interruption awaiting CONTINUE.
-    expect(outcome.dispatcherInterrupted).toBe(true);
     expect(sent()).toBe(1);
   });
 
@@ -214,29 +208,6 @@ describe("signVaultPsbt", () => {
     expect(stagedSender.sent()).toBe(script.length);
     expect(staged.signedPsbtHex).toBe(composed.signedPsbtHex);
     expect(staged.yields).toEqual(composed.yields);
-  });
-
-  it("threads resendOnceOnIncorrectData through the composed entry point", async () => {
-    // Pins the options forwarding: a first-exchange 0x6A80 with the recovery
-    // armed resends the identical APDU once, then the ceremony completes.
-    const leafHashHex = fixtureLeafHashHex();
-    const script = peginScript(leafHashHex);
-    const initialHex = script[0].expectApduHex;
-    const withEatenFirst: ScriptedExchange[] = [
-      { expectApduHex: initialHex, respondSw: 0x6a80, respondDataHex: "" },
-      ...script,
-    ];
-    const { send, sent } = createScriptedSender(withEatenFirst);
-
-    const result = await signVaultPsbt(send, {
-      psbtHex: vector.psbt_hex,
-      depositorXOnlyHex: TEST_DEPOSITOR_KEY_HEX,
-      signal: new AbortController().signal,
-      resendOnceOnIncorrectData: true,
-    });
-
-    expect(sent()).toBe(withEatenFirst.length);
-    expect(result.yields).toHaveLength(1);
   });
 
   it("rejects reuse of a prepared signing state after success, with zero device I/O", async () => {

--- a/packages/babylon-ledger-vault-signer/src/__tests__/signPsbtLoop.test.ts
+++ b/packages/babylon-ledger-vault-signer/src/__tests__/signPsbtLoop.test.ts
@@ -253,54 +253,10 @@ describe("happy-path trace replay through the loop (T1, T11, T12)", () => {
   });
 });
 
-describe("resend-once on 0x6A80 (T2-T5)", () => {
-  function peginSetup() {
+describe("0x6A80 on the initial APDU (T3)", () => {
+  it("is terminal after exactly one send — the loop never resends", async () => {
     const traceFile = loadJson<TraceFile>(join(TRACES_DIR, "generated__deposit-flow__pegin__0.json"));
     const prepared = prepareFromVector(traceFile.vector_id);
-    return { prepared, traces: tracesWithValidYields(prepared, traceFile.traces) };
-  }
-
-  it("T2: flag on — the initial APDU is resent byte-identical once, then the loop completes", async () => {
-    const { prepared, traces } = peginSetup();
-    const initial = initialApduHexOf(prepared);
-    const script: ScriptedExchange[] = [
-      { expectApduHex: initial, respondSw: 0x6a80, respondDataHex: "" },
-      ...scriptFromTraces(initial, traces),
-    ];
-    const { send, sent } = createScriptedSender(script);
-
-    const yields = await runSignPsbtLoop(send, prepared, { resendOnceOnIncorrectData: true, signal: NEVER_ABORTED });
-
-    expect(yields.length).toBe(1);
-    expect(sent()).toBe(script.length);
-  });
-
-  it("T3b: abort racing the first exchange suppresses the recovery resend", async () => {
-    const { prepared } = peginSetup();
-    const controller = new AbortController();
-    // The sender aborts DURING the first exchange; the 0x6A80 recovery branch
-    // must observe it and never issue the second APDU.
-    const script: ScriptedExchange[] = [
-      { expectApduHex: initialApduHexOf(prepared), respondSw: 0x6a80, respondDataHex: "" },
-    ];
-    const { send: rawSend, sent } = createScriptedSender(script);
-    const send: typeof rawSend = async (apdu) => {
-      const response = await rawSend(apdu);
-      controller.abort();
-      return response;
-    };
-
-    await expect(
-      runSignPsbtLoop(send, prepared, {
-        resendOnceOnIncorrectData: true,
-        signal: controller.signal,
-      }),
-    ).rejects.toMatchObject({ name: LedgerSignPsbtAbortedError.name, dispatcherInterrupted: false });
-    expect(sent()).toBe(1);
-  });
-
-  it("T3: flag off — 0x6A80 on the initial APDU is terminal after exactly one send", async () => {
-    const { prepared } = peginSetup();
     const script: ScriptedExchange[] = [
       { expectApduHex: initialApduHexOf(prepared), respondSw: 0x6a80, respondDataHex: "" },
     ];
@@ -311,40 +267,6 @@ describe("resend-once on 0x6A80 (T2-T5)", () => {
       statusWord: 0x6a80,
     });
     expect(sent()).toBe(1);
-  });
-
-  it("T4: a second 0x6A80 after the resend is terminal — never a second resend", async () => {
-    const { prepared } = peginSetup();
-    const initial = initialApduHexOf(prepared);
-    const script: ScriptedExchange[] = [
-      { expectApduHex: initial, respondSw: 0x6a80, respondDataHex: "" },
-      { expectApduHex: initial, respondSw: 0x6a80, respondDataHex: "" },
-    ];
-    const { send, sent } = createScriptedSender(script);
-
-    await expect(
-      runSignPsbtLoop(send, prepared, { resendOnceOnIncorrectData: true, signal: NEVER_ABORTED }),
-    ).rejects.toMatchObject({
-      statusWord: 0x6a80,
-    });
-    expect(sent()).toBe(2);
-  });
-
-  it("T5: 0xB007 on the resent APDU is terminal (signing-phase abandonment invalidated the intent)", async () => {
-    const { prepared } = peginSetup();
-    const initial = initialApduHexOf(prepared);
-    const script: ScriptedExchange[] = [
-      { expectApduHex: initial, respondSw: 0x6a80, respondDataHex: "" },
-      { expectApduHex: initial, respondSw: 0xb007, respondDataHex: "" },
-    ];
-    const { send, sent } = createScriptedSender(script);
-
-    await expect(
-      runSignPsbtLoop(send, prepared, { resendOnceOnIncorrectData: true, signal: NEVER_ABORTED }),
-    ).rejects.toMatchObject({
-      statusWord: 0xb007,
-    });
-    expect(sent()).toBe(2);
   });
 });
 
@@ -478,9 +400,9 @@ describe("abort signal (T7 + entry check)", () => {
 
   it("requires a signal in the options bag — omitting it must not typecheck", () => {
     // @ts-expect-error `signal` is required; if this ever compiles, the loop is unbounded again.
-    const withoutSignal: RunSignPsbtLoopOptions = { resendOnceOnIncorrectData: true };
+    const withoutSignal: RunSignPsbtLoopOptions = { appIdentity: { appName: "Babylon Vault" } };
 
-    expect(withoutSignal.resendOnceOnIncorrectData).toBe(true);
+    expect(withoutSignal.appIdentity?.appName).toBe("Babylon Vault");
   });
 
   it("reports how many yields had already arrived when the host aborted", async () => {

--- a/packages/babylon-ledger-vault-signer/src/envelope.ts
+++ b/packages/babylon-ledger-vault-signer/src/envelope.ts
@@ -36,8 +36,10 @@ function requireIntInRange(field: string, value: number, lo: number, hi: number)
  * @throws {DepositTermsRejectedError} on the first violation
  */
 export function assertDepositTermsDeviceCompatible(terms: DepositTerms): void {
-  // No tx-graph version check (2026-08-23 decision): the WASM capability gate
-  // stops unconstructable versions upstream; bad shapes fail closed on-device.
+  // No tx-graph version gate: v3 is Core 2's Bitcoin tx shape byte-for-byte (btc-vault
+  // e1e50f66; SDK parity vector pegin.test.ts "builds the v3 Pre-PegIn byte-identical to
+  // the v2 vector"); v1 is unreachable fresh (ProtocolParams setter rejects
+  // `newVersion <= prev`, and no Ledger v1 vault exists); v4+ needs a new WASM release.
 
   // The >= 1 floor is enforced by both the contract and the device
   // (vault_tlv.c:73 rejects rate == 0).

--- a/packages/babylon-ledger-vault-signer/src/errors.ts
+++ b/packages/babylon-ledger-vault-signer/src/errors.ts
@@ -169,36 +169,26 @@ export class LedgerSignPsbtProtocolError extends Error {
 
 /**
  * The host abandoned the SIGN_PSBT loop (abort signal) — the loop stops
- * sending, nothing else. What the device does next (verified at base app rev
- * `e400d8d8` + fw `90cf41f`; the `6fcad4fd`→`90cf41f` delta is payout-validation
- * only and touches neither path below):
+ * sending, nothing else. Retry after this is always a FULL re-ceremony (the
+ * provider resets its mirror to idle). Device aftermath (verified at base app
+ * rev `e400d8d8` + fw `90cf41f`):
  *
  * - Within ~5 s (50 ticks, `base:io_ext.h:28`) the device sits blocked
- *   awaiting CONTINUE; the next non-CONTINUE APDU is eaten with 0x6A80 and the
- *   interrupted handler unwinds (`base:dispatcher.c:107-111`) — a direct retry
- *   uses `resendOnceOnIncorrectData`.
- * - A validation-phase abandonment leaves the intent intact; a Payout/NoPayout
- *   SIGNING-phase abandonment invalidates it (`fw:sign_custom_inputs.c:207-344`)
- *   — post-abort "intent-loaded" is a HINT only, and the retry path must also
- *   absorb 0xB007.
+ *   awaiting CONTINUE and eats the next non-CONTINUE APDU with 0x6A80
+ *   (`base:dispatcher.c:107-111`) — a fast retry's first DERIVE APDU surfaces
+ *   as the generic invalid-data error; the second attempt is clean.
  * - After >5 s of host silence the app exits to the dashboard
- *   (`base:io_ext.c:103-111` → SDK `app_exit()`); the host then sees 0x6E00 or
- *   a transport failure — full re-ceremony required.
+ *   (`base:io_ext.c:103-111` → SDK `app_exit()`); the host then sees 0x6E00,
+ *   whose wrong-app copy guides reopening the app.
  */
 export class LedgerSignPsbtAbortedError extends Error {
   /** Yields the device had already delivered when the host stopped sending. */
   readonly yieldedCount: number;
-  /**
-   * True only when the abort left a dispatcher mid-interruption (device
-   * awaiting CONTINUE) — the one state the resend-once recovery exists for.
-   */
-  readonly dispatcherInterrupted: boolean;
 
-  constructor(yieldedCount: number, dispatcherInterrupted: boolean) {
+  constructor(yieldedCount: number) {
     super("SIGN_PSBT was abandoned host-side before completion");
     this.name = LEDGER_SIGN_PSBT_ABORTED_ERROR_NAME;
     this.yieldedCount = yieldedCount;
-    this.dispatcherInterrupted = dispatcherInterrupted;
   }
 }
 

--- a/packages/babylon-ledger-vault-signer/src/rawApdu.ts
+++ b/packages/babylon-ledger-vault-signer/src/rawApdu.ts
@@ -3,17 +3,13 @@
  *
  * The ceremony's `ApduSender` throws on every status word except 0x9000;
  * SIGN_PSBT cannot ride it: `0xE000` (SW_INTERRUPTED_EXECUTION — a
- * client-command request follows in the response data) is loop input, and the
- * loop's one gated resend must see the first `0x6A80` after a host-abandoned
- * interruption as data too — the dispatcher answers any non-CONTINUE APDU
- * with 0x6A80 and drops the interrupted command (`base:dispatcher.c:107-111`
- * `process_interruption`); every other `0x6A80` is a terminal validation
- * failure. A {@link RawApduSender} therefore never throws on ANY status word;
+ * client-command request follows in the response data) is loop input, not an
+ * error. A {@link RawApduSender} therefore never throws on ANY status word;
  * terminal words are classified by the caller via {@link classifyStatusWord},
  * so raw-seam consumers and the throwing sender raise identical typed errors.
  *
  * `base:` = LedgerHQ/app-bitcoin branch `baseapp` @ `e400d8d8`
- * (`src/boilerplate/dispatcher.c`); the same path on `develop` differs.
+ * (`src/boilerplate/sw.h`); the same path on `develop` differs.
  *
  * @module ledger-vault-signer/rawApdu
  */
@@ -76,7 +72,10 @@ const STATUS_WORDS: Record<number, string> = {
   0x6a86: "The device rejected the instruction parameters",
   0x6a87: "The device rejected the payload length",
   0x6d00: "The running app does not support this instruction",
-  [SW_CLA_NOT_SUPPORTED]: "The running app does not handle vault instructions — open the Babylon Vault app",
+  // Network-agnostic on purpose: the app is "Babylon Vault" on mainnet and
+  // "Babylon Vault Testnet" on test networks (dmkSession.readAppAndVersion).
+  [SW_CLA_NOT_SUPPORTED]:
+    "The running app does not handle vault instructions — open the Babylon Vault app for this network",
   0xb000: "The device reported a wrong response length",
   [SW_BAD_STATE]: "The device is not in the expected state for this step",
   0xb008: "The device rejected a signature or HMAC as invalid",

--- a/packages/babylon-ledger-vault-signer/src/signPsbt.ts
+++ b/packages/babylon-ledger-vault-signer/src/signPsbt.ts
@@ -45,12 +45,6 @@ export interface SignVaultPsbtParams {
    * diagnostics. Never gates control flow.
    */
   readonly appIdentity?: AppIdentity;
-  /**
-   * Provider's `loopAbandoned` flag: resend the initial SIGN_PSBT APDU once
-   * if it answers 0x6A80 (the dispatcher eats exactly one non-CONTINUE APDU
-   * after a host-abandoned interruption). Never set on a first attempt.
-   */
-  readonly resendOnceOnIncorrectData?: boolean;
 }
 
 export interface SignVaultPsbtResult {

--- a/packages/babylon-ledger-vault-signer/src/signPsbtLoop.ts
+++ b/packages/babylon-ledger-vault-signer/src/signPsbtLoop.ts
@@ -39,7 +39,6 @@ const P2_CONTINUE = 0x00;
 const SW_OK = 0x9000;
 /** A client-command request follows in the response data (`base:sw.h:90`). */
 const SW_INTERRUPTED_EXECUTION = 0xe000;
-const SW_INCORRECT_DATA = 0x6a80;
 
 export interface SignPsbtProgress {
   readonly inputIndex: number;
@@ -68,14 +67,6 @@ export interface RunSignPsbtLoopOptions {
    * diagnostics. Never gates control flow.
    */
   readonly appIdentity?: AppIdentity;
-  /**
-   * Provider's `loopAbandoned` flag: resend the initial SIGN_PSBT APDU once if
-   * it answers 0x6A80 — the dispatcher eats exactly one non-CONTINUE APDU
-   * after a host-abandoned interruption (`base:dispatcher.c:107-111`). A
-   * genuine validation 0x6A80 is indistinguishable on the wire, hence the
-   * explicit gate. Never applies to CONTINUEs; never more than one resend.
-   */
-  readonly resendOnceOnIncorrectData?: boolean;
 }
 
 /**
@@ -92,23 +83,13 @@ export async function runSignPsbtLoop(
   const { collector, interpreter, cdata } = getPreparedSignPsbtState(prepared);
   const { table } = prepared;
   if (opts.signal.aborted) {
-    // Abandoned before any I/O — no dispatcher interrupted.
-    throw new LedgerSignPsbtAbortedError(collector.yields.length, false);
+    // Abandoned before any I/O.
+    throw new LedgerSignPsbtAbortedError(collector.yields.length);
   }
 
   const signPsbtApdu = buildSignPsbtApdu(cdata);
   let lastSentApdu: Apdu = signPsbtApdu;
   let response = await send(signPsbtApdu);
-  if (response.sw === SW_INCORRECT_DATA && opts.resendOnceOnIncorrectData === true) {
-    if (opts.signal.aborted) {
-      // Abort raced the first exchange. The 0x6A80 either consumed the eaten
-      // slot or was a genuine rejection — either way the dispatcher is clean.
-      throw new LedgerSignPsbtAbortedError(collector.yields.length, false);
-    }
-    // Resend the SAME APDU once; this branch is structurally unreachable a
-    // second time — any later 0x6A80 (including on the resend) is terminal.
-    response = await send(signPsbtApdu);
-  }
 
   let reportedYields = 0;
   while (response.sw === SW_INTERRUPTED_EXECUTION) {
@@ -148,9 +129,9 @@ export async function runSignPsbtLoop(
       }
     }
     if (opts.signal.aborted) {
-      // Stop sending — the CONTINUE for this round is never sent, so the
-      // interrupted dispatcher will eat exactly one later non-CONTINUE APDU.
-      throw new LedgerSignPsbtAbortedError(collector.yields.length, true);
+      // Stop sending — the CONTINUE for this round is never sent. Recovery is
+      // a full re-ceremony (LedgerSignPsbtAbortedError's doc has the aftermath).
+      throw new LedgerSignPsbtAbortedError(collector.yields.length);
     }
     lastSentApdu = { cla: CLA_FRAMEWORK, ins: INS_CONTINUE, p1: P1_CONTINUE, p2: P2_CONTINUE, data: continueData };
     response = await send(lastSentApdu);

--- a/packages/babylon-wallet-connector/src/core/types.ts
+++ b/packages/babylon-wallet-connector/src/core/types.ts
@@ -402,6 +402,19 @@ export interface IBTCProvider extends IProvider {
   getAccounts?(): Promise<string[]>;
 
   /**
+   * Requests cancellation of the in-flight signing ceremony
+   * (signPsbt/signPsbts/signMessage). A REQUEST, not a settle: the provider
+   * aborts at its next device exchange boundary, and the sign promise rejects
+   * with `CONNECTION_REJECTED` only then. No-op when nothing is in flight.
+   *
+   * Implemented only by hardware providers whose ceremonies block on a
+   * physical device (currently the Ledger vault provider). Optional — callers
+   * MUST feature-detect (`typeof provider.cancelSigning === "function"`) and
+   * hide the cancel affordance when the method is missing.
+   */
+  cancelSigning?(): void;
+
+  /**
    * Signs a message using either BIP322-Simple or ECDSA signing method.
    * @param message - The message to sign.
    * @param type - The signing method to use.

--- a/packages/babylon-wallet-connector/src/core/wallets/btc/ledger-vault/__tests__/provider.test.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/ledger-vault/__tests__/provider.test.ts
@@ -409,7 +409,7 @@ describe("LedgerVaultProvider", () => {
       signMock.signPreparedVaultPsbt.mockImplementationOnce(
         (_send, _prepared, opts: { signal: AbortSignal }) =>
           new Promise((_resolve, reject) => {
-            opts.signal.addEventListener("abort", () => reject(new LedgerSignPsbtAbortedError(0, true)));
+            opts.signal.addEventListener("abort", () => reject(new LedgerSignPsbtAbortedError(0)));
           }),
       );
       const inFlight = p.signMessage(POP_MESSAGE, "bip322-simple");
@@ -700,7 +700,7 @@ describe("LedgerVaultProvider", () => {
       // Keep-intent retries risk SW_CAP_EXCEEDED (caps commit pre-yield):
       // the mirror drops and only a re-ceremony recovers.
       const provider = await approved();
-      signMock.signPreparedVaultPsbt.mockRejectedValueOnce(new LedgerSignPsbtAbortedError(0, true));
+      signMock.signPreparedVaultPsbt.mockRejectedValueOnce(new LedgerSignPsbtAbortedError(0));
 
       await expect(provider.signPsbt(PSBT_A)).rejects.toMatchObject({ code: ERROR_CODES.CONNECTION_REJECTED });
       await expect(provider.signPsbt(PSBT_A)).rejects.toMatchObject({ code: ERROR_CODES.DEVICE_CEREMONY_INVALID });
@@ -730,7 +730,7 @@ describe("LedgerVaultProvider", () => {
 
     it("a pre-send abort takes the same cancel classification and reset", async () => {
       const provider = await approved();
-      signMock.signPreparedVaultPsbt.mockRejectedValueOnce(new LedgerSignPsbtAbortedError(0, false));
+      signMock.signPreparedVaultPsbt.mockRejectedValueOnce(new LedgerSignPsbtAbortedError(0));
 
       await expect(provider.signPsbt(PSBT_A)).rejects.toMatchObject({ code: ERROR_CODES.CONNECTION_REJECTED });
       await expect(provider.signPsbt(PSBT_A)).rejects.toMatchObject({ code: ERROR_CODES.DEVICE_CEREMONY_INVALID });
@@ -825,7 +825,7 @@ describe("LedgerVaultProvider", () => {
       signMock.signPreparedVaultPsbt.mockImplementationOnce(
         (_send, _prepared, opts: { signal: AbortSignal }) =>
           new Promise((_resolve, reject) => {
-            opts.signal.addEventListener("abort", () => reject(new LedgerSignPsbtAbortedError(0, true)));
+            opts.signal.addEventListener("abort", () => reject(new LedgerSignPsbtAbortedError(0)));
           }),
       );
     }
@@ -843,7 +843,7 @@ describe("LedgerVaultProvider", () => {
 
       await expect(inFlight).rejects.toMatchObject({
         code: ERROR_CODES.CONNECTION_REJECTED,
-        message: expect.stringMatching(/cancelled/i),
+        message: expect.stringMatching(/canceled/i),
       });
       await expect(provider.signPsbt(PSBT_A)).rejects.toMatchObject({
         code: ERROR_CODES.DEVICE_CEREMONY_INVALID,
@@ -871,7 +871,7 @@ describe("LedgerVaultProvider", () => {
 
       await expect(pop).rejects.toMatchObject({
         code: ERROR_CODES.CONNECTION_REJECTED,
-        message: expect.stringMatching(/cancelled/i),
+        message: expect.stringMatching(/canceled/i),
       });
       await expect(provider.signPsbt(PSBT_A)).rejects.toMatchObject({
         code: ERROR_CODES.DEVICE_CEREMONY_INVALID,

--- a/packages/babylon-wallet-connector/src/core/wallets/btc/ledger-vault/provider.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/ledger-vault/provider.ts
@@ -704,7 +704,7 @@ export class LedgerVaultProvider implements IBTCProvider {
             throw new WalletError({
               code: cancelled ? ERROR_CODES.CONNECTION_REJECTED : ERROR_CODES.WALLET_NOT_CONNECTED,
               message: cancelled
-                ? `Signing cancelled after ${signed.length} of ${psbtsHexes.length} PSBT(s) — the ceremony restarts from the device approval screens on retry.`
+                ? `Signing canceled after ${signed.length} of ${psbtsHexes.length} PSBT(s) — the ceremony restarts from the device approval screens on retry.`
                 : `${WALLET_PROVIDER_NAME} stopped signing (disconnected) after ${signed.length} of ${psbtsHexes.length} PSBT(s).`,
               wallet: WALLET_PROVIDER_NAME,
             });
@@ -932,7 +932,7 @@ export class LedgerVaultProvider implements IBTCProvider {
       return new WalletError(
         {
           code: ERROR_CODES.CONNECTION_REJECTED,
-          message: `${label === "signPsbt" ? "" : `${label}: `}Signing cancelled — the ceremony restarts from the device approval screens on retry.`,
+          message: `${label === "signPsbt" ? "" : `${label}: `}Signing canceled — the ceremony restarts from the device approval screens on retry.`,
           wallet: WALLET_PROVIDER_NAME,
         },
         { cause: error },
@@ -970,9 +970,12 @@ export class LedgerVaultProvider implements IBTCProvider {
    * BIP-322 simple proof of possession via SIGN_PSBT tx_version 0 (#2221).
    * State-independent on the device (`sign_psbt_validate.c:3205-3213`): no
    * approved intent is required, and signing it never touches the intent
-   * mirror or the signed-fingerprint set. When an intent IS loaded the device
-   * requires the PoP key to equal the intent's depositor key (`:2764-2769`) —
-   * both derive from `depositorPath`, so that holds by construction.
+   * mirror or the signed-fingerprint set — with ONE exception: a user cancel
+   * resets both via {@link classifySignFailure}'s uniform post-cancel policy,
+   * so a cancelled PoP costs a full derive + re-approve like any other cancel.
+   * When an intent IS loaded the device requires the PoP key to equal the
+   * intent's depositor key (`:2764-2769`) — both derive from `depositorPath`,
+   * so that holds by construction.
    */
   signMessage = async (message: string, type: "bip322-simple" | "ecdsa"): Promise<string> =>
     this.withDeviceOperation("signMessage", () =>

--- a/services/vault/src/components/deposit/PayoutSignModal/__tests__/usePayoutSigningState.test.tsx
+++ b/services/vault/src/components/deposit/PayoutSignModal/__tests__/usePayoutSigningState.test.tsx
@@ -709,18 +709,26 @@ describe("usePayoutSigningState", () => {
     // Ledger-shaped provider: the only BTC provider exposing cancelSigning.
     // No approveDepositTerms on purpose — the cancel seam is orthogonal to
     // the approval rebuild, so these tests stay on the software-wallet path.
+    // Its signPsbt never settles on its own: armPendingSdkCall's `pending`
+    // settles the SDK call while that device window is still held open.
     function connectCancellableWallet() {
       const cancelSigning = vi.fn();
       mockBtcConnector = {
         connectedWallet: {
           account: { address: "tb1test" },
-          provider: { signPsbt: vi.fn(), cancelSigning },
+          provider: {
+            signPsbt: vi.fn(() => new Promise<string>(() => {})),
+            cancelSigning,
+          },
         },
       };
       return { cancelSigning };
     }
 
-    // Holds the SDK call open so cancel/settle ordering is test-controlled.
+    // Holds the SDK call open so cancel/settle ordering is test-controlled,
+    // driving one wrapped signPsbt so the cancellable device window the
+    // affordance tracks is active while the call is held (an instant no-op
+    // window for the plain software wallet).
     function armPendingSdkCall() {
       const pending: {
         resolve: () => void;
@@ -728,11 +736,19 @@ describe("usePayoutSigningState", () => {
         signal: AbortSignal | undefined;
       } = { resolve: () => {}, reject: () => {}, signal: undefined };
       mockSignAndSubmitPayouts.mockImplementation(
-        ({ signal }: { signal: AbortSignal }) => {
+        ({
+          btcWallet,
+          signal,
+        }: {
+          btcWallet: { signPsbt: (hex: string) => Promise<string> };
+          signal: AbortSignal;
+        }) => {
           pending.signal = signal;
           return new Promise<void>((resolve, reject) => {
             pending.resolve = resolve;
             pending.reject = reject;
+            // Settled only via `pending` — swallow the held-open device sign.
+            void btcWallet.signPsbt("payout-psbt").catch(() => {});
           });
         },
       );
@@ -986,6 +1002,84 @@ describe("usePayoutSigningState", () => {
       // consumed so the modal cannot wedge on the disabled cancel button.
       expect(result.current.cancelRequested).toBe(false);
       expect(result.current.isComplete).toBe(true);
+    });
+
+    it("keeps canCancel false during a hung VP-auth (deriveContextHash) phase", async () => {
+      // deriveContextHash is a real device screen, but the provider's
+      // cancelSigning is a no-op outside signPsbt/signPsbts/signMessage —
+      // showing the affordance there would be a dead button.
+      const cancelSigning = vi.fn();
+      let settleAuth: (root: string) => void = () => {};
+      mockBtcConnector = {
+        connectedWallet: {
+          account: { address: "tb1test" },
+          provider: {
+            signPsbt: vi.fn(),
+            deriveContextHash: vi.fn(
+              () =>
+                new Promise<string>((resolve) => {
+                  settleAuth = resolve;
+                }),
+            ),
+            cancelSigning,
+          },
+        },
+      };
+      mockSignAndSubmitPayouts.mockImplementation(
+        async ({
+          btcWallet,
+        }: {
+          btcWallet: {
+            deriveContextHash: (app: string, ctx: string) => Promise<string>;
+          };
+        }) => {
+          await btcWallet.deriveContextHash("app", "aa");
+        },
+      );
+      const { result } = renderHookWithProps();
+
+      let signPromise!: Promise<void>;
+      act(() => {
+        signPromise = result.current.handleSign();
+      });
+      await waitFor(() => expect(result.current.signing).toBe(true));
+
+      expect(result.current.canCancel).toBe(false);
+
+      await act(async () => {
+        settleAuth("cc".repeat(32));
+        await signPromise;
+      });
+    });
+
+    it("reports canCancel true during a hung signPsbts device window", async () => {
+      const cancelSigning = vi.fn();
+      mockBtcConnector = {
+        connectedWallet: {
+          account: { address: "tb1test" },
+          provider: {
+            signPsbt: vi.fn(),
+            signPsbts: vi.fn(() => new Promise<string[]>(() => {})),
+            cancelSigning,
+          },
+        },
+      };
+      mockSignAndSubmitPayouts.mockImplementation(
+        async ({
+          btcWallet,
+        }: {
+          btcWallet: { signPsbts: (hexes: string[]) => Promise<string[]> };
+        }) => {
+          await btcWallet.signPsbts(["p0", "p1"]);
+        },
+      );
+      const { result } = renderHookWithProps();
+
+      act(() => {
+        void result.current.handleSign();
+      });
+
+      await waitFor(() => expect(result.current.canCancel).toBe(true));
     });
   });
 

--- a/services/vault/src/components/deposit/PayoutSignModal/usePayoutSigningState.ts
+++ b/services/vault/src/components/deposit/PayoutSignModal/usePayoutSigningState.ts
@@ -45,6 +45,7 @@ import {
   shouldProbeWalletLiveness,
   verifyBtcWalletLiveness,
 } from "../../../utils/btc";
+import { supportsCancelSigning } from "../../../utils/cancelSigning";
 import { formatPayoutSignatureError } from "../../../utils/errors/formatting";
 import { isUserCancellation } from "../../../utils/errors/userCancellation";
 import { isVaultLifecycleStateError } from "../../../utils/errors/vaultLifecycleStateError";
@@ -80,9 +81,12 @@ export interface UsePayoutSigningStateResult {
   /** Handler to initiate signing */
   handleSign: () => Promise<void>;
   /**
-   * True while the in-flight sign can be cancelled: signing is active AND the
-   * provider that started the sign exposes `cancelSigning` (only the Ledger
-   * provider does — always capability-probed, never assumed).
+   * True while the in-flight sign sits in a cancellable device window
+   * (signPsbt/signPsbts/signMessage — the only calls `cancelSigning` can
+   * abort) AND the provider that started the sign exposes `cancelSigning`
+   * (only the Ledger provider does — always capability-probed, never
+   * assumed). False during the terms rebuild, VP auth, and submission, where
+   * no cancellable device prompt exists.
    */
   canCancel: boolean;
   /** True from {@link handleCancel} until the in-flight sign settles. */
@@ -115,6 +119,10 @@ export function usePayoutSigningState({
   const [error, setError] = useState<SigningError | null>(null);
   const [errorTerminal, setErrorTerminal] = useState(false);
   const [cancelRequested, setCancelRequested] = useState(false);
+  // True only while a cancellable device call (signPsbt/signPsbts/
+  // signMessage) is in flight — `cancelSigning` is a no-op everywhere else,
+  // including the deriveContextHash/approveDepositTerms device screens.
+  const [deviceWindowActive, setDeviceWindowActive] = useState(false);
   // Ref mirror so the settle paths inside handleSign read the live value —
   // the state itself is stale inside the long-lived async closure.
   const cancelRequestedRef = useRef(false);
@@ -288,6 +296,17 @@ export function usePayoutSigningState({
       abortRef.current?.abort();
       abortRef.current = new AbortController();
 
+      // Flags the cancellable device window around exactly the calls the
+      // provider's cancelSigning can abort — canCancel gates on it.
+      const withDeviceWindow = async <T>(run: () => Promise<T>): Promise<T> => {
+        setDeviceWindowActive(true);
+        try {
+          return await run();
+        } finally {
+          setDeviceWindowActive(false);
+        }
+      };
+
       const graphProgressWallet: BitcoinWallet & Partial<DepositTermsApprover> =
         {
           ...wallet,
@@ -304,7 +323,7 @@ export function usePayoutSigningState({
               setProgress({ phase: "graph", completed: 0, total: 1 });
             }
             try {
-              return await wallet.signPsbt(hex, opts);
+              return await withDeviceWindow(() => wallet.signPsbt(hex, opts));
             } finally {
               if (claimersDoneRef.current) {
                 setProgress({ phase: "graph", completed: 1, total: 1 });
@@ -322,7 +341,9 @@ export function usePayoutSigningState({
                     });
                   }
                   try {
-                    return await wallet.signPsbts!(hexes, opts);
+                    return await withDeviceWindow(() =>
+                      wallet.signPsbts!(hexes, opts),
+                    );
                   } finally {
                     if (claimersDoneRef.current) {
                       setProgress({
@@ -335,6 +356,8 @@ export function usePayoutSigningState({
                 },
               }
             : {}),
+          signMessage: (message, type) =>
+            withDeviceWindow(() => wallet.signMessage(message, type)),
           // Object spread drops prototype methods — see forwardDepositApproval.
           ...forwardDepositApproval(wallet),
         };
@@ -465,21 +488,20 @@ export function usePayoutSigningState({
   // Reads the provider that started the sign, not the live connector — a
   // wallet swapped in mid-prompt must not retarget the affordance. The ref is
   // only ever set/cleared together with the `signing` state, so this render
-  // read stays in sync.
-  const signingProvider = signingProviderRef.current as {
-    cancelSigning?: unknown;
-  } | null;
+  // read stays in sync. Gated on the device window: `signing` alone spans
+  // the terms rebuild, VP auth, and submission, where cancelSigning is a
+  // no-op and no device prompt exists.
   const canCancel =
-    signing && typeof signingProvider?.cancelSigning === "function";
+    signing &&
+    deviceWindowActive &&
+    supportsCancelSigning(signingProviderRef.current);
 
   const handleCancel = useCallback(() => {
     // Cancel the ceremony on the provider that started it — never the
     // connector's current provider.
-    const provider = signingProviderRef.current as {
-      cancelSigning?: () => void;
-    } | null;
+    const provider = signingProviderRef.current;
     if (!inFlightRef.current || cancelRequestedRef.current) return;
-    if (typeof provider?.cancelSigning !== "function") return;
+    if (!supportsCancelSigning(provider)) return;
     cancelRequestedRef.current = true;
     setCancelRequested(true);
     // A REQUEST, not a settle: the provider aborts at its next device

--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -67,8 +67,10 @@ const DEVICE_LOCKED_TITLE = "Signing device locked";
 const DEVICE_LOCKED_BODY =
   "Your signing device is locked. Unlock it with your PIN and try again.";
 const DEVICE_WRONG_APP_TITLE = "Wrong app on device";
+// Network-agnostic on purpose: the app is named "Babylon Vault" on mainnet
+// and "Babylon Vault Testnet" on test networks.
 const DEVICE_WRONG_APP_BODY =
-  "A different app is open on your signing device. Open the Babylon Vault app on the device and try again.";
+  "A different app is open on your signing device. Open the Babylon Vault app for this network and try again.";
 // Action-required labels shared between the in-app badges
 // (`pegin.actionRequiredBadges`) and the browser-notification titles so the two
 // surfaces can't drift.
@@ -797,6 +799,10 @@ export const COPY = {
         `Vault ${vaultNumber}: WOTS key submission failed - ${error}`,
       payoutSigningFailed: (vaultNumber: number, error: string) =>
         `Vault ${vaultNumber}: Payout signing failed - ${error}`,
+      // Self-requested device cancel: the loop stops here, so later vaults
+      // are left unattempted (no warning) rather than marked failed.
+      payoutSigningCancelled: (vaultNumber: number) =>
+        `Vault ${vaultNumber}: Payout signing canceled - you can finish signing when you're ready`,
       dismissReusesReservedUtxos: "Dismiss",
     },
     errors: {
@@ -880,6 +886,14 @@ export const COPY = {
       signingRejected: {
         title: "Signing rejected",
         body: "You rejected the request in your wallet. Click Retry to approve it and continue.",
+      },
+      // Self-requested cancel (the in-app "Cancel signing" affordance), as
+      // opposed to a rejection on the wallet/device itself. Names no button:
+      // this surface renders only Close. True on every cancellable window —
+      // the Pre-PegIn broadcast happens only after its signature completes.
+      signingCancelled: {
+        title: "Signing canceled",
+        body: "You canceled the signature request, so the deposit did not continue. No Bitcoin was spent.",
       },
       walletNotConnected: {
         title: "Wallet not connected",

--- a/services/vault/src/hooks/deposit/__tests__/useDepositFlow.test.tsx
+++ b/services/vault/src/hooks/deposit/__tests__/useDepositFlow.test.tsx
@@ -1705,15 +1705,18 @@ describe("useDepositFlow", () => {
       await settleAsCancelRejection();
     });
 
-    it("surfaces the cancel-settled rejection as the signing-rejected copy", async () => {
+    it("surfaces a settled self-cancel as the signing-cancelled copy, not the wallet-rejection copy", async () => {
       const { result, settleAsCancelRejection } =
         await startSignAndRequestCancel();
 
       // The flow controller was NOT aborted: the rejection reaches the normal
-      // error path (an aborted flow would have swallowed it silently).
+      // error path (an aborted flow would have swallowed it silently). The
+      // user clicked OUR cancel, so the "You rejected the request in your
+      // wallet. Click Retry" copy would misattribute it — and this surface
+      // renders no Retry button at all.
       const resolved = await settleAsCancelRejection();
       expect(resolved).toBeNull();
-      expect(result.current.error).toEqual(DEPOSIT_ERRORS.signingRejected);
+      expect(result.current.error).toEqual(DEPOSIT_ERRORS.signingCancelled);
     });
 
     it("sets deviceCancelRequested on request and clears it when the cancelled sign settles", async () => {
@@ -1910,6 +1913,154 @@ describe("useDepositFlow", () => {
         await flowPromise;
       });
       expect(result.current.canCancelDeviceSign).toBe(false);
+    });
+
+    it("stops the payout loop when a requested cancel settles — the next vault gets no ceremony", async () => {
+      const { signAndSubmitPayouts } = vi.mocked(
+        await import("../depositFlowSteps"),
+      );
+      const settle: { reject: (e: unknown) => void } = { reject: () => {} };
+      const signPsbt = vi
+        .fn()
+        // Vault 0's graph sign is held open for the cancel; a (buggy) second
+        // vault ceremony would resolve immediately and expose itself below.
+        .mockImplementationOnce(
+          () =>
+            new Promise<string>((_resolve, reject) => {
+              settle.reject = reject;
+            }),
+        )
+        .mockResolvedValue("mockSignedPsbtHex");
+      const wallet = { ...MOCK_BTC_WALLET, signPsbt, cancelSigning: vi.fn() };
+      vi.mocked(signAndSubmitPayouts).mockImplementation(
+        async ({ btcWallet }) => {
+          await btcWallet.signPsbt("graphPsbt");
+        },
+      );
+
+      const { result } = renderHook(() =>
+        useDepositFlow({ ...MOCK_PARAMS, btcWalletProvider: wallet as any }),
+      );
+
+      let flowPromise!: Promise<unknown>;
+      act(() => {
+        flowPromise = result.current.executeDeposit();
+      });
+      await waitFor(() =>
+        expect(result.current.canCancelDeviceSign).toBe(true),
+      );
+
+      act(() => {
+        result.current.cancelDeviceSign();
+      });
+
+      let resolved: unknown;
+      await act(async () => {
+        settle.reject(signingCancelledError());
+        resolved = await flowPromise;
+      });
+
+      // The cancel stops the loop: vault 1's ceremony must never start —
+      // before the fix it re-ran the full device ceremony seconds after
+      // the user asked to stop.
+      expect(signAndSubmitPayouts).toHaveBeenCalledTimes(1);
+      expect(resolved).not.toBeNull();
+      expect(result.current.error).toBeNull();
+      // Cancelled outcome, not a plain success: vault 0 carries the
+      // cancelled warning; vault 1 is unattempted, not failed (no warning).
+      expect(result.current.lastWarnings).toEqual([
+        {
+          vaultId: "0xVault0Id",
+          stage: "payout",
+          terminal: false,
+          message: COPY.deposit.warnings.payoutSigningCancelled(1),
+        },
+      ]);
+    });
+
+    it("surfaces a single-vault payout cancel as cancelled, not as a signing failure", async () => {
+      const {
+        signAndSubmitPayouts,
+        registerPeginBatchAndWait,
+        waitForWotsReadiness,
+        waitForPayoutReadiness,
+      } = vi.mocked(await import("../depositFlowSteps"));
+      const { preparePeginTransaction } = vi.mocked(
+        await import("@/services/vault/vaultTransactionService"),
+      );
+      vi.mocked(preparePeginTransaction).mockResolvedValueOnce({
+        ...MOCK_BATCH_RESULT,
+        perVault: [MOCK_BATCH_RESULT.perVault[0]],
+      } as any);
+      vi.mocked(registerPeginBatchAndWait).mockResolvedValueOnce({
+        ethTxHash: "0xSingleBatchEthTx" as Hex,
+        vaults: [
+          {
+            vaultId: "0xSingleVaultId" as Hex,
+            peginTxHash: "0xVault0BtcTxHash" as Hex,
+          },
+        ],
+      });
+      vi.mocked(waitForWotsReadiness).mockResolvedValueOnce({
+        readyVaultIds: new Set(["0xSingleVaultId"] as Hex[]),
+        terminalVaultIds: new Set<Hex>(),
+      });
+      vi.mocked(waitForPayoutReadiness).mockResolvedValueOnce({
+        readyVaultIds: new Set(["0xSingleVaultId"] as Hex[]),
+        terminalVaultIds: new Set<Hex>(),
+      });
+
+      const settle: { reject: (e: unknown) => void } = { reject: () => {} };
+      const signPsbt = vi.fn(
+        () =>
+          new Promise<string>((_resolve, reject) => {
+            settle.reject = reject;
+          }),
+      );
+      const wallet = { ...MOCK_BTC_WALLET, signPsbt, cancelSigning: vi.fn() };
+      vi.mocked(signAndSubmitPayouts).mockImplementation(
+        async ({ btcWallet }) => {
+          await btcWallet.signPsbt("graphPsbt");
+        },
+      );
+
+      const { result } = renderHook(() =>
+        useDepositFlow({
+          ...MOCK_PARAMS,
+          vaultAmounts: [100000n],
+          btcWalletProvider: wallet as any,
+        }),
+      );
+
+      let flowPromise!: Promise<unknown>;
+      act(() => {
+        flowPromise = result.current.executeDeposit();
+      });
+      await waitFor(() =>
+        expect(result.current.canCancelDeviceSign).toBe(true),
+      );
+
+      act(() => {
+        result.current.cancelDeviceSign();
+      });
+
+      let resolved: unknown;
+      await act(async () => {
+        settle.reject(signingCancelledError());
+        resolved = await flowPromise;
+      });
+
+      expect(resolved).not.toBeNull();
+      expect(result.current.error).toBeNull();
+      // Cancelled, not "Payout signing failed - <wallet error>".
+      expect(result.current.lastWarnings).toEqual([
+        {
+          vaultId: "0xSingleVaultId",
+          stage: "payout",
+          terminal: false,
+          message: COPY.deposit.warnings.payoutSigningCancelled(1),
+        },
+      ]);
     });
   });
 

--- a/services/vault/src/hooks/deposit/__tests__/useDepositFlow.test.tsx
+++ b/services/vault/src/hooks/deposit/__tests__/useDepositFlow.test.tsx
@@ -1915,7 +1915,9 @@ describe("useDepositFlow", () => {
       expect(result.current.canCancelDeviceSign).toBe(false);
     });
 
-    it("stops the payout loop when a requested cancel settles — the next vault gets no ceremony", async () => {
+    // Shared setup for the multi-vault payout-cancel tests below: hold vault
+    // 0's graph sign open, request the device cancel, hand back a settle helper.
+    async function startPayoutSignAndRequestCancel() {
       const { signAndSubmitPayouts } = vi.mocked(
         await import("../depositFlowSteps"),
       );
@@ -1923,7 +1925,8 @@ describe("useDepositFlow", () => {
       const signPsbt = vi
         .fn()
         // Vault 0's graph sign is held open for the cancel; a (buggy) second
-        // vault ceremony would resolve immediately and expose itself below.
+        // vault ceremony would resolve immediately and expose itself in the
+        // loop-stop test.
         .mockImplementationOnce(
           () =>
             new Promise<string>((_resolve, reject) => {
@@ -1954,18 +1957,51 @@ describe("useDepositFlow", () => {
         result.current.cancelDeviceSign();
       });
 
-      let resolved: unknown;
-      await act(async () => {
-        settle.reject(signingCancelledError());
-        resolved = await flowPromise;
-      });
+      const settleAsCancelRejection = async () => {
+        let resolved: unknown;
+        await act(async () => {
+          settle.reject(signingCancelledError());
+          resolved = await flowPromise;
+        });
+        return resolved;
+      };
+      return { result, signAndSubmitPayouts, settleAsCancelRejection };
+    }
+
+    it("stops the payout loop when a requested cancel settles — the next vault gets no ceremony", async () => {
+      const { signAndSubmitPayouts, settleAsCancelRejection } =
+        await startPayoutSignAndRequestCancel();
+
+      await settleAsCancelRejection();
 
       // The cancel stops the loop: vault 1's ceremony must never start —
       // before the fix it re-ran the full device ceremony seconds after
       // the user asked to stop.
       expect(signAndSubmitPayouts).toHaveBeenCalledTimes(1);
+    });
+
+    it("resolves the flow with a deposit result when a mid-loop payout cancel settles", async () => {
+      const { settleAsCancelRejection } =
+        await startPayoutSignAndRequestCancel();
+
+      const resolved = await settleAsCancelRejection();
       expect(resolved).not.toBeNull();
+    });
+
+    it("sets no flow error when a mid-loop payout cancel settles", async () => {
+      const { result, settleAsCancelRejection } =
+        await startPayoutSignAndRequestCancel();
+
+      await settleAsCancelRejection();
       expect(result.current.error).toBeNull();
+    });
+
+    it("warns only for the cancelled vault — the unattempted vault gets no warning", async () => {
+      const { result, settleAsCancelRejection } =
+        await startPayoutSignAndRequestCancel();
+
+      await settleAsCancelRejection();
+
       // Cancelled outcome, not a plain success: vault 0 carries the
       // cancelled warning; vault 1 is unattempted, not failed (no warning).
       expect(result.current.lastWarnings).toEqual([
@@ -1978,7 +2014,9 @@ describe("useDepositFlow", () => {
       ]);
     });
 
-    it("surfaces a single-vault payout cancel as cancelled, not as a signing failure", async () => {
+    // Same shape for a single-vault deposit: the whole batch is trimmed to
+    // one vault, its graph sign held open, and the device cancel requested.
+    async function startSingleVaultPayoutSignAndRequestCancel() {
       const {
         signAndSubmitPayouts,
         registerPeginBatchAndWait,
@@ -2044,14 +2082,39 @@ describe("useDepositFlow", () => {
         result.current.cancelDeviceSign();
       });
 
-      let resolved: unknown;
-      await act(async () => {
-        settle.reject(signingCancelledError());
-        resolved = await flowPromise;
-      });
+      const settleAsCancelRejection = async () => {
+        let resolved: unknown;
+        await act(async () => {
+          settle.reject(signingCancelledError());
+          resolved = await flowPromise;
+        });
+        return resolved;
+      };
+      return { result, settleAsCancelRejection };
+    }
 
+    it("resolves the flow with a deposit result when a single-vault payout cancel settles", async () => {
+      const { settleAsCancelRejection } =
+        await startSingleVaultPayoutSignAndRequestCancel();
+
+      const resolved = await settleAsCancelRejection();
       expect(resolved).not.toBeNull();
+    });
+
+    it("sets no flow error when a single-vault payout cancel settles", async () => {
+      const { result, settleAsCancelRejection } =
+        await startSingleVaultPayoutSignAndRequestCancel();
+
+      await settleAsCancelRejection();
       expect(result.current.error).toBeNull();
+    });
+
+    it("surfaces a single-vault payout cancel as the cancelled warning, not a signing failure", async () => {
+      const { result, settleAsCancelRejection } =
+        await startSingleVaultPayoutSignAndRequestCancel();
+
+      await settleAsCancelRejection();
+
       // Cancelled, not "Payout signing failed - <wallet error>".
       expect(result.current.lastWarnings).toEqual([
         {

--- a/services/vault/src/hooks/deposit/useDepositFlow.ts
+++ b/services/vault/src/hooks/deposit/useDepositFlow.ts
@@ -84,11 +84,13 @@ import {
   verifyBtcWalletLiveness,
 } from "@/utils/btc";
 import { satoshiToBtcNumber } from "@/utils/btcConversion";
+import { supportsCancelSigning } from "@/utils/cancelSigning";
 import {
   COMMISSION_UNAVAILABLE_ERROR,
   mapDepositError,
   type DepositErrorContent,
 } from "@/utils/errors";
+import { isUserCancellation } from "@/utils/errors/userCancellation";
 import { formatBtcValue } from "@/utils/formatting";
 import { getVpProxyUrl } from "@/utils/rpc";
 
@@ -307,8 +309,16 @@ export function useDepositFlow(
   // tracks exactly those calls — never derive/approve ceremonies or waits.
   const [deviceSignActive, setDeviceSignActive] = useState(false);
   const [deviceCancelRequested, setDeviceCancelRequested] = useState(false);
-  // Ref mirror so cancelDeviceSign reads the live value synchronously.
+  // Ref mirrors so cancelDeviceSign and the settle path read live values
+  // synchronously inside the long-lived async closures.
   const deviceSignActiveRef = useRef(false);
+  const deviceCancelRequestedRef = useRef(false);
+  // Sticky per-run signal: a requested cancel SETTLED as the wallet's
+  // user-cancel rejection. The multi-vault payout loop reads it to stop
+  // instead of re-running the next vault's device ceremony, and the outer
+  // catch reads it to surface cancelled (not rejected) copy. Reset only at
+  // the start of the next executeDeposit run.
+  const deviceCancelSettledRef = useRef(false);
   // Provider that STARTED the in-flight sign. Cancellation binds to it so a
   // wallet swapped in mid-prompt cannot orphan the original ceremony.
   const deviceSignProviderRef = useRef<unknown>(null);
@@ -320,12 +330,20 @@ export function useDepositFlow(
       setDeviceSignActive(true);
       try {
         return await sign();
+      } catch (error) {
+        // The requested cancel took effect (a late cancel that still signed
+        // successfully deliberately does NOT stick — the flow proceeds).
+        if (deviceCancelRequestedRef.current && isUserCancellation(error)) {
+          deviceCancelSettledRef.current = true;
+        }
+        throw error;
       } finally {
         deviceSignProviderRef.current = null;
         deviceSignActiveRef.current = false;
         setDeviceSignActive(false);
         // Either outcome consumes a pending cancel request — the UI must
         // never wedge on the disabled cancel button after a settle.
+        deviceCancelRequestedRef.current = false;
         setDeviceCancelRequested(false);
       }
     },
@@ -379,6 +397,7 @@ export function useDepositFlow(
       setError(null);
       setLastWarnings([]);
       setPeginSigningProgress(null);
+      deviceCancelSettledRef.current = false;
       advanceStep(DepositFlowStep.DERIVE_VAULT_SECRET);
       setPerVaultSteps(
         vaultAmounts.map(() => DepositFlowStep.DERIVE_VAULT_SECRET),
@@ -1276,6 +1295,12 @@ export function useDepositFlow(
 
           signal.throwIfAborted();
 
+          // A settled user cancel stops the loop: the next iteration would
+          // re-run the full device ceremony (requireFreshDeviceCeremony)
+          // seconds after the user asked to stop. Remaining vaults are left
+          // unattempted (no warning), not failed.
+          if (deviceCancelSettledRef.current) break;
+
           // Skip vaults whose WOTS key submission failed — the VP won't have
           // the keys needed, so payout signing would timeout.
           if (wotsFailedVaultIds.has(result.vaultId)) continue;
@@ -1344,6 +1369,21 @@ export function useDepositFlow(
           } catch (error) {
             // If the user cancelled, stop immediately — don't continue with other vaults
             if (signal.aborted) throw error;
+
+            // A settled self-cancel is a stop, not a per-vault failure: mark
+            // THIS vault cancelled and end the loop. Routine drop-off — no
+            // partial-failure telemetry.
+            if (deviceCancelSettledRef.current) {
+              recordWarning({
+                vaultId: result.vaultId,
+                stage: "payout",
+                terminal: false,
+                message: COPY.deposit.warnings.payoutSigningCancelled(
+                  result.vaultIndex + 1,
+                ),
+              });
+              break;
+            }
 
             if (isPayoutReadinessTimeout(error)) {
               setPerVaultSteps((prev) =>
@@ -1422,7 +1462,18 @@ export function useDepositFlow(
 
         // Don't show error if flow was aborted (user intentionally closed modal)
         if (!signal.aborted) {
-          setError(mapDepositError(err));
+          // A settled self-cancel gets its own copy: the generic mapper reads
+          // the wallet's CONNECTION_REJECTED as "You rejected the request in
+          // your wallet. Click Retry" — misattributed, and naming a button
+          // this surface doesn't render.
+          setError(
+            deviceCancelSettledRef.current && isUserCancellation(err)
+              ? {
+                  title: COPY.deposit.errors.signingCancelled.title,
+                  body: COPY.deposit.errors.signingCancelled.body,
+                }
+              : mapDepositError(err),
+          );
           logger.error(err instanceof Error ? err : new Error(String(err)), {
             tags: { depositStep: DepositFlowStep[currentStepRef.current] },
             data: {
@@ -1478,24 +1529,22 @@ export function useDepositFlow(
   const cancelDeviceSign = useCallback(() => {
     // Cancel the ceremony on the provider that started it — never the live
     // prop, which a mid-prompt wallet swap can replace.
-    const provider = deviceSignProviderRef.current as {
-      cancelSigning?: () => void;
-    } | null;
+    const provider = deviceSignProviderRef.current;
     if (!deviceSignActiveRef.current) return;
-    if (typeof provider?.cancelSigning !== "function") return;
+    if (!supportsCancelSigning(provider)) return;
+    deviceCancelRequestedRef.current = true;
     setDeviceCancelRequested(true);
-    // Device-only cancel (aborting the flow controller reads as a closed modal).
-    // Settles like an on-device reject: pre-broadcast = "Signing rejected"
-    // callout; post-broadcast payout stage = per-vault warning, loop continues.
+    // Device-only cancel (aborting the flow controller reads as a closed
+    // modal). Settles at the next device exchange boundary: pre-broadcast =
+    // "Signing cancelled" callout; post-broadcast payout stage = cancelled
+    // warning and the loop stops.
     provider.cancelSigning();
   }, []);
 
   // The ref is only ever set/cleared together with the `deviceSignActive`
   // state, so this render read stays in sync.
   const canCancelDeviceSign =
-    deviceSignActive &&
-    typeof (deviceSignProviderRef.current as { cancelSigning?: unknown } | null)
-      ?.cancelSigning === "function";
+    deviceSignActive && supportsCancelSigning(deviceSignProviderRef.current);
 
   return {
     executeDeposit,

--- a/services/vault/src/utils/cancelSigning.ts
+++ b/services/vault/src/utils/cancelSigning.ts
@@ -1,0 +1,27 @@
+/**
+ * Feature detection for `IBTCProvider.cancelSigning` — the optional
+ * device-cancel affordance only hardware providers implement (currently the
+ * Ledger vault provider). The interface documents that callers MUST
+ * feature-detect; this guard is the one place that probe lives.
+ */
+
+import type { IBTCProvider } from "@babylonlabs-io/wallet-connector";
+
+/** A provider that implements the optional cancel affordance. */
+export type CancellableSigningProvider = {
+  cancelSigning: NonNullable<IBTCProvider["cancelSigning"]>;
+};
+
+/**
+ * True when the provider that started a sign exposes `cancelSigning`.
+ * Takes `unknown` because callers hold the signing provider behind an
+ * untyped ref (the SDK's BitcoinWallet wraps the connector provider).
+ */
+export function supportsCancelSigning(
+  provider: unknown,
+): provider is CancellableSigningProvider {
+  return (
+    typeof (provider as { cancelSigning?: unknown } | null)?.cancelSigning ===
+    "function"
+  );
+}

--- a/services/vault/src/utils/errors/causeChain.ts
+++ b/services/vault/src/utils/errors/causeChain.ts
@@ -1,0 +1,50 @@
+/**
+ * The single `cause`-chain walk shared by the error classifiers
+ * (userCancellation.ts, deviceErrors.ts, walletMethodNotSupported.ts,
+ * formatting.ts) so their depth bound and walk semantics cannot drift apart.
+ *
+ * Deliberately dependency-free: `sentry.client.config.ts` imports
+ * userCancellation.ts at telemetry-init time, so nothing here may import
+ * COPY, the SDK, or the wallet-connector bundle.
+ */
+
+/** How far to walk a `cause` chain before giving up. */
+export const MAX_CAUSE_DEPTH = 10;
+
+/**
+ * True when the error — or anything in its `cause` chain — matches the frame
+ * predicate. The predicate sees every frame, including non-object frames
+ * (some wallet adapters reject with a bare string as a wrapper's `cause`);
+ * the walk itself stops at the first non-object frame after testing it.
+ */
+export function chainMatchesFrame(
+  error: unknown,
+  matchesFrame: (frame: unknown) => boolean,
+): boolean {
+  let cur: unknown = error;
+
+  for (let depth = 0; depth <= MAX_CAUSE_DEPTH && cur != null; depth++) {
+    if (matchesFrame(cur)) return true;
+
+    if (typeof cur !== "object") return false;
+
+    cur = (cur as { cause?: unknown }).cause;
+  }
+
+  return false;
+}
+
+/**
+ * True when the error or its `cause` chain carries the given `code`.
+ * Cause-walking: callers must run it AFTER their typed top-frame buckets so
+ * an inner code never shadows a more specific outer error.
+ */
+export function chainCarriesCode(error: unknown, code: string): boolean {
+  return chainMatchesFrame(
+    error,
+    (frame) =>
+      frame !== null &&
+      typeof frame === "object" &&
+      (frame as { code?: unknown }).code === code,
+  );
+}

--- a/services/vault/src/utils/errors/deviceErrors.ts
+++ b/services/vault/src/utils/errors/deviceErrors.ts
@@ -4,15 +4,14 @@
  * import from formatting.ts or depositErrors.ts.
  */
 
+import { chainCarriesCode } from "./causeChain";
+
 /** Device ceremony state unusable — the flow must restart from derivation. */
 export const DEVICE_CEREMONY_INVALID_CODE = "DEVICE_CEREMONY_INVALID";
 /** Hardware device is PIN-locked. */
 export const DEVICE_LOCKED_CODE = "DEVICE_LOCKED";
 /** Wrong app open on the hardware device. */
 export const DEVICE_WRONG_APP_CODE = "DEVICE_WRONG_APP";
-
-/** How far to walk a `cause` chain before giving up. */
-const MAX_CAUSE_DEPTH = 10;
 
 const DEVICE_CODES = [
   DEVICE_CEREMONY_INVALID_CODE,
@@ -32,20 +31,6 @@ export function deviceErrorCodeOfFrame(
   if (!frame || typeof frame !== "object") return undefined;
   const { code } = frame as { code?: unknown };
   return DEVICE_CODES.find((c) => c === code);
-}
-
-/**
- * True when the error or its cause chain carries the code. Cause-walking:
- * callers must run it AFTER their typed top-frame buckets.
- */
-function chainCarriesCode(error: unknown, code: string): boolean {
-  let cur: unknown = error;
-  for (let depth = 0; depth <= MAX_CAUSE_DEPTH && cur != null; depth++) {
-    if (typeof cur !== "object") return false;
-    if ((cur as { code?: unknown }).code === code) return true;
-    cur = (cur as { cause?: unknown }).cause;
-  }
-  return false;
 }
 
 export function isDeviceCeremonyInvalidError(error: unknown): boolean {

--- a/services/vault/src/utils/errors/formatting.ts
+++ b/services/vault/src/utils/errors/formatting.ts
@@ -13,6 +13,7 @@ import {
 
 import { COPY } from "@/copy";
 
+import { MAX_CAUSE_DEPTH } from "./causeChain";
 import { isDepositorWalletMismatchError } from "./depositorWalletMismatch";
 import {
   DEVICE_CEREMONY_INVALID_CODE,
@@ -138,7 +139,11 @@ const FRIENDLY_MESSAGES: Record<ErrorKind, string> = {
  */
 export function classifyError(err: unknown): ErrorKind | null {
   let cur: unknown = err;
-  for (let depth = 0; depth <= 10 && cur && typeof cur === "object"; depth++) {
+  for (
+    let depth = 0;
+    depth <= MAX_CAUSE_DEPTH && cur && typeof cur === "object";
+    depth++
+  ) {
     const obj = cur as {
       code?: unknown;
       name?: unknown;

--- a/services/vault/src/utils/errors/userCancellation.ts
+++ b/services/vault/src/utils/errors/userCancellation.ts
@@ -15,6 +15,8 @@
  * the dependency runs the other way.
  */
 
+import { chainMatchesFrame } from "./causeChain";
+
 /** EIP-1193 `userRejectedRequest`. */
 export const EIP1193_USER_REJECTED = 4001;
 
@@ -64,9 +66,6 @@ export const WALLET_CONNECTION_REJECTED_CODE = "CONNECTION_REJECTED";
 const USER_CANCELLATION_PATTERN =
   /(?:user|you) (?:rejected|denied|cancell?ed)|(?:rejected|denied|cancell?ed) by (?:the )?user|rejected by the wallet|(?:wallet|user|you) rejected the \w+ (?:approval|request)|user closed (?:the )?modal|connection (?:cancell?ed|rejected)|connection to \w+(?: \w+){0,2} was (?:cancell?ed|rejected)|denied request signature|proposal expired/i;
 
-/** How far to walk a `cause` chain before giving up. */
-const MAX_CAUSE_DEPTH = 10;
-
 /**
  * True when this single error frame carries a TYPED user-rejection signal:
  * EIP-1193 4001, viem's `UserRejectedRequestError`, or the wallet-connector
@@ -104,22 +103,9 @@ export function isUserCancellationFrame(frame: unknown): boolean {
 
 /**
  * True when the error - or anything in its `cause` chain - is the user
- * declining or dismissing a wallet prompt.
+ * declining or dismissing a wallet prompt. The shared walk tests every frame
+ * (bare-string causes from some wallet adapters included) before descending.
  */
 export function isUserCancellation(error: unknown): boolean {
-  let cur: unknown = error;
-
-  for (let depth = 0; depth <= MAX_CAUSE_DEPTH && cur != null; depth++) {
-    if (isUserCancellationFrame(cur)) return true;
-
-    // The string check is inside the loop, not only ahead of it: some wallet
-    // adapters reject with a bare string, and that string can be the `cause`
-    // of a wrapper Error rather than the top-level throw. A `typeof === object`
-    // loop guard stopped the walk at the first string cause and missed those.
-    if (typeof cur !== "object") return false;
-
-    cur = (cur as { cause?: unknown }).cause;
-  }
-
-  return false;
+  return chainMatchesFrame(error, isUserCancellationFrame);
 }

--- a/services/vault/src/utils/errors/walletMethodNotSupported.ts
+++ b/services/vault/src/utils/errors/walletMethodNotSupported.ts
@@ -9,6 +9,8 @@
  * module (and its test transform).
  */
 
+import { chainCarriesCode } from "./causeChain";
+
 /**
  * Wallet-connector error code thrown when a wallet does not implement a
  * required method (e.g. `deriveContextHash`). Mirrors
@@ -18,9 +20,6 @@
  */
 const WALLET_METHOD_NOT_SUPPORTED_CODE = "WALLET_METHOD_NOT_SUPPORTED";
 
-/** How far to walk a `cause` chain before giving up (mirrors isUserCancellation). */
-const MAX_CAUSE_DEPTH = 10;
-
 /**
  * True when the error — or anything in its `cause` chain — carries the
  * wallet-connector WALLET_METHOD_NOT_SUPPORTED code. Walks `cause` because
@@ -28,17 +27,5 @@ const MAX_CAUSE_DEPTH = 10;
  * original as `cause`) before the mappers see them.
  */
 export function isWalletMethodNotSupported(error: unknown): boolean {
-  let cur: unknown = error;
-
-  for (let depth = 0; depth <= MAX_CAUSE_DEPTH && cur != null; depth++) {
-    if (typeof cur !== "object") return false;
-
-    if ((cur as { code?: unknown }).code === WALLET_METHOD_NOT_SUPPORTED_CODE) {
-      return true;
-    }
-
-    cur = (cur as { cause?: unknown }).cause;
-  }
-
-  return false;
+  return chainCarriesCode(error, WALLET_METHOD_NOT_SUPPORTED_CODE);
 }


### PR DESCRIPTION
Addresses the nine open review comments on #2298 (all replied inline):
cancel stops the multi-vault payout loop (remaining vaults stay resumable
via the continuation view); self-cancel gets its own copy; the payout
modal's cancel button appears only during actual device-sign windows;
resendOnceOnIncorrectData/dispatcherInterrupted deleted end-to-end (no
production caller since the loopAbandoned removal — note for the signer's
next release notes: LedgerSignPsbtAbortedError lost a field and ctor arg);
envelope removal comment now cites the firmware-completes-v3 evidence;
shared causeChain leaf replaces three duplicated cause walks;
cancelSigning?() is a typed optional on IBTCProvider; wrong-app copy is
network-agnostic (testnet app is "Babylon Vault Testnet").