### PR TITLE
feat(vault): let depositors adjust pre-pegin BTC fee rate

### DIFF
--- a/services/vault/src/components/simple/DepositFeesBreakdown.tsx
+++ b/services/vault/src/components/simple/DepositFeesBreakdown.tsx
@@ -32,6 +32,10 @@ interface DepositFeesBreakdownProps {
    * `undefined` while a two-vault split's per-vault amounts are loading.
    */
   commissionBaseValues?: readonly bigint[];
+  /** BTC network fee rate (sat/vB) used for the pre-pegin funding tx. */
+  networkFeeRate?: number;
+  /** Estimated funding fee in satoshis at {@link networkFeeRate}. */
+  networkFeeSats?: bigint | null;
 }
 
 export function DepositFeesBreakdown({
@@ -44,6 +48,8 @@ export function DepositFeesBreakdown({
   amountSats,
   commissionBps,
   commissionBaseValues,
+  networkFeeRate,
+  networkFeeSats,
 }: DepositFeesBreakdownProps) {
   // Format a satoshi value as a BTC amount plus an optional "($X USD)" suffix,
   // matching the existing fee-line presentation. `null` sats render as the
@@ -67,6 +73,10 @@ export function DepositFeesBreakdown({
 
   const transactionReserve = formatSatsLine(
     depositorClaimValue === undefined ? null : depositorClaimValue,
+  );
+
+  const networkFee = formatSatsLine(
+    networkFeeSats === undefined ? null : networkFeeSats,
   );
 
   // The protocol charges commission on the vault deposit amount only —
@@ -98,8 +108,24 @@ export function DepositFeesBreakdown({
       ? FORM_COPY.vpCommissionLabel
       : `${FORM_COPY.vpCommissionLabel} (${formatBasisPointsAsPercent(commissionBps)})`;
 
+  const networkFeeRateValue =
+    networkFeeRate !== undefined && networkFeeRate > 0
+      ? `${networkFeeRate} sats/vB`
+      : METRIC_PLACEHOLDER;
+
   return (
     <div className="flex flex-col gap-2">
+      <FeeDetailRow
+        label={FORM_COPY.networkFeeRateLabel}
+        tooltip={FORM_COPY.networkFeeRateTooltip}
+        value={networkFeeRateValue}
+      />
+      <FeeDetailRow
+        label={FORM_COPY.btcNetworkFeeLabel}
+        tooltip={FORM_COPY.btcNetworkFeeTooltip}
+        value={networkFee.amount}
+        secondaryValue={networkFee.price}
+      />
       <FeeDetailRow
         label={FORM_COPY.transactionReserveLabel}
         tooltip={FORM_COPY.transactionReserveTooltip}

--- a/services/vault/src/components/simple/DepositForm.tsx
+++ b/services/vault/src/components/simple/DepositForm.tsx
@@ -526,6 +526,8 @@ export function DepositForm({
         amountSats={amountSats}
         commissionBps={selectedProviderCommissionBps}
         commissionBaseValues={commissionBaseValues}
+        networkFeeRate={estimatedFeeRate}
+        networkFeeSats={estimatedFeeSats}
       />
 
       {/* Protocol & risk parameters */}

--- a/services/vault/src/components/simple/DepositProgressView/DepositProgressView.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/DepositProgressView.tsx
@@ -161,6 +161,10 @@ export interface DepositProgressViewProps {
   cancelSigningRequested?: boolean;
   /** Requests cancellation of the in-flight device signing ceremony. */
   onCancelSigning?: () => void;
+  /** Inline fee-rate panel rendered in the pre-sign entry state (`!started`). */
+  preSignFeeSelector?: ReactNode;
+  /** Disables the pre-sign entry CTA (e.g. an invalid custom fee rate). */
+  signDisabled?: boolean;
 }
 
 /**
@@ -265,6 +269,8 @@ export function DepositProgressView(props: DepositProgressViewProps) {
     canCancelSigning = false,
     cancelSigningRequested = false,
     onCancelSigning,
+    preSignFeeSelector,
+    signDisabled = false,
   } = props;
 
   // Every flow that renders this view requires the BTC wallet, so surface a
@@ -481,7 +487,7 @@ export function DepositProgressView(props: DepositProgressViewProps) {
                   ? cancelSigningRequested
                   : started
                     ? !canClose && !isTerminalSuccess
-                    : false
+                    : signDisabled
             }
             variant="contained"
             color="secondary"
@@ -570,6 +576,8 @@ export function DepositProgressView(props: DepositProgressViewProps) {
             started={started}
           />
         )}
+
+        {!started && preSignFeeSelector}
 
         {/* Persist through errors: a retry still needs signing, so the nudge
             stays useful. Only a finished deposit (complete / terminal success)

--- a/services/vault/src/components/simple/DepositProgressView/DepositProgressView.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/DepositProgressView.tsx
@@ -161,7 +161,11 @@ export interface DepositProgressViewProps {
   cancelSigningRequested?: boolean;
   /** Requests cancellation of the in-flight device signing ceremony. */
   onCancelSigning?: () => void;
-  /** Inline fee-rate panel rendered in the pre-sign entry state (`!started`). */
+  /**
+   * Inline fee-rate panel for the pre-sign entry state (`!started`). Rendered
+   * inside the "Register deposit" card, under the Pre-PegIn step whose
+   * transaction the rate pays for.
+   */
   preSignFeeSelector?: ReactNode;
   /** Disables the pre-sign entry CTA (e.g. an invalid custom fee rate). */
   signDisabled?: boolean;
@@ -351,8 +355,9 @@ export function DepositProgressView(props: DepositProgressViewProps) {
   // a current group with none of its own work done reads not-started, so
   // nothing spins or announces progress while the flow idles awaiting the
   // click. Flows entering at step 1 have nothing completed, so they render
-  // exactly as before: no bar, no pill, every group a collapsed not-started
-  // header.
+  // as no bar, no pill, and collapsed not-started headers — except the group
+  // owning the Pre-PegIn step, which opens to carry the fee selector on its
+  // one relevant row (see GroupBlock).
   const visualStep = isComplete
     ? TOTAL_VISUAL_STEPS + 1
     : getVisualStep(currentStep);
@@ -566,6 +571,7 @@ export function DepositProgressView(props: DepositProgressViewProps) {
             renderStepDetail={renderStepDetail}
             perVaultSteps={perVaultSteps}
             started={started}
+            preSignDetail={started ? undefined : preSignFeeSelector}
           />
         ) : (
           <GroupedProgress
@@ -574,10 +580,9 @@ export function DepositProgressView(props: DepositProgressViewProps) {
             activeStepDetail={activeStepDetail}
             hasError={Boolean(error)}
             started={started}
+            preSignDetail={started ? undefined : preSignFeeSelector}
           />
         )}
-
-        {!started && preSignFeeSelector}
 
         {/* Persist through errors: a retry still needs signing, so the nudge
             stays useful. Only a finished deposit (complete / terminal success)

--- a/services/vault/src/components/simple/DepositProgressView/FeeRateSelector.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/FeeRateSelector.tsx
@@ -1,0 +1,290 @@
+/**
+ * FeeRateSelector
+ *
+ * Inline network fee-rate picker rendered in the Deposit Progress view's
+ * pre-sign entry state (replaces the old DepositFeeModal). Owns its own
+ * selection state, seeded once from the committed `feeRate` prop; a selected
+ * mempool tier live-follows its tier value on refetch, while a custom rate is
+ * frozen until the user edits it. See the parent spec for the full contract.
+ */
+
+import { Input, Text } from "@babylonlabs-io/core-ui";
+import { peginOutputCount } from "@babylonlabs-io/ts-sdk/tbv/core";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { IoClose } from "react-icons/io5";
+
+import { getNetworkConfigBTC } from "@/config";
+import { MIN_RELAY_FEE_RATE_SATS_VB } from "@/constants";
+import { useBTCWallet } from "@/context/wallet";
+import { COPY } from "@/copy";
+import { useEstimatedBtcFee } from "@/hooks/deposit/useEstimatedBtcFee";
+import { useNetworkFees } from "@/hooks/useNetworkFees";
+import { useUTXOs } from "@/hooks/useUTXOs";
+import { satoshiToBtcNumber } from "@/utils/btcConversion";
+import { getFeeRateBounds } from "@/utils/feeRateBounds";
+import { formatBtcAmount } from "@/utils/formatting";
+
+const FEE_SELECTOR_COPY = COPY.deposit.feeSelector;
+const btcConfig = getNetworkConfigBTC();
+
+type TierKey = "slow" | "avg" | "fast" | "custom";
+
+interface FeeRateSelectorProps {
+  /** Per-vault deposit amounts (satoshis); sum is the total pre-pegin amount. */
+  vaultAmounts: bigint[];
+  /** Committed fee rate (sat/vB) — the DepositState value the sign flow uses. */
+  feeRate: number;
+  onFeeRateChange: (rate: number) => void;
+  /** False while the fee estimate errors, or custom is selected with no valid value. */
+  onValidityChange?: (canSign: boolean) => void;
+}
+
+function parseValidCustom(
+  value: string,
+  minFeeRate: number,
+  maxFeeRate: number,
+): number | null {
+  const parsed = Number.parseFloat(value);
+  if (!Number.isFinite(parsed)) return null;
+  if (parsed < minFeeRate || parsed > maxFeeRate) return null;
+  return parsed;
+}
+
+export function FeeRateSelector({
+  vaultAmounts,
+  feeRate,
+  onFeeRateChange,
+  onValidityChange,
+}: FeeRateSelectorProps) {
+  const {
+    defaultFeeRate: fastestFee,
+    halfHourFeeRate: avgFee,
+    hourFeeRate: slowFee,
+    isLoading,
+  } = useNetworkFees();
+  const { address } = useBTCWallet();
+  const { spendableMempoolUTXOs } = useUTXOs(address);
+
+  const totalAmountSats = useMemo(
+    () => vaultAmounts.reduce((sum, amount) => sum + amount, 0n),
+    [vaultAmounts],
+  );
+  const numOutputs = peginOutputCount(vaultAmounts.length, true);
+  const estimatedFee = useEstimatedBtcFee(
+    totalAmountSats,
+    spendableMempoolUTXOs,
+    numOutputs,
+    feeRate,
+  );
+
+  const [selectedKey, setSelectedKey] = useState<TierKey>("fast");
+  const [customValue, setCustomValue] = useState("");
+  const seededRef = useRef(false);
+
+  const { minFeeRate, maxFeeRate } = getFeeRateBounds({
+    defaultFeeRate: fastestFee,
+    hourFeeRate: slowFee,
+  });
+
+  // Seed the selection once, when the fee tiers first resolve, from the
+  // committed `feeRate` prop. After that this effect only live-follows: a
+  // selected tier's committed rate tracks the tier's current mempool value; a
+  // custom rate is frozen and only changes on user input. Never re-derive the
+  // selection itself from props or fee tiers again.
+  useEffect(() => {
+    if (isLoading) return;
+
+    let key = selectedKey;
+    let custom = customValue;
+
+    if (!seededRef.current) {
+      seededRef.current = true;
+      if (feeRate === slowFee) {
+        key = "slow";
+      } else if (feeRate === avgFee) {
+        key = "avg";
+      } else if (feeRate === fastestFee) {
+        key = "fast";
+      } else {
+        key = "custom";
+        custom = String(feeRate);
+      }
+      setSelectedKey(key);
+      setCustomValue(custom);
+    }
+
+    const tierRate =
+      key === "slow" ? slowFee : key === "avg" ? avgFee : fastestFee;
+    const derivedRate =
+      key === "custom"
+        ? parseValidCustom(custom, minFeeRate, maxFeeRate)
+        : tierRate;
+
+    if (derivedRate !== null && derivedRate !== feeRate) {
+      onFeeRateChange(derivedRate);
+    }
+  }, [
+    isLoading,
+    feeRate,
+    slowFee,
+    avgFee,
+    fastestFee,
+    selectedKey,
+    customValue,
+    minFeeRate,
+    maxFeeRate,
+    onFeeRateChange,
+  ]);
+
+  const lastValidityRef = useRef<boolean | null>(null);
+  useEffect(() => {
+    if (!onValidityChange) return;
+
+    const customInvalid =
+      selectedKey === "custom" &&
+      parseValidCustom(customValue, minFeeRate, maxFeeRate) === null;
+    const canSign = !customInvalid && !estimatedFee.error;
+
+    if (lastValidityRef.current === canSign) return;
+    lastValidityRef.current = canSign;
+    onValidityChange(canSign);
+  }, [
+    onValidityChange,
+    selectedKey,
+    customValue,
+    minFeeRate,
+    maxFeeRate,
+    estimatedFee.error,
+  ]);
+
+  const handleClearCustom = () => {
+    setCustomValue("");
+    setSelectedKey("fast");
+    onFeeRateChange(fastestFee);
+  };
+
+  const showLowFeeWarning = feeRate < slowFee;
+
+  const tiers: Array<{
+    key: TierKey;
+    label: string;
+    rate: number;
+    hint: string;
+  }> = [
+    {
+      key: "slow",
+      label: FEE_SELECTOR_COPY.slowLabel,
+      rate: slowFee,
+      hint: FEE_SELECTOR_COPY.slowHint,
+    },
+    {
+      key: "avg",
+      label: FEE_SELECTOR_COPY.avgLabel,
+      rate: avgFee,
+      hint: FEE_SELECTOR_COPY.avgHint,
+    },
+    {
+      key: "fast",
+      label: FEE_SELECTOR_COPY.fastLabel,
+      rate: fastestFee,
+      hint: FEE_SELECTOR_COPY.fastHint,
+    },
+  ];
+
+  return (
+    <div className="flex flex-col gap-2 rounded-lg border border-secondary-strokeLight bg-secondary-highlight p-3">
+      <div className="flex items-center justify-between">
+        <Text variant="body2" className="text-accent-primary">
+          {FEE_SELECTOR_COPY.title}
+        </Text>
+        <Text variant="body2" className="text-accent-primary">
+          {feeRate} {FEE_SELECTOR_COPY.headerUnit}
+        </Text>
+      </div>
+
+      <div className="grid grid-cols-4 gap-2.5">
+        {tiers.map((tier) => (
+          <button
+            key={tier.key}
+            type="button"
+            aria-pressed={selectedKey === tier.key}
+            onClick={() => setSelectedKey(tier.key)}
+            className={`flex flex-col items-center gap-1 rounded border p-2 text-center ${
+              selectedKey === tier.key
+                ? "border-accent-primary bg-accent-primary/10"
+                : "border-secondary-strokeLight"
+            }`}
+          >
+            <Text variant="body2">{tier.label}</Text>
+            <Text variant="caption">
+              <span className="text-accent-primary">
+                {tier.rate} {FEE_SELECTOR_COPY.cardUnit}
+              </span>{" "}
+              <span className="text-accent-secondary">{tier.hint}</span>
+            </Text>
+          </button>
+        ))}
+        <button
+          type="button"
+          aria-pressed={selectedKey === "custom"}
+          onClick={() => setSelectedKey("custom")}
+          className={`flex items-center justify-center rounded border p-2 ${
+            selectedKey === "custom"
+              ? "border-accent-primary bg-accent-primary/10"
+              : "border-secondary-strokeLight"
+          }`}
+        >
+          <Text variant="body2">{FEE_SELECTOR_COPY.customLabel}</Text>
+        </button>
+      </div>
+
+      {selectedKey === "custom" && (
+        <div className="flex flex-col gap-1">
+          <div className="flex items-center gap-2">
+            <Input
+              type="number"
+              min={MIN_RELAY_FEE_RATE_SATS_VB}
+              step={1}
+              value={customValue}
+              onChange={(e) => setCustomValue(e.currentTarget.value)}
+              suffix={
+                <Text as="span" variant="body2">
+                  {FEE_SELECTOR_COPY.customInputSuffix}
+                </Text>
+              }
+              wrapperClassName="flex-1"
+            />
+            <button
+              type="button"
+              aria-label={FEE_SELECTOR_COPY.clearCustomAria}
+              onClick={handleClearCustom}
+              className="flex size-10 shrink-0 items-center justify-center rounded border border-secondary-strokeLight"
+            >
+              <IoClose size={20} />
+            </button>
+          </div>
+          {!estimatedFee.error && estimatedFee.fee !== null && (
+            <Text variant="caption" className="text-accent-secondary">
+              {formatBtcAmount(satoshiToBtcNumber(estimatedFee.fee))}{" "}
+              {btcConfig.coinSymbol}
+            </Text>
+          )}
+        </div>
+      )}
+
+      {/* An estimate error blocks Sign for tier rates too, so it must be
+          visible regardless of which option is selected. */}
+      {estimatedFee.error && (
+        <Text variant="caption" className="text-error-main">
+          {estimatedFee.error}
+        </Text>
+      )}
+
+      {showLowFeeWarning && (
+        <Text variant="caption" className="text-warning-main">
+          {FEE_SELECTOR_COPY.lowFeeWarning}
+        </Text>
+      )}
+    </div>
+  );
+}

--- a/services/vault/src/components/simple/DepositProgressView/FeeRateSelector.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/FeeRateSelector.tsx
@@ -13,7 +13,6 @@ import { peginOutputCount } from "@babylonlabs-io/ts-sdk/tbv/core";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { IoClose } from "react-icons/io5";
 
-import { getNetworkConfigBTC } from "@/config";
 import { MIN_RELAY_FEE_RATE_SATS_VB } from "@/constants";
 import { useBTCWallet } from "@/context/wallet";
 import { COPY } from "@/copy";
@@ -25,7 +24,6 @@ import { getFeeRateBounds } from "@/utils/feeRateBounds";
 import { formatBtcAmount } from "@/utils/formatting";
 
 const FEE_SELECTOR_COPY = COPY.deposit.feeSelector;
-const btcConfig = getNetworkConfigBTC();
 
 type TierKey = "slow" | "avg" | "fast" | "custom";
 
@@ -202,21 +200,23 @@ export function FeeRateSelector({
         </Text>
       </div>
 
-      <div className="grid grid-cols-4 gap-2.5">
+      <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
         {tiers.map((tier) => (
           <button
             key={tier.key}
             type="button"
             aria-pressed={selectedKey === tier.key}
             onClick={() => setSelectedKey(tier.key)}
-            className={`flex flex-col items-center gap-1 rounded border p-2 text-center ${
+            className={`flex flex-col items-center gap-0.5 rounded border px-1.5 py-1.5 text-center ${
               selectedKey === tier.key
                 ? "border-accent-primary bg-accent-primary/10"
                 : "border-secondary-strokeLight"
             }`}
           >
-            <Text variant="body2">{tier.label}</Text>
-            <Text variant="caption">
+            <Text variant="caption" className="font-medium">
+              {tier.label}
+            </Text>
+            <Text variant="caption" className="whitespace-nowrap">
               <span className="text-accent-primary">
                 {tier.rate} {FEE_SELECTOR_COPY.cardUnit}
               </span>{" "}
@@ -228,13 +228,15 @@ export function FeeRateSelector({
           type="button"
           aria-pressed={selectedKey === "custom"}
           onClick={() => setSelectedKey("custom")}
-          className={`flex items-center justify-center rounded border p-2 ${
+          className={`flex items-center justify-center rounded border px-2 py-1.5 ${
             selectedKey === "custom"
               ? "border-accent-primary bg-accent-primary/10"
               : "border-secondary-strokeLight"
           }`}
         >
-          <Text variant="body2">{FEE_SELECTOR_COPY.customLabel}</Text>
+          <Text variant="caption" className="font-medium">
+            {FEE_SELECTOR_COPY.customLabel}
+          </Text>
         </button>
       </div>
 
@@ -248,7 +250,7 @@ export function FeeRateSelector({
               value={customValue}
               onChange={(e) => setCustomValue(e.currentTarget.value)}
               suffix={
-                <Text as="span" variant="body2">
+                <Text as="span" variant="body2" className="whitespace-nowrap">
                   {FEE_SELECTOR_COPY.customInputSuffix}
                 </Text>
               }
@@ -265,8 +267,7 @@ export function FeeRateSelector({
           </div>
           {!estimatedFee.error && estimatedFee.fee !== null && (
             <Text variant="caption" className="text-accent-secondary">
-              {formatBtcAmount(satoshiToBtcNumber(estimatedFee.fee))}{" "}
-              {btcConfig.coinSymbol}
+              {formatBtcAmount(satoshiToBtcNumber(estimatedFee.fee))}
             </Text>
           )}
         </div>

--- a/services/vault/src/components/simple/DepositProgressView/GroupBlock.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/GroupBlock.tsx
@@ -55,10 +55,10 @@ export function GroupBlock({
   preSignDetail,
 }: GroupBlockProps) {
   // Pre-sign entry: this group owns the Pre-PegIn step, so it opens into the
-  // card and shows that one row carrying the fee selector. The other rows stay
-  // hidden — the entry screen is about the one decision left to make, not the
-  // whole group. The row reads active (that is what `StepRow` gates its detail
-  // on) even though nothing is running yet.
+  // card and shows that one row with the fee selector rendered below it as a
+  // sibling. The other rows stay hidden — the entry screen is about the one
+  // decision left to make, not the whole group. The row reads active even
+  // though nothing is running yet.
   const showPreSignDetail =
     !group.expanded &&
     Boolean(preSignDetail) &&
@@ -95,15 +95,17 @@ export function GroupBlock({
         <div className="border-t border-secondary-strokeLight" />
         <div className="flex flex-col gap-2 px-2">
           {showPreSignDetail ? (
-            <StepRow
-              state="active"
-              number={PRE_PEGIN_VISUAL_STEP - group.startStep + 1}
-              ariaNumber={PRE_PEGIN_VISUAL_STEP}
-              label={steps[PRE_PEGIN_VISUAL_STEP - 1]?.label ?? ""}
-              detail={preSignDetail}
-              compact={compact}
-              inCard
-            />
+            <>
+              <StepRow
+                state="active"
+                number={PRE_PEGIN_VISUAL_STEP - group.startStep + 1}
+                ariaNumber={PRE_PEGIN_VISUAL_STEP}
+                label={steps[PRE_PEGIN_VISUAL_STEP - 1]?.label ?? ""}
+                compact={compact}
+                inCard
+              />
+              {preSignDetail}
+            </>
           ) : (
             stepNumbers.map((globalStepNum, subIndex) => {
               const step = steps[globalStepNum - 1];

--- a/services/vault/src/components/simple/DepositProgressView/GroupBlock.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/GroupBlock.tsx
@@ -11,9 +11,16 @@
 import type { StepperItem } from "@babylonlabs-io/core-ui";
 import type { ReactNode } from "react";
 
+import { DepositFlowStep } from "@/hooks/deposit/depositFlowSteps/types";
+
 import { GroupHeader } from "./GroupHeader";
 import { StepRow, type StepRowState } from "./StepRow";
-import type { StepGroupView } from "./steps";
+import { getVisualStep, type StepGroupView } from "./steps";
+
+/** The step whose transaction the pre-sign fee rate pays for. */
+const PRE_PEGIN_VISUAL_STEP = getVisualStep(
+  DepositFlowStep.BROADCAST_PRE_PEGIN,
+);
 
 interface GroupBlockProps {
   group: StepGroupView;
@@ -28,6 +35,13 @@ interface GroupBlockProps {
   activeStepDetail?: ReactNode;
   /** Narrow per-vault column → stack each row's sub-counter below its label. */
   compact?: boolean;
+  /**
+   * Pre-sign entry panel (the fee-rate selector). Passed only while the flow
+   * has not started; renders inside this group's card under the Pre-PegIn
+   * step — the transaction the rate pays for — instead of the collapsed
+   * header. Ignored by groups that don't contain that step.
+   */
+  preSignDetail?: ReactNode;
 }
 
 export function GroupBlock({
@@ -38,8 +52,20 @@ export function GroupBlock({
   hasError = false,
   activeStepDetail,
   compact = false,
+  preSignDetail,
 }: GroupBlockProps) {
-  if (!group.expanded) {
+  // Pre-sign entry: this group owns the Pre-PegIn step, so it opens into the
+  // card and shows that one row carrying the fee selector. The other rows stay
+  // hidden — the entry screen is about the one decision left to make, not the
+  // whole group. The row reads active (that is what `StepRow` gates its detail
+  // on) even though nothing is running yet.
+  const showPreSignDetail =
+    !group.expanded &&
+    Boolean(preSignDetail) &&
+    group.startStep <= PRE_PEGIN_VISUAL_STEP &&
+    PRE_PEGIN_VISUAL_STEP <= group.endStep;
+
+  if (!group.expanded && !showPreSignDetail) {
     return (
       <GroupHeader
         number={number}
@@ -68,34 +94,46 @@ export function GroupBlock({
         />
         <div className="border-t border-secondary-strokeLight" />
         <div className="flex flex-col gap-2 px-2">
-          {stepNumbers.map((globalStepNum, subIndex) => {
-            const step = steps[globalStepNum - 1];
-            if (!step) return null;
+          {showPreSignDetail ? (
+            <StepRow
+              state="active"
+              number={PRE_PEGIN_VISUAL_STEP - group.startStep + 1}
+              ariaNumber={PRE_PEGIN_VISUAL_STEP}
+              label={steps[PRE_PEGIN_VISUAL_STEP - 1]?.label ?? ""}
+              detail={preSignDetail}
+              compact={compact}
+              inCard
+            />
+          ) : (
+            stepNumbers.map((globalStepNum, subIndex) => {
+              const step = steps[globalStepNum - 1];
+              if (!step) return null;
 
-            const state: StepRowState =
-              globalStepNum < currentStep
-                ? "completed"
-                : globalStepNum === currentStep
-                  ? hasError
-                    ? "error"
-                    : "active"
-                  : "pending";
+              const state: StepRowState =
+                globalStepNum < currentStep
+                  ? "completed"
+                  : globalStepNum === currentStep
+                    ? hasError
+                      ? "error"
+                      : "active"
+                    : "pending";
 
-            return (
-              <StepRow
-                key={globalStepNum}
-                state={state}
-                number={subIndex + 1}
-                ariaNumber={globalStepNum}
-                label={step.label}
-                description={step.description}
-                detail={activeStepDetail}
-                hasNext={subIndex < stepNumbers.length - 1}
-                compact={compact}
-                inCard
-              />
-            );
-          })}
+              return (
+                <StepRow
+                  key={globalStepNum}
+                  state={state}
+                  number={subIndex + 1}
+                  ariaNumber={globalStepNum}
+                  label={step.label}
+                  description={step.description}
+                  detail={activeStepDetail}
+                  hasNext={subIndex < stepNumbers.length - 1}
+                  compact={compact}
+                  inCard
+                />
+              );
+            })
+          )}
         </div>
       </div>
     </div>

--- a/services/vault/src/components/simple/DepositProgressView/GroupedProgress.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/GroupedProgress.tsx
@@ -26,6 +26,8 @@ interface GroupedProgressProps {
   hasError?: boolean;
   /** False in the pre-entry state — no group expands (see buildStepGroups). */
   started?: boolean;
+  /** Pre-sign entry panel, rendered under the Pre-PegIn step (see GroupBlock). */
+  preSignDetail?: ReactNode;
 }
 
 export function GroupedProgress({
@@ -34,6 +36,7 @@ export function GroupedProgress({
   activeStepDetail,
   hasError = false,
   started = true,
+  preSignDetail,
 }: GroupedProgressProps) {
   const groups = buildStepGroups(currentStep, started);
 
@@ -58,6 +61,7 @@ export function GroupedProgress({
               currentStep={currentStep}
               hasError={hasError}
               activeStepDetail={activeStepDetail}
+              preSignDetail={preSignDetail}
             />
 
             {!isLastGroup && <StepConnector />}

--- a/services/vault/src/components/simple/DepositProgressView/SplitGroupedProgress.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/SplitGroupedProgress.tsx
@@ -59,6 +59,11 @@ interface SplitGroupedProgressProps {
    * (see the per-column gate below).
    */
   started?: boolean;
+  /**
+   * Pre-sign entry panel. Goes on the shared trunk only — one Pre-PegIn
+   * transaction, one fee rate, however many vaults the deposit splits into.
+   */
+  preSignDetail?: ReactNode;
 }
 
 /** One group list per vault, rendered as the new filled-card / header blocks. */
@@ -123,6 +128,7 @@ export function SplitGroupedProgress({
   renderStepDetail,
   perVaultSteps,
   started = true,
+  preSignDetail,
 }: SplitGroupedProgressProps) {
   // Shared trunk groups (Register deposit). Keep original 1-based numbers, hide
   // completed groups (they fold into the steps-completed pill).
@@ -145,6 +151,7 @@ export function SplitGroupedProgress({
             hasError={hasError}
             // Trunk is full-width → inline detail (e.g. the pegin-fee notice).
             activeStepDetail={renderStepDetail?.(rawStep, { stacked: false })}
+            preSignDetail={preSignDetail}
           />
           <StepConnector />
         </div>

--- a/services/vault/src/components/simple/DepositProgressView/__tests__/DepositProgressView.test.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/__tests__/DepositProgressView.test.tsx
@@ -266,7 +266,15 @@ describe("DepositProgressView", () => {
       expect(
         screen.getByText(COPY.deposit.steps.signAndBroadcastPrePegin),
       ).toBeInTheDocument();
-      expect(screen.getByText("fee selector")).toBeInTheDocument();
+      const selector = screen.getByText("fee selector");
+      expect(selector).toBeInTheDocument();
+
+      // The selector renders as a sibling of the Pre-PegIn step row, not
+      // nested in its indented detail column.
+      const stepRow = screen
+        .getByText(COPY.deposit.steps.signAndBroadcastPrePegin)
+        .closest("div.flex.gap-3");
+      expect(selector.parentElement).toBe(stepRow?.parentElement);
 
       // Only the Pre-PegIn row opens — the rest of the group stays folded.
       expect(

--- a/services/vault/src/components/simple/DepositProgressView/__tests__/DepositProgressView.test.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/__tests__/DepositProgressView.test.tsx
@@ -247,6 +247,61 @@ describe("DepositProgressView", () => {
       ).toHaveLength(4);
     });
 
+    it("renders the fee selector under the Pre-PegIn step inside the Register deposit card", () => {
+      // The rate pays for the Pre-PegIn broadcast, so the entry screen opens
+      // that group and hangs the selector off that one step — not off the CTA.
+      render(
+        <DepositProgressView
+          {...baseProps}
+          started={false}
+          onSign={vi.fn()}
+          currentStep={DepositFlowStep.DERIVE_VAULT_SECRET}
+          preSignFeeSelector={<div>fee selector</div>}
+        />,
+      );
+
+      expect(
+        screen.getByText(COPY.deposit.groups.registerDeposit),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(COPY.deposit.steps.signAndBroadcastPrePegin),
+      ).toBeInTheDocument();
+      expect(screen.getByText("fee selector")).toBeInTheDocument();
+
+      // Only the Pre-PegIn row opens — the rest of the group stays folded.
+      expect(
+        screen.queryByText(COPY.deposit.steps.generateSecret),
+      ).not.toBeInTheDocument();
+    });
+
+    it("renders the fee selector once on a split deposit's shared trunk", () => {
+      // One Pre-PegIn transaction, one rate — however many vaults.
+      render(
+        <DepositProgressView
+          {...baseProps}
+          started={false}
+          onSign={vi.fn()}
+          currentStep={DepositFlowStep.DERIVE_VAULT_SECRET}
+          vaultCount={2}
+          preSignFeeSelector={<div>fee selector</div>}
+        />,
+      );
+
+      expect(screen.getAllByText("fee selector")).toHaveLength(1);
+    });
+
+    it("drops the fee selector once signing has started", () => {
+      render(
+        <DepositProgressView
+          {...baseProps}
+          currentStep={DepositFlowStep.BROADCAST_PRE_PEGIN}
+          preSignFeeSelector={<div>fee selector</div>}
+        />,
+      );
+
+      expect(screen.queryByText("fee selector")).not.toBeInTheDocument();
+    });
+
     it("keeps a sibling vault's live progress expanded on a split re-offer", () => {
       // The gate is about the flow's own un-started action. A sibling lane
       // sitting on a different step is driven by its own polled state — its

--- a/services/vault/src/components/simple/DepositProgressView/__tests__/FeeRateSelector.test.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/__tests__/FeeRateSelector.test.tsx
@@ -1,0 +1,225 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useEstimatedBtcFee } from "@/hooks/deposit/useEstimatedBtcFee";
+import { useNetworkFees } from "@/hooks/useNetworkFees";
+import { useUTXOs } from "@/hooks/useUTXOs";
+
+import { FeeRateSelector } from "../FeeRateSelector";
+
+vi.mock("@/context/wallet", () => ({
+  useBTCWallet: () => ({ address: "bc1qtest" }),
+}));
+
+vi.mock("@/hooks/useUTXOs", () => ({
+  useUTXOs: vi.fn(() => ({ spendableMempoolUTXOs: [] })),
+}));
+
+vi.mock("@/hooks/useNetworkFees", () => ({
+  useNetworkFees: vi.fn(),
+}));
+
+vi.mock("@/hooks/deposit/useEstimatedBtcFee", () => ({
+  useEstimatedBtcFee: vi.fn(),
+}));
+
+// Slow=2, Avg=5, Fast=10 — kept low so nextPowerOfTwo(fastest) < 128 and the
+// custom-input cap is pinned at the LEAST_MAX_FEE_RATE floor for every test.
+const FEE_TIERS = {
+  defaultFeeRate: 10,
+  halfHourFeeRate: 5,
+  hourFeeRate: 2,
+  isLoading: false,
+  error: null,
+};
+
+function buttonFor(text: string): HTMLButtonElement {
+  const el = screen.getByText(text).closest("button");
+  if (!el) throw new Error(`no button ancestor for "${text}"`);
+  return el as HTMLButtonElement;
+}
+
+describe("FeeRateSelector", () => {
+  beforeEach(() => {
+    vi.mocked(useNetworkFees).mockReturnValue(FEE_TIERS);
+    vi.mocked(useUTXOs).mockReturnValue({
+      spendableMempoolUTXOs: [],
+    } as unknown as ReturnType<typeof useUTXOs>);
+    vi.mocked(useEstimatedBtcFee).mockReturnValue({
+      fee: 1500n,
+      feeRate: 10,
+      isLoading: false,
+      error: null,
+      maxDeposit: null,
+    });
+  });
+
+  it("renders the 4 tiers with rates and hints, Fast selected by default", () => {
+    render(
+      <FeeRateSelector
+        vaultAmounts={[100_000n]}
+        feeRate={10}
+        onFeeRateChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Slow")).toBeInTheDocument();
+    expect(screen.getByText("Avg")).toBeInTheDocument();
+    expect(screen.getByText("Fast")).toBeInTheDocument();
+    expect(screen.getByText("Custom")).toBeInTheDocument();
+    expect(screen.getByText("2 sat/vB")).toBeInTheDocument();
+    expect(screen.getByText("~1 hour")).toBeInTheDocument();
+    expect(screen.getByText("5 sat/vB")).toBeInTheDocument();
+    expect(screen.getByText("~30 min")).toBeInTheDocument();
+    expect(screen.getByText("10 sat/vB")).toBeInTheDocument();
+    expect(screen.getByText("~10 min")).toBeInTheDocument();
+
+    expect(buttonFor("Fast")).toHaveAttribute("aria-pressed", "true");
+    expect(buttonFor("Slow")).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("commits the hour fee rate when Slow is clicked", () => {
+    const onFeeRateChange = vi.fn();
+    render(
+      <FeeRateSelector
+        vaultAmounts={[100_000n]}
+        feeRate={10}
+        onFeeRateChange={onFeeRateChange}
+      />,
+    );
+
+    fireEvent.click(buttonFor("Slow"));
+
+    expect(onFeeRateChange).toHaveBeenCalledWith(2);
+    expect(buttonFor("Slow")).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("commits a valid custom rate but not one above the max cap", () => {
+    const onFeeRateChange = vi.fn();
+    render(
+      <FeeRateSelector
+        vaultAmounts={[100_000n]}
+        feeRate={10}
+        onFeeRateChange={onFeeRateChange}
+      />,
+    );
+
+    fireEvent.click(buttonFor("Custom"));
+    const input = screen.getByRole("spinbutton");
+
+    fireEvent.change(input, { target: { value: "15" } });
+    expect(onFeeRateChange).toHaveBeenCalledWith(15);
+
+    onFeeRateChange.mockClear();
+    // fastest=10 -> nextPowerOfTwo=32, cap floors at 128; 9999 exceeds it.
+    fireEvent.change(input, { target: { value: "9999" } });
+    expect(onFeeRateChange).not.toHaveBeenCalled();
+  });
+
+  it("keeps the custom selection and input value across a mempool refetch", () => {
+    const onFeeRateChange = vi.fn();
+    const { rerender } = render(
+      <FeeRateSelector
+        vaultAmounts={[100_000n]}
+        feeRate={10}
+        onFeeRateChange={onFeeRateChange}
+      />,
+    );
+
+    fireEvent.click(buttonFor("Custom"));
+    fireEvent.change(screen.getByRole("spinbutton"), {
+      target: { value: "20" },
+    });
+    onFeeRateChange.mockClear();
+
+    // Mempool refetch changes the mempool tiers mid-edit.
+    vi.mocked(useNetworkFees).mockReturnValue({
+      ...FEE_TIERS,
+      defaultFeeRate: 25,
+      halfHourFeeRate: 12,
+      hourFeeRate: 6,
+    });
+    rerender(
+      <FeeRateSelector
+        vaultAmounts={[100_000n]}
+        feeRate={10}
+        onFeeRateChange={onFeeRateChange}
+      />,
+    );
+
+    expect(screen.getByRole("spinbutton")).toHaveValue(20);
+    expect(buttonFor("Custom")).toHaveAttribute("aria-pressed", "true");
+    expect(onFeeRateChange).not.toHaveBeenCalledWith(25);
+  });
+
+  it("live-follows the selected tier's mempool value on refetch", () => {
+    const onFeeRateChange = vi.fn();
+    const { rerender } = render(
+      <FeeRateSelector
+        vaultAmounts={[100_000n]}
+        feeRate={10}
+        onFeeRateChange={onFeeRateChange}
+      />,
+    );
+
+    vi.mocked(useNetworkFees).mockReturnValue({
+      ...FEE_TIERS,
+      defaultFeeRate: 25,
+    });
+    rerender(
+      <FeeRateSelector
+        vaultAmounts={[100_000n]}
+        feeRate={10}
+        onFeeRateChange={onFeeRateChange}
+      />,
+    );
+
+    expect(onFeeRateChange).toHaveBeenCalledWith(25);
+  });
+
+  it("resets to Fast and commits the fastest rate when cleared", () => {
+    const onFeeRateChange = vi.fn();
+    render(
+      <FeeRateSelector
+        vaultAmounts={[100_000n]}
+        feeRate={10}
+        onFeeRateChange={onFeeRateChange}
+      />,
+    );
+
+    fireEvent.click(buttonFor("Custom"));
+    fireEvent.change(screen.getByRole("spinbutton"), {
+      target: { value: "50" },
+    });
+    onFeeRateChange.mockClear();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Clear custom fee rate" }),
+    );
+
+    expect(onFeeRateChange).toHaveBeenCalledWith(10);
+    expect(buttonFor("Fast")).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("reports invalid when the fee estimate errors", () => {
+    vi.mocked(useEstimatedBtcFee).mockReturnValue({
+      fee: null,
+      feeRate: 10,
+      isLoading: false,
+      error: "Insufficient funds",
+      maxDeposit: null,
+    });
+    const onValidityChange = vi.fn();
+
+    render(
+      <FeeRateSelector
+        vaultAmounts={[100_000n]}
+        feeRate={10}
+        onFeeRateChange={vi.fn()}
+        onValidityChange={onValidityChange}
+      />,
+    );
+
+    expect(onValidityChange).toHaveBeenCalledWith(false);
+  });
+});

--- a/services/vault/src/components/simple/DepositProgressView/layout.ts
+++ b/services/vault/src/components/simple/DepositProgressView/layout.ts
@@ -9,5 +9,8 @@
  * (DepositProgressView) and the activated success screen use this so the card
  * stays the same width across the flow. 612px card = 564px content + 24px
  * padding either side, so the stepper content lines up with the deposit form.
+ * The wrappers hosting these surfaces (SimpleDeposit, VaultsLifecycleSections)
+ * also pin their outer container to this constant, so the width is enforced
+ * both here and at each hosting call site.
  */
 export const DEPOSIT_VIEW_MAX_WIDTH_CLASS = "max-w-[612px]";

--- a/services/vault/src/components/simple/DepositSignContent.tsx
+++ b/services/vault/src/components/simple/DepositSignContent.tsx
@@ -19,6 +19,7 @@ import { useDepositFlow } from "@/hooks/deposit/useDepositFlow";
 import { useDepositSigningNotification } from "@/hooks/deposit/useDepositSigningNotification";
 
 import { DepositProgressView } from "./DepositProgressView";
+import { FeeRateSelector } from "./DepositProgressView/FeeRateSelector";
 import { PostDepositContinuationContent } from "./PostDepositContinuationContent";
 
 interface DepositSignContentProps {
@@ -37,6 +38,8 @@ interface DepositSignContentProps {
   overlappingPendingVaultCount?: number | null;
   onClose: () => void;
   onRefetchActivities?: () => Promise<void>;
+  /** Persists a user-chosen pre-sign fee rate (sat/vB) into DepositState. */
+  onFeeRateChange: (rate: number) => void;
 }
 
 export function DepositSignContent({
@@ -44,6 +47,7 @@ export function DepositSignContent({
   onRefetchActivities,
   vaultAmounts,
   overlappingPendingVaultCount = null,
+  onFeeRateChange,
   ...flowParams
 }: DepositSignContentProps) {
   const {
@@ -78,6 +82,10 @@ export function DepositSignContent({
   // pre-sign entry state (started=false) and the depositor begins signing by
   // clicking "Sign Transaction". Once started, the live stepper takes over.
   const [started, setStarted] = useState(false);
+
+  // Tracks the pre-sign fee-rate selector's validity (e.g. an out-of-range
+  // custom rate, or a fee estimate error). Gates the pre-sign Sign CTA.
+  const [feeRateValid, setFeeRateValid] = useState(true);
 
   // Notify the depositor (if they've tabbed away) when the active flow reaches
   // a signing step. Gated on `started` so the initial DERIVE_VAULT_SECRET value
@@ -216,6 +224,15 @@ export function DepositSignContent({
         canCancelSigning={canCancelDeviceSign}
         cancelSigningRequested={deviceCancelRequested}
         onCancelSigning={cancelDeviceSign}
+        signDisabled={!feeRateValid}
+        preSignFeeSelector={
+          <FeeRateSelector
+            vaultAmounts={vaultAmounts}
+            feeRate={flowParams.mempoolFeeRate}
+            onFeeRateChange={onFeeRateChange}
+            onValidityChange={setFeeRateValid}
+          />
+        }
       />
     </>
   );

--- a/services/vault/src/components/simple/SimpleDeposit.tsx
+++ b/services/vault/src/components/simple/SimpleDeposit.tsx
@@ -32,6 +32,7 @@ import { useDepositPageFlow } from "../../hooks/deposit/useDepositPageFlow";
 import { useDepositPageForm } from "../../hooks/deposit/useDepositPageForm";
 
 import { DepositForm } from "./DepositForm";
+import { DEPOSIT_VIEW_MAX_WIDTH_CLASS } from "./DepositProgressView/layout";
 import { DepositSignContent } from "./DepositSignContent";
 import { FadeTransition } from "./FadeTransition";
 import { ResumeBroadcastContent } from "./ResumeDepositContent";
@@ -537,7 +538,7 @@ function SimpleDepositContent({
         )}
 
         {renderedStep === DepositStep.SIGN && btcWalletProvider && (
-          <div className="mx-auto w-full max-w-[520px]">
+          <div className={`mx-auto w-full ${DEPOSIT_VIEW_MAX_WIDTH_CLASS}`}>
             <DepositSignContent
               vaultAmounts={
                 isSplitDeposit && splitVaultAmounts
@@ -580,7 +581,7 @@ export default function SimpleDeposit(props: SimpleDepositProps) {
         <V3ModalShell
           open={open}
           onClose={onClose}
-          contentClassName="max-w-[520px]"
+          contentClassName={DEPOSIT_VIEW_MAX_WIDTH_CLASS}
         >
           <ResumeBroadcastContent
             activity={props.activity}

--- a/services/vault/src/components/simple/SimpleDeposit.tsx
+++ b/services/vault/src/components/simple/SimpleDeposit.tsx
@@ -545,6 +545,7 @@ function SimpleDepositContent({
                   : [depositAmount]
               }
               mempoolFeeRate={feeRate}
+              onFeeRateChange={setFeeRate}
               btcWalletProvider={btcWalletProvider}
               depositorEthAddress={ethAddress}
               selectedApplication={selectedApplication}

--- a/services/vault/src/components/simple/WithdrawFlow/__tests__/WithdrawReviewContent.test.tsx
+++ b/services/vault/src/components/simple/WithdrawFlow/__tests__/WithdrawReviewContent.test.tsx
@@ -13,7 +13,11 @@ import { HEALTH_FACTOR_COLORS } from "@/applications/aave/utils";
 import { WithdrawReviewContent } from "../WithdrawReviewContent";
 
 vi.mock("@/hooks/useNetworkFees", () => ({
-  useNetworkFees: () => ({ defaultFeeRate: 3 }),
+  useNetworkFees: () => ({
+    defaultFeeRate: 3,
+    halfHourFeeRate: 2,
+    hourFeeRate: 1,
+  }),
 }));
 
 vi.mock("@/context/ProtocolParamsContext", () => ({

--- a/services/vault/src/components/simple/__tests__/DepositFeesBreakdown.test.tsx
+++ b/services/vault/src/components/simple/__tests__/DepositFeesBreakdown.test.tsx
@@ -89,14 +89,33 @@ describe("DepositFeesBreakdown commission disclosure", () => {
     );
 
     // The shared fee row hangs the tooltip off core-ui's info icon rather than
-    // the bare label, so each of the four lines carries its own trigger.
+    // the bare label, so each of the six lines carries its own trigger.
     const tooltips = Array.from(
       document.querySelectorAll("[data-tooltip-content]"),
     ).map((node) => node.getAttribute("data-tooltip-content"));
 
-    expect(tooltips).toHaveLength(4);
+    expect(tooltips).toHaveLength(6);
     expect(tooltips.every((content) => Boolean(content))).toBe(true);
-    expect(new Set(tooltips).size).toBe(4);
+    expect(new Set(tooltips).size).toBe(6);
+  });
+
+  it("renders the network fee rate as a read-only row", () => {
+    render(
+      <DepositFeesBreakdown
+        {...baseProps}
+        amountSats={100_000_000n}
+        depositorClaimValue={3_000_000n}
+        commissionBaseValues={[100_000_000n]}
+        commissionBps={250}
+        networkFeeRate={12}
+        networkFeeSats={1500n}
+      />,
+    );
+
+    expect(screen.getByText("Network Fee Rate")).toBeInTheDocument();
+    expect(screen.getByText("BTC Network Fee")).toBeInTheDocument();
+    expect(screen.getByText("12 sats/vB")).toBeInTheDocument();
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
   });
 
   it("floors commission per vault for split deposits", () => {

--- a/services/vault/src/components/simple/__tests__/DepositSignContent.test.tsx
+++ b/services/vault/src/components/simple/__tests__/DepositSignContent.test.tsx
@@ -50,6 +50,10 @@ vi.mock("@/components/deposit/DepositSignModal/depositStepHelpers", () => ({
   }),
 }));
 
+vi.mock("../DepositProgressView/FeeRateSelector", () => ({
+  FeeRateSelector: () => null,
+}));
+
 vi.mock("../PostDepositContinuationContent", () => ({
   PostDepositContinuationContent: ({ vaultIds }: { vaultIds: string[] }) => (
     <div data-testid="continuation" data-count={vaultIds.length} />
@@ -92,6 +96,7 @@ function renderContent(
       universalChallengerBtcPubkeys={["0xchallenger"]}
       onClose={vi.fn()}
       onRefetchActivities={overrides.onRefetchActivities}
+      onFeeRateChange={vi.fn()}
     />,
   );
 }

--- a/services/vault/src/components/vaults/VaultsLifecycleSections.tsx
+++ b/services/vault/src/components/vaults/VaultsLifecycleSections.tsx
@@ -36,6 +36,7 @@ import {
   PRIMARY_ROW_BUTTON_CLASS,
 } from "@/components/shared/buttonClasses";
 import { ProgressBar } from "@/components/simple/DepositProgressView/ProgressBar";
+import { DEPOSIT_VIEW_MAX_WIDTH_CLASS } from "@/components/simple/DepositProgressView/layout";
 import {
   getStepFillPercent,
   getVisualStep,
@@ -739,7 +740,7 @@ export function VaultsLifecycleSections({
 
       {viewingBatch && ethAddress && (
         <V3ModalShell open onClose={handleViewingClose}>
-          <div className="mx-auto w-full max-w-[520px]">
+          <div className={`mx-auto w-full ${DEPOSIT_VIEW_MAX_WIDTH_CLASS}`}>
             <PostDepositContinuationContent
               vaultIds={viewingBatch}
               depositorEthAddress={ethAddress as Address}

--- a/services/vault/src/constants.ts
+++ b/services/vault/src/constants.ts
@@ -37,3 +37,7 @@ export const BTC_BLOCK_TIME_MINS = 10;
 export const MINS_PER_HOUR = 60;
 export const MINS_PER_DAY = 1440;
 export const FALLBACK_FEE_RATE_SATS_VB = 1;
+
+// Bitcoin's default minimum relay fee. Anything below this is not forwarded by
+// most nodes, so a pre-pegin funded at a lower rate would never broadcast.
+export const MIN_RELAY_FEE_RATE_SATS_VB = 1;

--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -508,6 +508,21 @@ export const COPY = {
       retryButton: "Retry",
       confirmButton: "Confirm",
     },
+    feeSelector: {
+      title: "Network Fee Rate",
+      headerUnit: "sats/vB",
+      slowLabel: "Slow",
+      slowHint: "~1 hour",
+      avgLabel: "Avg",
+      avgHint: "~30 min",
+      fastLabel: "Fast",
+      fastHint: "~10 min",
+      customLabel: "Custom",
+      cardUnit: "sat/vB",
+      customInputSuffix: "sats vB",
+      clearCustomAria: "Clear custom fee rate",
+      lowFeeWarning: "Fees are low; inclusion is not guaranteed",
+    },
     activateConfirmation: {
       title: "Activate your BTCVault",
       // The download instruction is emphasized (primary text color) per the
@@ -710,6 +725,12 @@ export const COPY = {
       // Fee-breakdown lines (DepositFeesBreakdown) shown before the user
       // submits. The commission label appends the percent, e.g. "VP commission
       // (2.50%)"; net payout is the deposit minus that commission.
+      networkFeeRateLabel: "Network Fee Rate",
+      networkFeeRateTooltip:
+        "Bitcoin network fee rate for your pre-pegin funding transaction. Raise it during congestion so the transaction confirms sooner.",
+      btcNetworkFeeLabel: "BTC Network Fee",
+      btcNetworkFeeTooltip:
+        "Estimated Bitcoin miner fee for the pre-pegin funding transaction at the selected fee rate.",
       vpCommissionLabel: "VP commission",
       vpCommissionTooltip:
         "The vault provider's fee, deducted from your payout when you redeem. Set by the vault provider and shown here before you deposit.",

--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -508,6 +508,14 @@ export const COPY = {
       retryButton: "Retry",
       confirmButton: "Confirm",
     },
+    // The tier hints are static: they name the confirmation target of the
+    // mempool.space field each tile reads (hourFee / halfHourFee / fastestFee),
+    // not a live estimate of the current queue. simple-staking's FeeModal does
+    // the same ("Next Block" / "Estimated 30mins" / "Estimated 60mins"). On a
+    // quiet signet all three fields return the 1 sat/vB floor, so one rate ends
+    // up wearing three different time promises. Follow-up: port staking's
+    // per-tile `warning={tierRate < defaultFeeRate}` flag, which marks the tiles
+    // that are genuinely too cheap instead of hiding the hints.
     feeSelector: {
       title: "Network Fee Rate",
       headerUnit: "sats/vB",
@@ -519,7 +527,7 @@ export const COPY = {
       fastHint: "~10 min",
       customLabel: "Custom",
       cardUnit: "sat/vB",
-      customInputSuffix: "sats vB",
+      customInputSuffix: "sats/vB",
       clearCustomAria: "Clear custom fee rate",
       lowFeeWarning: "Fees are low; inclusion is not guaranteed",
     },

--- a/services/vault/src/hooks/deposit/__tests__/useEstimatedBtcFee.test.tsx
+++ b/services/vault/src/hooks/deposit/__tests__/useEstimatedBtcFee.test.tsx
@@ -1,0 +1,119 @@
+import type { MempoolUTXO } from "@babylonlabs-io/ts-sdk";
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useEstimatedBtcFee } from "../useEstimatedBtcFee";
+
+const networkFees = vi.hoisted(() => ({
+  defaultFeeRate: 10,
+  isLoading: false,
+  error: null as Error | null,
+}));
+
+vi.mock("@/hooks/useNetworkFees", () => ({
+  useNetworkFees: () => networkFees,
+}));
+
+vi.mock("../../useNetworkFees", () => ({
+  useNetworkFees: () => networkFees,
+}));
+
+// Both SDK helpers are linear in the fee rate, which is all these tests need:
+// they assert which rate reaches the SDK, not the SDK's own vsize model.
+vi.mock("@babylonlabs-io/ts-sdk/tbv/core", () => ({
+  selectUtxosForPegin: vi.fn((_utxos, _amount, feeRate: number) => ({
+    fee: BigInt(Math.round(feeRate * 100)),
+  })),
+  computeMaxDeposit: vi.fn(
+    ({ totalBalance, feeRate }: { totalBalance: bigint; feeRate: number }) =>
+      totalBalance - BigInt(Math.round(feeRate * 100)),
+  ),
+}));
+
+const UTXOS = [
+  { txid: "a".repeat(64), vout: 0, value: 1_000_000, scriptPubKey: "00" },
+] as unknown as MempoolUTXO[];
+
+const AMOUNT = 100_000n;
+const NUM_OUTPUTS = 2;
+
+const render = (override?: number) =>
+  renderHook(() => useEstimatedBtcFee(AMOUNT, UTXOS, NUM_OUTPUTS, override));
+
+beforeEach(() => {
+  networkFees.defaultFeeRate = 10;
+  networkFees.isLoading = false;
+  networkFees.error = null;
+});
+
+describe("useEstimatedBtcFee fee-rate override", () => {
+  it("uses the mempool default when no override is given", () => {
+    const { result } = render();
+
+    expect(result.current.feeRate).toBe(10);
+    expect(result.current.fee).toBe(1_000n);
+  });
+
+  it("prefers a positive override over the mempool default", () => {
+    const { result } = render(25);
+
+    expect(result.current.feeRate).toBe(25);
+    expect(result.current.fee).toBe(2_500n);
+  });
+
+  it.each([
+    ["zero", 0],
+    ["negative", -5],
+    ["NaN", Number.NaN],
+    ["Infinity", Number.POSITIVE_INFINITY],
+  ])("ignores a %s override and falls back to mempool", (_label, override) => {
+    const { result } = render(override);
+
+    expect(result.current.feeRate).toBe(10);
+  });
+
+  it("shrinks maxDeposit as the override rises", () => {
+    const atDefault = render().result.current.maxDeposit;
+    const atHigherRate = render(40).result.current.maxDeposit;
+
+    expect(atDefault).toBe(999_000n);
+    expect(atHigherRate).toBe(996_000n);
+    expect(atHigherRate).toBeLessThan(atDefault as bigint);
+  });
+
+  it("keeps the override when the mempool rate changes underneath it", () => {
+    const { result, rerender } = renderHook(
+      ({ override }) =>
+        useEstimatedBtcFee(AMOUNT, UTXOS, NUM_OUTPUTS, override),
+      { initialProps: { override: 25 } },
+    );
+
+    expect(result.current.feeRate).toBe(25);
+
+    networkFees.defaultFeeRate = 77;
+    rerender({ override: 25 });
+
+    expect(result.current.feeRate).toBe(25);
+  });
+
+  it("resolves out of the loading state when only the override is usable", () => {
+    networkFees.defaultFeeRate = 0;
+    networkFees.isLoading = true;
+
+    const { result } = render(25);
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.feeRate).toBe(25);
+    expect(result.current.fee).toBe(2_500n);
+  });
+
+  it("still reports loading when neither mempool nor override is usable", () => {
+    networkFees.defaultFeeRate = 0;
+    networkFees.isLoading = true;
+
+    const { result } = render(0);
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.fee).toBeNull();
+  });
+});

--- a/services/vault/src/hooks/deposit/useEstimatedBtcFee.ts
+++ b/services/vault/src/hooks/deposit/useEstimatedBtcFee.ts
@@ -1,3 +1,22 @@
+/**
+ * Hook to calculate estimated BTC transaction fee using iterative UTXO selection.
+ *
+ * When UTXOs are provided, uses the SDK's selectUtxosForPegin for accurate
+ * fee calculation that accounts for the actual number of inputs needed.
+ *
+ * The algorithm iteratively:
+ * 1. Adds UTXOs (sorted by value, largest first)
+ * 2. Recalculates fee based on current inputs
+ * 3. Checks if change output needed (affects fee)
+ * 4. Continues until accumulated >= amount + fee
+ *
+ * @param amount - Amount to peg in (in satoshis)
+ * @param utxos - Available UTXOs for fee calculation
+ * @param numOutputs - Number of outputs before change (e.g. N HTLCs + 1 CPFP anchor)
+ * @param feeRateOverride - Optional sat/vB rate; when > 0, replaces mempool default
+ * @returns Estimated fee, fee rate, loading state, and error
+ */
+
 import type { MempoolUTXO } from "@babylonlabs-io/ts-sdk";
 import {
   computeMaxDeposit,
@@ -20,45 +39,37 @@ export interface EstimatedBtcFeeResult {
   maxDeposit: bigint | null;
 }
 
-/**
- * Hook to calculate estimated BTC transaction fee using iterative UTXO selection.
- *
- * When UTXOs are provided, uses the SDK's selectUtxosForPegin for accurate
- * fee calculation that accounts for the actual number of inputs needed.
- *
- * The algorithm iteratively:
- * 1. Adds UTXOs (sorted by value, largest first)
- * 2. Recalculates fee based on current inputs
- * 3. Checks if change output needed (affects fee)
- * 4. Continues until accumulated >= amount + fee
- *
- * @param amount - Amount to peg in (in satoshis)
- * @param utxos - Available UTXOs for fee calculation
- * @param numOutputs - Number of outputs before change (e.g. N HTLCs + 1 CPFP anchor)
- * @returns Estimated fee, fee rate, loading state, and error
- */
 export function useEstimatedBtcFee(
   amount: bigint,
   utxos: MempoolUTXO[] | undefined,
   numOutputs: number,
+  feeRateOverride?: number,
 ): EstimatedBtcFeeResult {
   const { defaultFeeRate, isLoading, error: feeError } = useNetworkFees();
 
+  // Prefer a positive caller override (user-adjusted rate); otherwise mempool.
+  const feeRate =
+    feeRateOverride !== undefined &&
+    Number.isFinite(feeRateOverride) &&
+    feeRateOverride > 0
+      ? feeRateOverride
+      : defaultFeeRate;
+
   // Max deposit only depends on UTXOs + fee rate, not the user's amount
   const maxDeposit = useMemo(() => {
-    if (isLoading || defaultFeeRate === 0 || !utxos?.length) return null;
+    if (isLoading || feeRate === 0 || !utxos?.length) return null;
     const totalBalance = utxos.reduce((sum, u) => sum + BigInt(u.value), 0n);
     return computeMaxDeposit({
       numInputs: utxos.length,
       numOutputs,
       totalBalance,
-      feeRate: defaultFeeRate,
+      feeRate,
     });
-  }, [utxos, defaultFeeRate, numOutputs, isLoading]);
+  }, [utxos, feeRate, numOutputs, isLoading]);
 
   const result = useMemo((): EstimatedBtcFeeResult => {
-    // Still loading fee rates
-    if (isLoading) {
+    // Still loading fee rates — and no usable override yet
+    if (isLoading && feeRate === 0) {
       return {
         fee: null,
         feeRate: 0,
@@ -69,7 +80,7 @@ export function useEstimatedBtcFee(
     }
 
     // Fee rate not available
-    if (defaultFeeRate === 0) {
+    if (feeRate === 0) {
       return {
         fee: null,
         feeRate: 0,
@@ -83,7 +94,7 @@ export function useEstimatedBtcFee(
     if (!utxos || utxos.length === 0) {
       return {
         fee: null,
-        feeRate: defaultFeeRate,
+        feeRate,
         isLoading: false,
         error: null,
         maxDeposit,
@@ -94,7 +105,7 @@ export function useEstimatedBtcFee(
     if (amount === 0n) {
       return {
         fee: null,
-        feeRate: defaultFeeRate,
+        feeRate,
         isLoading: false,
         error: null,
         maxDeposit,
@@ -102,43 +113,28 @@ export function useEstimatedBtcFee(
     }
 
     try {
-      // Use SDK's iterative UTXO selection with fee calculation
-      const { fee } = selectUtxosForPegin(
-        utxos,
-        amount,
-        defaultFeeRate,
-        numOutputs,
-      );
+      const { fee } = selectUtxosForPegin(utxos, amount, feeRate, numOutputs);
 
       return {
         fee,
-        feeRate: defaultFeeRate,
+        feeRate,
         isLoading: false,
         error: null,
         maxDeposit,
       };
     } catch (err) {
-      // Handle insufficient funds or other errors
       const errorMessage =
         err instanceof Error ? err.message : "Failed to estimate fee";
 
       return {
         fee: null,
-        feeRate: defaultFeeRate,
+        feeRate,
         isLoading: false,
         error: errorMessage,
         maxDeposit,
       };
     }
-  }, [
-    amount,
-    utxos,
-    defaultFeeRate,
-    numOutputs,
-    isLoading,
-    feeError,
-    maxDeposit,
-  ]);
+  }, [amount, utxos, feeRate, numOutputs, isLoading, feeError, maxDeposit]);
 
   return result;
 }

--- a/services/vault/src/hooks/useNetworkFees.ts
+++ b/services/vault/src/hooks/useNetworkFees.ts
@@ -8,6 +8,10 @@ const NETWORK_FEES_KEY = "NETWORK_FEES";
 export interface FeeRates {
   /** Default fee rate for next-block confirmation (fastestFee from mempool) */
   defaultFeeRate: number;
+  /** ~30 minute confirmation estimate (halfHourFee) */
+  halfHourFeeRate: number;
+  /** ~60 minute confirmation estimate (hourFee) */
+  hourFeeRate: number;
   /** Whether fee rates are still loading */
   isLoading: boolean;
   /** Error if fee rates could not be fetched */
@@ -17,11 +21,9 @@ export interface FeeRates {
 /**
  * Fetches Bitcoin network fee recommendations from mempool.space API.
  *
- * Returns the fastestFee rate for next-block confirmation.
- * Auto-refetches every 60 seconds with retry logic (3 attempts).
- * Globally cached - all components share the same data.
- *
- * @returns Fee rate with loading/error state
+ * Defaults to fastestFee for next-block confirmation; also exposes slower
+ * tiers for fee-rate pickers. Auto-refetches every 60 seconds with retry
+ * logic (3 attempts). Globally cached — all components share the same data.
  */
 export function useNetworkFees(): FeeRates {
   const query = useQuery({
@@ -36,6 +38,8 @@ export function useNetworkFees(): FeeRates {
   if (query.data) {
     return {
       defaultFeeRate: query.data.fastestFee,
+      halfHourFeeRate: query.data.halfHourFee,
+      hourFeeRate: query.data.hourFee,
       isLoading: false,
       error: null,
     };
@@ -43,6 +47,8 @@ export function useNetworkFees(): FeeRates {
 
   return {
     defaultFeeRate: 0,
+    halfHourFeeRate: 0,
+    hourFeeRate: 0,
     isLoading: query.isLoading,
     error: query.error ?? null,
   };

--- a/services/vault/src/utils/__tests__/feeRateBounds.test.ts
+++ b/services/vault/src/utils/__tests__/feeRateBounds.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+
+import { MIN_RELAY_FEE_RATE_SATS_VB } from "@/constants";
+
+import { getFeeRateBounds } from "../feeRateBounds";
+
+describe("getFeeRateBounds", () => {
+  it("floors minFeeRate at the min relay fee", () => {
+    const bounds = getFeeRateBounds({ defaultFeeRate: 10, hourFeeRate: 2 });
+
+    expect(bounds.minFeeRate).toBe(MIN_RELAY_FEE_RATE_SATS_VB);
+    expect(bounds.defaultFeeRate).toBe(10);
+  });
+
+  it("caps at 128 when nextPowerOfTwo(fastest) is below 128", () => {
+    // fastestFee=10 -> nextPowerOfTwo=32, below LEAST_MAX_FEE_RATE.
+    const bounds = getFeeRateBounds({ defaultFeeRate: 10, hourFeeRate: 5 });
+
+    expect(bounds.maxFeeRate).toBe(128);
+  });
+
+  it("caps at nextPowerOfTwo(fastest) when it exceeds 128", () => {
+    // fastestFee=200 -> nextPowerOfTwo=512, above LEAST_MAX_FEE_RATE.
+    const bounds = getFeeRateBounds({ defaultFeeRate: 200, hourFeeRate: 100 });
+
+    expect(bounds.maxFeeRate).toBe(512);
+  });
+
+  it("returns the floor and 128 cap for zero fees", () => {
+    const bounds = getFeeRateBounds({ defaultFeeRate: 0, hourFeeRate: 0 });
+
+    expect(bounds.minFeeRate).toBe(MIN_RELAY_FEE_RATE_SATS_VB);
+    expect(bounds.defaultFeeRate).toBe(0);
+    expect(bounds.maxFeeRate).toBe(128);
+  });
+});

--- a/services/vault/src/utils/feeRateBounds.ts
+++ b/services/vault/src/utils/feeRateBounds.ts
@@ -1,0 +1,47 @@
+/**
+ * Fee-rate bounds for the pre-pegin funding tx's custom fee-rate input.
+ *
+ * Port of simple-staking's `getFeeRateFromMempool` (see
+ * `services/simple-staking/src/ui/common/utils/getFeeRateFromMempool.ts` and
+ * its `nextPowerOfTwo` helper) — reimplemented locally so the vault service
+ * doesn't import across services.
+ */
+
+import { MIN_RELAY_FEE_RATE_SATS_VB } from "@/constants";
+
+// simple-staking's `getFeeRateFromMempool` floors the fee-rate range's cap at
+// 128 sat/vB so a slow mempool (small fastestFee) still leaves headroom for a
+// user-entered custom rate above the current tiers.
+const LEAST_MAX_FEE_RATE = 128;
+
+function nextPowerOfTwo(x: number): number {
+  if (x <= 0) return 2;
+  if (x === 1) return 4;
+
+  return Math.pow(2, Math.ceil(Math.log2(x)) + 1);
+}
+
+export interface FeeRateBounds {
+  minFeeRate: number;
+  defaultFeeRate: number;
+  maxFeeRate: number;
+}
+
+/**
+ * Computes the min/default/max sat/vB range for the custom fee-rate input.
+ * The hard floor is the Bitcoin min relay fee (`MIN_RELAY_FEE_RATE_SATS_VB`);
+ * `hourFeeRate` is only a soft warn threshold, surfaced separately by callers.
+ */
+export function getFeeRateBounds(fees: {
+  defaultFeeRate: number;
+  hourFeeRate: number;
+}): FeeRateBounds {
+  return {
+    minFeeRate: MIN_RELAY_FEE_RATE_SATS_VB,
+    defaultFeeRate: fees.defaultFeeRate,
+    maxFeeRate: Math.max(
+      LEAST_MAX_FEE_RATE,
+      nextPowerOfTwo(fees.defaultFeeRate),
+    ),
+  };
+}


### PR DESCRIPTION
## Summary
- The deposit progress card now carries the designed inline **Network Fee Rate** selector in its pre-sign state — Slow / Avg / Fast cards fed by live mempool tiers, plus a Custom sat/vB input with an estimated-fee readout and a clear button. The rate the depositor picks is the rate the pre-pegin funding tx is built with.
- Slow/Avg/Fast track their mempool tier across the 60s refetch; a Custom value stays frozen until edited. Custom values are bounded by the minimum relay fee and simple-staking's `getFeeRateFromMempool`-style cap (`max(128, nextPowerOfTwo(fastestFee))`); an out-of-range value or a failing fee estimate disables Sign Transaction.
- `useEstimatedBtcFee` takes the chosen rate as an override feeding both the fee estimate and the max-deposit ceiling. The form's fee breakdown keeps read-only Network Fee Rate and BTC Network Fee rows.

Closes #2304

## Test plan
- [ ] Open deposit form; fee breakdown shows Network Fee Rate + BTC Network Fee (read-only)
- [ ] Continue to the signing card; the fee selector renders below the steps with live tier rates
- [ ] Pick Slow/Avg/Fast; header rate updates; leave it open past a mempool refetch (60s) — selection holds, tier values update
- [ ] Custom: type a rate; estimated BTC fee updates; out-of-range value disables Sign; ✕ returns to Fast
- [ ] Sign; confirm the built pre-pegin uses the selected rate
- [ ] `pnpm --filter @services/vault exec vitest run src/components/simple/ src/hooks/deposit/ src/utils/__tests__/feeRateBounds.test.ts`
