### PR TITLE
fix(core-ui, vault): update Telegram footer links

### DIFF
--- a/packages/babylon-core-ui/src/components/Footer/Footer.tsx
+++ b/packages/babylon-core-ui/src/components/Footer/Footer.tsx
@@ -1,5 +1,5 @@
 import { Text } from "../Text";
-import { BsDiscord, BsGithub, BsLinkedin } from "react-icons/bs";
+import { BsDiscord, BsGithub, BsLinkedin, BsTelegram } from "react-icons/bs";
 import { FaXTwitter } from "react-icons/fa6";
 import { GoHome } from "react-icons/go";
 import { IoMdBook } from "react-icons/io";
@@ -47,6 +47,11 @@ export const DEFAULT_SOCIAL_LINKS: SocialLink[] = [
     name: "GitHub",
     url: "https://github.com/babylonlabs-io",
     Icon: BsGithub,
+  },
+  {
+    name: "Telegram",
+    url: "https://t.me/babylonofficialcommunity",
+    Icon: BsTelegram,
   },
   {
     name: "LinkedIn",
@@ -132,5 +137,4 @@ export const Footer = ({
     </footer>
   );
 };
-
 

--- a/services/vault/src/config/socialLinks.ts
+++ b/services/vault/src/config/socialLinks.ts
@@ -8,7 +8,7 @@ export const SOCIAL_LINK_URLS = {
   github: "https://github.com/babylonlabs-io",
   // Matches the org convention used elsewhere (countdown, tbv-faucet,
   // coming-soon) — babylonlabs_io is an unrelated ~200-subscriber channel.
-  telegram: "https://t.me/babyloncommunity",
+  telegram: "https://t.me/babylonofficialcommunity",
   linkedin: "https://www.linkedin.com/company/babylon-labs-official",
   email: "mailto:contact@babylonlabs.io",
   discord: "https://discord.gg/babylonglobal",


### PR DESCRIPTION
## Summary

- Update the Vault footer Telegram URL.
- Restore the Telegram link in the shared footer used by simple-staking.
- Use `https://t.me/babylonofficialcommunity` in both applications.
