### PR TITLE
fix(ts-sdk, vault, ledger-vault): post-merge review fixes for #2299/#…

### DIFF
--- a/packages/babylon-ledger-vault-signer/src/__tests__/envelope.test.ts
+++ b/packages/babylon-ledger-vault-signer/src/__tests__/envelope.test.ts
@@ -8,6 +8,8 @@ import { describe, expect, it } from "vitest";
 
 import {
   DEVICE_MAX_PARTICIPANTS_PER_ROLE,
+  DEVICE_MAX_VAULT_CORE_VERSION,
+  DEVICE_MIN_VAULT_CORE_VERSION,
   DEVICE_PAYOUT_TIMELOCK_MAX_BLOCKS,
   DEVICE_PAYOUT_TIMELOCK_MIN_BLOCKS,
   DEVICE_PEGIN_CSV_TIMELOCK_MAX_BLOCKS,
@@ -66,13 +68,23 @@ describe("assertDepositTermsDeviceCompatible", () => {
     }
   });
 
-  it("does not gate on the tx-graph version — every reachable version is device-signable", () => {
-    // v3 is Core 2's Bitcoin tx shape byte-for-byte (btc-vault e1e50f66; SDK parity
-    // vector pegin.test.ts "builds the v3 Pre-PegIn byte-identical to the v2 vector");
-    // v1 is unreachable fresh (ProtocolParams setter rejects `newVersion <= prev`,
-    // no Ledger v1 vault exists); v4+ needs a new WASM release.
-    for (const vaultCoreVersion of [1, 2, 3, 4]) {
+  it("accepts the device-signable tx-graph versions 2 and 3", () => {
+    // v2 is the firmware's Core-2 tx shape; v3 is byte-identical (btc-vault
+    // e1e50f66; SDK parity vector pegin.test.ts "builds the v3 Pre-PegIn
+    // byte-identical to the v2 vector").
+    for (const vaultCoreVersion of [DEVICE_MIN_VAULT_CORE_VERSION, DEVICE_MAX_VAULT_CORE_VERSION]) {
       expect(() => assertDepositTermsDeviceCompatible(makeTerms({ vaultCoreVersion }))).not.toThrow();
+    }
+  });
+
+  it("rejects tx-graph versions outside the device band with the seam's typed error", () => {
+    // v1's tx shape differs (no P2A anchor) and v4+ has no device-compat
+    // evidence — either must fail BEFORE any device I/O, not mid-ceremony.
+    for (const vaultCoreVersion of [DEVICE_MIN_VAULT_CORE_VERSION - 1, DEVICE_MAX_VAULT_CORE_VERSION + 1]) {
+      expect(() => assertDepositTermsDeviceCompatible(makeTerms({ vaultCoreVersion }))).toThrow(
+        DepositTermsRejectedError,
+      );
+      expect(() => assertDepositTermsDeviceCompatible(makeTerms({ vaultCoreVersion }))).toThrow(/vaultCoreVersion/);
     }
   });
 

--- a/packages/babylon-ledger-vault-signer/src/deviceCaps.ts
+++ b/packages/babylon-ledger-vault-signer/src/deviceCaps.ts
@@ -11,6 +11,14 @@
  */
 
 /**
+ * Vault-core (tx-graph) versions the device can sign: v2 is the firmware's
+ * Core-2 tx shape; v3 is byte-identical (btc-vault e1e50f66; SDK parity vector
+ * pegin.test.ts). Widen only on evidence a future version is device-compatible.
+ */
+export const DEVICE_MIN_VAULT_CORE_VERSION = 2;
+export const DEVICE_MAX_VAULT_CORE_VERSION = 3;
+
+/**
  * Keeper and universal-challenger counts, each `[1, 32]` (`vault_intent.h:8-9`,
  * checked `vault_tlv.c:130,137`). Far below the protocol: the contract allows
  * 1500 universal challengers and sets no keeper cap at all.

--- a/packages/babylon-ledger-vault-signer/src/envelope.ts
+++ b/packages/babylon-ledger-vault-signer/src/envelope.ts
@@ -10,8 +10,10 @@
 import {
   DEVICE_MAX_BASE_FEE_RATE_SAT_PER_VB,
   DEVICE_MAX_PARTICIPANTS_PER_ROLE,
+  DEVICE_MAX_VAULT_CORE_VERSION,
   DEVICE_MAX_VAULTS_PER_INTENT,
   DEVICE_MIN_DEPOSITOR_CLAIM_VALUE_SATS,
+  DEVICE_MIN_VAULT_CORE_VERSION,
   DEVICE_PAYOUT_TIMELOCK_MAX_BLOCKS,
   DEVICE_PAYOUT_TIMELOCK_MIN_BLOCKS,
   DEVICE_PEGIN_AMOUNT_DUST_MULTIPLE,
@@ -36,10 +38,12 @@ function requireIntInRange(field: string, value: number, lo: number, hi: number)
  * @throws {DepositTermsRejectedError} on the first violation
  */
 export function assertDepositTermsDeviceCompatible(terms: DepositTerms): void {
-  // No tx-graph version gate: v3 is Core 2's Bitcoin tx shape byte-for-byte (btc-vault
-  // e1e50f66; SDK parity vector pegin.test.ts "builds the v3 Pre-PegIn byte-identical to
-  // the v2 vector"); v1 is unreachable fresh (ProtocolParams setter rejects
-  // `newVersion <= prev`, and no Ledger v1 vault exists); v4+ needs a new WASM release.
+  requireIntInRange(
+    "vaultCoreVersion",
+    terms.vaultCoreVersion,
+    DEVICE_MIN_VAULT_CORE_VERSION,
+    DEVICE_MAX_VAULT_CORE_VERSION,
+  );
 
   // The >= 1 floor is enforced by both the contract and the device
   // (vault_tlv.c:73 rejects rate == 0).

--- a/packages/babylon-ledger-vault-signer/src/signPsbtLoop.ts
+++ b/packages/babylon-ledger-vault-signer/src/signPsbtLoop.ts
@@ -10,7 +10,7 @@
  * ≈ 5 s device deadline, `base:io_ext.h:28`).
  *
  * `base:` = LedgerHQ/app-bitcoin branch `baseapp` @ `e400d8d8`:
- * `io_ext.h`, `sw.h` and `dispatcher.c` live under `src/boilerplate/`,
+ * `io_ext.h` and `sw.h` live under `src/boilerplate/`,
  * `constants.h` under `src/`. The pin is load-bearing — the same paths on
  * `develop` describe different behaviour.
  *

--- a/packages/babylon-ts-sdk/docs/api/primitives.md
+++ b/packages/babylon-ts-sdk/docs/api/primitives.md
@@ -2511,8 +2511,8 @@ finalized witness item for wallets that auto-finalize — and when both are
 present they must be the same bytes. P2WPKH: `partialSig`, or the finalized
 2-item witness, verified as ECDSA over the BIP-143 sighash
 (assertReturnedP2wpkhSignature); a failure throws but the input is
-NOT counted. Script-path and unknown script types are skipped (they have
-their own checks).
+NOT counted. Any other input type (script-path, P2WSH, ...) throws — no
+verifier here covers it, so it cannot be treated as verified.
 
 #### Parameters
 
@@ -2531,9 +2531,10 @@ How many inputs were verified KEY-PATH. A caller that knows every
 
 #### Throws
 
-If the input counts differ, an eligible input carries no signature, a
-        finalized witness disagrees with its `tapKeySig`/`partialSig`, or any
-        signature does not verify.
+If the input counts differ, an input is neither key-path P2TR nor
+        P2WPKH, an eligible input carries no signature, a finalized witness
+        disagrees with its `tapKeySig`/`partialSig`, or any signature does
+        not verify.
 
 ***
 

--- a/packages/babylon-ts-sdk/src/shared/wallets/__tests__/BitcoinWallet.test.ts
+++ b/packages/babylon-ts-sdk/src/shared/wallets/__tests__/BitcoinWallet.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it } from "vitest";
+import { MockBitcoinWallet } from "../../../testing/MockBitcoinWallet";
 import { BitcoinNetworks } from "../interfaces";
 import type { BitcoinWallet } from "../interfaces/BitcoinWallet";
-import { MockBitcoinWallet } from "../../../testing/MockBitcoinWallet";
 
 describe("BitcoinWallet Interface", () => {
   let wallet: BitcoinWallet;
@@ -80,7 +80,7 @@ describe("BitcoinWallet Interface", () => {
   describe("signMessage", () => {
     it("should sign a message and return signature", async () => {
       const message = "Hello, Bitcoin!";
-      const signature = await wallet.signMessage(message, "ecdsa");
+      const signature = await wallet.signMessage(message, "bip322-simple");
 
       expect(signature).toBeDefined();
       expect(typeof signature).toBe("string");
@@ -88,14 +88,14 @@ describe("BitcoinWallet Interface", () => {
     });
 
     it("should produce different signatures for different messages", async () => {
-      const sig1 = await wallet.signMessage("Message 1", "ecdsa");
-      const sig2 = await wallet.signMessage("Message 2", "ecdsa");
+      const sig1 = await wallet.signMessage("Message 1", "bip322-simple");
+      const sig2 = await wallet.signMessage("Message 2", "bip322-simple");
 
       expect(sig1).not.toBe(sig2);
     });
 
     it("should throw error for empty message", async () => {
-      await expect(wallet.signMessage("", "ecdsa")).rejects.toThrow();
+      await expect(wallet.signMessage("", "bip322-simple")).rejects.toThrow();
     });
 
     it("should handle signing failures", async () => {
@@ -103,15 +103,18 @@ describe("BitcoinWallet Interface", () => {
         shouldFailSigning: true,
       });
 
-      await expect(failingWallet.signMessage("test", "ecdsa")).rejects.toThrow(
-        "Mock signing failed",
-      );
+      await expect(
+        failingWallet.signMessage("test", "bip322-simple"),
+      ).rejects.toThrow("Mock signing failed");
     });
   });
 
   describe("deriveContextHash", () => {
     it("should return a 64-char lowercase hex string", async () => {
-      const out = await wallet.deriveContextHash("babylon-btc-vault", "deadbeef");
+      const out = await wallet.deriveContextHash(
+        "babylon-btc-vault",
+        "deadbeef",
+      );
       expect(typeof out).toBe("string");
       expect(out).toHaveLength(64);
       expect(out).toMatch(/^[0-9a-f]+$/);
@@ -124,8 +127,14 @@ describe("BitcoinWallet Interface", () => {
     });
 
     it("returns different values when context changes", async () => {
-      const a = await wallet.deriveContextHash("babylon-btc-vault", "aa".repeat(36));
-      const b = await wallet.deriveContextHash("babylon-btc-vault", "bb".repeat(36));
+      const a = await wallet.deriveContextHash(
+        "babylon-btc-vault",
+        "aa".repeat(36),
+      );
+      const b = await wallet.deriveContextHash(
+        "babylon-btc-vault",
+        "bb".repeat(36),
+      );
       expect(a).not.toBe(b);
     });
 
@@ -160,7 +169,11 @@ describe("BitcoinWallet Interface", () => {
       const network = await wallet.getNetwork();
 
       expect(network).toBeDefined();
-      expect([BitcoinNetworks.MAINNET, BitcoinNetworks.TESTNET, BitcoinNetworks.SIGNET]).toContain(network);
+      expect([
+        BitcoinNetworks.MAINNET,
+        BitcoinNetworks.TESTNET,
+        BitcoinNetworks.SIGNET,
+      ]).toContain(network);
     });
 
     it("should return signet by default", async () => {
@@ -170,7 +183,9 @@ describe("BitcoinWallet Interface", () => {
     });
 
     it("should return configured network", async () => {
-      const mainnetWallet = new MockBitcoinWallet({ network: BitcoinNetworks.MAINNET });
+      const mainnetWallet = new MockBitcoinWallet({
+        network: BitcoinNetworks.MAINNET,
+      });
       const network = await mainnetWallet.getNetwork();
 
       expect(network).toBe(BitcoinNetworks.MAINNET);

--- a/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/__tests__/bip322Verify.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/__tests__/bip322Verify.test.ts
@@ -157,6 +157,11 @@ const TEST_PRIV = Buffer.alloc(32, 0);
 TEST_PRIV[31] = 1; // privkey 1 → pubkey G; public test material.
 const TEST_PUB = Buffer.from(ecc.pointFromScalar(TEST_PRIV, true)!);
 
+/** secp256k1 group order n — (r, s) and (r, n−s) verify the same message. */
+const SECP256K1_ORDER = BigInt(
+  "0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141",
+);
+
 function bip322P2wpkhSighash(
   messageBytes: Uint8Array,
   pubkey: Buffer,
@@ -239,6 +244,26 @@ describe("verifyBip322P2wpkhSimple — BIP-322 official P2WPKH vectors", () => {
     }
   });
 
+  it("accepts an in-test signature over bip322P2wpkhSighash (pins the helper against production)", () => {
+    // Positive anchor for the helper: if its sighash drifted from the
+    // production construction, the gate tests below would only ever assert
+    // "invalid signature" and pass vacuously.
+    const message = utf8("helper round-trip");
+    const sighash = bip322P2wpkhSighash(message, TEST_PUB, 0x01);
+    let encoded: Buffer | undefined;
+    for (let i = 0; i < 100 && !encoded; i++) {
+      const entropy = Buffer.alloc(32, 0);
+      entropy.writeUInt32LE(i, 0);
+      const candidate = bscript.signature.encode(
+        Buffer.from(ecc.sign(sighash, TEST_PRIV, entropy)),
+        0x01,
+      );
+      if (candidate.length >= 71) encoded = candidate;
+    }
+    expect(encoded).toBeDefined();
+    expect(verifyBip322P2wpkhSimple(message, TEST_PUB, encoded!)).toBe(true);
+  });
+
   it("rejects a cryptographically valid SIGHASH_NONE signature (gate, not sig failure)", () => {
     // Signed over the real NONE sighash: without the explicit SIGHASH_ALL
     // gate (bip322 crate 0.0.10 verify.rs:156-161) this would verify.
@@ -281,6 +306,76 @@ describe("verifyBip322P2wpkhSimple — BIP-322 official P2WPKH vectors", () => {
     expect(verifyBip322P2wpkhSimple(message, TEST_PUB, shortEncoded!)).toBe(
       false,
     );
+  });
+
+  it("rejects a canonical high-S signature (only the strict verify flag catches it)", () => {
+    // libsecp's verify rejects high-S (bip322 crate verify.rs:180-182); on the
+    // host only ecc.verify's strict flag does — DER shape and the canonicality
+    // round-trip both accept (r, n−s), so this pins the flag itself.
+    const { message, encodedSignatureHexes } = BIP322_P2WPKH_SIGNATURES[1];
+    const sig71 = fromHex(encodedSignatureHexes[0]); // 71 bytes: 32-byte R and S
+    expect(sig71.length).toBe(71);
+    const { signature } = bscript.signature.decode(Buffer.from(sig71));
+    const s = BigInt(`0x${signature.subarray(32).toString("hex")}`);
+    const highSCompact = Buffer.concat([
+      signature.subarray(0, 32),
+      Buffer.from((SECP256K1_ORDER - s).toString(16).padStart(64, "0"), "hex"),
+    ]);
+    const encoded = bscript.signature.encode(highSCompact, 0x01);
+    // n−s carries the sign-pad: 72 bytes, still inside the 71/72 gate.
+    expect(encoded.length).toBe(72);
+    const sighash = bip322P2wpkhSighash(
+      utf8(message),
+      Buffer.from(VECTOR_PUBKEY),
+      0x01,
+    );
+    // Sanity: (r, n−s) verifies with strictness off — only strict rejects.
+    expect(ecc.verify(sighash, VECTOR_PUBKEY, highSCompact, false)).toBe(true);
+    expect(ecc.verify(sighash, VECTOR_PUBKEY, highSCompact, true)).toBe(false);
+
+    expect(
+      verifyBip322P2wpkhSimple(utf8(message), VECTOR_PUBKEY, encoded),
+    ).toBe(false);
+  });
+
+  it("rejects a 72-byte non-canonical encoding (oversized padded R) that decodes to a valid signature", () => {
+    // bip66.decode never bounds lenR at 33 and bitcoinjs fromDER truncates an
+    // oversized integer back to the true value (bitcoinjs-lib 6.1.7
+    // bip66.js:36-38, script_signature.js:29-35), so without a canonicality
+    // gate these bytes reach ecc.verify and pass — while vaultd's strict
+    // libsecp parse rejects them (secp256k1-sys ecdsa_impl.h:127-136).
+    const message = utf8("wide r");
+    const sighash = bip322P2wpkhSighash(message, TEST_PUB, 0x01);
+    // Grind for r with its high bit set (so the 0x00 pad survives bip66's
+    // excessively-padded check) and a 31-byte canonical S (total lands on 72).
+    let compact: Buffer | undefined;
+    let canonical: Buffer | undefined;
+    for (let i = 0; i < 20000 && !compact; i++) {
+      const entropy = Buffer.alloc(32, 0);
+      entropy.writeUInt32LE(i, 0);
+      const candidate = Buffer.from(ecc.sign(sighash, TEST_PRIV, entropy));
+      const encoded = bscript.signature.encode(candidate, 0x01);
+      const lenS = encoded[5 + encoded[3]];
+      if (candidate[0] & 0x80 && lenS === 31) {
+        compact = candidate;
+        canonical = encoded;
+      }
+    }
+    expect(compact).toBeDefined();
+    const lenR = canonical![3]; // 33: 0x00 pad ‖ r (high bit set)
+    const crafted = Buffer.concat([
+      Buffer.from([0x30, canonical![1] + 1, 0x02, lenR + 1]),
+      canonical!.subarray(4, 4 + lenR), // 0x00 ‖ true r
+      Buffer.from([0xab]), // junk byte fromDER's truncation drops
+      canonical!.subarray(4 + lenR), // 0x02 ‖ lenS ‖ S ‖ 0x01
+    ]);
+    expect(crafted.length).toBe(72);
+    // Sanity: today's decode path accepts it and recovers the true (r, s).
+    const decoded = bscript.signature.decode(crafted);
+    expect(Buffer.from(decoded.signature).equals(compact!)).toBe(true);
+    expect(ecc.verify(sighash, TEST_PUB, decoded.signature, true)).toBe(true);
+
+    expect(verifyBip322P2wpkhSimple(message, TEST_PUB, crafted)).toBe(false);
   });
 
   it("rejects a pubkey that is not on the curve or not 33 bytes", () => {

--- a/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/bip322Verify.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/bip322Verify.ts
@@ -56,10 +56,11 @@ const COMPRESSED_PUBKEY_SIZE = 33;
  * vaultd's P2WPKH BIP-322 verifier accepts ONLY 71/72-byte encoded
  * signatures — DER (70/71B) + sighash byte (`bip322` crate 0.0.10
  * `verify.rs:141-153`). A shorter (short-DER) signature fails ingestion
- * permanently, so this gate must be exactly as strict.
+ * permanently, so this gate must be exactly as strict. Exported so
+ * `verifyPopWitness` can pre-screen with a cause-naming error.
  */
-const P2WPKH_ENCODED_SIG_MIN = 71;
-const P2WPKH_ENCODED_SIG_MAX = 72;
+export const P2WPKH_ENCODED_SIG_MIN = 71;
+export const P2WPKH_ENCODED_SIG_MAX = 72;
 
 // NOTE: bitcoinjs-lib v6.x's `Transaction.addOutput` and its sighash
 // methods are typed for `Satoshi` (a UInt53 number), not `bigint`.
@@ -271,6 +272,17 @@ export function verifyBip322P2wpkhSimple(
     const { signature, hashType } = bscript.signature.decode(
       Buffer.from(encodedSignature),
     );
+    // decode tolerates non-minimal integers (bip66.js never bounds lenR/lenS at 33;
+    // fromDER truncates, script_signature.js:29-35) that vaultd's strict libsecp
+    // parse rejects (secp256k1-sys ecdsa_impl.h:127-136) — require the unique
+    // minimal encoding by re-encoding and byte-comparing.
+    if (
+      !bscript.signature
+        .encode(signature, hashType)
+        .equals(Buffer.from(encodedSignature))
+    ) {
+      return false;
+    }
     if (hashType !== Transaction.SIGHASH_ALL) return false;
 
     // scriptPubKey = OP_0 PUSH20 hash160(pubkey) (`message.rs:127 Address::p2wpkh`).

--- a/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts
@@ -1212,7 +1212,7 @@ export class PeginManager {
     // Far-side check of the returned signatures (CLAUDE.md §8: never trust
     // the wallet's success/finalization). Taproot key-path inputs are
     // Schnorr-verified and counted; P2WPKH funding is ECDSA-verified
-    // (throwing on failure) without counting; P2WSH stays skipped.
+    // (throwing on failure) without counting; any other input type throws.
     const verifiedInputs = assertReturnedKeyPathSignatures({
       requestedPsbtHex,
       returnedPsbtHex: signedPsbtHex,

--- a/packages/babylon-ts-sdk/src/tbv/core/managers/__tests__/PeginManager.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/__tests__/PeginManager.test.ts
@@ -156,6 +156,8 @@ const TEST_PUBLIC_CLIENT = {
 
 // Test constants - use valid secp256k1 x-only public keys
 const TEST_KEYS = {
+  // Must stay = MockBitcoinWallet's default privkey-1 pubkey (G.x): the PoP
+  // tests sign with the mock's default key.
   DEPOSITOR: "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
   VAULT_PROVIDER:
     "c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5",

--- a/packages/babylon-ts-sdk/src/tbv/core/managers/pegin/__tests__/verifyPopWitness.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/pegin/__tests__/verifyPopWitness.test.ts
@@ -13,6 +13,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   BIP322_P2WPKH_HELLO_WORLD_WITNESS_HEX,
+  BIP322_P2WPKH_PUBKEY_HEX,
   BIP322_P2WPKH_PUBKEY_XONLY_HEX,
 } from "../../../clients/vault-provider/auth/__tests__/bip322P2wpkhVectors";
 import {
@@ -159,6 +160,29 @@ describe("verifyPopWitness", () => {
     expect(() =>
       verifyPopWitness(HELLO_WORLD, "22".repeat(32), HELLO_WORLD_WITNESS),
     ).toThrow(/does not match the depositor key/);
+  });
+
+  it("names the 71/72-byte requirement for a short P2WPKH signature instead of blaming the key", () => {
+    // vaultd only ingests 71/72-byte encoded signatures, and an RFC-6979
+    // wallet re-produces the same short signature on every retry — the error
+    // must name the real cause, not report a key mismatch.
+    const shortSig = "11".repeat(70);
+    const witness =
+      `0x0246${shortSig}21${BIP322_P2WPKH_PUBKEY_HEX}` as `0x${string}`;
+    expect(() =>
+      verifyPopWitness(HELLO_WORLD, BIP322_P2WPKH_PUBKEY_XONLY_HEX, witness),
+    ).toThrow(/71\/72-byte/);
+  });
+
+  it("names the SIGHASH_ALL requirement when the trailing sighash byte is not 0x01", () => {
+    // 71-byte item ending 0x83: passes the length gate, so the distinct
+    // sighash-type error is the one that must surface.
+    const sig = `${"22".repeat(70)}83`;
+    const witness =
+      `0x0247${sig}21${BIP322_P2WPKH_PUBKEY_HEX}` as `0x${string}`;
+    expect(() =>
+      verifyPopWitness(HELLO_WORLD, BIP322_P2WPKH_PUBKEY_XONLY_HEX, witness),
+    ).toThrow(/SIGHASH_ALL/);
   });
 
   it("rejects a two-item witness whose item 1 is not a compressed pubkey", () => {

--- a/packages/babylon-ts-sdk/src/tbv/core/managers/pegin/verifyPopWitness.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/pegin/verifyPopWitness.ts
@@ -26,6 +26,8 @@ import type { Hex } from "viem";
 import { decodeWitnessStack } from "../../utils/witness/witnessStack";
 
 import {
+  P2WPKH_ENCODED_SIG_MAX,
+  P2WPKH_ENCODED_SIG_MIN,
   verifyBip322P2wpkhSimple,
   verifyBip322Simple,
 } from "../../clients/vault-provider/auth/bip322Verify";
@@ -156,6 +158,29 @@ export function verifyPopWitness(
       throw new Error(
         `proof of possession witness pubkey does not match the depositor key: ` +
           `witness carries ${witnessXOnlyHex}, expected ${depositorXOnlyHex}`,
+      );
+    }
+    // vaultd only ingests 71/72-byte DER+sighash signatures (bip322 crate
+    // 0.0.10 verify.rs:140-154); RFC-6979 wallets re-sign identically on
+    // retry, so name the real cause instead of a wrong-key diagnosis.
+    if (
+      encodedSignature.length < P2WPKH_ENCODED_SIG_MIN ||
+      encodedSignature.length > P2WPKH_ENCODED_SIG_MAX
+    ) {
+      throw new Error(
+        `proof of possession signature is ${encodedSignature.length} bytes; ` +
+          `vault ingestion accepts only 71/72-byte DER signatures with a ` +
+          `sighash byte — try a different account or a Taproot address`,
+      );
+    }
+    // The trailing byte is the sighash type (bitcoinjs script_signature.js
+    // decode reads it) and the verifier accepts SIGHASH_ALL only — surface it.
+    if (encodedSignature[encodedSignature.length - 1] !== SIGHASH_ALL) {
+      throw new Error(
+        `proof of possession P2WPKH signature must end in a SIGHASH_ALL ` +
+          `(0x01) byte, got 0x${encodedSignature[
+            encodedSignature.length - 1
+          ].toString(16)}`,
       );
     }
     // BIP-322 simple verification against the P2WPKH address of the witness

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/__tests__/verifyKeyPathSchnorrSignature.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/__tests__/verifyKeyPathSchnorrSignature.test.ts
@@ -307,7 +307,9 @@ describe("assertReturnedKeyPathSignatures", () => {
     ).toThrow(/non-minimal/);
   });
 
-  it("skips inputs that are not key-path eligible (script-path inputs are the script-path verifier's job)", () => {
+  it("throws on a script-path input instead of treating it as verified", () => {
+    // No verifier here covers script-path spends: silently skipping would
+    // report the PSBT as checked with an input nothing looked at.
     const req = new Psbt();
     req.addInput({
       hash: Buffer.alloc(32, 1),
@@ -328,7 +330,7 @@ describe("assertReturnedKeyPathSignatures", () => {
         requestedPsbtHex: req.toHex(),
         returnedPsbtHex: req.toHex(),
       }),
-    ).not.toThrow();
+    ).toThrow(/input 0.*neither key-path P2TR nor P2WPKH/i);
   });
 });
 
@@ -535,6 +537,125 @@ describe("assertReturnedKeyPathSignatures — P2WPKH inputs", () => {
     ).toThrow(/input 0/);
   });
 
+  it("rejects a canonical high-S signature (only the strict verify flag catches it), naming the input", () => {
+    // libsecp's verify_ecdsa rejects high-S (client.rs:992-999); on the host
+    // only ecc.verify's strict flag does — DER shape and the canonicality
+    // round-trip both accept (r, n−s), so this pins the flag itself.
+    const SECP256K1_ORDER = BigInt(
+      "0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141",
+    );
+    const req = p2wpkhRequestedPsbt();
+    const { signature } = bscript.signature.decode(signP2wpkh(req, 0));
+    const s = BigInt(`0x${signature.subarray(32).toString("hex")}`);
+    const highSCompact = Buffer.concat([
+      signature.subarray(0, 32),
+      Buffer.from((SECP256K1_ORDER - s).toString(16).padStart(64, "0"), "hex"),
+    ]);
+    const encoded = Buffer.from(
+      bscript.signature.encode(highSCompact, Transaction.SIGHASH_ALL),
+    );
+    // Sanity: (r, n−s) verifies with strictness off — only strict rejects.
+    const tx = Transaction.fromBuffer(req.data.globalMap.unsignedTx.toBuffer());
+    const sighash = tx.hashForWitnessV0(
+      0,
+      p2wpkhScriptCode(PUB),
+      req.data.inputs[0].witnessUtxo!.value,
+      Transaction.SIGHASH_ALL,
+    );
+    expect(ecc.verify(sighash, PUB, highSCompact, false)).toBe(true);
+    expect(ecc.verify(sighash, PUB, highSCompact, true)).toBe(false);
+
+    const ret = Psbt.fromHex(req.toHex());
+    ret.data.inputs[0].partialSig = [{ pubkey: PUB, signature: encoded }];
+    ret.updateInput(1, {
+      partialSig: [{ pubkey: PUB, signature: signP2wpkh(req, 1) }],
+    });
+    expect(() =>
+      assertReturnedKeyPathSignatures({
+        requestedPsbtHex: req.toHex(),
+        returnedPsbtHex: ret.toHex(),
+      }),
+    ).toThrow(/input 0 does not verify/);
+  });
+
+  it("rejects an input carrying two partialSig entries, naming the input", () => {
+    const req = p2wpkhRequestedPsbt();
+    const ret = Psbt.fromHex(req.toHex());
+    const otherPub = Buffer.from(
+      ecc.pointFromScalar(Buffer.alloc(32, 9), true)!,
+    );
+    // Direct assignment (same bypass as the corrupted-DER test): the bip174
+    // parser doesn't validate, so a wallet can return two entries.
+    ret.data.inputs[0].partialSig = [
+      { pubkey: PUB, signature: signP2wpkh(req, 0) },
+      { pubkey: otherPub, signature: signP2wpkh(req, 0) },
+    ];
+    ret.updateInput(1, {
+      partialSig: [{ pubkey: PUB, signature: signP2wpkh(req, 1) }],
+    });
+    expect(() =>
+      assertReturnedKeyPathSignatures({
+        requestedPsbtHex: req.toHex(),
+        returnedPsbtHex: ret.toHex(),
+      }),
+    ).toThrow(/input 0.*at most one partial signature/);
+  });
+
+  it("rejects a non-canonical DER encoding (oversized R with a junk tail) that decodes to a valid signature", () => {
+    // bip66.decode never bounds lenR at 33 and bitcoinjs fromDER truncates an
+    // oversized integer back to the true value (bitcoinjs-lib 6.1.7
+    // bip66.js:36-38, script_signature.js:29-35) — but libsecp's strict
+    // consensus parse rejects these bytes (secp256k1-sys ecdsa_impl.h:127-136),
+    // so blessing them would broadcast a consensus-invalid witness.
+    const req = p2wpkhRequestedPsbt();
+    const tx = Transaction.fromBuffer(req.data.globalMap.unsignedTx.toBuffer());
+    const sighash = tx.hashForWitnessV0(
+      0,
+      p2wpkhScriptCode(PUB),
+      req.data.inputs[0].witnessUtxo!.value,
+      Transaction.SIGHASH_ALL,
+    );
+    // Grind for r[0] in (0, 0x80): the widened R stays a positive,
+    // non-padded DER integer, so only the junk tail is non-canonical.
+    let compact: Buffer | undefined;
+    for (let i = 0; i < 1000 && !compact; i++) {
+      const entropy = Buffer.alloc(32, 0);
+      entropy.writeUInt32LE(i, 0);
+      const candidate = Buffer.from(ecc.sign(sighash, PRIV, entropy));
+      if (candidate[0] !== 0 && !(candidate[0] & 0x80)) compact = candidate;
+    }
+    expect(compact).toBeDefined();
+    const canonical = bscript.signature.encode(
+      compact!,
+      Transaction.SIGHASH_ALL,
+    );
+    const lenR = canonical[3]; // 32: r[0] < 0x80 needs no pad
+    const mutated = Buffer.concat([
+      Buffer.from([0x30, canonical[1] + 1, 0x02, lenR + 1]),
+      canonical.subarray(4, 4 + lenR), // true r
+      Buffer.from([0xab]), // junk byte fromDER's truncation drops
+      canonical.subarray(4 + lenR), // 0x02 ‖ lenS ‖ S ‖ 0x01
+    ]);
+    // Sanity: today's decode path accepts the mutation and recovers the true sig.
+    const decoded = bscript.signature.decode(mutated);
+    expect(Buffer.from(decoded.signature).equals(compact!)).toBe(true);
+    expect(ecc.verify(sighash, PUB, decoded.signature, true)).toBe(true);
+
+    const ret = Psbt.fromHex(req.toHex());
+    // Direct assignment: bip174 refuses mangled DER via updateInput, but its
+    // PARSER doesn't validate signature bytes — a wallet can return this.
+    ret.data.inputs[0].partialSig = [{ pubkey: PUB, signature: mutated }];
+    ret.updateInput(1, {
+      partialSig: [{ pubkey: PUB, signature: signP2wpkh(req, 1) }],
+    });
+    expect(() =>
+      assertReturnedKeyPathSignatures({
+        requestedPsbtHex: req.toHex(),
+        returnedPsbtHex: ret.toHex(),
+      }),
+    ).toThrow(/input 0.*not canonical DER/);
+  });
+
   it("rejects a pubkey that does not hash to the prevout's witness program", () => {
     const req = p2wpkhRequestedPsbt();
     const ret = Psbt.fromHex(req.toHex());
@@ -648,7 +769,9 @@ describe("assertReturnedKeyPathSignatures — P2WPKH inputs", () => {
     ).toBe(1);
   });
 
-  it("still skips genuinely unknown script types (P2WSH)", () => {
+  it("throws on a P2WSH input instead of treating it as verified", () => {
+    // No P2WSH verifier exists anywhere in the SDK — fail closed like
+    // btc-vault's check_signatures_valid rather than skipping silently.
     const req = new Psbt();
     req.addInput({
       hash: Buffer.alloc(32, 1),
@@ -667,7 +790,7 @@ describe("assertReturnedKeyPathSignatures — P2WPKH inputs", () => {
         requestedPsbtHex: req.toHex(),
         returnedPsbtHex: req.toHex(),
       }),
-    ).not.toThrow();
+    ).toThrow(/input 0.*neither key-path P2TR nor P2WPKH/i);
   });
 
   it("differential over varied keys and values: accepts honest signatures, rejects one-byte tampering", () => {

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/verifyKeyPathSchnorrSignature.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/verifyKeyPathSchnorrSignature.ts
@@ -208,16 +208,17 @@ export interface AssertReturnedKeyPathSignaturesParams {
  * present they must be the same bytes. P2WPKH: `partialSig`, or the finalized
  * 2-item witness, verified as ECDSA over the BIP-143 sighash
  * ({@link assertReturnedP2wpkhSignature}); a failure throws but the input is
- * NOT counted. Script-path and unknown script types are skipped (they have
- * their own checks).
+ * NOT counted. Any other input type (script-path, P2WSH, ...) throws — no
+ * verifier here covers it, so it cannot be treated as verified.
  *
  * @returns How many inputs were verified KEY-PATH. A caller that knows every
  *          input is taproot key-path (e.g. an approval wallet) must assert
  *          this equals its input count — P2WPKH inputs never count toward it,
  *          so that gate stays exact.
- * @throws If the input counts differ, an eligible input carries no signature, a
- *         finalized witness disagrees with its `tapKeySig`/`partialSig`, or any
- *         signature does not verify.
+ * @throws If the input counts differ, an input is neither key-path P2TR nor
+ *         P2WPKH, an eligible input carries no signature, a finalized witness
+ *         disagrees with its `tapKeySig`/`partialSig`, or any signature does
+ *         not verify.
  */
 export function assertReturnedKeyPathSignatures(
   params: AssertReturnedKeyPathSignaturesParams,
@@ -239,16 +240,21 @@ export function assertReturnedKeyPathSignatures(
     const returnedInput = returned.data.inputs[inputIndex];
 
     if (!isKeyPathEligible(input)) {
-      // Native SegWit funding inputs get the ECDSA check; anything else
-      // (script-path, P2WSH, ...) is another verifier's job.
+      // Native SegWit funding inputs get the ECDSA check.
       if (isP2wpkhScript(input.witnessUtxo?.script)) {
         assertReturnedP2wpkhSignature({
           requestedPsbtHex,
           returnedInput,
           inputIndex,
         });
+        return;
       }
-      return;
+      // No verifier exists for any other type — fail closed like btc-vault's
+      // check_signatures_valid rather than silently reporting it checked.
+      throw new Error(
+        `Input ${inputIndex} of the requested PSBT is neither key-path P2TR ` +
+          `nor P2WPKH; refusing to treat it as verified.`,
+      );
     }
     verified++;
 

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/verifyP2wpkhEcdsaSignature.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/verifyP2wpkhEcdsaSignature.ts
@@ -203,6 +203,19 @@ function assertP2wpkhEcdsaSignature(
         `defined sighash byte: ${e instanceof Error ? e.message : String(e)}`,
     );
   }
+  // decode tolerates non-minimal integers (bip66.js never bounds lenR/lenS at 33;
+  // fromDER truncates, script_signature.js:29-35) that libsecp's strict consensus
+  // parse rejects (secp256k1-sys ecdsa_impl.h:127-136) — require the unique
+  // minimal encoding by re-encoding and byte-comparing.
+  if (
+    !bscript.signature
+      .encode(decoded.signature, decoded.hashType)
+      .equals(Buffer.from(encodedSignature))
+  ) {
+    throw new Error(
+      `Returned PSBT input ${inputIndex}: P2WPKH signature is not canonical DER.`,
+    );
+  }
   if (decoded.hashType !== Transaction.SIGHASH_ALL) {
     throw new Error(
       `Returned PSBT input ${inputIndex}: P2WPKH signature has sighash type ` +

--- a/packages/babylon-ts-sdk/src/testing/MockBitcoinWallet.ts
+++ b/packages/babylon-ts-sdk/src/testing/MockBitcoinWallet.ts
@@ -152,8 +152,15 @@ export class MockBitcoinWallet implements BitcoinWallet {
 
   async signMessage(
     message: string,
-    _type: "bip322-simple" | "ecdsa",
+    type: "bip322-simple" | "ecdsa",
   ): Promise<string> {
+    // Only BIP-322 witnesses are implemented; returning one for "ecdsa"
+    // would hand a future ECDSA-flow test the wrong artifact silently.
+    if (type !== "bip322-simple") {
+      throw new Error(
+        "MockBitcoinWallet.signMessage: only bip322-simple is implemented",
+      );
+    }
     if (this.config.shouldFailSigning) {
       throw new Error("Mock signing failed");
     }
@@ -181,8 +188,7 @@ export class MockBitcoinWallet implements BitcoinWallet {
 
     // The SDK cryptographically verifies what a wallet returns
     // (`verifyPopWitness`), so the mock signs a REAL BIP-322 P2WPKH witness
-    // with its private key. The type is not consulted: PoP flows only ever
-    // request "bip322-simple", and the interface tests assert shape only.
+    // with its private key.
     const witness = signBip322P2wpkhWitness(
       new TextEncoder().encode(message),
       Uint8Array.from(Buffer.from(this.config.privateKeyHex, "hex")),
@@ -204,6 +210,11 @@ export class MockBitcoinWallet implements BitcoinWallet {
       ...this.config,
       ...updates,
     };
+    // Mirror the constructor: a private-key-only update re-derives the
+    // matching pubkey; an explicit publicKeyHex still wins.
+    if (updates.privateKeyHex && !updates.publicKeyHex) {
+      this.config.publicKeyHex = xOnlyPubkeyHexOf(updates.privateKeyHex);
+    }
   }
 
   /** Resets to default configuration. */

--- a/packages/babylon-ts-sdk/src/testing/__tests__/MockBitcoinWallet.test.ts
+++ b/packages/babylon-ts-sdk/src/testing/__tests__/MockBitcoinWallet.test.ts
@@ -70,6 +70,27 @@ describe("MockBitcoinWallet key consistency", () => {
     ).resolves.toMatch(/^0x[0-9a-f]+$/);
   });
 
+  it("throws for the ecdsa message type — only bip322-simple is implemented", async () => {
+    // The mock only produces BIP-322 P2WPKH witnesses; silently returning one
+    // for "ecdsa" would hand a future ECDSA-flow test the wrong artifact.
+    const wallet = new MockBitcoinWallet();
+
+    await expect(wallet.signMessage("pop message", "ecdsa")).rejects.toThrow(
+      /only bip322-simple/,
+    );
+  });
+
+  it("re-derives publicKeyHex when updateConfig sets only privateKeyHex", async () => {
+    const wallet = new MockBitcoinWallet();
+
+    wallet.updateConfig({ privateKeyHex: PRIVKEY_TWO_HEX });
+
+    expect(await wallet.getPublicKeyHex()).toBe(PUBKEY_TWO_XONLY_HEX);
+    await expect(
+      wallet.signMessage("pop message", "bip322-simple"),
+    ).resolves.toMatch(/^0x[0-9a-f]+$/);
+  });
+
   it("keeps the default pair working unchanged", async () => {
     const wallet = new MockBitcoinWallet();
 

--- a/packages/babylon-ts-sdk/src/testing/signBip322P2wpkhWitness.ts
+++ b/packages/babylon-ts-sdk/src/testing/signBip322P2wpkhWitness.ts
@@ -9,6 +9,11 @@
  * (`tbv/core/clients/vault-provider/auth/bip322Verify.ts`) mirrors, and
  * the BIP-322 official vectors pin.
  *
+ * Conscious call: `./testing` deliberately depends on the Bitcoin stack
+ * (bitcoinjs-lib was already in this entry's graph via MockBitcoinWallet;
+ * tiny-secp256k1-asmjs is new here) — out of scope for the CLAUDE.md §9
+ * optional-BTC split.
+ *
  * Test-only: never feed real key material to this module.
  */
 
@@ -23,9 +28,9 @@ const SIGHASH_ALL = 0x01;
 const ZERO_SATS = 0;
 /**
  * vaultd accepts only 71/72-byte encoded signatures (`bip322` crate 0.0.10
- * `verify.rs:141-153`); a short-DER signature (~0.8% of draws) is ground
+ * `verify.rs:141-153`); a short-DER signature (~0.4% of draws) is ground
  * away by re-signing with fresh entropy. 100 attempts bounds the failure
- * probability around 0.008^100.
+ * probability around 0.004^100.
  */
 const MIN_ENCODED_SIG_BYTES = 71;
 const MAX_SIGN_GRIND_ATTEMPTS = 100;

--- a/services/vault/src/components/deposit/PayoutSignModal/__tests__/usePayoutSigningState.test.tsx
+++ b/services/vault/src/components/deposit/PayoutSignModal/__tests__/usePayoutSigningState.test.tsx
@@ -757,10 +757,10 @@ describe("usePayoutSigningState", () => {
 
     // What the Ledger provider rejects with when a requested cancel settles
     // at the next device exchange boundary (WalletError, typed code).
-    function signingCancelledError() {
+    function signingCanceledError() {
       return Object.assign(
         new Error(
-          "Signing cancelled after 0 of 3 PSBT(s) — the ceremony restarts from the device approval screens on retry.",
+          "Signing canceled after 0 of 3 PSBT(s) — the ceremony restarts from the device approval screens on retry.",
         ),
         { code: "CONNECTION_REJECTED" },
       );
@@ -835,7 +835,7 @@ describe("usePayoutSigningState", () => {
       expect(replacementCancelSigning).not.toHaveBeenCalled();
 
       await act(async () => {
-        pending.reject(signingCancelledError());
+        pending.reject(signingCanceledError());
         await signPromise;
       });
     });
@@ -859,7 +859,7 @@ describe("usePayoutSigningState", () => {
 
       const settleAsCancelRejection = async () => {
         await act(async () => {
-          pending.reject(signingCancelledError());
+          pending.reject(signingCanceledError());
           await signPromise;
         });
       };
@@ -917,7 +917,7 @@ describe("usePayoutSigningState", () => {
         result.current.handleCancel();
       });
       await act(async () => {
-        pending.reject(signingCancelledError());
+        pending.reject(signingCanceledError());
         await signPromise;
       });
 
@@ -942,7 +942,7 @@ describe("usePayoutSigningState", () => {
       await waitFor(() => expect(result.current.signing).toBe(true));
 
       await act(async () => {
-        pending.reject(signingCancelledError());
+        pending.reject(signingCanceledError());
         await signPromise;
       });
 
@@ -1006,8 +1006,8 @@ describe("usePayoutSigningState", () => {
 
     it("keeps canCancel false during a hung VP-auth (deriveContextHash) phase", async () => {
       // deriveContextHash is a real device screen, but the provider's
-      // cancelSigning is a no-op outside signPsbt/signPsbts/signMessage —
-      // showing the affordance there would be a dead button.
+      // cancelSigning cannot abort it — showing the affordance there
+      // would be a dead button.
       const cancelSigning = vi.fn();
       let settleAuth: (root: string) => void = () => {};
       mockBtcConnector = {

--- a/services/vault/src/components/deposit/PayoutSignModal/usePayoutSigningState.ts
+++ b/services/vault/src/components/deposit/PayoutSignModal/usePayoutSigningState.ts
@@ -82,8 +82,8 @@ export interface UsePayoutSigningStateResult {
   handleSign: () => Promise<void>;
   /**
    * True while the in-flight sign sits in a cancellable device window
-   * (signPsbt/signPsbts/signMessage — the only calls `cancelSigning` can
-   * abort) AND the provider that started the sign exposes `cancelSigning`
+   * (signPsbt/signPsbts — the only wallet calls this flow makes that
+   * `cancelSigning` can abort) AND the provider that started the sign exposes `cancelSigning`
    * (only the Ledger provider does — always capability-probed, never
    * assumed). False during the terms rebuild, VP auth, and submission, where
    * no cancellable device prompt exists.
@@ -119,9 +119,9 @@ export function usePayoutSigningState({
   const [error, setError] = useState<SigningError | null>(null);
   const [errorTerminal, setErrorTerminal] = useState(false);
   const [cancelRequested, setCancelRequested] = useState(false);
-  // True only while a cancellable device call (signPsbt/signPsbts/
-  // signMessage) is in flight — `cancelSigning` is a no-op everywhere else,
-  // including the deriveContextHash/approveDepositTerms device screens.
+  // True only while a cancellable device call (signPsbt/signPsbts — the only
+  // such calls this flow makes) is in flight — `cancelSigning` cannot abort
+  // the deriveContextHash/approveDepositTerms device screens.
   const [deviceWindowActive, setDeviceWindowActive] = useState(false);
   // Ref mirror so the settle paths inside handleSign read the live value —
   // the state itself is stale inside the long-lived async closure.
@@ -356,8 +356,6 @@ export function usePayoutSigningState({
                 },
               }
             : {}),
-          signMessage: (message, type) =>
-            withDeviceWindow(() => wallet.signMessage(message, type)),
           // Object spread drops prototype methods — see forwardDepositApproval.
           ...forwardDepositApproval(wallet),
         };

--- a/services/vault/src/components/simple/ResumeDepositContent.tsx
+++ b/services/vault/src/components/simple/ResumeDepositContent.tsx
@@ -32,6 +32,7 @@ import { computeDepositDerivedState } from "@/components/deposit/DepositSignModa
 import { usePayoutSigningState } from "@/components/deposit/PayoutSignModal/usePayoutSigningState";
 import { useDepositPollingResult } from "@/context/deposit/PeginPollingContext";
 import {
+  hasPayoutSignCancelRecord,
   hasWotsSubmissionRecord,
   markWotsSubmitted,
 } from "@/context/deposit/optimisticDepositState";
@@ -122,13 +123,20 @@ export function ResumeSignContent({
     onSuccess,
   });
 
-  useRunOnce(handleSign);
+  // A cancel recorded by the deposit flow means this mount is the post-cancel
+  // continuation handoff, not a first visit: auto-running would re-prompt the
+  // device moments after the user asked to stop. Read once at mount, like
+  // ResumeWotsContent's isReoffer — re-reading would swap modes mid-flight.
+  const [wasCanceled] = useState(() => hasPayoutSignCancelRecord(activity.id));
+
+  useRunOnce(handleSign, !wasCanceled);
 
   // A self-requested cancel settles QUIETLY in the hook (idle, no error, not
   // complete). Left alone, that state renders a disabled Sign button with no
   // retry seam, so route it into the view's pre-sign entry state instead —
   // its CTA re-runs the full ceremony, matching the WOTS re-offer pattern.
-  const [reofferAfterCancel, setReofferAfterCancel] = useState(false);
+  // Starts true for a recorded cancel so the handoff parks there directly.
+  const [reofferAfterCancel, setReofferAfterCancel] = useState(wasCanceled);
   const sawCancelRequestRef = useRef(false);
   useEffect(() => {
     if (cancelRequested) {

--- a/services/vault/src/components/simple/__tests__/ResumeDepositContent.test.tsx
+++ b/services/vault/src/components/simple/__tests__/ResumeDepositContent.test.tsx
@@ -13,6 +13,7 @@ import { getVaultRegistryReader } from "@/clients/eth-contract/sdk-readers";
 import { usePayoutSigningState } from "@/components/deposit/PayoutSignModal/usePayoutSigningState";
 import {
   getOptimisticDepositState,
+  markPayoutSignCanceled,
   markWotsSubmitted,
   resetOptimisticDepositState,
 } from "@/context/deposit/optimisticDepositState";
@@ -858,6 +859,67 @@ describe("ResumeSignContent — reactive verification terminal", () => {
     const callsBeforeClick = handleSign.mock.calls.length;
     fireEvent.click(getByTestId("sign"));
     expect(handleSign.mock.calls.length).toBe(callsBeforeClick + 1);
+  });
+});
+
+describe("ResumeSignContent — post-cancel re-offer", () => {
+  const handleSign = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseDepositPollingResult.mockReturnValue(undefined);
+    vi.mocked(usePayoutSigningState).mockReturnValue({
+      signing: false,
+      progress: { phase: "auth", completed: 0, total: 0 },
+      error: null,
+      errorTerminal: false,
+      isComplete: false,
+      handleSign,
+      canCancel: false,
+      cancelRequested: false,
+      handleCancel: vi.fn(),
+    });
+  });
+
+  function renderSign() {
+    return render(
+      <ResumeSignContent
+        activity={baseActivity}
+        btcPublicKey="0xbtcpub"
+        depositorEthAddress={"0xdepositor" as never}
+        onClose={vi.fn()}
+        onSuccess={vi.fn()}
+      />,
+    );
+  }
+
+  it("auto-runs the signing ceremony at mount when no cancel is recorded", async () => {
+    renderSign();
+
+    await waitFor(() => expect(handleSign).toHaveBeenCalledTimes(1));
+  });
+
+  it("withholds the auto-run and parks on the pre-sign entry state after a recorded cancel", () => {
+    // The deposit flow records the marker when a settled device cancel breaks
+    // its payout loop; the continuation handoff mounts this component for the
+    // same still-actionable vault. Auto-running here would re-prompt the
+    // device moments after the user asked to stop.
+    markPayoutSignCanceled(baseActivity.id);
+
+    const { getByTestId } = renderSign();
+
+    expect(handleSign).not.toHaveBeenCalled();
+    expect(getByTestId("started").textContent).toBe("false");
+  });
+
+  it("re-runs the ceremony only on the explicit CTA click after a recorded cancel", () => {
+    markPayoutSignCanceled(baseActivity.id);
+
+    const { getByTestId } = renderSign();
+    fireEvent.click(getByTestId("sign"));
+
+    expect(handleSign).toHaveBeenCalledTimes(1);
+    expect(getByTestId("started").textContent).toBe("true");
   });
 });
 

--- a/services/vault/src/context/deposit/optimisticDepositState.ts
+++ b/services/vault/src/context/deposit/optimisticDepositState.ts
@@ -31,6 +31,14 @@ export interface OptimisticDepositState {
    * recorded separately rather than by widening the status enum.
    */
   wotsSubmittedAt: ReadonlyMap<string, number>;
+  /**
+   * Deposits whose payout-signing ceremony the user cancelled this session
+   * (settled device cancel in the deposit flow). `ResumeSignContent` reads it
+   * to withhold its mount auto-run — re-signing then needs an explicit click.
+   * No TTL: unlike the WOTS marker it never suppresses an action, it only
+   * converts an auto-run into a re-offer, so staying set is harmless.
+   */
+  payoutSignCanceledIds: ReadonlySet<string>;
 }
 
 /**
@@ -69,6 +77,7 @@ const EMPTY_STATE: OptimisticDepositState = {
   statuses: new Map(),
   refundBroadcastAt: new Map(),
   wotsSubmittedAt: new Map(),
+  payoutSignCanceledIds: new Set(),
 };
 
 let currentState: OptimisticDepositState = EMPTY_STATE;
@@ -127,6 +136,7 @@ export function setOptimisticDepositStatus(
             refundBroadcastAt,
           ),
     wotsSubmittedAt: currentState.wotsSubmittedAt,
+    payoutSignCanceledIds: currentState.payoutSignCanceledIds,
   });
 }
 
@@ -149,7 +159,38 @@ export function markWotsSubmitted(depositId: string): void {
       depositId,
       Date.now(),
     ),
+    payoutSignCanceledIds: currentState.payoutSignCanceledIds,
   });
+}
+
+/**
+ * Record that the user's own cancel settled during this deposit's payout
+ * signing. Written by `useDepositFlow` when the settled cancel breaks its
+ * payout loop; read once at mount by `ResumeSignContent` so the continuation
+ * handoff re-offers signing behind a click instead of re-prompting the device.
+ */
+export function markPayoutSignCanceled(depositId: string): void {
+  // Repeat writes must not publish — same discipline as the setters above.
+  if (currentState.payoutSignCanceledIds.has(depositId)) {
+    return;
+  }
+  publish({
+    statuses: currentState.statuses,
+    refundBroadcastAt: currentState.refundBroadcastAt,
+    wotsSubmittedAt: currentState.wotsSubmittedAt,
+    payoutSignCanceledIds: new Set(currentState.payoutSignCanceledIds).add(
+      depositId,
+    ),
+  });
+}
+
+/**
+ * Whether this deposit's payout signing was cancelled by the user this
+ * session. Tells a post-cancel re-offer apart from a first visit — the signal
+ * `ResumeSignContent` needs to decide whether it may auto-sign on mount.
+ */
+export function hasPayoutSignCancelRecord(depositId: string): boolean {
+  return currentState.payoutSignCanceledIds.has(depositId);
 }
 
 /**

--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -801,7 +801,7 @@ export const COPY = {
         `Vault ${vaultNumber}: Payout signing failed - ${error}`,
       // Self-requested device cancel: the loop stops here, so later vaults
       // are left unattempted (no warning) rather than marked failed.
-      payoutSigningCancelled: (vaultNumber: number) =>
+      payoutSigningCanceled: (vaultNumber: number) =>
         `Vault ${vaultNumber}: Payout signing canceled - you can finish signing when you're ready`,
       dismissReusesReservedUtxos: "Dismiss",
     },
@@ -889,11 +889,18 @@ export const COPY = {
       },
       // Self-requested cancel (the in-app "Cancel signing" affordance), as
       // opposed to a rejection on the wallet/device itself. Names no button:
-      // this surface renders only Close. True on every cancellable window —
-      // the Pre-PegIn broadcast happens only after its signature completes.
-      signingCancelled: {
+      // this surface renders only Close. Pre-registration windows only —
+      // "did not continue" is true there because nothing is on-chain yet.
+      signingCanceled: {
         title: "Signing canceled",
         body: "You canceled the signature request, so the deposit did not continue. No Bitcoin was spent.",
+      },
+      // A cancel settling after the Ethereum registration is mined: gas is
+      // spent and the vaults await the Pre-PegIn, so point at the resume path
+      // instead of implying nothing happened. No Bitcoin has moved.
+      signingCanceledAfterRegistration: {
+        title: "Signing canceled",
+        body: "You canceled the signature request. No Bitcoin was spent, but your deposit is already registered on Ethereum. Resume it from your dashboard to broadcast, or the registration will expire on its own.",
       },
       walletNotConnected: {
         title: "Wallet not connected",

--- a/services/vault/src/hooks/deposit/__tests__/useDepositFlow.test.tsx
+++ b/services/vault/src/hooks/deposit/__tests__/useDepositFlow.test.tsx
@@ -16,6 +16,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   getOptimisticDepositState,
+  hasPayoutSignCancelRecord,
   resetOptimisticDepositState,
 } from "@/context/deposit/optimisticDepositState";
 import { COPY } from "@/copy";
@@ -1312,6 +1313,31 @@ describe("useDepositFlow", () => {
       expect(depositResult?.warnings).toHaveLength(2);
     });
 
+    it("resets a failed vault's per-vault step to the payout wait before continuing", async () => {
+      const { signAndSubmitPayouts } = vi.mocked(
+        await import("../depositFlowSteps"),
+      );
+      // Vault 0 fails mid-graph-signing; vault 1 succeeds.
+      vi.mocked(signAndSubmitPayouts)
+        .mockImplementationOnce(async ({ onProgress }) => {
+          onProgress?.({ phase: "graph", completed: 0, total: 1 });
+          throw new Error("VP timeout");
+        })
+        .mockResolvedValueOnce(undefined);
+
+      const { result } = renderHook(() => useDepositFlow(MOCK_PARAMS));
+      const depositResult = await executeDepositFlow(result);
+
+      // The failed vault must not be left rendering a mid-signing step next
+      // to its failure warning (post-loop invariant: unsigned vaults rest at
+      // AWAIT_PAYOUT_TRANSACTIONS).
+      expect(depositResult).not.toBeNull();
+      expect(result.current.perVaultSteps).toEqual([
+        DepositFlowStep.AWAIT_PAYOUT_TRANSACTIONS,
+        DepositFlowStep.AWAIT_VP_VERIFICATION,
+      ]);
+    });
+
     it("should not show error when flow is aborted", async () => {
       const { preparePeginTransaction } = vi.mocked(
         await import("@/services/vault/vaultTransactionService"),
@@ -1539,10 +1565,10 @@ describe("useDepositFlow", () => {
     }
 
     /** What the Ledger provider rejects with when a requested cancel settles. */
-    function signingCancelledError() {
+    function signingCanceledError() {
       return Object.assign(
         new Error(
-          "Signing cancelled after 0 of 1 PSBT(s) — the ceremony restarts from the device approval screens on retry.",
+          "Signing canceled after 0 of 1 PSBT(s) — the ceremony restarts from the device approval screens on retry.",
         ),
         { code: "CONNECTION_REJECTED" },
       );
@@ -1652,7 +1678,7 @@ describe("useDepositFlow", () => {
       expect(replacementCancelSigning).not.toHaveBeenCalled();
 
       await act(async () => {
-        settle.reject(signingCancelledError());
+        settle.reject(signingCanceledError());
         await flowPromise;
       });
     });
@@ -1688,7 +1714,7 @@ describe("useDepositFlow", () => {
       const settleAsCancelRejection = async () => {
         let resolved: unknown;
         await act(async () => {
-          settle.reject(signingCancelledError());
+          settle.reject(signingCanceledError());
           resolved = await flowPromise;
         });
         return resolved;
@@ -1716,7 +1742,7 @@ describe("useDepositFlow", () => {
       // renders no Retry button at all.
       const resolved = await settleAsCancelRejection();
       expect(resolved).toBeNull();
-      expect(result.current.error).toEqual(DEPOSIT_ERRORS.signingCancelled);
+      expect(result.current.error).toEqual(DEPOSIT_ERRORS.signingCanceled);
     });
 
     it("sets deviceCancelRequested on request and clears it when the cancelled sign settles", async () => {
@@ -1873,6 +1899,94 @@ describe("useDepositFlow", () => {
       expect(result.current.canCancelDeviceSign).toBe(false);
     });
 
+    it("withholds the Pre-PegIn broadcast when a late cancel settles after its signature completes", async () => {
+      const { broadcastPrePeginTransaction } = vi.mocked(
+        await import("@/services/vault/vaultPeginBroadcastService"),
+      );
+      const { updatePendingPeginStatus } = vi.mocked(
+        await import("@/storage/peginStorage"),
+      );
+      const { wallet, settle } = pendingSignWallet(true);
+      vi.mocked(broadcastPrePeginTransaction).mockImplementation(
+        async ({ btcWalletProvider }) => {
+          // Mirrors the real service: the sign must succeed before pushTx.
+          await btcWalletProvider.signPsbt("fundedPrePegin");
+          return "mockBroadcastTxId";
+        },
+      );
+
+      const { result } = renderHook(() =>
+        useDepositFlow({ ...MOCK_PARAMS, btcWalletProvider: wallet as any }),
+      );
+
+      let flowPromise!: Promise<unknown>;
+      act(() => {
+        flowPromise = result.current.executeDeposit();
+      });
+      await waitFor(() =>
+        expect(result.current.canCancelDeviceSign).toBe(true),
+      );
+
+      act(() => {
+        result.current.cancelDeviceSign();
+      });
+
+      let resolved: unknown;
+      await act(async () => {
+        settle.resolve("signedFundedPrePegin"); // sign completes AFTER the cancel
+        resolved = await flowPromise;
+      });
+
+      // Elsewhere a late cancel + successful sign deliberately proceeds; at
+      // the broadcast site the next step is the irreversible pushTx, so the
+      // signed tx is withheld: cancelled copy, records stay PENDING so the
+      // resume flow's Broadcast button recovers the deposit.
+      expect(resolved).toBeNull();
+      expect(result.current.error).toEqual(
+        DEPOSIT_ERRORS.signingCanceledAfterRegistration,
+      );
+      expect(updatePendingPeginStatus).not.toHaveBeenCalled();
+    });
+
+    it("shows the after-registration cancel copy when a broadcast-window cancel settles", async () => {
+      const { broadcastPrePeginTransaction } = vi.mocked(
+        await import("@/services/vault/vaultPeginBroadcastService"),
+      );
+      const { wallet, settle } = pendingSignWallet(true);
+      vi.mocked(broadcastPrePeginTransaction).mockImplementation(
+        async ({ btcWalletProvider }) => {
+          await btcWalletProvider.signPsbt("fundedPrePegin");
+          return "mockBroadcastTxId";
+        },
+      );
+
+      const { result } = renderHook(() =>
+        useDepositFlow({ ...MOCK_PARAMS, btcWalletProvider: wallet as any }),
+      );
+
+      let flowPromise!: Promise<unknown>;
+      act(() => {
+        flowPromise = result.current.executeDeposit();
+      });
+      await waitFor(() =>
+        expect(result.current.canCancelDeviceSign).toBe(true),
+      );
+      act(() => {
+        result.current.cancelDeviceSign();
+      });
+
+      await act(async () => {
+        settle.reject(signingCanceledError());
+        await flowPromise;
+      });
+
+      // The vaults are already registered on Ethereum with PENDING resume
+      // rows — "the deposit did not continue" would hide the resume path.
+      expect(result.current.error).toEqual(
+        DEPOSIT_ERRORS.signingCanceledAfterRegistration,
+      );
+    });
+
     it("covers the post-broadcast depositor-graph window", async () => {
       const { signAndSubmitPayouts } = vi.mocked(
         await import("../depositFlowSteps"),
@@ -1960,7 +2074,7 @@ describe("useDepositFlow", () => {
       const settleAsCancelRejection = async () => {
         let resolved: unknown;
         await act(async () => {
-          settle.reject(signingCancelledError());
+          settle.reject(signingCanceledError());
           resolved = await flowPromise;
         });
         return resolved;
@@ -1996,6 +2110,71 @@ describe("useDepositFlow", () => {
       expect(result.current.error).toBeNull();
     });
 
+    it("records the payout-sign cancel marker for the cancelled vault only", async () => {
+      const { settleAsCancelRejection } =
+        await startPayoutSignAndRequestCancel();
+
+      await settleAsCancelRejection();
+
+      // ResumeSignContent reads this to withhold its auto-run — without it
+      // the continuation view re-prompts the device moments after the cancel.
+      expect(hasPayoutSignCancelRecord("0xVault0Id")).toBe(true);
+      // Vault 1 was left unattempted, not cancelled.
+      expect(hasPayoutSignCancelRecord("0xVault1Id")).toBe(false);
+    });
+
+    it("resets the cancelled vault's per-vault step to the payout wait when the cancel settles", async () => {
+      const { signAndSubmitPayouts } = vi.mocked(
+        await import("../depositFlowSteps"),
+      );
+      const settle: { reject: (e: unknown) => void } = { reject: () => {} };
+      const signPsbt = vi
+        .fn()
+        .mockImplementationOnce(
+          () =>
+            new Promise<string>((_resolve, reject) => {
+              settle.reject = reject;
+            }),
+        )
+        .mockResolvedValue("mockSignedPsbtHex");
+      const wallet = { ...MOCK_BTC_WALLET, signPsbt, cancelSigning: vi.fn() };
+      vi.mocked(signAndSubmitPayouts).mockImplementation(
+        async ({ btcWallet, onProgress }) => {
+          // Advance the vault's step off the wait, as the real flow does
+          // once graph signing starts.
+          onProgress?.({ phase: "graph", completed: 0, total: 1 });
+          await btcWallet.signPsbt("graphPsbt");
+        },
+      );
+
+      const { result } = renderHook(() =>
+        useDepositFlow({ ...MOCK_PARAMS, btcWalletProvider: wallet as any }),
+      );
+      let flowPromise!: Promise<unknown>;
+      act(() => {
+        flowPromise = result.current.executeDeposit();
+      });
+      await waitFor(() =>
+        expect(result.current.canCancelDeviceSign).toBe(true),
+      );
+      act(() => {
+        result.current.cancelDeviceSign();
+      });
+
+      await act(async () => {
+        settle.reject(signingCanceledError());
+        await flowPromise;
+      });
+
+      // The cancelled vault must not be left rendering a mid-signing step
+      // next to the cancelled warning (post-loop invariant: unsigned vaults
+      // rest at AWAIT_PAYOUT_TRANSACTIONS).
+      expect(result.current.perVaultSteps).toEqual([
+        DepositFlowStep.AWAIT_PAYOUT_TRANSACTIONS,
+        DepositFlowStep.AWAIT_PAYOUT_TRANSACTIONS,
+      ]);
+    });
+
     it("warns only for the cancelled vault — the unattempted vault gets no warning", async () => {
       const { result, settleAsCancelRejection } =
         await startPayoutSignAndRequestCancel();
@@ -2009,7 +2188,7 @@ describe("useDepositFlow", () => {
           vaultId: "0xVault0Id",
           stage: "payout",
           terminal: false,
-          message: COPY.deposit.warnings.payoutSigningCancelled(1),
+          message: COPY.deposit.warnings.payoutSigningCanceled(1),
         },
       ]);
     });
@@ -2085,7 +2264,7 @@ describe("useDepositFlow", () => {
       const settleAsCancelRejection = async () => {
         let resolved: unknown;
         await act(async () => {
-          settle.reject(signingCancelledError());
+          settle.reject(signingCanceledError());
           resolved = await flowPromise;
         });
         return resolved;
@@ -2121,7 +2300,7 @@ describe("useDepositFlow", () => {
           vaultId: "0xSingleVaultId",
           stage: "payout",
           terminal: false,
-          message: COPY.deposit.warnings.payoutSigningCancelled(1),
+          message: COPY.deposit.warnings.payoutSigningCanceled(1),
         },
       ]);
     });

--- a/services/vault/src/hooks/deposit/useDepositFlow.ts
+++ b/services/vault/src/hooks/deposit/useDepositFlow.ts
@@ -46,7 +46,10 @@ import {
 } from "@/clients/eth-contract/sdk-readers";
 import { isDepositBlocked } from "@/components/shared/protocolStatus";
 import { useProtocolParamsContext } from "@/context/ProtocolParamsContext";
-import { markWotsSubmitted } from "@/context/deposit/optimisticDepositState";
+import {
+  markPayoutSignCanceled,
+  markWotsSubmitted,
+} from "@/context/deposit/optimisticDepositState";
 import { COPY } from "@/copy";
 import { useProtocolGateState } from "@/hooks/useProtocolGate";
 import { UTXOS_QUERY_KEY } from "@/hooks/useUTXOs";
@@ -90,7 +93,10 @@ import {
   mapDepositError,
   type DepositErrorContent,
 } from "@/utils/errors";
-import { isUserCancellation } from "@/utils/errors/userCancellation";
+import {
+  isUserCancellation,
+  WALLET_CONNECTION_REJECTED_CODE,
+} from "@/utils/errors/userCancellation";
 import { formatBtcValue } from "@/utils/formatting";
 import { getVpProxyUrl } from "@/utils/rpc";
 
@@ -319,6 +325,10 @@ export function useDepositFlow(
   // catch reads it to surface cancelled (not rejected) copy. Reset only at
   // the start of the next executeDeposit run.
   const deviceCancelSettledRef = useRef(false);
+  // Set when the LAST runCancellableSign settled successfully with a cancel
+  // request still pending (the late-cancel race). Only the broadcast wrapper
+  // consults it — everywhere else the successful sign deliberately proceeds.
+  const lastSignSettledWithCancelPendingRef = useRef(false);
   // Provider that STARTED the in-flight sign. Cancellation binds to it so a
   // wallet swapped in mid-prompt cannot orphan the original ceremony.
   const deviceSignProviderRef = useRef<unknown>(null);
@@ -328,8 +338,14 @@ export function useDepositFlow(
       deviceSignProviderRef.current = signingProvider;
       deviceSignActiveRef.current = true;
       setDeviceSignActive(true);
+      lastSignSettledWithCancelPendingRef.current = false;
       try {
-        return await sign();
+        const signed = await sign();
+        // Captured before the finally consumes the request — the broadcast
+        // wrapper reads it to withhold pushTx on a late cancel.
+        lastSignSettledWithCancelPendingRef.current =
+          deviceCancelRequestedRef.current;
+        return signed;
       } catch (error) {
         // The requested cancel took effect (a late cancel that still signed
         // successfully deliberately does NOT stick — the flow proceeds).
@@ -413,6 +429,10 @@ export function useDepositFlow(
       // Track registry entries we primed so we can release them on
       // user-cancel (bound `authAnchorHex` lifetime to the flow).
       const primedRegistryTxids: string[] = [];
+
+      // Flips once the ETH batch registration is mined: a cancel after that
+      // point gets the after-registration copy pointing at the resume path.
+      let registeredOnEth = false;
 
       try {
         // Deposit (pegin) is a protocol-scope ENTRY action. The dialog-open is
@@ -711,6 +731,7 @@ export function useDepositFlow(
           popSignature,
           quotedCommissionBps,
         });
+        registeredOnEth = true;
 
         // 3f. Build pegin results from batch response
         const peginResults: PeginCreationResult[] =
@@ -928,10 +949,26 @@ export function useDepositFlow(
           prePeginBroadcastTxid = await broadcastPrePeginTransaction({
             unsignedTxHex: batchResult.fundedPrePeginTxHex,
             btcWalletProvider: {
-              signPsbt: (psbtHex: string) =>
-                runCancellableSign(confirmedBtcWallet, () =>
-                  confirmedBtcWallet.signPsbt(psbtHex),
-                ),
+              signPsbt: async (psbtHex: string) => {
+                const signedPsbtHex = await runCancellableSign(
+                  confirmedBtcWallet,
+                  () => confirmedBtcWallet.signPsbt(psbtHex),
+                );
+                // A late cancel that still signed successfully proceeds
+                // elsewhere — but here the next step is the irreversible
+                // pushTx, so honor the cancel: throw before the tx leaves,
+                // keeping the records PENDING and resumable (Broadcast CTA).
+                if (lastSignSettledWithCancelPendingRef.current) {
+                  deviceCancelSettledRef.current = true;
+                  throw Object.assign(
+                    new Error(
+                      "Signing canceled — the signed Pre-PegIn was not broadcast",
+                    ),
+                    { code: WALLET_CONNECTION_REJECTED_CODE },
+                  );
+                }
+                return signedPsbtHex;
+              },
               deriveContextHash: (appName: string, context: string) =>
                 confirmedBtcWallet.deriveContextHash(appName, context),
               // Object spread drops prototype methods — see forwardDepositApproval.
@@ -1298,7 +1335,8 @@ export function useDepositFlow(
           // A settled user cancel stops the loop: the next iteration would
           // re-run the full device ceremony (requireFreshDeviceCeremony)
           // seconds after the user asked to stop. Remaining vaults are left
-          // unattempted (no warning), not failed.
+          // unattempted (no warning), not failed. Backstop only: the settle
+          // rejects into the catch below, whose break is the operative stop.
           if (deviceCancelSettledRef.current) break;
 
           // Skip vaults whose WOTS key submission failed — the VP won't have
@@ -1374,14 +1412,26 @@ export function useDepositFlow(
             // THIS vault cancelled and end the loop. Routine drop-off — no
             // partial-failure telemetry.
             if (deviceCancelSettledRef.current) {
+              // ResumeSignContent reads this to withhold its mount auto-run —
+              // the handoff must not re-prompt the device after the cancel.
+              markPayoutSignCanceled(result.vaultId);
               recordWarning({
                 vaultId: result.vaultId,
                 stage: "payout",
                 terminal: false,
-                message: COPY.deposit.warnings.payoutSigningCancelled(
+                message: COPY.deposit.warnings.payoutSigningCanceled(
                   result.vaultIndex + 1,
                 ),
               });
+              // Post-loop invariant: unsigned vaults rest at the payout wait,
+              // not the mid-signing step onProgress last set.
+              setPerVaultSteps((prev) =>
+                prev.map((step, index) =>
+                  index === vi
+                    ? DepositFlowStep.AWAIT_PAYOUT_TRANSACTIONS
+                    : step,
+                ),
+              );
               break;
             }
 
@@ -1421,6 +1471,13 @@ export function useDepositFlow(
                   providerAddress: provider.id,
                 },
               },
+            );
+            // Post-loop invariant: unsigned vaults rest at the payout wait,
+            // not the mid-signing step onProgress last set.
+            setPerVaultSteps((prev) =>
+              prev.map((step, index) =>
+                index === vi ? DepositFlowStep.AWAIT_PAYOUT_TRANSACTIONS : step,
+              ),
             );
             // Continue with other vaults
           }
@@ -1465,13 +1522,22 @@ export function useDepositFlow(
           // A settled self-cancel gets its own copy: the generic mapper reads
           // the wallet's CONNECTION_REJECTED as "You rejected the request in
           // your wallet. Click Retry" — misattributed, and naming a button
-          // this surface doesn't render.
+          // this surface doesn't render. Post-registration cancels get the
+          // variant pointing at the resume path — vaults are already on-chain.
           setError(
             deviceCancelSettledRef.current && isUserCancellation(err)
-              ? {
-                  title: COPY.deposit.errors.signingCancelled.title,
-                  body: COPY.deposit.errors.signingCancelled.body,
-                }
+              ? registeredOnEth
+                ? {
+                    title:
+                      COPY.deposit.errors.signingCanceledAfterRegistration
+                        .title,
+                    body: COPY.deposit.errors.signingCanceledAfterRegistration
+                      .body,
+                  }
+                : {
+                    title: COPY.deposit.errors.signingCanceled.title,
+                    body: COPY.deposit.errors.signingCanceled.body,
+                  }
               : mapDepositError(err),
           );
           logger.error(err instanceof Error ? err : new Error(String(err)), {
@@ -1536,7 +1602,7 @@ export function useDepositFlow(
     setDeviceCancelRequested(true);
     // Device-only cancel (aborting the flow controller reads as a closed
     // modal). Settles at the next device exchange boundary: pre-broadcast =
-    // "Signing cancelled" callout; post-broadcast payout stage = cancelled
+    // "Signing canceled" callout; post-broadcast payout stage = cancelled
     // warning and the loop stops.
     provider.cancelSigning();
   }, []);

--- a/services/vault/src/utils/errors/__tests__/formatting.test.ts
+++ b/services/vault/src/utils/errors/__tests__/formatting.test.ts
@@ -24,6 +24,7 @@ import { COPY } from "@/copy";
 
 import { DepositorWalletMismatchError } from "../depositorWalletMismatch";
 import {
+  classifyError,
   formatErrorDiagnostics,
   formatErrorMessage,
   formatPayoutSignatureError,
@@ -252,6 +253,16 @@ describe("Error Formatting", () => {
       });
 
       expect(sanitizeErrorMessage(err)).not.toMatch(/Transaction rejected/);
+    });
+
+    it("classifies a wrapper Error with a bare-string cancellation cause as user-rejection", () => {
+      // Mirrors userCancellation.test.ts: isUserCancellation matches this
+      // shape (some wallet adapters reject with a bare string as `cause`),
+      // so classifyError must too — both walks share chainMatchesFrame.
+      const err = new Error("Failed to broadcast batch Pre-PegIn transaction", {
+        cause: "User rejected the request",
+      });
+      expect(classifyError(err)).toBe("user-rejection");
     });
 
     it("does not collapse non-rejection errors", () => {

--- a/services/vault/src/utils/errors/causeChain.ts
+++ b/services/vault/src/utils/errors/causeChain.ts
@@ -9,7 +9,7 @@
  */
 
 /** How far to walk a `cause` chain before giving up. */
-export const MAX_CAUSE_DEPTH = 10;
+const MAX_CAUSE_DEPTH = 10;
 
 /**
  * True when the error — or anything in its `cause` chain — matches the frame

--- a/services/vault/src/utils/errors/formatting.ts
+++ b/services/vault/src/utils/errors/formatting.ts
@@ -13,7 +13,7 @@ import {
 
 import { COPY } from "@/copy";
 
-import { MAX_CAUSE_DEPTH } from "./causeChain";
+import { chainMatchesFrame } from "./causeChain";
 import { isDepositorWalletMismatchError } from "./depositorWalletMismatch";
 import {
   DEVICE_CEREMONY_INVALID_CODE,
@@ -138,152 +138,159 @@ const FRIENDLY_MESSAGES: Record<ErrorKind, string> = {
  *      classifies.
  */
 export function classifyError(err: unknown): ErrorKind | null {
-  let cur: unknown = err;
-  for (
-    let depth = 0;
-    depth <= MAX_CAUSE_DEPTH && cur && typeof cur === "object";
-    depth++
+  let kind: ErrorKind | null = null;
+  chainMatchesFrame(err, (frame) => {
+    kind = classifyFrame(frame);
+    return kind !== null;
+  });
+  return kind;
+}
+
+/**
+ * Classify one frame in isolation — no `cause` walk (classifyError's shared
+ * walk enforces precedence (b)). `null` means "descend to the next frame".
+ */
+function classifyFrame(frame: unknown): ErrorKind | null {
+  // User rejection — MUST stay first within the frame; see precedence (a).
+  // Shared with the telemetry-side drop so the two cannot drift: a wording
+  // this recognises but the classifier did not used to (e.g. "Connection to
+  // Keystone was canceled") was dropped from Sentry while still rendering
+  // generic error copy. Runs before the object gate below because it also
+  // handles bare-string frames (some wallet adapters reject with a string
+  // as a wrapper's `cause`).
+  if (isUserCancellationFrame(frame)) return "user-rejection";
+
+  if (frame === null || typeof frame !== "object") return null;
+
+  const obj = frame as {
+    code?: unknown;
+    name?: unknown;
+    message?: unknown;
+    walk?: unknown;
+  };
+
+  // Insufficient ETH for gas + value
+  if (obj.name === "InsufficientFundsError") return "insufficient-funds";
+  if (
+    typeof obj.message === "string" &&
+    matchesInsufficientGasFundsMessage(obj.message)
   ) {
-    const obj = cur as {
-      code?: unknown;
-      name?: unknown;
-      message?: unknown;
-      cause?: unknown;
-      walk?: unknown;
-    };
-
-    // User rejection — MUST stay first within the frame; see precedence (a).
-    // Shared with the telemetry-side drop so the two cannot drift: a wording
-    // this recognises but the classifier did not used to (e.g. "Connection to
-    // Keystone was canceled") was dropped from Sentry while still rendering
-    // generic error copy. `isUserCancellationFrame` deliberately does not walk
-    // `cause` — the walk here is what enforces precedence (b).
-    if (isUserCancellationFrame(cur)) return "user-rejection";
-
-    // Insufficient ETH for gas + value
-    if (obj.name === "InsufficientFundsError") return "insufficient-funds";
-    if (
-      typeof obj.message === "string" &&
-      matchesInsufficientGasFundsMessage(obj.message)
-    ) {
-      return "insufficient-funds";
-    }
-    if (
-      typeof obj.message === "string" &&
-      EVM_OUT_OF_FUNDS_PATTERN.test(obj.message)
-    ) {
-      return "insufficient-funds";
-    }
-
-    // Wallet disconnected from chain / all chains
-    if (
-      obj.code === EIP1193.PROVIDER_DISCONNECTED ||
-      obj.code === EIP1193.CHAIN_DISCONNECTED ||
-      obj.name === "ProviderDisconnectedError" ||
-      obj.name === "ChainDisconnectedError"
-    ) {
-      return "wallet-disconnected";
-    }
-
-    // Site not authorized in wallet
-    if (
-      obj.code === EIP1193.UNAUTHORIZED ||
-      obj.name === "UnauthorizedProviderError"
-    ) {
-      return "unauthorized";
-    }
-
-    // Wallet refused / failed to switch chain. The deposit flow's wagmi
-    // helper catches this locally (ethereumSubmit.ts), but cover the
-    // escape path in case it surfaces from elsewhere.
-    if (
-      obj.code === EIP1193.CHAIN_SWITCH_FAILED ||
-      obj.name === "SwitchChainError"
-    ) {
-      return "chain-switch-failed";
-    }
-
-    // Tx accepted but receipt didn't arrive in time
-    if (obj.name === "WaitForTransactionReceiptTimeoutError") {
-      return "receipt-timeout";
-    }
-
-    // Nonce-too-low / "already known" — the tx is already in the mempool (or
-    // mined). "Retry" would re-send and reproduce it, so point the user at
-    // their wallet / an explorer. viem folds these into NonceTooLowError; raw
-    // providers surface the message unwrapped. (NonceTooHigh is a gap, not a
-    // duplicate, so it stays in the generic rpc-error retry bucket.)
-    if (
-      obj.name === "NonceTooLowError" ||
-      (typeof obj.message === "string" &&
-        ALREADY_SUBMITTED_PATTERN.test(obj.message))
-    ) {
-      return "already-submitted";
-    }
-
-    // Transport failures — "check your connection" is only honest here.
-    //
-    // `HttpRequestError` covers TWO cases (viem `utils/rpc/http`): with a
-    // numeric `status` the server DID answer (429 rate limit, 5xx outage) —
-    // a provider problem, not the user's connection — so route those to
-    // `rpc-error`. A status-less HttpRequestError (fetch threw) is a real
-    // transport failure. Since the app wires `http()` exclusively, a
-    // provider 429/503 is the most likely RPC failure a depositor hits.
-    if (obj.name === "HttpRequestError") {
-      return typeof (obj as { status?: unknown }).status === "number"
-        ? "rpc-error"
-        : "network";
-    }
-    // `WebSocketRequestError` / `SocketClosedError` are genuine transport
-    // failures; the names are viem-specific enough not to collide.
-    // `SocketClosedError` is forward-looking — the app wires `http()` today,
-    // so it only becomes reachable if a WS transport lands later.
-    if (
-      obj.name === "WebSocketRequestError" ||
-      obj.name === "SocketClosedError"
-    ) {
-      return "network";
-    }
-    // `TimeoutError` is generic (AbortSignal.timeout, `ky`, DOM APIs) — gate
-    // on viem shape.
-    if (obj.name === "TimeoutError" && isViemShape(obj)) {
-      return "network";
-    }
-
-    // `RpcRequestError` wraps a JSON-RPC error the node/provider returned:
-    // rate limit (-32005), resource unavailable (-32002), tx rejected
-    // (-32003), internal (-32603), and node-execution errors (nonce /
-    // "already known") whose inner frame is an RpcRequestError. None of
-    // these are the user's connection, so they get their own copy — never
-    // "check your connection".
-    //
-    // Exception: viem also reuses `RpcRequestError` to carry contract reverts.
-    // A `0x` payload is a revert; so is `code === 3` even when the provider
-    // returns no revert data (some don't). Either is a real revert, not an
-    // RPC failure — fall through so the underlying reason bubbles up.
-    if (obj.name === "RpcRequestError" && isViemShape(obj)) {
-      const data = (obj as { data?: unknown }).data;
-      if (
-        (typeof data === "string" && data.startsWith("0x")) ||
-        obj.code === EXECUTION_REVERTED_RPC_CODE
-      ) {
-        cur = obj.cause;
-        continue;
-      }
-      return "rpc-error";
-    }
-
-    // Vite chunk 404 after a redeploy — the underlying error is a browser
-    // TypeError, so match on the message rather than a class name.
-    if (
-      typeof obj.message === "string" &&
-      STALE_DEPLOY_PATTERN.test(obj.message)
-    ) {
-      return "stale-deploy";
-    }
-
-    cur = obj.cause;
+    return "insufficient-funds";
   }
+  if (
+    typeof obj.message === "string" &&
+    EVM_OUT_OF_FUNDS_PATTERN.test(obj.message)
+  ) {
+    return "insufficient-funds";
+  }
+
+  // Wallet disconnected from chain / all chains
+  if (
+    obj.code === EIP1193.PROVIDER_DISCONNECTED ||
+    obj.code === EIP1193.CHAIN_DISCONNECTED ||
+    obj.name === "ProviderDisconnectedError" ||
+    obj.name === "ChainDisconnectedError"
+  ) {
+    return "wallet-disconnected";
+  }
+
+  // Site not authorized in wallet
+  if (
+    obj.code === EIP1193.UNAUTHORIZED ||
+    obj.name === "UnauthorizedProviderError"
+  ) {
+    return "unauthorized";
+  }
+
+  // Wallet refused / failed to switch chain. The deposit flow's wagmi
+  // helper catches this locally (ethereumSubmit.ts), but cover the
+  // escape path in case it surfaces from elsewhere.
+  if (
+    obj.code === EIP1193.CHAIN_SWITCH_FAILED ||
+    obj.name === "SwitchChainError"
+  ) {
+    return "chain-switch-failed";
+  }
+
+  // Tx accepted but receipt didn't arrive in time
+  if (obj.name === "WaitForTransactionReceiptTimeoutError") {
+    return "receipt-timeout";
+  }
+
+  // Nonce-too-low / "already known" — the tx is already in the mempool (or
+  // mined). "Retry" would re-send and reproduce it, so point the user at
+  // their wallet / an explorer. viem folds these into NonceTooLowError; raw
+  // providers surface the message unwrapped. (NonceTooHigh is a gap, not a
+  // duplicate, so it stays in the generic rpc-error retry bucket.)
+  if (
+    obj.name === "NonceTooLowError" ||
+    (typeof obj.message === "string" &&
+      ALREADY_SUBMITTED_PATTERN.test(obj.message))
+  ) {
+    return "already-submitted";
+  }
+
+  // Transport failures — "check your connection" is only honest here.
+  //
+  // `HttpRequestError` covers TWO cases (viem `utils/rpc/http`): with a
+  // numeric `status` the server DID answer (429 rate limit, 5xx outage) —
+  // a provider problem, not the user's connection — so route those to
+  // `rpc-error`. A status-less HttpRequestError (fetch threw) is a real
+  // transport failure. Since the app wires `http()` exclusively, a
+  // provider 429/503 is the most likely RPC failure a depositor hits.
+  if (obj.name === "HttpRequestError") {
+    return typeof (obj as { status?: unknown }).status === "number"
+      ? "rpc-error"
+      : "network";
+  }
+  // `WebSocketRequestError` / `SocketClosedError` are genuine transport
+  // failures; the names are viem-specific enough not to collide.
+  // `SocketClosedError` is forward-looking — the app wires `http()` today,
+  // so it only becomes reachable if a WS transport lands later.
+  if (
+    obj.name === "WebSocketRequestError" ||
+    obj.name === "SocketClosedError"
+  ) {
+    return "network";
+  }
+  // `TimeoutError` is generic (AbortSignal.timeout, `ky`, DOM APIs) — gate
+  // on viem shape.
+  if (obj.name === "TimeoutError" && isViemShape(obj)) {
+    return "network";
+  }
+
+  // `RpcRequestError` wraps a JSON-RPC error the node/provider returned:
+  // rate limit (-32005), resource unavailable (-32002), tx rejected
+  // (-32003), internal (-32603), and node-execution errors (nonce /
+  // "already known") whose inner frame is an RpcRequestError. None of
+  // these are the user's connection, so they get their own copy — never
+  // "check your connection".
+  //
+  // Exception: viem also reuses `RpcRequestError` to carry contract reverts.
+  // A `0x` payload is a revert; so is `code === 3` even when the provider
+  // returns no revert data (some don't). Either is a real revert, not an
+  // RPC failure — leave this frame unclassified so the walk descends and
+  // the underlying reason bubbles up.
+  if (obj.name === "RpcRequestError" && isViemShape(obj)) {
+    const data = (obj as { data?: unknown }).data;
+    if (
+      (typeof data === "string" && data.startsWith("0x")) ||
+      obj.code === EXECUTION_REVERTED_RPC_CODE
+    ) {
+      return null;
+    }
+    return "rpc-error";
+  }
+
+  // Vite chunk 404 after a redeploy — the underlying error is a browser
+  // TypeError, so match on the message rather than a class name.
+  if (
+    typeof obj.message === "string" &&
+    STALE_DEPLOY_PATTERN.test(obj.message)
+  ) {
+    return "stale-deploy";
+  }
+
   return null;
 }
 


### PR DESCRIPTION
Fixes the verified review findings from #2299 and #2300. Notable: the DER canonicality tests use the actual reachable vector (an oversized 34-byte R integer with a trailing junk byte) — the simpler pad-byte variant is rejected by bip66 before it reaches the verifier. Two findings intentionally not fixed (0x6A80 post-cancel copy self-heals in ~5s; the loop-top cancel guard stays as a backstop), and the signer package's next release should be minted as 0.7.0 rather than a patch.