### PR TITLE
feat(packages): load the Bitcoin engine only when it is needed

### DIFF
--- a/.github/workflows/claude-md-drift.yml
+++ b/.github/workflows/claude-md-drift.yml
@@ -44,6 +44,11 @@ jobs:
             "packages/babylon-ledger-vault-signer/src/"
             "packages/babylon-ledger-vault-signer/scripts/"
             "packages/babylon-ts-sdk/src/tbv/core/clients/eth/onChainBtcPubkey.ts"
+            "packages/babylon-ts-sdk/src/tbv/core/wasm/"
+            "packages/babylon-tbv-rust-wasm/src/wasm-loader.ts"
+            "packages/babylon-tbv-rust-wasm/src/wasm-loader-node.ts"
+            "packages/babylon-tbv-rust-wasm/src/raw.ts"
+            "packages/babylon-tbv-rust-wasm/src/raw-node.ts"
           )
 
           # Registered in CLAUDE.md > "CRITICAL PATHS" section 9, CODEOWNERS and
@@ -56,11 +61,6 @@ jobs:
           pending=(
             "packages/babylon-ts-sdk/src/tbv/core/clients/eth/pegin-transaction.ts"
             "packages/babylon-ts-sdk/src/tbv/core/clients/eth/pegin-registration-client.ts"
-            "packages/babylon-ts-sdk/src/tbv/core/wasm/"
-            "packages/babylon-tbv-rust-wasm/src/wasm-loader.ts"
-            "packages/babylon-tbv-rust-wasm/src/wasm-loader-node.ts"
-            "packages/babylon-tbv-rust-wasm/src/raw.ts"
-            "packages/babylon-tbv-rust-wasm/src/raw-node.ts"
             "services/vault/src/utils/btc/scriptPubKeyAddress.ts"
           )
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,8 @@ These paths handle irreversible value movement. An AI-generated mistake here is 
 - Files (all marked `@stability frozen` in JSDoc):
   - `packages/babylon-ts-sdk/src/tbv/core/vault-secrets/context.ts` — `buildVaultContext`, `buildFundingOutpointsCommitment`
   - `packages/babylon-ts-sdk/src/tbv/core/vault-secrets/deriveVaultRoot.ts` — `deriveVaultRoot`, `VAULT_APP_NAME`
-  - `packages/babylon-ts-sdk/src/tbv/core/vault-secrets/index.ts` — re-exports `expandAuthAnchor`, `expandHashlockSecret`, `expandWotsSeed` from the WASM package
+  - `packages/babylon-ts-sdk/src/tbv/core/vault-secrets/index.ts` — re-exports `expandAuthAnchor`, `expandHashlockSecret`, `expandWotsSeed` from the SDK's lazy WASM boundary
+  - `packages/babylon-ts-sdk/src/tbv/core/wasm/index.ts` — the lazy boundary's async wrappers for the three expanders; every SDK caller now reaches the WASM package through this hop (also registered in section 9)
   - `packages/babylon-tbv-rust-wasm/src/index.ts` — browser-side async wrappers for the three expanders
   - `packages/babylon-tbv-rust-wasm/src/index-node.ts` — node-side async wrappers for the three expanders
   - `packages/babylon-tbv-rust-wasm/scripts/build-wasm.js` — `VAULT_WASM_COMMIT` pin (the vault-wasm facade at this commit, and the btc-vault revs it bundles, are the byte-level source of truth for the HKDF `info` encoding, labels, and i2osp prefixes)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,7 @@ These paths handle irreversible value movement. An AI-generated mistake here is 
 - File: `packages/babylon-tbv-rust-wasm/src/index.ts`
 - The Rust/WASM layer computes `htlcValue = peginAmount + depositorClaimValue + p2aAnchorValue + minPeginFee` internally (the anchor term is 0 for tx-graph v1, 240 sats for v2 and v3). JS receives outputs with no runtime validation.
 - **Rule:** Every WASM output consumed by JS must be asserted against expected bounds before use. If a WASM-returned value feeds a signed transaction, cross-check it against an independently computed expected value.
+- The package exports a second crossing at `@babylonlabs-io/babylon-tbv-rust-wasm/raw` (`src/raw.ts`, `src/raw-node.ts`, registered in section 9). It hands out the wasm-bindgen classes with no facade value guards, so the rule above binds at the call site, not at the export. The only SDK consumer is `packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/refund.ts`. It guards `pegInAmounts` with `assertPositiveBigintArray`, compares the reconstructed template's HTLC scriptPubKey and HTLC value with the funded transaction output at `htlcVout`, and re-parses the built refund transaction to assert exactly 1 input (Pre-PegIn txid, index `htlcVout`) and exactly 1 output (the depositor's BIP-86 scriptPubKey, value `htlcValue - refundFee`) before it emits the PSBT. Every new `/raw` consumer must do equivalent cross-checks.
 
 ### 2. Fee calculation consistency
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -85,7 +85,8 @@ rubric below.
   Ethereum, Bitcoin, an indexer, and a vault provider; it writes only through the user's wallet.
 - **Security boundaries to preserve:**
   - Assertion of every WASM-returned value before it reaches a signed transaction
-    (`packages/babylon-tbv-rust-wasm/src/value-guards.ts`, `.../src/index.ts`)
+    (`packages/babylon-tbv-rust-wasm/src/value-guards.ts`, `.../src/index.ts`,
+    `packages/babylon-ts-sdk/src/tbv/core/wasm/value-guards.ts`)
   - Agreement between the SDK fee model and the dApp estimate
     (`packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts`,
     `.../utils/utxo/selectUtxos.ts`, `services/vault/src/hooks/deposit/useEstimatedBtcFee.ts`)
@@ -197,21 +198,34 @@ _why_ they exist. Both documents must be updated together.
 
 ### The WASM value boundary
 
-`packages/babylon-tbv-rust-wasm/src/index.ts` is the JS surface over a Rust/WASM module that computes
-`htlcValue = peginAmount + depositorClaimValue + p2aAnchorValue + minPeginFee` internally. JavaScript
-receives numbers with no inherent validation: `wasm-bindgen` will happily hand back `0n`, and a
-`0n` HTLC value silently produces a transaction that funds nothing.
+`packages/babylon-tbv-rust-wasm/src/index.ts` is the guarded JS surface over a Rust/WASM module that
+computes `htlcValue = peginAmount + depositorClaimValue + p2aAnchorValue + minPeginFee` internally.
+JavaScript receives numbers with no inherent validation: `wasm-bindgen` will happily hand back `0n`,
+and a `0n` HTLC value silently produces a transaction that funds nothing. SDK callers reach that
+surface through a lazy boundary, `packages/babylon-ts-sdk/src/tbv/core/wasm/index.ts`, which forwards
+without adding guards of its own — the facade's guards still apply.
+
+There is a second crossing, and it is unguarded. The
+`@babylonlabs-io/babylon-tbv-rust-wasm/raw` subpath (`src/raw.ts`, `src/raw-node.ts`) hands out the
+wasm-bindgen classes directly, so no value is checked at the export. Every `/raw` consumer must
+cross-check at the call site instead. The only SDK consumer is
+`packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/refund.ts`.
 
 The mitigation is `assertWasmBigint` / `assertPositiveBigintArray`
 (`packages/babylon-tbv-rust-wasm/src/value-guards.ts`), applied to every value crossing the boundary
-before it is used. Reviewer rule, restated from CLAUDE.md:
+before it is used. The input guard is duplicated at
+`packages/babylon-ts-sdk/src/tbv/core/wasm/value-guards.ts` for callers that must not statically
+import the WASM engine. The two copies are pinned to identical behaviour by
+`packages/babylon-ts-sdk/src/tbv/core/wasm/__tests__/value-guards.test.ts` and must be changed
+together. Reviewer rule, restated from CLAUDE.md:
 
 > **Every WASM output consumed by JS must be asserted against expected bounds before use.** If a
 > WASM-returned value feeds a signed transaction, cross-check it against an independently computed
 > expected value.
 
-Adding a new WASM getter without a guard is the easiest way to introduce a silent-wrong-value bug in
-this repository. The guard is not defence in depth here — it is the only check.
+Adding a new WASM getter without a guard, or a new `/raw` consumer without call-site cross-checks, is
+the easiest way to introduce a silent-wrong-value bug in this repository. On the facade crossing the
+guard is not defence in depth — it is the only check.
 
 ### Fee model consistency
 
@@ -749,7 +763,7 @@ only repository-local safeguards.
 
 | Area                | Adversary | Scenario                                                                          | Impact                                                                  | Mitigation                                                                                                      | Test / evidence                                                   |
 | ------------------- | --------- | --------------------------------------------------------------------------------- | ----------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
-| WASM boundary       | F/—       | A WASM getter returns `0n` or a wrong value and reaches a signed tx               | **User fund loss**                                                      | `assertWasmBigint` / `assertPositiveBigintArray` on every crossing; independent cross-check                     | `babylon-tbv-rust-wasm` value-guard tests                         |
+| WASM boundary       | F/—       | A WASM getter returns `0n` or a wrong value and reaches a signed tx               | **User fund loss**                                                      | `assertWasmBigint` / `assertPositiveBigintArray` at the facade; call-site cross-checks on `/raw`                | `babylon-tbv-rust-wasm` value-guard tests                         |
 | Fee model           | —         | SDK and dApp fee models diverge; the tx is underfunded                            | User fund loss (stuck / failed deposit)                                 | Shared `peginFeeMath`; cross-check at broadcast                                                                 | SDK fee + `selectUtxos` tests                                     |
 | Critical-path guard | G         | A critical path moves but one hand-maintained inventory keeps the stale path      | Integrity (process)                                                     | Sections 1-8 are aligned; section 9 is pre-registered ahead of #2228; the existence check does not gate merges  | SECURITY.md, CLAUDE.md, CODEOWNERS, both critical-path workflows  |
 | Presigning          | A         | VP supplies PSBT metadata making a signature valid for a different spend          | **User fund loss**                                                      | PSBTs built locally from on-chain connector data only                                                           | `signDepositorGraph` tests                                        |

--- a/knip.json
+++ b/knip.json
@@ -9,6 +9,7 @@
         "src/tbv/core/primitives/index.ts",
         "src/tbv/core/utils/index.ts",
         "src/tbv/core/clients/index.ts",
+        "src/tbv/core/clients/vault-provider/status/index.ts",
         "src/tbv/core/services/index.ts",
         "src/tbv/core/managers/index.ts",
         "src/tbv/core/contracts/index.ts",

--- a/packages/babylon-tbv-rust-wasm/README.md
+++ b/packages/babylon-tbv-rust-wasm/README.md
@@ -2,6 +2,17 @@
 
 WASM bindings for Babylon Trustless Bitcoin Vaults (TBV), providing TypeScript/JavaScript interfaces for creating Bitcoin peg-in transactions.
 
+The normal package entry is a lazy facade: importing it does not load the
+wasm-bindgen glue or instantiate/download the `.wasm` binary. The generated
+module is fetched on the first facade call that needs it. Type-only consumers
+can use `@babylonlabs-io/babylon-tbv-rust-wasm/types` without touching the
+runtime at all.
+
+Low-level consumers that construct wasm-bindgen classes directly must opt in
+to the eager `@babylonlabs-io/babylon-tbv-rust-wasm/raw` subpath and call its
+`initWasm` export before constructing a class. Raw classes are intentionally
+not exported from the lazy root entry.
+
 ## Overview
 
 This package provides WebAssembly bindings built from the [vault-wasm](https://github.com/babylonlabs-io/vault-wasm) facade — a single binary bundling every supported [btc-vault](https://github.com/babylonlabs-io/btc-vault) tx-graph version behind version-taking constructors, enabling browser and Node.js applications to construct Bitcoin transactions for TBV.
@@ -460,9 +471,26 @@ The same as `TAP_INTERNAL_KEY` but as a Buffer for convenience.
 
 ### Raw WASM Types
 
-The package also exports raw WASM classes for advanced usage:
+Raw WASM classes moved from the package root to the explicit eager subpath.
+This is the one intentional breaking API change required to keep a normal
+facade import lazy:
 
+```ts
+import {
+  initWasm,
+  WasmPrePeginTx,
+} from "@babylonlabs-io/babylon-tbv-rust-wasm/raw";
+
+await initWasm();
+const transaction = new WasmPrePeginTx(/* ... */);
+```
+
+The raw entry exports:
+
+- `initWasm` - Loads and initializes the binary; shares one initializer with the facade
 - `WasmPeginTx` - Low-level peg-in transaction class
+- `WasmPrePeginTx` - Low-level Pre-PegIn transaction class
 - `WasmPeginPayoutConnector` - Low-level payout connector class
+- `WasmPrePeginHtlcConnector` - Low-level Pre-PegIn HTLC connector class
 - `WasmAssertPayoutNoPayoutConnector` - Low-level Assert Payout/NoPayout connector class
 - `WasmAssertChallengeAssertConnector` - Low-level ChallengeAssert connector class

--- a/packages/babylon-tbv-rust-wasm/README.md
+++ b/packages/babylon-tbv-rust-wasm/README.md
@@ -4,9 +4,7 @@ WASM bindings for Babylon Trustless Bitcoin Vaults (TBV), providing TypeScript/J
 
 The normal package entry is a lazy facade: importing it does not load the
 wasm-bindgen glue or instantiate/download the `.wasm` binary. The generated
-module is fetched on the first facade call that needs it. Type-only consumers
-can use `@babylonlabs-io/babylon-tbv-rust-wasm/types` without touching the
-runtime at all.
+module is fetched on the first facade call that needs it.
 
 Low-level consumers that construct wasm-bindgen classes directly must opt in
 to the eager `@babylonlabs-io/babylon-tbv-rust-wasm/raw` subpath and call its
@@ -492,5 +490,3 @@ The raw entry exports:
 - `WasmPrePeginTx` - Low-level Pre-PegIn transaction class
 - `WasmPeginPayoutConnector` - Low-level payout connector class
 - `WasmPrePeginHtlcConnector` - Low-level Pre-PegIn HTLC connector class
-- `WasmAssertPayoutNoPayoutConnector` - Low-level Assert Payout/NoPayout connector class
-- `WasmAssertChallengeAssertConnector` - Low-level ChallengeAssert connector class

--- a/packages/babylon-tbv-rust-wasm/eslint.config.mjs
+++ b/packages/babylon-tbv-rust-wasm/eslint.config.mjs
@@ -15,9 +15,17 @@ export default defineConfig([
   },
   // CRITICAL PATHS - see CLAUDE.md > "CRITICAL PATHS — HUMAN REVIEW REQUIRED".
   // The WASM boundary is the highest-risk critical path - silent type coercion
-  // here can produce wrong BTC amounts.
+  // here can produce wrong BTC amounts. The loader and raw entries are the
+  // crossing itself, so they carry the same rules as the facade.
   {
-    files: ["src/index.ts"],
+    files: [
+      "src/index.ts",
+      "src/index-node.ts",
+      "src/wasm-loader.ts",
+      "src/wasm-loader-node.ts",
+      "src/raw.ts",
+      "src/raw-node.ts",
+    ],
     rules: {
       "@typescript-eslint/no-explicit-any": "error",
       "@typescript-eslint/no-non-null-assertion": "error",

--- a/packages/babylon-tbv-rust-wasm/package.json
+++ b/packages/babylon-tbv-rust-wasm/package.json
@@ -24,10 +24,6 @@
         "types": "./dist/raw.d.ts",
         "default": "./dist/raw.js"
       }
-    },
-    "./types": {
-      "types": "./dist/types.d.ts",
-      "default": "./dist/types.js"
     }
   },
   "scripts": {

--- a/packages/babylon-tbv-rust-wasm/package.json
+++ b/packages/babylon-tbv-rust-wasm/package.json
@@ -14,10 +14,24 @@
         "types": "./dist/index.d.ts",
         "default": "./dist/index.js"
       }
+    },
+    "./raw": {
+      "node": {
+        "types": "./dist/raw-node.d.ts",
+        "default": "./dist/raw-node.js"
+      },
+      "default": {
+        "types": "./dist/raw.d.ts",
+        "default": "./dist/raw.js"
+      }
+    },
+    "./types": {
+      "types": "./dist/types.d.ts",
+      "default": "./dist/types.js"
     }
   },
   "scripts": {
-    "build": "tsc -b tsconfig.lib.json",
+    "build": "tsc -b tsconfig.lib.json && node scripts/check-lazy-entries.js",
     "build-wasm": "node scripts/build-wasm.js",
     "lint": "eslint ."
   },

--- a/packages/babylon-tbv-rust-wasm/scripts/check-lazy-entries.js
+++ b/packages/babylon-tbv-rust-wasm/scripts/check-lazy-entries.js
@@ -59,9 +59,15 @@ function resolveLocal(from, specifier) {
   throw new Error(`Could not resolve ${specifier} from ${from}`);
 }
 
-function staticClosure(entry) {
+// The glue is matched on the specifier, not on a resolved path: it ships only
+// as dist/generated/vault_wasm.js, so an eager edge to it never resolves to a
+// file this walk can visit.
+const generatedSpecifier = /(?:^|\/)generated\//;
+
+function eagerGeneratedEdges(entry) {
   const pending = [entry];
   const visited = new Set();
+  const edges = [];
   while (pending.length > 0) {
     const file = pending.pop();
     if (visited.has(file)) continue;
@@ -69,21 +75,26 @@ function staticClosure(entry) {
     const source = stripComments(readFileSync(file, 'utf8'));
     for (const match of source.matchAll(staticSpecifier)) {
       const specifier = match[1];
-      if (specifier.startsWith('.'))
-        pending.push(resolveLocal(file, specifier));
+      if (!specifier.startsWith('.')) continue;
+      if (generatedSpecifier.test(specifier)) {
+        edges.push(`${file} -> ${specifier}`);
+        continue;
+      }
+      pending.push(resolveLocal(file, specifier));
     }
   }
-  return visited;
+  return edges;
 }
 
 for (const entryName of ['index.ts', 'index-node.ts']) {
   const entry = resolve(packageRoot, 'src', entryName);
-  const generated = Array.from(staticClosure(entry)).filter((file) =>
-    file.includes('/generated/'),
-  );
-  if (generated.length > 0) {
+  const edges = eagerGeneratedEdges(entry);
+  if (edges.length > 0) {
     throw new Error(
-      `${entryName} statically reaches generated WASM glue:\n${generated.join('\n')}`,
+      `${entryName} statically reaches generated WASM glue, so importing the ` +
+        `facade loads the engine eagerly. Reach the glue only through ` +
+        `import('./generated/vault_wasm.js') inside a loader, or through the ` +
+        `explicit raw entry:\n${edges.join('\n')}`,
     );
   }
 }
@@ -93,6 +104,35 @@ for (const loaderName of ['wasm-loader.ts', 'wasm-loader-node.ts']) {
   if (!source.includes("import('./generated/vault_wasm.js')")) {
     throw new Error(
       `${loaderName} must dynamically import generated WASM glue`,
+    );
+  }
+}
+
+// Each loader's type-only import is copied into its emitted declaration
+// verbatim, so it has to resolve from dist too. Nothing reports it when it
+// stops resolving: tsc is silent here, and every consumer inherits
+// skipLibCheck, which drops the error inside the emitted declaration.
+for (const loaderName of ['wasm-loader.d.ts', 'wasm-loader-node.d.ts']) {
+  const emitted = resolve(packageRoot, 'dist', loaderName);
+  const match = readFileSync(emitted, 'utf8').match(
+    /from ['"]([^'"]*generated\/vault_wasm\.js)['"]/,
+  );
+  if (!match) {
+    throw new Error(
+      `${loaderName} no longer pins its bindings to the generated declarations`,
+    );
+  }
+  const [, specifier] = match;
+  try {
+    readFileSync(
+      resolve(dirname(emitted), specifier.replace(/\.js$/, '.d.ts')),
+    );
+  } catch {
+    throw new Error(
+      `${loaderName} emits '${specifier}', which resolves to no declaration ` +
+        `from dist. The emitted specifier reaches the generated surface only ` +
+        `while the emit directory and src stay siblings one level under the ` +
+        `package root.`,
     );
   }
 }
@@ -177,6 +217,14 @@ const connectorParams = {
   councilMembers: xOnlyKeys.slice(3),
   councilQuorum: 2,
 };
+const payoutConnectorParams = {
+  txGraphVersion: 1,
+  depositor: xOnlyKeys[0],
+  vaultProvider: xOnlyKeys[1],
+  vaultKeepers: [xOnlyKeys[2]],
+  universalChallengers: [xOnlyKeys[3]],
+  timelockPegin: 144,
+};
 
 // Browser raw and facade entry points must share one in-flight initializer.
 // A second wasm-bindgen initialization replaces the module-global memory and
@@ -225,14 +273,13 @@ try {
   const rawInit = rawBrowser.initWasm();
   const facadeInit = facadeBrowser.initWasm();
   await rawInit;
-  browserRaceConnector = new rawBrowser.WasmAssertPayoutNoPayoutConnector(
-    connectorParams.txGraphVersion,
-    connectorParams.claimer,
-    connectorParams.localChallengers,
-    connectorParams.universalChallengers,
-    connectorParams.timelockAssert,
-    connectorParams.councilMembers,
-    connectorParams.councilQuorum,
+  browserRaceConnector = new rawBrowser.WasmPeginPayoutConnector(
+    payoutConnectorParams.txGraphVersion,
+    payoutConnectorParams.depositor,
+    payoutConnectorParams.vaultProvider,
+    payoutConnectorParams.vaultKeepers,
+    payoutConnectorParams.universalChallengers,
+    payoutConnectorParams.timelockPegin,
   );
   const payoutScriptBefore = browserRaceConnector.getPayoutScript();
   await facadeInit;

--- a/packages/babylon-tbv-rust-wasm/scripts/check-lazy-entries.js
+++ b/packages/babylon-tbv-rust-wasm/scripts/check-lazy-entries.js
@@ -1,0 +1,303 @@
+import { cpSync, readFileSync, rmSync, mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, extname, join, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+// The third alternative matches a bare side-effect import (`import './x.js'`),
+// which has no `from` clause. Without it the closure walks past an eager edge.
+const staticSpecifier =
+  /(?:import\s+(?!type\b)[\s\S]*?\sfrom\s*|export\s+(?!type\b)[\s\S]*?\sfrom\s*|import\s*)['"]([^'"]+)['"]/g;
+
+// Comments are removed before the specifier scan. Prose in a JSDoc block can
+// contain the bare word `import` or `export`, and the lazy `[\s\S]*?` between
+// the keyword and its `from` clause would otherwise swallow the next real
+// specifier. A commented-out import must not count as an eager edge either.
+function stripComments(source) {
+  let out = '';
+  let index = 0;
+  while (index < source.length) {
+    const char = source[index];
+    if (char === '/' && source[index + 1] === '/') {
+      const end = source.indexOf('\n', index);
+      index = end === -1 ? source.length : end;
+      continue;
+    }
+    if (char === '/' && source[index + 1] === '*') {
+      const end = source.indexOf('*/', index + 2);
+      index = end === -1 ? source.length : end + 2;
+      continue;
+    }
+    if (char === "'" || char === '"' || char === '`') {
+      let cursor = index + 1;
+      while (cursor < source.length && source[cursor] !== char) {
+        cursor += source[cursor] === '\\' ? 2 : 1;
+      }
+      out += source.slice(index, cursor + 1);
+      index = cursor + 1;
+      continue;
+    }
+    out += char;
+    index += 1;
+  }
+  return out;
+}
+
+function resolveLocal(from, specifier) {
+  const target = resolve(dirname(from), specifier);
+  const candidates = extname(target)
+    ? [target.replace(/\.js$/, '.ts'), `${target}.ts`]
+    : [`${target}.ts`, resolve(target, 'index.ts')];
+  for (const candidate of candidates) {
+    try {
+      readFileSync(candidate);
+      return candidate;
+    } catch {
+      // Continue through TypeScript resolution candidates.
+    }
+  }
+  throw new Error(`Could not resolve ${specifier} from ${from}`);
+}
+
+function staticClosure(entry) {
+  const pending = [entry];
+  const visited = new Set();
+  while (pending.length > 0) {
+    const file = pending.pop();
+    if (visited.has(file)) continue;
+    visited.add(file);
+    const source = stripComments(readFileSync(file, 'utf8'));
+    for (const match of source.matchAll(staticSpecifier)) {
+      const specifier = match[1];
+      if (specifier.startsWith('.'))
+        pending.push(resolveLocal(file, specifier));
+    }
+  }
+  return visited;
+}
+
+for (const entryName of ['index.ts', 'index-node.ts']) {
+  const entry = resolve(packageRoot, 'src', entryName);
+  const generated = Array.from(staticClosure(entry)).filter((file) =>
+    file.includes('/generated/'),
+  );
+  if (generated.length > 0) {
+    throw new Error(
+      `${entryName} statically reaches generated WASM glue:\n${generated.join('\n')}`,
+    );
+  }
+}
+
+for (const loaderName of ['wasm-loader.ts', 'wasm-loader-node.ts']) {
+  const source = readFileSync(resolve(packageRoot, 'src', loaderName), 'utf8');
+  if (!source.includes("import('./generated/vault_wasm.js')")) {
+    throw new Error(
+      `${loaderName} must dynamically import generated WASM glue`,
+    );
+  }
+}
+
+for (const [rawName, loaderName] of [
+  ['raw.ts', 'wasm-loader.js'],
+  ['raw-node.ts', 'wasm-loader-node.js'],
+]) {
+  const source = readFileSync(resolve(packageRoot, 'src', rawName), 'utf8');
+  if (!/from ['"]\.\/generated\/vault_wasm\.js['"]/.test(source)) {
+    throw new Error(`${rawName} must remain the explicit eager raw entry`);
+  }
+  if (!source.includes(`export { initWasm } from './${loaderName}'`)) {
+    throw new Error(
+      `${rawName} must re-export initWasm from ./${loaderName}, so the raw ` +
+        `and facade entries share one initializer and cannot initialize the ` +
+        `generated module twice`,
+    );
+  }
+}
+
+// Runtime proof against the compiled artifacts: remove generated glue from an
+// isolated package copy. Lazy browser/Node roots must still import, then fail
+// only when the first facade call attempts the dynamic import. The explicit
+// raw entries must fail during import because their generated import is eager.
+const isolatedPackage = mkdtempSync(join(tmpdir(), 'tbv-wasm-lazy-'));
+try {
+  cpSync(
+    resolve(packageRoot, 'package.json'),
+    join(isolatedPackage, 'package.json'),
+  );
+  cpSync(resolve(packageRoot, 'dist'), join(isolatedPackage, 'dist'), {
+    recursive: true,
+  });
+  rmSync(join(isolatedPackage, 'dist', 'generated'), {
+    recursive: true,
+    force: true,
+  });
+
+  for (const entryName of ['index.js', 'index-node.js']) {
+    const url = pathToFileURL(join(isolatedPackage, 'dist', entryName)).href;
+    const facade = await import(`${url}?lazy-root=${entryName}`);
+    try {
+      await facade.initWasm();
+      throw new Error(`${entryName} first call unexpectedly found WASM glue`);
+    } catch (error) {
+      if (!String(error).includes('generated/vault_wasm.js')) {
+        throw error;
+      }
+    }
+  }
+
+  for (const entryName of ['raw.js', 'raw-node.js']) {
+    const url = pathToFileURL(join(isolatedPackage, 'dist', entryName)).href;
+    try {
+      await import(`${url}?eager-raw=${entryName}`);
+      throw new Error(`${entryName} unexpectedly imported without WASM glue`);
+    } catch (error) {
+      if (!String(error).includes('generated/vault_wasm.js')) {
+        throw error;
+      }
+    }
+  }
+} finally {
+  rmSync(isolatedPackage, { recursive: true, force: true });
+}
+
+const xOnlyKeys = [
+  '79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798',
+  'c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5',
+  'f9308a019258c31049344f85f89d5229b531c845836f99b08601f113bce036f9',
+  'e493dbf1c10d80f3581e4904930b1404cc6c13900ee0758474fa94abe8c4cd13',
+  '2f8bde4d1a07209355b4a7250a5c5128e88b84bddc619ab7cba8d569b240efe4',
+  'fff97bd5755eeea420453a14355235d382f6472f8568a18b2f057a1460297556',
+].sort();
+const connectorParams = {
+  txGraphVersion: 1,
+  claimer: xOnlyKeys[0],
+  localChallengers: [xOnlyKeys[1]],
+  universalChallengers: [xOnlyKeys[2]],
+  timelockAssert: 144,
+  councilMembers: xOnlyKeys.slice(3),
+  councilQuorum: 2,
+};
+
+// Browser raw and facade entry points must share one in-flight initializer.
+// A second wasm-bindgen initialization replaces the module-global memory and
+// invalidates raw objects created after the first initialization completes.
+const browserRacePackage = mkdtempSync(join(tmpdir(), 'tbv-wasm-race-'));
+const originalFetch = globalThis.fetch;
+let browserRaceConnector;
+let browserRaceCompleted = false;
+try {
+  cpSync(
+    resolve(packageRoot, 'package.json'),
+    join(browserRacePackage, 'package.json'),
+  );
+  cpSync(resolve(packageRoot, 'dist'), join(browserRacePackage, 'dist'), {
+    recursive: true,
+  });
+  const wasmBytes = readFileSync(
+    join(
+      browserRacePackage,
+      'dist',
+      'generated',
+      'vault_wasm_bg.wasm',
+    ),
+  );
+  let fetchCalls = 0;
+  globalThis.fetch = async () => {
+    fetchCalls += 1;
+    const delayMs = fetchCalls === 1 ? 20 : 200;
+    await new Promise((resolveDelay) => setTimeout(resolveDelay, delayMs));
+    return new Response(wasmBytes, {
+      headers: { 'Content-Type': 'application/wasm' },
+    });
+  };
+
+  const rawBrowserUrl = pathToFileURL(
+    join(browserRacePackage, 'dist', 'raw.js'),
+  ).href;
+  const facadeBrowserUrl = pathToFileURL(
+    join(browserRacePackage, 'dist', 'index.js'),
+  ).href;
+  const rawBrowser = await import(`${rawBrowserUrl}?shared-browser-init=raw`);
+  const facadeBrowser = await import(
+    `${facadeBrowserUrl}?shared-browser-init=facade`
+  );
+
+  const rawInit = rawBrowser.initWasm();
+  const facadeInit = facadeBrowser.initWasm();
+  await rawInit;
+  browserRaceConnector = new rawBrowser.WasmAssertPayoutNoPayoutConnector(
+    connectorParams.txGraphVersion,
+    connectorParams.claimer,
+    connectorParams.localChallengers,
+    connectorParams.universalChallengers,
+    connectorParams.timelockAssert,
+    connectorParams.councilMembers,
+    connectorParams.councilQuorum,
+  );
+  const payoutScriptBefore = browserRaceConnector.getPayoutScript();
+  await facadeInit;
+  const payoutScriptAfter = browserRaceConnector.getPayoutScript();
+
+  if (fetchCalls !== 1) {
+    throw new Error(
+      `Browser raw and facade entries initialized WASM ${fetchCalls} times`,
+    );
+  }
+  if (payoutScriptAfter !== payoutScriptBefore) {
+    throw new Error('Concurrent browser initialization invalidated a raw object');
+  }
+  browserRaceCompleted = true;
+} finally {
+  try {
+    if (browserRaceCompleted) browserRaceConnector?.free();
+  } finally {
+    globalThis.fetch = originalFetch;
+    rmSync(browserRacePackage, { recursive: true, force: true });
+  }
+}
+
+// Concurrent browser-facade calls with different parameters must each return
+// their own complete result. That is what per-call connector ownership buys:
+// neither call can free or overwrite the object the other is reading. The
+// generated module is initialized through the Node raw entry first so this
+// file://-based check does not rely on fetch(file://...).
+const rawNodeUrl = pathToFileURL(
+  resolve(packageRoot, 'dist', 'raw-node.js'),
+).href;
+const rawNode = await import(`${rawNodeUrl}?concurrent-connector-init`);
+await rawNode.initWasm();
+
+const browserFacadeUrl = pathToFileURL(
+  resolve(packageRoot, 'dist', 'index.js'),
+).href;
+const browserFacade = await import(
+  `${browserFacadeUrl}?concurrent-connector-facade`
+);
+const concurrentConnectorResults = await Promise.all([
+  browserFacade.getAssertPayoutScriptInfo(connectorParams),
+  browserFacade.getAssertPayoutScriptInfo({
+    ...connectorParams,
+    timelockAssert: 145,
+  }),
+]);
+for (const result of concurrentConnectorResults) {
+  if (!result.payoutScript || !result.payoutControlBlock) {
+    throw new Error('Concurrent connector facade returned empty script data');
+  }
+}
+// The two calls differ only in `timelockAssert`, so their script data must
+// differ too. Truthiness alone would pass a cache that hands both callers the
+// same connector — the wrong taproot leaf, fully populated.
+const [firstConnectorResult, secondConnectorResult] =
+  concurrentConnectorResults;
+if (
+  firstConnectorResult.payoutScript === secondConnectorResult.payoutScript ||
+  firstConnectorResult.payoutControlBlock ===
+    secondConnectorResult.payoutControlBlock
+) {
+  throw new Error(
+    'Concurrent connector facade returned aliased script data for different timelockAssert values',
+  );
+}
+
+console.log('Lazy WASM facade boundary verified (browser, node, and raw).');

--- a/packages/babylon-tbv-rust-wasm/src/assertPayoutNoPayoutConnector.ts
+++ b/packages/babylon-tbv-rust-wasm/src/assertPayoutNoPayoutConnector.ts
@@ -1,6 +1,4 @@
-// @ts-expect-error - WASM files are in dist/generated/ (checked into git), not src/generated/
-import { WasmAssertPayoutNoPayoutConnector } from "./generated/vault_wasm.js";
-import { initWasm } from "./index.js";
+import { getWasmBindings } from "./wasm-loader.js";
 import type {
   AssertPayoutNoPayoutConnectorParams,
   AssertPayoutScriptInfo,
@@ -9,33 +7,27 @@ import type {
 
 /** @see btc-vault crates/vault/src/assert/payout_nopayout_connector.rs — Rust WASM bindings */
 
-let connector: InstanceType<typeof WasmAssertPayoutNoPayoutConnector> | null = null;
-let connectorKey: string | null = null;
+interface AssertPayoutNoPayoutConnector {
+  free(): void;
+  getPayoutScript(): string;
+  getPayoutControlBlock(): string;
+  getNoPayoutScript(challengerPubkey: string): string;
+  getNoPayoutControlBlock(challengerPubkey: string): string;
+}
 
 /**
- * Get or create a cached Assert Payout/NoPayout connector instance.
- *
- * The connector is reused when the same parameters are provided.
+ * Create an Assert Payout/NoPayout connector owned by one facade call.
+ * The caller allocates the WASM object, reads it, and frees it before
+ * returning, so no allocation outlives the call that made it and no call can
+ * observe or free another call's object. This is how every connector in this
+ * package is constructed — see `payoutConnector.ts`,
+ * `challengeAssertConnector.ts`, and the Node entry in `index-node.ts`.
  */
-function getConnector(
+async function createConnector(
   params: AssertPayoutNoPayoutConnectorParams,
-): InstanceType<typeof WasmAssertPayoutNoPayoutConnector> {
-  const key = JSON.stringify(params);
-  if (connector && connectorKey === key) {
-    return connector;
-  }
-
-  // Invalidate the cache BEFORE freeing: if the replacement constructor
-  // throws (fail-closed version, malformed params), a freed instance must
-  // not remain cached under a still-matching key — later valid calls would
-  // hit it and fail with an opaque wasm null-pointer error.
-  const superseded = connector;
-  connector = null;
-  connectorKey = null;
-  superseded?.free();
-  // `params.txGraphVersion` is part of the JSON cache key above, so a cached
-  // connector can never serve a different version's scripts.
-  connector = new WasmAssertPayoutNoPayoutConnector(
+): Promise<AssertPayoutNoPayoutConnector> {
+  const { WasmAssertPayoutNoPayoutConnector } = await getWasmBindings();
+  return new WasmAssertPayoutNoPayoutConnector(
     params.txGraphVersion,
     params.claimer,
     params.localChallengers,
@@ -44,8 +36,6 @@ function getConnector(
     params.councilMembers,
     params.councilQuorum,
   );
-  connectorKey = key;
-  return connector;
 }
 
 /**
@@ -59,13 +49,15 @@ function getConnector(
 export async function getAssertPayoutScriptInfo(
   params: AssertPayoutNoPayoutConnectorParams,
 ): Promise<AssertPayoutScriptInfo> {
-  await initWasm();
-
-  const conn = getConnector(params);
-  return {
-    payoutScript: conn.getPayoutScript(),
-    payoutControlBlock: conn.getPayoutControlBlock(),
-  };
+  const conn = await createConnector(params);
+  try {
+    return {
+      payoutScript: conn.getPayoutScript(),
+      payoutControlBlock: conn.getPayoutControlBlock(),
+    };
+  } finally {
+    conn.free();
+  }
 }
 
 /**
@@ -82,11 +74,13 @@ export async function getAssertNoPayoutScriptInfo(
   params: AssertPayoutNoPayoutConnectorParams,
   challengerPubkey: string,
 ): Promise<AssertNoPayoutScriptInfo> {
-  await initWasm();
-
-  const conn = getConnector(params);
-  return {
-    noPayoutScript: conn.getNoPayoutScript(challengerPubkey),
-    noPayoutControlBlock: conn.getNoPayoutControlBlock(challengerPubkey),
-  };
+  const conn = await createConnector(params);
+  try {
+    return {
+      noPayoutScript: conn.getNoPayoutScript(challengerPubkey),
+      noPayoutControlBlock: conn.getNoPayoutControlBlock(challengerPubkey),
+    };
+  } finally {
+    conn.free();
+  }
 }

--- a/packages/babylon-tbv-rust-wasm/src/challengeAssertConnector.ts
+++ b/packages/babylon-tbv-rust-wasm/src/challengeAssertConnector.ts
@@ -1,6 +1,4 @@
-// @ts-expect-error - WASM files are in dist/generated/ (checked into git), not src/generated/
-import { WasmAssertChallengeAssertConnector } from "./generated/vault_wasm.js";
-import { initWasm } from "./index.js";
+import { getWasmBindings } from "./wasm-loader.js";
 import type {
   ChallengeAssertConnectorParams,
   ChallengeAssertScriptInfo,
@@ -21,7 +19,7 @@ import type {
 export async function getChallengeAssertScriptInfo(
   params: ChallengeAssertConnectorParams,
 ): Promise<ChallengeAssertScriptInfo> {
-  await initWasm();
+  const { WasmAssertChallengeAssertConnector } = await getWasmBindings();
 
   const conn = new WasmAssertChallengeAssertConnector(
     params.txGraphVersion,

--- a/packages/babylon-tbv-rust-wasm/src/index-node.ts
+++ b/packages/babylon-tbv-rust-wasm/src/index-node.ts
@@ -5,13 +5,10 @@
 // loading, which does not work in Node.js environments, and does not require
 // a separate wasm-pack --target nodejs build step.
 
-import { readFileSync } from 'node:fs';
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
-
-// prettier-ignore
-// @ts-expect-error - WASM files are in dist/generated/ (checked into git), not src/generated/
-import { initSync, WasmPrePeginTx, WasmPeginTx, WasmPrePeginHtlcConnector, WasmPeginPayoutConnector, WasmAssertPayoutNoPayoutConnector, WasmAssertChallengeAssertConnector, computeMinClaimValue as wasmComputeMinClaimValue, computeMinPeginFee as wasmComputeMinPeginFee, computePayoutFeeFloor as wasmComputePayoutFeeFloor, deriveVaultId as wasmDeriveVaultId, expandAuthAnchor as wasmExpandAuthAnchor, expandHashlockSecret as wasmExpandHashlockSecret, expandWotsSeed as wasmExpandWotsSeed, peginP2aAnchorOutput as wasmPeginP2aAnchorOutput, supportedTxGraphVersions as wasmSupportedTxGraphVersions, validatePeginP2aAnchor as wasmValidatePeginP2aAnchor } from './generated/vault_wasm.js';
+import {
+  getWasmBindings,
+  initWasm as initializeWasm,
+} from './wasm-loader-node.js';
 
 import type {
   PrePeginParams,
@@ -35,23 +32,14 @@ import { assertPositiveBigintArray, assertWasmBigint } from './value-guards.js';
  * HTLC output index for single deposits.
  */
 
-let wasmInitialized = false;
-
 export async function initWasm(): Promise<void> {
-  if (wasmInitialized) return;
-  const wasmPath = join(
-    dirname(fileURLToPath(import.meta.url)),
-    'generated',
-    'vault_wasm_bg.wasm',
-  );
-  initSync({ module: readFileSync(wasmPath) });
-  wasmInitialized = true;
+  await initializeWasm();
 }
 
 export async function createPrePeginTransaction(
   params: PrePeginParams,
 ): Promise<PrePeginResult> {
-  await initWasm();
+  const { WasmPrePeginTx } = await getWasmBindings();
 
   // Leading arg selects the tx-graph version inside the vault-wasm facade;
   // an unsupported version throws before any construction (fail closed).
@@ -114,7 +102,7 @@ export async function buildPeginTxFromPrePegin(
   fundedPrePeginTxHex: string,
   htlcVout: number,
 ): Promise<PeginTxResult> {
-  await initWasm();
+  const { WasmPrePeginTx } = await getWasmBindings();
 
   const unfundedTx = new WasmPrePeginTx(
     params.txGraphVersion,
@@ -136,8 +124,8 @@ export async function buildPeginTxFromPrePegin(
     params.authAnchorHash,
   );
 
-  let fundedTx: WasmPrePeginTx | null = null;
-  let peginTx: WasmPeginTx | null = null;
+  let fundedTx: typeof unfundedTx | null = null;
+  let peginTx: ReturnType<typeof unfundedTx.buildPeginTx> | null = null;
   try {
     fundedTx = unfundedTx.fromFundedTransaction(fundedPrePeginTxHex);
     peginTx = fundedTx.buildPeginTx(timelockPegin, htlcVout);
@@ -158,7 +146,7 @@ export async function buildPeginTxFromPrePegin(
 export async function getPrePeginHtlcConnectorInfo(
   params: HtlcConnectorParams,
 ): Promise<HtlcConnectorInfo> {
-  await initWasm();
+  const { WasmPrePeginHtlcConnector } = await getWasmBindings();
 
   const connector = new WasmPrePeginHtlcConnector(
     params.txGraphVersion,
@@ -192,7 +180,8 @@ export async function computeMinClaimValue(
   councilSize: number,
   feeRate: bigint,
 ): Promise<bigint> {
-  await initWasm();
+  const { computeMinClaimValue: wasmComputeMinClaimValue } =
+    await getWasmBindings();
   try {
     return assertWasmBigint(
       wasmComputeMinClaimValue(
@@ -216,7 +205,8 @@ export async function computeMinPeginFee(
   numUcs: number,
   minPeginFeeRate: bigint,
 ): Promise<bigint> {
-  await initWasm();
+  const { computeMinPeginFee: wasmComputeMinPeginFee } =
+    await getWasmBindings();
   try {
     return assertWasmBigint(
       wasmComputeMinPeginFee(txGraphVersion, numVks, numUcs, minPeginFeeRate),
@@ -249,7 +239,8 @@ export async function computePayoutFeeFloor(
   out1Len: number | null | undefined,
   feeRate: bigint,
 ): Promise<bigint> {
-  await initWasm();
+  const { computePayoutFeeFloor: wasmComputePayoutFeeFloor } =
+    await getWasmBindings();
   try {
     return assertWasmBigint(
       wasmComputePayoutFeeFloor(
@@ -280,7 +271,8 @@ export async function computePayoutFeeFloor(
  * byte-parity tests, not in a per-call version echo.
  */
 export async function supportedTxGraphVersions(): Promise<number[]> {
-  await initWasm();
+  const { supportedTxGraphVersions: wasmSupportedTxGraphVersions } =
+    await getWasmBindings();
   return Array.from(wasmSupportedTxGraphVersions());
 }
 
@@ -292,7 +284,8 @@ export async function supportedTxGraphVersions(): Promise<number[]> {
 export async function peginP2aAnchorOutput(
   txGraphVersion: number,
 ): Promise<PeginP2aAnchorInfo | null> {
-  await initWasm();
+  const { peginP2aAnchorOutput: wasmPeginP2aAnchorOutput } =
+    await getWasmBindings();
   let anchor;
   try {
     anchor = wasmPeginP2aAnchorOutput(txGraphVersion);
@@ -320,7 +313,8 @@ export async function validatePeginP2aAnchor(
   txGraphVersion: number,
   txHex: string,
 ): Promise<void> {
-  await initWasm();
+  const { validatePeginP2aAnchor: wasmValidatePeginP2aAnchor } =
+    await getWasmBindings();
   try {
     wasmValidatePeginP2aAnchor(txGraphVersion, txHex);
   } catch (err) {
@@ -332,7 +326,7 @@ export async function createPayoutConnector(
   params: PayoutConnectorParams,
   network: Network,
 ): Promise<PayoutConnectorInfo> {
-  await initWasm();
+  const { WasmPeginPayoutConnector } = await getWasmBindings();
 
   const connector = new WasmPeginPayoutConnector(
     params.txGraphVersion,
@@ -359,7 +353,7 @@ export async function createPayoutConnector(
 export async function getPeginPayoutScriptInfo(
   params: PayoutConnectorParams,
 ): Promise<{ payoutScript: string; payoutControlBlock: string }> {
-  await initWasm();
+  const { WasmPeginPayoutConnector } = await getWasmBindings();
 
   const connector = new WasmPeginPayoutConnector(
     params.txGraphVersion,
@@ -380,10 +374,14 @@ export async function getPeginPayoutScriptInfo(
   }
 }
 
+// The Assert Payout/NoPayout connector is allocated, read and freed inside the
+// call that needs it, so no allocation outlives the call that made it and no
+// call can observe or free another call's object. Same construction as the
+// browser facade in assertPayoutNoPayoutConnector.ts.
 export async function getAssertPayoutScriptInfo(
   params: AssertPayoutNoPayoutConnectorParams,
 ): Promise<AssertPayoutScriptInfo> {
-  await initWasm();
+  const { WasmAssertPayoutNoPayoutConnector } = await getWasmBindings();
 
   const conn = new WasmAssertPayoutNoPayoutConnector(
     params.txGraphVersion,
@@ -409,7 +407,7 @@ export async function getAssertNoPayoutScriptInfo(
   params: AssertPayoutNoPayoutConnectorParams,
   challengerPubkey: string,
 ): Promise<AssertNoPayoutScriptInfo> {
-  await initWasm();
+  const { WasmAssertPayoutNoPayoutConnector } = await getWasmBindings();
 
   const conn = new WasmAssertPayoutNoPayoutConnector(
     params.txGraphVersion,
@@ -434,7 +432,7 @@ export async function getAssertNoPayoutScriptInfo(
 export async function getChallengeAssertScriptInfo(
   params: ChallengeAssertConnectorParams,
 ): Promise<ChallengeAssertScriptInfo> {
-  await initWasm();
+  const { WasmAssertChallengeAssertConnector } = await getWasmBindings();
 
   const conn = new WasmAssertChallengeAssertConnector(
     params.txGraphVersion,
@@ -468,7 +466,7 @@ function toError(err: unknown, fnName: string): Error {
  * @stability frozen — owned by btc-vault Rust via the vault-wasm pin (`VAULT_WASM_COMMIT`); rotation breaks VP auth for existing deposits.
  */
 export async function expandAuthAnchor(root: Uint8Array): Promise<Uint8Array> {
-  await initWasm();
+  const { expandAuthAnchor: wasmExpandAuthAnchor } = await getWasmBindings();
   try {
     return wasmExpandAuthAnchor(root);
   } catch (err) {
@@ -484,7 +482,8 @@ export async function expandHashlockSecret(
   root: Uint8Array,
   htlcVout: number,
 ): Promise<Uint8Array> {
-  await initWasm();
+  const { expandHashlockSecret: wasmExpandHashlockSecret } =
+    await getWasmBindings();
   try {
     return wasmExpandHashlockSecret(root, htlcVout);
   } catch (err) {
@@ -500,7 +499,7 @@ export async function expandWotsSeed(
   root: Uint8Array,
   htlcVout: number,
 ): Promise<Uint8Array> {
-  await initWasm();
+  const { expandWotsSeed: wasmExpandWotsSeed } = await getWasmBindings();
   try {
     return wasmExpandWotsSeed(root, htlcVout);
   } catch (err) {
@@ -522,7 +521,7 @@ export async function deriveVaultId(
   peginTxHash: string,
   depositor: string,
 ): Promise<string> {
-  await initWasm();
+  const { deriveVaultId: wasmDeriveVaultId } = await getWasmBindings();
   const hashBytes = hexToBytes(peginTxHash);
   if (hashBytes.length !== 32) {
     throw new Error(`peginTxHash must be 32 bytes, got ${hashBytes.length}`);
@@ -574,11 +573,3 @@ export { TAP_INTERNAL_KEY, tapInternalPubkey } from './constants.js';
 
 // Export boundary value guards (input validation for callers)
 export { assertPositiveBigintArray } from './value-guards.js';
-
-// Re-export WASM classes (mirrors index.ts browser entry)
-export {
-  WasmPrePeginTx,
-  WasmPeginTx,
-  WasmPrePeginHtlcConnector,
-  WasmPeginPayoutConnector,
-};

--- a/packages/babylon-tbv-rust-wasm/src/index.ts
+++ b/packages/babylon-tbv-rust-wasm/src/index.ts
@@ -323,9 +323,9 @@ export async function peginP2aAnchorOutput(
 
 /**
  * Validate a PegIn transaction's P2A anchor against a graph version's rules:
- * v2 requires the exact anchor (240 sats, vout 2, P2A script) and v1 requires
- * that NO output carries the P2A script. Throws on any mismatch — a v2 PegIn
- * checked as v1 fails closed, and vice versa.
+ * v2 and v3 require the exact anchor (240 sats, vout 2, P2A script) and v1
+ * requires that NO output carries the P2A script. Throws on any mismatch — a
+ * v2 PegIn checked as v1 fails closed, and vice versa.
  */
 export async function validatePeginP2aAnchor(
   txGraphVersion: number,

--- a/packages/babylon-tbv-rust-wasm/src/index.ts
+++ b/packages/babylon-tbv-rust-wasm/src/index.ts
@@ -1,6 +1,4 @@
-// prettier-ignore
-// @ts-expect-error - WASM files are in dist/generated/ (checked into git), not src/generated/
-import init, { WasmPrePeginTx, WasmPrePeginHtlcConnector, WasmPeginTx, computeMinClaimValue as wasmComputeMinClaimValue, computeMinPeginFee as wasmComputeMinPeginFee, computePayoutFeeFloor as wasmComputePayoutFeeFloor, deriveVaultId as wasmDeriveVaultId, expandAuthAnchor as wasmExpandAuthAnchor, expandHashlockSecret as wasmExpandHashlockSecret, expandWotsSeed as wasmExpandWotsSeed, peginP2aAnchorOutput as wasmPeginP2aAnchorOutput, supportedTxGraphVersions as wasmSupportedTxGraphVersions, validatePeginP2aAnchor as wasmValidatePeginP2aAnchor } from './generated/vault_wasm.js';
+import { getWasmBindings, initWasm as initializeWasm } from './wasm-loader.js';
 import type {
   PrePeginParams,
   PrePeginResult,
@@ -11,23 +9,8 @@ import type {
 } from './types.js';
 import { assertPositiveBigintArray, assertWasmBigint } from './value-guards.js';
 
-let wasmInitialized = false;
-let wasmInitPromise: Promise<void> | null = null;
-
 export async function initWasm() {
-  if (wasmInitialized) return;
-  if (wasmInitPromise) return wasmInitPromise;
-
-  wasmInitPromise = (async () => {
-    try {
-      await init();
-      wasmInitialized = true;
-    } finally {
-      wasmInitPromise = null;
-    }
-  })();
-
-  return wasmInitPromise;
+  await initializeWasm();
 }
 
 /**
@@ -49,7 +32,7 @@ export async function initWasm() {
 export async function createPrePeginTransaction(
   params: PrePeginParams,
 ): Promise<PrePeginResult> {
-  await initWasm();
+  const { WasmPrePeginTx } = await getWasmBindings();
 
   // Leading arg selects the tx-graph version inside the vault-wasm facade;
   // an unsupported version throws before any construction (fail closed).
@@ -124,7 +107,7 @@ export async function buildPeginTxFromPrePegin(
   fundedPrePeginTxHex: string,
   htlcVout: number,
 ): Promise<PeginTxResult> {
-  await initWasm();
+  const { WasmPrePeginTx } = await getWasmBindings();
 
   const unfundedTx = new WasmPrePeginTx(
     params.txGraphVersion,
@@ -146,8 +129,8 @@ export async function buildPeginTxFromPrePegin(
     params.authAnchorHash,
   );
 
-  let fundedTx: WasmPrePeginTx | null = null;
-  let peginTx: WasmPeginTx | null = null;
+  let fundedTx: typeof unfundedTx | null = null;
+  let peginTx: ReturnType<typeof unfundedTx.buildPeginTx> | null = null;
   try {
     fundedTx = unfundedTx.fromFundedTransaction(fundedPrePeginTxHex);
     peginTx = fundedTx.buildPeginTx(timelockPegin, htlcVout);
@@ -178,7 +161,7 @@ export async function buildPeginTxFromPrePegin(
 export async function getPrePeginHtlcConnectorInfo(
   params: HtlcConnectorParams,
 ): Promise<HtlcConnectorInfo> {
-  await initWasm();
+  const { WasmPrePeginHtlcConnector } = await getWasmBindings();
 
   const connector = new WasmPrePeginHtlcConnector(
     params.txGraphVersion,
@@ -218,7 +201,8 @@ export async function computeMinClaimValue(
   councilSize: number,
   feeRate: bigint,
 ): Promise<bigint> {
-  await initWasm();
+  const { computeMinClaimValue: wasmComputeMinClaimValue } =
+    await getWasmBindings();
   try {
     return assertWasmBigint(
       wasmComputeMinClaimValue(
@@ -252,7 +236,8 @@ export async function computeMinPeginFee(
   numUcs: number,
   minPeginFeeRate: bigint,
 ): Promise<bigint> {
-  await initWasm();
+  const { computeMinPeginFee: wasmComputeMinPeginFee } =
+    await getWasmBindings();
   try {
     return assertWasmBigint(
       wasmComputeMinPeginFee(txGraphVersion, numVks, numUcs, minPeginFeeRate),
@@ -285,7 +270,8 @@ export async function computePayoutFeeFloor(
   out1Len: number | null | undefined,
   feeRate: bigint,
 ): Promise<bigint> {
-  await initWasm();
+  const { computePayoutFeeFloor: wasmComputePayoutFeeFloor } =
+    await getWasmBindings();
   try {
     return assertWasmBigint(
       wasmComputePayoutFeeFloor(
@@ -315,7 +301,8 @@ export async function computePayoutFeeFloor(
 export async function peginP2aAnchorOutput(
   txGraphVersion: number,
 ): Promise<PeginP2aAnchorInfo | null> {
-  await initWasm();
+  const { peginP2aAnchorOutput: wasmPeginP2aAnchorOutput } =
+    await getWasmBindings();
   let anchor;
   try {
     anchor = wasmPeginP2aAnchorOutput(txGraphVersion);
@@ -344,7 +331,8 @@ export async function validatePeginP2aAnchor(
   txGraphVersion: number,
   txHex: string,
 ): Promise<void> {
-  await initWasm();
+  const { validatePeginP2aAnchor: wasmValidatePeginP2aAnchor } =
+    await getWasmBindings();
   try {
     wasmValidatePeginP2aAnchor(txGraphVersion, txHex);
   } catch (err) {
@@ -363,7 +351,8 @@ export async function validatePeginP2aAnchor(
  * byte-parity tests, not in a per-call version echo.
  */
 export async function supportedTxGraphVersions(): Promise<number[]> {
-  await initWasm();
+  const { supportedTxGraphVersions: wasmSupportedTxGraphVersions } =
+    await getWasmBindings();
   return Array.from(wasmSupportedTxGraphVersions());
 }
 
@@ -381,7 +370,7 @@ function toError(err: unknown, fnName: string): Error {
  * @stability frozen — owned by btc-vault Rust via the vault-wasm pin (`VAULT_WASM_COMMIT`); rotation breaks VP auth for existing deposits.
  */
 export async function expandAuthAnchor(root: Uint8Array): Promise<Uint8Array> {
-  await initWasm();
+  const { expandAuthAnchor: wasmExpandAuthAnchor } = await getWasmBindings();
   try {
     return wasmExpandAuthAnchor(root);
   } catch (err) {
@@ -397,7 +386,8 @@ export async function expandHashlockSecret(
   root: Uint8Array,
   htlcVout: number,
 ): Promise<Uint8Array> {
-  await initWasm();
+  const { expandHashlockSecret: wasmExpandHashlockSecret } =
+    await getWasmBindings();
   try {
     return wasmExpandHashlockSecret(root, htlcVout);
   } catch (err) {
@@ -413,7 +403,7 @@ export async function expandWotsSeed(
   root: Uint8Array,
   htlcVout: number,
 ): Promise<Uint8Array> {
-  await initWasm();
+  const { expandWotsSeed: wasmExpandWotsSeed } = await getWasmBindings();
   try {
     return wasmExpandWotsSeed(root, htlcVout);
   } catch (err) {
@@ -435,7 +425,7 @@ export async function deriveVaultId(
   peginTxHash: string,
   depositor: string,
 ): Promise<string> {
-  await initWasm();
+  const { deriveVaultId: wasmDeriveVaultId } = await getWasmBindings();
   const hashBytes = hexToBytes(peginTxHash);
   if (hashBytes.length !== 32) {
     throw new Error(`peginTxHash must be 32 bytes, got ${hashBytes.length}`);
@@ -502,8 +492,3 @@ export {
 
 // Export challenge assert connector utilities (depositor-as-claimer)
 export { getChallengeAssertScriptInfo } from './challengeAssertConnector.js';
-
-// Re-export raw WASM types for callers that need direct access
-// prettier-ignore
-// @ts-expect-error - WASM files are in dist/generated/ (checked into git), not src/generated/
-export { WasmPeginTx, WasmPeginPayoutConnector, WasmPrePeginTx, WasmPrePeginHtlcConnector } from './generated/vault_wasm.js';

--- a/packages/babylon-tbv-rust-wasm/src/payoutConnector.ts
+++ b/packages/babylon-tbv-rust-wasm/src/payoutConnector.ts
@@ -1,6 +1,4 @@
-// @ts-expect-error - WASM files are in dist/generated/ (checked into git), not src/generated/
-import { WasmPeginPayoutConnector } from "./generated/vault_wasm.js";
-import { initWasm } from "./index.js";
+import { getWasmBindings } from "./wasm-loader.js";
 import type { PayoutConnectorParams, PayoutConnectorInfo, Network } from "./types.js";
 
 /**
@@ -30,7 +28,7 @@ export async function createPayoutConnector(
   params: PayoutConnectorParams,
   network: Network
 ): Promise<PayoutConnectorInfo> {
-  await initWasm();
+  const { WasmPeginPayoutConnector } = await getWasmBindings();
 
   const connector = new WasmPeginPayoutConnector(
     params.txGraphVersion,
@@ -66,7 +64,7 @@ export async function createPayoutConnector(
 export async function getPeginPayoutScriptInfo(
   params: PayoutConnectorParams,
 ): Promise<{ payoutScript: string; payoutControlBlock: string }> {
-  await initWasm();
+  const { WasmPeginPayoutConnector } = await getWasmBindings();
 
   const connector = new WasmPeginPayoutConnector(
     params.txGraphVersion,

--- a/packages/babylon-tbv-rust-wasm/src/raw-node.ts
+++ b/packages/babylon-tbv-rust-wasm/src/raw-node.ts
@@ -7,5 +7,5 @@
  */
 // prettier-ignore
 // @ts-expect-error - generated artifacts live in dist/generated
-export { WasmPeginTx, WasmPeginPayoutConnector, WasmPrePeginTx, WasmPrePeginHtlcConnector, WasmAssertPayoutNoPayoutConnector, WasmAssertChallengeAssertConnector } from './generated/vault_wasm.js';
+export { WasmPeginTx, WasmPeginPayoutConnector, WasmPrePeginTx, WasmPrePeginHtlcConnector } from './generated/vault_wasm.js';
 export { initWasm } from './wasm-loader-node.js';

--- a/packages/babylon-tbv-rust-wasm/src/raw-node.ts
+++ b/packages/babylon-tbv-rust-wasm/src/raw-node.ts
@@ -1,0 +1,11 @@
+/**
+ * Explicit eager Node.js entry for direct wasm-bindgen class access.
+ *
+ * `initWasm` is re-exported from the facade's loader so that the raw and
+ * facade entries share one initializer: a process that uses both must not
+ * initialize the generated module twice, and must not read the binary twice.
+ */
+// prettier-ignore
+// @ts-expect-error - generated artifacts live in dist/generated
+export { WasmPeginTx, WasmPeginPayoutConnector, WasmPrePeginTx, WasmPrePeginHtlcConnector, WasmAssertPayoutNoPayoutConnector, WasmAssertChallengeAssertConnector } from './generated/vault_wasm.js';
+export { initWasm } from './wasm-loader-node.js';

--- a/packages/babylon-tbv-rust-wasm/src/raw.ts
+++ b/packages/babylon-tbv-rust-wasm/src/raw.ts
@@ -7,5 +7,5 @@
  */
 // prettier-ignore
 // @ts-expect-error - generated artifacts live in dist/generated
-export { WasmPeginTx, WasmPeginPayoutConnector, WasmPrePeginTx, WasmPrePeginHtlcConnector, WasmAssertPayoutNoPayoutConnector, WasmAssertChallengeAssertConnector } from './generated/vault_wasm.js';
+export { WasmPeginTx, WasmPeginPayoutConnector, WasmPrePeginTx, WasmPrePeginHtlcConnector } from './generated/vault_wasm.js';
 export { initWasm } from './wasm-loader.js';

--- a/packages/babylon-tbv-rust-wasm/src/raw.ts
+++ b/packages/babylon-tbv-rust-wasm/src/raw.ts
@@ -1,0 +1,11 @@
+/**
+ * Explicit eager access to wasm-bindgen's generated browser module.
+ *
+ * Most consumers should use the package root, whose facade loads this module
+ * lazily. This subpath exists for low-level callers that construct raw WASM
+ * classes directly and therefore necessarily opt into eager glue loading.
+ */
+// prettier-ignore
+// @ts-expect-error - generated artifacts live in dist/generated
+export { WasmPeginTx, WasmPeginPayoutConnector, WasmPrePeginTx, WasmPrePeginHtlcConnector, WasmAssertPayoutNoPayoutConnector, WasmAssertChallengeAssertConnector } from './generated/vault_wasm.js';
+export { initWasm } from './wasm-loader.js';

--- a/packages/babylon-tbv-rust-wasm/src/wasm-loader-node.ts
+++ b/packages/babylon-tbv-rust-wasm/src/wasm-loader-node.ts
@@ -1,0 +1,48 @@
+import { readFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// The generated declarations are committed under dist/generated and are the
+// only description of the pinned wasm-bindgen surface. Typing the lazy binding
+// against them turns a renamed or removed export into a compile error instead
+// of a `new undefined(...)` at first use.
+import type * as VaultWasm from '../dist/generated/vault_wasm.js';
+
+type WasmBindings = typeof VaultWasm;
+
+let bindingsPromise: Promise<WasmBindings> | null = null;
+
+async function importGeneratedBindings(): Promise<WasmBindings> {
+  // @ts-expect-error - generated artifacts live in dist/generated
+  return import('./generated/vault_wasm.js');
+}
+
+/**
+ * Load generated glue and initialize its local binary on demand.
+ *
+ * `initSync` needs the bytes synchronously, but the read does not have to be:
+ * deferring the first load to a facade call would otherwise put a
+ * multi-megabyte blocking read on a server's request path.
+ */
+export function getWasmBindings(): Promise<WasmBindings> {
+  bindingsPromise ??= (async () => {
+    try {
+      const bindings = await importGeneratedBindings();
+      const wasmPath = join(
+        dirname(fileURLToPath(import.meta.url)),
+        'generated',
+        'vault_wasm_bg.wasm',
+      );
+      bindings.initSync({ module: await readFile(wasmPath) });
+      return bindings;
+    } catch (error) {
+      bindingsPromise = null;
+      throw error;
+    }
+  })();
+  return bindingsPromise;
+}
+
+export async function initWasm(): Promise<void> {
+  await getWasmBindings();
+}

--- a/packages/babylon-tbv-rust-wasm/src/wasm-loader-node.ts
+++ b/packages/babylon-tbv-rust-wasm/src/wasm-loader-node.ts
@@ -6,6 +6,9 @@ import { fileURLToPath } from 'node:url';
 // only description of the pinned wasm-bindgen surface. Typing the lazy binding
 // against them turns a renamed or removed export into a compile error instead
 // of a `new undefined(...)` at first use.
+// tsc copies this specifier into the emitted declaration unchanged, so it has
+// to resolve from dist as well as from src. It does that only while both stay
+// siblings one level under the package root; check-lazy-entries.js asserts it.
 import type * as VaultWasm from '../dist/generated/vault_wasm.js';
 
 type WasmBindings = typeof VaultWasm;
@@ -26,19 +29,29 @@ async function importGeneratedBindings(): Promise<WasmBindings> {
  */
 export function getWasmBindings(): Promise<WasmBindings> {
   bindingsPromise ??= (async () => {
+    let bindings: WasmBindings;
+    let binary: Buffer;
     try {
-      const bindings = await importGeneratedBindings();
-      const wasmPath = join(
-        dirname(fileURLToPath(import.meta.url)),
-        'generated',
-        'vault_wasm_bg.wasm',
+      bindings = await importGeneratedBindings();
+      binary = await readFile(
+        join(
+          dirname(fileURLToPath(import.meta.url)),
+          'generated',
+          'vault_wasm_bg.wasm',
+        ),
       );
-      bindings.initSync({ module: await readFile(wasmPath) });
-      return bindings;
     } catch (error) {
+      // Neither a failed resolve nor a failed read initializes anything, so a
+      // later call can still work. Only the init below is terminal.
       bindingsPromise = null;
       throw error;
     }
+    // The glue sets `wasm = instance.exports` before it runs
+    // `__wbindgen_start()`, and its own `if (wasm !== undefined) return wasm`
+    // guard would then hand that half-started module to a retry. Keep this
+    // rejection latched: only a fresh module graph can safely retry.
+    bindings.initSync({ module: binary });
+    return bindings;
   })();
   return bindingsPromise;
 }

--- a/packages/babylon-tbv-rust-wasm/src/wasm-loader.ts
+++ b/packages/babylon-tbv-rust-wasm/src/wasm-loader.ts
@@ -2,6 +2,9 @@
 // only description of the pinned wasm-bindgen surface. Typing the lazy binding
 // against them turns a renamed or removed export into a compile error instead
 // of a `new undefined(...)` at first use.
+// tsc copies this specifier into the emitted declaration unchanged, so it has
+// to resolve from dist as well as from src. It does that only while both stay
+// siblings one level under the package root; check-lazy-entries.js asserts it.
 import type * as VaultWasm from '../dist/generated/vault_wasm.js';
 
 type WasmBindings = typeof VaultWasm;
@@ -18,14 +21,20 @@ async function importGeneratedBindings(): Promise<WasmBindings> {
 /** Load and initialize browser WASM only when a facade operation is invoked. */
 export function getWasmBindings(): Promise<WasmBindings> {
   bindingsPromise ??= (async () => {
+    let bindings: WasmBindings;
     try {
-      const bindings = await importGeneratedBindings();
-      await bindings.default();
-      return bindings;
+      bindings = await importGeneratedBindings();
     } catch (error) {
+      // A failed resolve initializes nothing, so a later call can still work.
       bindingsPromise = null;
       throw error;
     }
+    // The glue sets `wasm = instance.exports` before it runs
+    // `__wbindgen_start()`, and its own `if (wasm !== undefined) return wasm`
+    // guard would then hand that half-started module to a retry. Keep this
+    // rejection latched: only a fresh module graph can safely retry.
+    await bindings.default();
+    return bindings;
   })();
   return bindingsPromise;
 }

--- a/packages/babylon-tbv-rust-wasm/src/wasm-loader.ts
+++ b/packages/babylon-tbv-rust-wasm/src/wasm-loader.ts
@@ -1,0 +1,35 @@
+// The generated declarations are committed under dist/generated and are the
+// only description of the pinned wasm-bindgen surface. Typing the lazy binding
+// against them turns a renamed or removed export into a compile error instead
+// of a `new undefined(...)` at first use.
+import type * as VaultWasm from '../dist/generated/vault_wasm.js';
+
+type WasmBindings = typeof VaultWasm;
+
+let bindingsPromise: Promise<WasmBindings> | null = null;
+
+async function importGeneratedBindings(): Promise<WasmBindings> {
+  // Generated artifacts are committed under dist/generated and deliberately
+  // absent from src. The build includes their declarations separately.
+  // @ts-expect-error - generated during the pinned Rust/WASM build
+  return import('./generated/vault_wasm.js');
+}
+
+/** Load and initialize browser WASM only when a facade operation is invoked. */
+export function getWasmBindings(): Promise<WasmBindings> {
+  bindingsPromise ??= (async () => {
+    try {
+      const bindings = await importGeneratedBindings();
+      await bindings.default();
+      return bindings;
+    } catch (error) {
+      bindingsPromise = null;
+      throw error;
+    }
+  })();
+  return bindingsPromise;
+}
+
+export async function initWasm(): Promise<void> {
+  await getWasmBindings();
+}

--- a/packages/babylon-ts-sdk/docs/api/primitives.md
+++ b/packages/babylon-ts-sdk/docs/api/primitives.md
@@ -1919,215 +1919,6 @@ Derive with `deriveVaultId(peginTxHash, depositorAddress)`.
 
 ## Functions
 
-### computeMinClaimValue()
-
-```ts
-function computeMinClaimValue(
-   txGraphVersion, 
-   numLocalChallengers, 
-   numUniversalChallengers, 
-   councilQuorum, 
-   councilSize, 
-feeRate): Promise<bigint>;
-```
-
-Defined in: packages/babylon-tbv-rust-wasm/dist/index.d.ts
-
-Compute the minimum depositor claim value (PegIn output 1) in satoshis.
-
-This covers the full downstream tx graph cost (Claim → Assert → Payout)
-based on the protocol parameters.
-
-#### Parameters
-
-##### txGraphVersion
-
-`number`
-
-##### numLocalChallengers
-
-`number`
-
-##### numUniversalChallengers
-
-`number`
-
-##### councilQuorum
-
-`number`
-
-##### councilSize
-
-`number`
-
-##### feeRate
-
-`bigint`
-
-#### Returns
-
-`Promise`\<`bigint`\>
-
-***
-
-### computeMinPeginFee()
-
-```ts
-function computeMinPeginFee(
-   txGraphVersion, 
-   numVks, 
-   numUcs, 
-minPeginFeeRate): Promise<bigint>;
-```
-
-Defined in: packages/babylon-tbv-rust-wasm/dist/index.d.ts
-
-Compute the minimum PegIn (activation) transaction fee in satoshis.
-
-`minPeginFee = peginTxVsize(numVks, numUcs) × minPeginFeeRate`. Each HTLC
-the depositor funds in the Pre-PegIn tx must reserve at least this fee
-inside its value (`htlcValue = peginAmount + depositorClaimValue +
-minPeginFee`), otherwise the VP cannot afford to broadcast the PegIn at
-activation. The vsize comes from a Taproot script-path-spend weight
-prediction whose witness shape depends on the VK + UC signer count.
-
-#### Parameters
-
-##### txGraphVersion
-
-`number`
-
-##### numVks
-
-`number`
-
-##### numUcs
-
-`number`
-
-##### minPeginFeeRate
-
-`bigint`
-
-#### Returns
-
-`Promise`\<`bigint`\>
-
-***
-
-### peginP2aAnchorOutput()
-
-```ts
-function peginP2aAnchorOutput(txGraphVersion): Promise<PeginP2aAnchorInfo | null>;
-```
-
-Defined in: packages/babylon-tbv-rust-wasm/dist/index.d.ts
-
-The PegIn transaction's P2A (pay-to-anchor) output for a graph version, or
-`null` when that version's PegIn carries no anchor (v1). The facade returns
-one record per version — never a zero-valued placeholder — so an absent
-anchor can't be mistaken for a real output. For v2/v3: 240 sats at vout 2,
-script `51024e73`.
-
-#### Parameters
-
-##### txGraphVersion
-
-`number`
-
-#### Returns
-
-`Promise`\<[`PeginP2aAnchorInfo`](#peginp2aanchorinfo) \| `null`\>
-
-***
-
-### validatePeginP2aAnchor()
-
-```ts
-function validatePeginP2aAnchor(txGraphVersion, txHex): Promise<void>;
-```
-
-Defined in: packages/babylon-tbv-rust-wasm/dist/index.d.ts
-
-Validate a PegIn transaction's P2A anchor against a graph version's rules:
-v2 requires the exact anchor (240 sats, vout 2, P2A script) and v1 requires
-that NO output carries the P2A script. Throws on any mismatch — a v2 PegIn
-checked as v1 fails closed, and vice versa.
-
-#### Parameters
-
-##### txGraphVersion
-
-`number`
-
-##### txHex
-
-`string`
-
-#### Returns
-
-`Promise`\<`void`\>
-
-***
-
-### supportedTxGraphVersions()
-
-```ts
-function supportedTxGraphVersions(): Promise<number[]>;
-```
-
-Defined in: packages/babylon-tbv-rust-wasm/dist/index.d.ts
-
-Tx graph versions the shipped vault-wasm binary can build. Callers must
-preflight the required version (fresh: active; resume: stamped) against
-this list and fail closed instead of hitting per-call errors mid-flow.
-
-Note: the facade constructors themselves fail closed on unsupported
-versions, and derived objects carry the version they were built with —
-value-level cross-checks live in `assertWasmPeginSizing` and the golden
-byte-parity tests, not in a per-call version echo.
-
-#### Returns
-
-`Promise`\<`number`[]\>
-
-***
-
-### deriveVaultId()
-
-```ts
-function deriveVaultId(peginTxHash, depositor): Promise<string>;
-```
-
-Defined in: packages/babylon-tbv-rust-wasm/dist/index.d.ts
-
-Derives the vault ID from a PegIn transaction hash and depositor ETH address.
-
-Vault ID = keccak256(abi.encode(peginTxHash, depositor))
-This matches the Solidity-side derivation in BTCVaultRegistry.
-
-#### Parameters
-
-##### peginTxHash
-
-`string`
-
-32-byte PegIn tx hash in display order (big-endian), hex encoded
-
-##### depositor
-
-`string`
-
-20-byte Ethereum address of the depositor, hex encoded
-
-#### Returns
-
-`Promise`\<`string`\>
-
-Hex-encoded vault ID (32 bytes)
-
-***
-
 ### computeNumLocalChallengers()
 
 ```ts
@@ -3484,6 +3275,215 @@ Where the value came from, for the error message
 #### Returns
 
 `void`
+
+***
+
+### computeMinClaimValue()
+
+```ts
+function computeMinClaimValue(
+   txGraphVersion, 
+   numLocalChallengers, 
+   numUniversalChallengers, 
+   councilQuorum, 
+   councilSize, 
+feeRate): Promise<bigint>;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/wasm/index.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/wasm/index.ts)
+
+Compute the minimum depositor claim value (PegIn output 1) in satoshis.
+
+This covers the full downstream tx graph cost (Claim → Assert → Payout)
+based on the protocol parameters.
+
+#### Parameters
+
+##### txGraphVersion
+
+`number`
+
+##### numLocalChallengers
+
+`number`
+
+##### numUniversalChallengers
+
+`number`
+
+##### councilQuorum
+
+`number`
+
+##### councilSize
+
+`number`
+
+##### feeRate
+
+`bigint`
+
+#### Returns
+
+`Promise`\<`bigint`\>
+
+***
+
+### computeMinPeginFee()
+
+```ts
+function computeMinPeginFee(
+   txGraphVersion, 
+   numVks, 
+   numUcs, 
+minPeginFeeRate): Promise<bigint>;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/wasm/index.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/wasm/index.ts)
+
+Compute the minimum PegIn (activation) transaction fee in satoshis.
+
+`minPeginFee = peginTxVsize(numVks, numUcs) × minPeginFeeRate`. Each HTLC
+the depositor funds in the Pre-PegIn tx must reserve at least this fee
+inside its value (`htlcValue = peginAmount + depositorClaimValue +
+minPeginFee`), otherwise the VP cannot afford to broadcast the PegIn at
+activation. The vsize comes from a Taproot script-path-spend weight
+prediction whose witness shape depends on the VK + UC signer count.
+
+#### Parameters
+
+##### txGraphVersion
+
+`number`
+
+##### numVks
+
+`number`
+
+##### numUcs
+
+`number`
+
+##### minPeginFeeRate
+
+`bigint`
+
+#### Returns
+
+`Promise`\<`bigint`\>
+
+***
+
+### supportedTxGraphVersions()
+
+```ts
+function supportedTxGraphVersions(): Promise<number[]>;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/wasm/index.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/wasm/index.ts)
+
+Tx graph versions the shipped vault-wasm binary can build. Callers must
+preflight the required version (fresh: active; resume: stamped) against
+this list and fail closed instead of hitting per-call errors mid-flow.
+
+Note: the facade constructors themselves fail closed on unsupported
+versions, and derived objects carry the version they were built with —
+value-level cross-checks live in `assertWasmPeginSizing` and the golden
+byte-parity tests, not in a per-call version echo.
+
+#### Returns
+
+`Promise`\<`number`[]\>
+
+***
+
+### peginP2aAnchorOutput()
+
+```ts
+function peginP2aAnchorOutput(txGraphVersion): Promise<PeginP2aAnchorInfo | null>;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/wasm/index.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/wasm/index.ts)
+
+The PegIn transaction's P2A (pay-to-anchor) output for a graph version, or
+`null` when that version's PegIn carries no anchor (v1). The facade returns
+one record per version — never a zero-valued placeholder — so an absent
+anchor can't be mistaken for a real output. For v2/v3: 240 sats at vout 2,
+script `51024e73`.
+
+#### Parameters
+
+##### txGraphVersion
+
+`number`
+
+#### Returns
+
+`Promise`\<[`PeginP2aAnchorInfo`](#peginp2aanchorinfo) \| `null`\>
+
+***
+
+### validatePeginP2aAnchor()
+
+```ts
+function validatePeginP2aAnchor(txGraphVersion, txHex): Promise<void>;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/wasm/index.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/wasm/index.ts)
+
+Validate a PegIn transaction's P2A anchor against a graph version's rules:
+v2 and v3 require the exact anchor (240 sats, vout 2, P2A script) and v1
+requires that NO output carries the P2A script. Throws on any mismatch — a
+v2 PegIn checked as v1 fails closed, and vice versa.
+
+#### Parameters
+
+##### txGraphVersion
+
+`number`
+
+##### txHex
+
+`string`
+
+#### Returns
+
+`Promise`\<`void`\>
+
+***
+
+### deriveVaultId()
+
+```ts
+function deriveVaultId(peginTxHash, depositor): Promise<string>;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/wasm/index.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/wasm/index.ts)
+
+Derives the vault ID from a PegIn transaction hash and depositor ETH address.
+
+Vault ID = keccak256(abi.encode(peginTxHash, depositor))
+This matches the Solidity-side derivation in BTCVaultRegistry.
+
+#### Parameters
+
+##### peginTxHash
+
+`string`
+
+32-byte PegIn tx hash in display order (big-endian), hex encoded
+
+##### depositor
+
+`string`
+
+20-byte Ethereum address of the depositor, hex encoded
+
+#### Returns
+
+`Promise`\<`string`\>
+
+Hex-encoded vault ID (32 bytes)
 
 ## Variables
 

--- a/packages/babylon-ts-sdk/docs/api/utils.md
+++ b/packages/babylon-ts-sdk/docs/api/utils.md
@@ -1740,6 +1740,30 @@ Bitcoin txid: exactly 64 hex characters (32 bytes).
 
 ***
 
+### X\_ONLY\_PUBKEY\_HEX\_LEN
+
+```ts
+const X_ONLY_PUBKEY_HEX_LEN: 64 = 64;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/validation.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/validation.ts)
+
+Hex-string length of a 32-byte BIP-340 x-only public key.
+
+***
+
+### COMPRESSED\_PUBKEY\_HEX\_LEN
+
+```ts
+const COMPRESSED_PUBKEY_HEX_LEN: 66 = 66;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/validation.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/validation.ts)
+
+Hex-string length of a 33-byte SEC1-compressed secp256k1 public key.
+
+***
+
 ### BITCOIN\_ADDRESS\_RE
 
 ```ts

--- a/packages/babylon-ts-sdk/eslint.config.mjs
+++ b/packages/babylon-ts-sdk/eslint.config.mjs
@@ -35,6 +35,44 @@ export default defineConfig([
       "@typescript-eslint/ban-ts-comment": "error",
     },
   },
+  // LAZY WASM BOUNDARY - see the module JSDoc in src/tbv/core/wasm/index.ts.
+  // The optional engine peer is reachable only through src/tbv/core/wasm,
+  // which imports it dynamically. A value import anywhere else in src/ puts
+  // the engine back into every chunk that reaches the file, evaluated at
+  // import time. Type-only imports are erased, so they stay allowed. Tests
+  // read the engine directly on purpose - they are the differential oracle
+  // for the values the boundary re-exports, and are never bundled.
+  {
+    files: ["src/**/*.ts"],
+    ignores: ["src/tbv/core/wasm/**", "**/__tests__/**", "**/*.test.{ts,tsx}"],
+    rules: {
+      "@typescript-eslint/no-restricted-imports": [
+        "error",
+        {
+          patterns: [
+            {
+              group: [
+                "@babylonlabs-io/babylon-tbv-rust-wasm",
+                "@babylonlabs-io/babylon-tbv-rust-wasm/*",
+              ],
+              allowTypeImports: true,
+              message:
+                "Reach the vault WASM engine through src/tbv/core/wasm, which loads it lazily.",
+            },
+          ],
+        },
+      ],
+    },
+  },
+  // `import { type X } from "pkg"` leaves a side-effect import behind under
+  // verbatimModuleSyntax, which would defeat allowTypeImports above. Keep
+  // every type-only import in the top-level `import type` form.
+  {
+    files: ["src/**/*.ts"],
+    rules: {
+      "@typescript-eslint/no-import-type-side-effects": "error",
+    },
+  },
   {
     ignores: [
       "dist/**",

--- a/packages/babylon-ts-sdk/eslint.config.mjs
+++ b/packages/babylon-ts-sdk/eslint.config.mjs
@@ -23,6 +23,8 @@ export default defineConfig([
     files: [
       "src/tbv/core/utils/utxo/selectUtxos.ts",
       "src/tbv/core/primitives/psbt/payout.ts",
+      "src/tbv/core/vault-secrets/**/*.ts",
+      "src/tbv/core/wasm/**/*.ts",
       "src/tbv/integrations/aave/utils/vaultSplit.ts",
       "src/tbv/core/utils/signing.ts",
     ],

--- a/packages/babylon-ts-sdk/package.json
+++ b/packages/babylon-ts-sdk/package.json
@@ -39,6 +39,11 @@
       "require": "./dist/tbv/core/clients/index.cjs",
       "import": "./dist/tbv/core/clients/index.js"
     },
+    "./tbv/core/wasm": {
+      "types": "./dist/tbv/core/wasm/index.d.ts",
+      "require": "./dist/tbv/core/wasm/index.cjs",
+      "import": "./dist/tbv/core/wasm/index.js"
+    },
     "./tbv/core/services": {
       "types": "./dist/tbv/core/services/index.d.ts",
       "require": "./dist/tbv/core/services/index.cjs",

--- a/packages/babylon-ts-sdk/package.json
+++ b/packages/babylon-ts-sdk/package.json
@@ -39,6 +39,11 @@
       "require": "./dist/tbv/core/clients/index.cjs",
       "import": "./dist/tbv/core/clients/index.js"
     },
+    "./tbv/core/clients/vault-provider/status": {
+      "types": "./dist/tbv/core/clients/vault-provider/status/index.d.ts",
+      "require": "./dist/tbv/core/clients/vault-provider/status/index.cjs",
+      "import": "./dist/tbv/core/clients/vault-provider/status/index.js"
+    },
     "./tbv/core/wasm": {
       "types": "./dist/tbv/core/wasm/index.d.ts",
       "require": "./dist/tbv/core/wasm/index.cjs",

--- a/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/serverIdentity.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/serverIdentity.ts
@@ -20,12 +20,14 @@
 import * as ecc from "@bitcoin-js/tiny-secp256k1-asmjs";
 
 import {
-  COMPRESSED_PUBKEY_HEX_LEN,
   SCHNORR_SIG_HEX_LEN,
   stripHexPrefix,
-  X_ONLY_PUBKEY_HEX_LEN,
 } from "../../../primitives/utils/bitcoin";
-import { HEX_RE } from "../../../utils/validation";
+import {
+  COMPRESSED_PUBKEY_HEX_LEN,
+  HEX_RE,
+  X_ONLY_PUBKEY_HEX_LEN,
+} from "../../../utils/validation";
 
 import { verifyBip322Simple } from "./bip322Verify";
 import { encodeServerIdentityPayload } from "./cbor";
@@ -104,7 +106,6 @@ function hexToBytes(hex: string): Uint8Array {
   }
   return out;
 }
-
 
 /**
  * Verify a server identity proof against a pinned server pubkey.
@@ -237,7 +238,11 @@ export function verifyServerIdentity(input: VerifyServerIdentityInput): void {
     hexToBytes(eph),
     proof.expires_at,
   );
-  const verified = verifyBip322Simple(payload, hexToBytes(actual), hexToBytes(sig));
+  const verified = verifyBip322Simple(
+    payload,
+    hexToBytes(actual),
+    hexToBytes(sig),
+  );
   if (!verified) {
     throw new ServerIdentityError(
       "BIP-322 signature verification failed — ephemeral key is not attested by pinned server pubkey",

--- a/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/verifyDepositorCwt.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/auth/verifyDepositorCwt.ts
@@ -16,12 +16,14 @@ import * as ecc from "@bitcoin-js/tiny-secp256k1-asmjs";
 import { sha256 } from "@noble/hashes/sha2.js";
 
 import {
-  COMPRESSED_PUBKEY_HEX_LEN,
   hexToUint8Array,
   stripHexPrefix,
-  X_ONLY_PUBKEY_HEX_LEN,
 } from "../../../primitives/utils/bitcoin";
-import { HEX_RE } from "../../../utils/validation";
+import {
+  COMPRESSED_PUBKEY_HEX_LEN,
+  HEX_RE,
+  X_ONLY_PUBKEY_HEX_LEN,
+} from "../../../utils/validation";
 
 import { CborReader, decodeCbor } from "./cborDecode";
 

--- a/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/status/index.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/status/index.ts
@@ -1,0 +1,21 @@
+/**
+ * Dependency-clean Vault Provider status polling facade.
+ *
+ * This entry point deliberately excludes `../auth`, whose BIP-322 and CWT
+ * verification implementations require Bitcoin cryptography packages. Use it
+ * for unauthenticated status reads and polling that must remain usable in an
+ * Ethereum-only application session.
+ *
+ * @module clients/vault-provider/status
+ */
+
+export { VaultProviderRpcClient } from "../api";
+export type { VaultProviderRpcClientOptions } from "../api";
+export type { BatchResultEntry } from "../batchAttribution";
+export {
+  batchPollByProvider,
+  type BatchPollByProviderOptions,
+} from "../batchPoll";
+export { JSON_RPC_ERROR_CODES, JsonRpcError } from "../json-rpc-client";
+export * from "../types";
+export { VpResponseValidationError } from "../validators";

--- a/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/validators.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/validators.ts
@@ -12,11 +12,10 @@
 import { CHALLENGE_ASSERT_CONNECTORS_PER_CHALLENGER } from "../../primitives/psbt/constants";
 import {
   COMPRESSED_PUBKEY_HEX_LEN,
+  HEX_RE,
   X_ONLY_PUBKEY_HEX_LEN,
-} from "../../primitives/utils/bitcoin";
-import { HEX_RE } from "../../utils/validation";
+} from "../../utils/validation";
 
-import { DaemonStatus } from "./types";
 import type {
   BatchGetPeginStatusResponse,
   BatchGetPegoutStatusResponse,
@@ -25,6 +24,7 @@ import type {
   RequestDepositorClaimerArtifactsResponse,
   RequestDepositorPresignTransactionsResponse,
 } from "./types";
+import { DaemonStatus } from "./types";
 
 const DAEMON_STATUS_VALUES = new Set<string>(Object.values(DaemonStatus));
 

--- a/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/rebuildDepositTermsCore.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/rebuildDepositTermsCore.ts
@@ -17,7 +17,7 @@ import {
   computeMinPeginFee,
   getPrePeginHtlcConnectorInfo,
   peginP2aAnchorOutput,
-} from "@babylonlabs-io/babylon-tbv-rust-wasm";
+} from "../wasm";
 import { Transaction } from "bitcoinjs-lib";
 
 import { findAuthAnchorOpReturn } from "../managers/pegin/assertAuthAnchorOpReturn";

--- a/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts
@@ -80,8 +80,8 @@ import {
   isAddressFromPublicKey,
   stripHexPrefix,
   uint8ArrayToHex,
-  X_ONLY_PUBKEY_HEX_LEN,
 } from "../primitives/utils/bitcoin";
+import { X_ONLY_PUBKEY_HEX_LEN } from "../utils/validation";
 import {
   calculateBtcTxHash,
   fundPeginTransaction,

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/index.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/index.ts
@@ -87,14 +87,14 @@ export {
   peginP2aAnchorOutput,
   supportedTxGraphVersions,
   validatePeginP2aAnchor,
-} from "@babylonlabs-io/babylon-tbv-rust-wasm";
+} from "../wasm";
 export type {
   AssertPayoutNoPayoutConnectorParams,
   ChallengeAssertConnectorParams,
   Network,
   PayoutConnectorParams,
   PeginP2aAnchorInfo,
-} from "@babylonlabs-io/babylon-tbv-rust-wasm";
+} from "../wasm";
 
 /**
  * 0x-prefixed bytes32, keccak256(abi.encode(peginTxHash, depositor)).

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/__tests__/assertPeginTxShape.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/__tests__/assertPeginTxShape.test.ts
@@ -31,14 +31,6 @@ vi.mock("@babylonlabs-io/babylon-tbv-rust-wasm", () => ({
   createPrePeginTransaction: vi.fn(),
   peginP2aAnchorOutput: peginP2aAnchorOutputMock,
   validatePeginP2aAnchor: validatePeginP2aAnchorMock,
-  // Real NUMS constant (BIP-341 lift_x example) — the claim-script
-  // derivation under test must use the byte-identical internal key.
-  tapInternalPubkey: new Uint8Array(
-    Buffer.from(
-      "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0",
-      "hex",
-    ),
-  ),
 }));
 
 import { buildPeginTxFromFundedPrePegin, type PrePeginParams } from "../pegin";

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/assertPayoutFeeBand.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/assertPayoutFeeBand.ts
@@ -12,7 +12,7 @@
  * @module primitives/psbt/assertPayoutFeeBand
  */
 
-import { computePayoutFeeFloor } from "@babylonlabs-io/babylon-tbv-rust-wasm";
+import { computePayoutFeeFloor } from "../../wasm";
 
 /**
  * Floor-model limit, NOT a protocol bound: vault-wasm seeds dummy keys from a

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/assertWasmPeginSizing.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/assertWasmPeginSizing.ts
@@ -20,7 +20,7 @@ import {
   computeMinPeginFee,
   peginP2aAnchorOutput,
   type PrePeginResult,
-} from "@babylonlabs-io/babylon-tbv-rust-wasm";
+} from "../../wasm";
 
 import { MAX_REASONABLE_PEGIN_VBYTES } from "../../utils/fee/constants";
 import type { ParsedOutput } from "../../utils/transaction/fundPeginTransaction";

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/challengeAssert.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/challengeAssert.ts
@@ -16,7 +16,7 @@ import {
   type ChallengeAssertConnectorParams,
   getChallengeAssertScriptInfo,
   tapInternalPubkey,
-} from "@babylonlabs-io/babylon-tbv-rust-wasm";
+} from "../../wasm";
 import { Buffer } from "buffer";
 import { Psbt, Transaction } from "bitcoinjs-lib";
 

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/depositorClaim.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/depositorClaim.ts
@@ -23,7 +23,7 @@
  * @module primitives/psbt/depositorClaim
  */
 
-import { tapInternalPubkey } from "@babylonlabs-io/babylon-tbv-rust-wasm";
+import { tapInternalPubkey } from "../../wasm";
 import { Buffer } from "buffer";
 import { payments, script as bscript, opcodes } from "bitcoinjs-lib";
 

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/noPayout.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/noPayout.ts
@@ -14,7 +14,7 @@ import {
   type Network,
   getAssertNoPayoutScriptInfo,
   tapInternalPubkey,
-} from "@babylonlabs-io/babylon-tbv-rust-wasm";
+} from "../../wasm";
 import { Buffer } from "buffer";
 import { Psbt, Transaction, payments } from "bitcoinjs-lib";
 

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts
@@ -14,7 +14,7 @@ import {
   getAssertPayoutScriptInfo,
   tapInternalPubkey,
   type Network,
-} from "@babylonlabs-io/babylon-tbv-rust-wasm";
+} from "../../wasm";
 import { Psbt, Transaction, type TxInput, type TxOutput } from "bitcoinjs-lib";
 import { Buffer } from "buffer";
 import { deriveLocalChallengers } from "../challengers";

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts
@@ -21,7 +21,7 @@ import {
   peginP2aAnchorOutput,
   validatePeginP2aAnchor,
   type Network,
-} from "@babylonlabs-io/babylon-tbv-rust-wasm";
+} from "../../wasm";
 import { Transaction } from "bitcoinjs-lib";
 
 import { parseUnfundedWasmTransaction } from "../../utils/transaction/fundPeginTransaction";

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/peginInput.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/peginInput.ts
@@ -15,7 +15,7 @@ import {
   getPrePeginHtlcConnectorInfo,
   tapInternalPubkey,
   type Network,
-} from "@babylonlabs-io/babylon-tbv-rust-wasm";
+} from "../../wasm";
 import { Psbt, Transaction, payments } from "bitcoinjs-lib";
 import { Buffer } from "buffer";
 import {

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/refund.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/refund.ts
@@ -12,12 +12,11 @@
  */
 
 import {
-  assertPositiveBigintArray,
   getPrePeginHtlcConnectorInfo,
-  initWasm,
+  loadRawTbvWasm,
   tapInternalPubkey,
-  WasmPrePeginTx,
-} from "@babylonlabs-io/babylon-tbv-rust-wasm";
+} from "../../wasm";
+import { assertPositiveBigintArray } from "../../wasm/value-guards";
 import { Buffer } from "buffer";
 import { Psbt, Transaction } from "bitcoinjs-lib";
 
@@ -74,7 +73,7 @@ export interface BuildRefundPsbtResult {
 export async function buildRefundPsbt(
   params: BuildRefundPsbtParams,
 ): Promise<BuildRefundPsbtResult> {
-  await initWasm();
+  const { WasmPrePeginTx } = await loadRawTbvWasm();
 
   const { prePeginParams, fundedPrePeginTxHex, htlcVout, refundFee, hashlock } =
     params;
@@ -114,7 +113,7 @@ export async function buildRefundPsbt(
     normalizedAuthAnchorHash,
   );
 
-  let fundedTx: WasmPrePeginTx | null = null;
+  let fundedTx: typeof unfundedTx | null = null;
   try {
     // Cross-check the reconstructed unfunded template against the funded
     // transaction: the WASM template's HTLC scriptPubKey at `htlcVout`

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/verifyScriptPathSchnorrSignature.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/verifyScriptPathSchnorrSignature.ts
@@ -34,10 +34,10 @@ import { Psbt, Transaction } from "bitcoinjs-lib";
 
 import { Buffer } from "buffer";
 
+import { X_ONLY_PUBKEY_HEX_LEN } from "../../utils/validation";
 import {
   SCHNORR_SIG_HEX_LEN,
   TAPSCRIPT_LEAF_VERSION,
-  X_ONLY_PUBKEY_HEX_LEN,
   hexToUint8Array,
   stripHexPrefix,
 } from "../utils/bitcoin";

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/scripts/payout.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/scripts/payout.ts
@@ -21,7 +21,7 @@
 import {
   createPayoutConnector,
   type Network,
-} from "@babylonlabs-io/babylon-tbv-rust-wasm";
+} from "../../wasm";
 
 /**
  * Parameters for creating a payout script.

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/utils/bitcoin.ts
@@ -19,24 +19,17 @@ import { Buffer } from "buffer";
 import type { Network } from "@babylonlabs-io/babylon-tbv-rust-wasm";
 import type { Hex } from "viem";
 
+import {
+  COMPRESSED_PUBKEY_HEX_LEN,
+  X_ONLY_PUBKEY_HEX_LEN,
+} from "../../utils/validation";
+
 /**
  * BIP-341 Tapscript leaf version for script-path spends.
  * @see https://github.com/bitcoin/bips/blob/master/bip-0341.mediawiki
  * @see Rust: bitcoin::taproot::LeafVersion::TapScript
  */
 export const TAPSCRIPT_LEAF_VERSION = 0xc0;
-
-/**
- * Hex-string length of a 32-byte BIP-340 x-only public key (taproot,
- * Schnorr). Doubles the byte count: `2 * 32 = 64`.
- */
-export const X_ONLY_PUBKEY_HEX_LEN = 64;
-
-/**
- * Hex-string length of a 33-byte SEC1-compressed secp256k1 public key
- * (`0x02` or `0x03` prefix + 32-byte x-coordinate). `2 * 33 = 66`.
- */
-export const COMPRESSED_PUBKEY_HEX_LEN = 66;
 
 /**
  * Hex-string length of a 65-byte SEC1-uncompressed secp256k1 public

--- a/packages/babylon-ts-sdk/src/tbv/core/recovery/reconstructPeginParams.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/recovery/reconstructPeginParams.ts
@@ -16,12 +16,7 @@
  * @module recovery/reconstructPeginParams
  */
 
-import {
-  computeMinClaimValue,
-  computeMinPeginFee,
-  peginP2aAnchorOutput,
-  type Network,
-} from "@babylonlabs-io/babylon-tbv-rust-wasm";
+import type { Network } from "@babylonlabs-io/babylon-tbv-rust-wasm";
 import { Transaction } from "bitcoinjs-lib";
 
 import type { DepositTerms } from "../deposit-terms/depositTerms";
@@ -33,6 +28,11 @@ import {
   stripHexPrefix,
 } from "../primitives/utils/bitcoin";
 import { calculateBtcTxHash } from "../utils/transaction/btcTxHash";
+import {
+  computeMinClaimValue,
+  computeMinPeginFee,
+  peginP2aAnchorOutput,
+} from "../wasm";
 
 import {
   describePeginParamsCandidate,

--- a/packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts
@@ -18,7 +18,7 @@
  * @see btc-vault crates/vault/src/transactions/nopayout.rs - NoPayout structure
  */
 
-import { type Network } from "@babylonlabs-io/babylon-tbv-rust-wasm";
+import type { Network } from "@babylonlabs-io/babylon-tbv-rust-wasm";
 import { Transaction } from "bitcoinjs-lib";
 
 import type {

--- a/packages/babylon-ts-sdk/src/tbv/core/utils/utxo/reservation.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/utils/utxo/reservation.ts
@@ -16,7 +16,7 @@ import { Buffer } from "buffer";
 import { stripHexPrefix } from "../../primitives/utils/bitcoin";
 import { ContractStatus } from "../../services/deposit/peginState";
 
-import { type UtxoRef } from "./availability";
+import type { UtxoRef } from "./availability";
 
 /** Locally-known pending pegin. `id` is the bytes32 vault id. */
 export interface PendingPeginLike {

--- a/packages/babylon-ts-sdk/src/tbv/core/utils/validation.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/utils/validation.ts
@@ -11,6 +11,12 @@ export const HEX_RE = /^[0-9a-fA-F]+$/;
 /** Bitcoin txid: exactly 64 hex characters (32 bytes). */
 export const TXID_RE = /^[0-9a-fA-F]{64}$/;
 
+/** Hex-string length of a 32-byte BIP-340 x-only public key. */
+export const X_ONLY_PUBKEY_HEX_LEN = 64;
+
+/** Hex-string length of a 33-byte SEC1-compressed secp256k1 public key. */
+export const COMPRESSED_PUBKEY_HEX_LEN = 66;
+
 /**
  * Bitcoin address format gate: 25–90 alphanumeric characters.
  * Covers legacy (P2PKH/P2SH), bech32 (P2WPKH/P2WSH), bech32m (P2TR),

--- a/packages/babylon-ts-sdk/src/tbv/core/vault-secrets/__tests__/deriveVaultRoot.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/vault-secrets/__tests__/deriveVaultRoot.test.ts
@@ -16,6 +16,7 @@ import { uint8ArrayToHex } from "../../primitives/utils/bitcoin";
 import { buildVaultContext, type FundingOutpoint } from "../context";
 import {
   deriveVaultRoot,
+  forwardDeriveContextHash,
   VAULT_APP_NAME,
   type DeriveContextHashCapableWallet,
 } from "../deriveVaultRoot";
@@ -37,6 +38,44 @@ function makeMockWallet(
 ): DeriveContextHashCapableWallet {
   return { deriveContextHash: vi.fn(override) };
 }
+
+describe("forwardDeriveContextHash", () => {
+  class ReceiverAwareWallet implements DeriveContextHashCapableWallet {
+    readonly calls: [string, string][] = [];
+
+    constructor(private readonly rootHex: string) {}
+
+    async deriveContextHash(appName: string, context: string): Promise<string> {
+      this.calls.push([appName, context]);
+      return this.rootHex;
+    }
+  }
+
+  it("preserves the wallet receiver", async () => {
+    const forwarded = forwardDeriveContextHash(
+      new ReceiverAwareWallet(VALID_ROOT_HEX),
+    );
+    if (!forwarded.deriveContextHash) {
+      throw new Error("deriveContextHash was not forwarded");
+    }
+
+    await expect(forwarded.deriveContextHash("app", "context")).resolves.toBe(
+      VALID_ROOT_HEX,
+    );
+  });
+
+  it("forwards both appName and context to the wallet unchanged", async () => {
+    const wallet = new ReceiverAwareWallet(VALID_ROOT_HEX);
+    const forwarded = forwardDeriveContextHash(wallet);
+    if (!forwarded.deriveContextHash) {
+      throw new Error("deriveContextHash was not forwarded");
+    }
+
+    await forwarded.deriveContextHash(VAULT_APP_NAME, "aabbcc");
+
+    expect(wallet.calls).toEqual([[VAULT_APP_NAME, "aabbcc"]]);
+  });
+});
 
 describe("deriveVaultRoot — happy path wiring", () => {
   it("forwards the canonical appName 'babylon-btc-vault'", async () => {

--- a/packages/babylon-ts-sdk/src/tbv/core/vault-secrets/deriveVaultRoot.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/vault-secrets/deriveVaultRoot.ts
@@ -54,10 +54,14 @@ export interface DeriveContextHashCapableWallet {
 export function forwardDeriveContextHash(
   wallet: Partial<DeriveContextHashCapableWallet>,
 ): Partial<DeriveContextHashCapableWallet> {
-  return typeof wallet.deriveContextHash === "function"
+  // Captured before the closure so the narrowing survives it. The property
+  // read cannot be narrowed across a closure boundary, which is what forced
+  // the non-null assertion this replaces; forwarding is otherwise unchanged.
+  const deriveContextHash = wallet.deriveContextHash;
+  return typeof deriveContextHash === "function"
     ? {
         deriveContextHash: (appName, context) =>
-          wallet.deriveContextHash!(appName, context),
+          deriveContextHash.call(wallet, appName, context),
       }
     : {};
 }

--- a/packages/babylon-ts-sdk/src/tbv/core/vault-secrets/index.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/vault-secrets/index.ts
@@ -17,7 +17,7 @@ export {
   expandAuthAnchor,
   expandHashlockSecret,
   expandWotsSeed,
-} from "@babylonlabs-io/babylon-tbv-rust-wasm";
+} from "../wasm";
 
 export { buildFundingOutpointsCommitment, buildVaultContext } from "./context";
 

--- a/packages/babylon-ts-sdk/src/tbv/core/wasm/__tests__/constants.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/wasm/__tests__/constants.test.ts
@@ -1,0 +1,23 @@
+import {
+  TAP_INTERNAL_KEY as WASM_TAP_INTERNAL_KEY,
+  tapInternalPubkey as wasmTapInternalPubkey,
+} from "@babylonlabs-io/babylon-tbv-rust-wasm";
+import { describe, expect, it } from "vitest";
+
+import { TAP_INTERNAL_KEY, tapInternalPubkey } from "../constants";
+
+describe("WASM-free protocol constants", () => {
+  it("keeps the local BIP-341 internal key hex identical to the WASM package's", () => {
+    expect(TAP_INTERNAL_KEY).toBe(WASM_TAP_INTERNAL_KEY);
+  });
+
+  it("keeps the decoded internal key bytes identical to the WASM package's", () => {
+    expect(Array.from(tapInternalPubkey)).toEqual(
+      Array.from(wasmTapInternalPubkey),
+    );
+  });
+
+  it("decodes the internal key to 32 bytes", () => {
+    expect(tapInternalPubkey).toHaveLength(32);
+  });
+});

--- a/packages/babylon-ts-sdk/src/tbv/core/wasm/__tests__/constants.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/wasm/__tests__/constants.test.ts
@@ -1,19 +1,29 @@
-import {
-  TAP_INTERNAL_KEY as WASM_TAP_INTERNAL_KEY,
-  tapInternalPubkey as wasmTapInternalPubkey,
-} from "@babylonlabs-io/babylon-tbv-rust-wasm";
+import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 
 import { TAP_INTERNAL_KEY, tapInternalPubkey } from "../constants";
 
+// Differential source of truth: the engine's own constants, loaded from its
+// TypeScript source rather than its package specifier. The specifier resolves
+// to the engine's built `dist/`, so a stale build would pin this copy to bytes
+// the engine no longer ships.
+const ENGINE_CONSTANTS_SOURCE = resolve(
+  __dirname,
+  "../../../../../../babylon-tbv-rust-wasm/src/constants.ts",
+);
+
+const engineConstants = (await import(
+  /* @vite-ignore */ ENGINE_CONSTANTS_SOURCE
+)) as { TAP_INTERNAL_KEY: string; tapInternalPubkey: Uint8Array };
+
 describe("WASM-free protocol constants", () => {
-  it("keeps the local BIP-341 internal key hex identical to the WASM package's", () => {
-    expect(TAP_INTERNAL_KEY).toBe(WASM_TAP_INTERNAL_KEY);
+  it("keeps the local BIP-341 internal key hex identical to the engine source's", () => {
+    expect(TAP_INTERNAL_KEY).toBe(engineConstants.TAP_INTERNAL_KEY);
   });
 
-  it("keeps the decoded internal key bytes identical to the WASM package's", () => {
+  it("keeps the decoded internal key bytes identical to the engine source's", () => {
     expect(Array.from(tapInternalPubkey)).toEqual(
-      Array.from(wasmTapInternalPubkey),
+      Array.from(engineConstants.tapInternalPubkey),
     );
   });
 

--- a/packages/babylon-ts-sdk/src/tbv/core/wasm/__tests__/loader.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/wasm/__tests__/loader.test.ts
@@ -21,7 +21,7 @@ afterEach(() => {
 });
 
 describe("loadTbvWasm", () => {
-  it("names the missing peer when the engine cannot be resolved", async () => {
+  it("names the engine package when the import fails", async () => {
     vi.doMock(ENGINE, () => {
       throw new Error("Cannot find package");
     });
@@ -29,7 +29,7 @@ describe("loadTbvWasm", () => {
     const { loadTbvWasm } = await import("../index");
 
     await expect(loadTbvWasm()).rejects.toThrow(
-      "requires the optional @babylonlabs-io/babylon-tbv-rust-wasm peer dependency",
+      "@babylonlabs-io/babylon-tbv-rust-wasm failed to load",
     );
   });
 
@@ -59,7 +59,7 @@ describe("loadTbvWasm", () => {
 
     const { loadTbvWasm } = await import("../index");
 
-    await expect(loadTbvWasm()).rejects.toThrow("peer dependency");
+    await expect(loadTbvWasm()).rejects.toThrow("failed to load");
     const engine = await loadTbvWasm();
     expect(engine).toMatchObject({ deriveVaultId: expect.any(Function) });
     expect(attempt).toBe(2);
@@ -76,7 +76,7 @@ describe("loadTbvWasm", () => {
 });
 
 describe("loadRawTbvWasm", () => {
-  it("names the missing raw entry when it cannot be resolved", async () => {
+  it("names the raw entry when the import fails", async () => {
     vi.doMock(RAW, () => {
       throw new Error("Cannot find package");
     });
@@ -84,7 +84,7 @@ describe("loadRawTbvWasm", () => {
     const { loadRawTbvWasm } = await import("../index");
 
     await expect(loadRawTbvWasm()).rejects.toThrow(
-      "requires the optional raw vault-WASM peer entry",
+      "@babylonlabs-io/babylon-tbv-rust-wasm/raw failed to load",
     );
   });
 

--- a/packages/babylon-ts-sdk/src/tbv/core/wasm/__tests__/loader.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/wasm/__tests__/loader.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+/** Every message in an error's `cause` chain, outermost first. */
+function causeMessages(error: unknown): string[] {
+  const messages: string[] = [];
+  let current = error;
+  while (current instanceof Error) {
+    messages.push(current.message);
+    current = current.cause;
+  }
+  return messages;
+}
+
+const ENGINE = "@babylonlabs-io/babylon-tbv-rust-wasm";
+const RAW = "@babylonlabs-io/babylon-tbv-rust-wasm/raw";
+
+afterEach(() => {
+  vi.resetModules();
+  vi.doUnmock(ENGINE);
+  vi.doUnmock(RAW);
+});
+
+describe("loadTbvWasm", () => {
+  it("names the missing peer when the engine cannot be resolved", async () => {
+    vi.doMock(ENGINE, () => {
+      throw new Error("Cannot find package");
+    });
+
+    const { loadTbvWasm } = await import("../index");
+
+    await expect(loadTbvWasm()).rejects.toThrow(
+      "requires the optional @babylonlabs-io/babylon-tbv-rust-wasm peer dependency",
+    );
+  });
+
+  it("keeps the original resolution failure in the cause chain", async () => {
+    vi.doMock(ENGINE, () => {
+      throw new Error("Cannot find package");
+    });
+
+    const { loadTbvWasm } = await import("../index");
+
+    // The operator needs the underlying resolver message, not just ours. Depth
+    // is not asserted: the loader adds one link, the module runner may add its
+    // own, and only the message surviving to the operator matters.
+    const error = await loadTbvWasm().catch((thrown: unknown) => thrown);
+    expect(causeMessages(error)).toContain("Cannot find package");
+  });
+
+  it("succeeds on a retry after a transient load failure", async () => {
+    // A failed load clears the cached promise, so the next call imports again
+    // rather than replaying the rejection forever.
+    let attempt = 0;
+    vi.doMock(ENGINE, () => {
+      attempt += 1;
+      if (attempt === 1) throw new Error("transient network failure");
+      return { deriveVaultId: () => "recovered" };
+    });
+
+    const { loadTbvWasm } = await import("../index");
+
+    await expect(loadTbvWasm()).rejects.toThrow("peer dependency");
+    const engine = await loadTbvWasm();
+    expect(engine).toMatchObject({ deriveVaultId: expect.any(Function) });
+    expect(attempt).toBe(2);
+  });
+
+  it("imports once and shares the module across callers", async () => {
+    vi.doMock(ENGINE, () => ({ deriveVaultId: () => "ok" }));
+
+    const { loadTbvWasm } = await import("../index");
+
+    const [first, second] = await Promise.all([loadTbvWasm(), loadTbvWasm()]);
+    expect(first).toBe(second);
+  });
+});
+
+describe("loadRawTbvWasm", () => {
+  it("names the missing raw entry when it cannot be resolved", async () => {
+    vi.doMock(RAW, () => {
+      throw new Error("Cannot find package");
+    });
+
+    const { loadRawTbvWasm } = await import("../index");
+
+    await expect(loadRawTbvWasm()).rejects.toThrow(
+      "requires the optional raw vault-WASM peer entry",
+    );
+  });
+
+  it("blames initialization, not a missing dependency, when initWasm throws", async () => {
+    // The entry resolved: telling an operator to install a package they already
+    // have hides the real cause, which survives only in the cause chain.
+    vi.doMock(RAW, () => ({
+      initWasm: async () => {
+        throw new Error("wasm instantiation failed");
+      },
+    }));
+
+    const { loadRawTbvWasm } = await import("../index");
+
+    const error = await loadRawTbvWasm().catch((thrown: unknown) => thrown);
+    expect((error as Error).message).toMatch(/binary failed to initialize/);
+    expect(causeMessages(error)).toContain("wasm instantiation failed");
+  });
+
+  it("clears the cache after an initWasm failure so a retry re-initializes", async () => {
+    // initWasm runs inside the cached promise, so a failure there has to clear
+    // the cache too or the engine is unusable for the rest of the session.
+    let initCalls = 0;
+    vi.doMock(RAW, () => ({
+      initWasm: async () => {
+        initCalls += 1;
+        if (initCalls === 1) throw new Error("wasm instantiation failed");
+      },
+    }));
+
+    const { loadRawTbvWasm } = await import("../index");
+
+    await expect(loadRawTbvWasm()).rejects.toThrow(/failed to initialize/);
+    await expect(loadRawTbvWasm()).resolves.toMatchObject({
+      initWasm: expect.any(Function),
+    });
+    expect(initCalls).toBe(2);
+  });
+});

--- a/packages/babylon-ts-sdk/src/tbv/core/wasm/__tests__/value-guards.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/wasm/__tests__/value-guards.test.ts
@@ -1,7 +1,21 @@
-import { assertPositiveBigintArray as wasmAssertPositiveBigintArray } from "@babylonlabs-io/babylon-tbv-rust-wasm";
+import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 
 import { assertPositiveBigintArray } from "../value-guards";
+
+// Differential source of truth: the engine's own guard, loaded from its
+// TypeScript source rather than its package specifier. The specifier resolves
+// to the engine's built `dist/`, so a stale build would pin this copy to bytes
+// the engine no longer ships.
+const ENGINE_VALUE_GUARDS_SOURCE = resolve(
+  __dirname,
+  "../../../../../../babylon-tbv-rust-wasm/src/value-guards.ts",
+);
+
+const { assertPositiveBigintArray: engineAssertPositiveBigintArray } =
+  (await import(/* @vite-ignore */ ENGINE_VALUE_GUARDS_SOURCE)) as {
+    assertPositiveBigintArray: (values: unknown, label: string) => bigint[];
+  };
 
 const U64_MAX = 18446744073709551615n;
 const ABOVE_U64_MAX = 18446744073709551616n;
@@ -108,7 +122,7 @@ describe("assertPositiveBigintArray", () => {
     );
   });
 
-  it("behaves identically to the WASM package's copy on boundary vectors", () => {
+  it("behaves identically to the engine source's copy on boundary vectors", () => {
     const vectors: unknown[] = [
       [1n],
       [1n, 2n, 100_000n],
@@ -127,17 +141,17 @@ describe("assertPositiveBigintArray", () => {
       { 0: 1n, length: 1 },
     ];
     const local = outcome(assertPositiveBigintArray);
-    const wasm = outcome(wasmAssertPositiveBigintArray);
+    const wasm = outcome(engineAssertPositiveBigintArray);
 
     for (const vector of vectors) {
       expect(local(vector)).toEqual(wasm(vector));
     }
   });
 
-  it("behaves identically to the WASM package's copy on seeded random vectors", () => {
+  it("behaves identically to the engine source's copy on seeded random vectors", () => {
     const next = mulberry32(RANDOM_VECTOR_SEED);
     const local = outcome(assertPositiveBigintArray);
-    const wasm = outcome(wasmAssertPositiveBigintArray);
+    const wasm = outcome(engineAssertPositiveBigintArray);
 
     for (let index = 0; index < RANDOM_VECTOR_COUNT; index += 1) {
       const vector = randomVector(next);

--- a/packages/babylon-ts-sdk/src/tbv/core/wasm/__tests__/value-guards.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/wasm/__tests__/value-guards.test.ts
@@ -1,0 +1,150 @@
+import { assertPositiveBigintArray as wasmAssertPositiveBigintArray } from "@babylonlabs-io/babylon-tbv-rust-wasm";
+import { describe, expect, it } from "vitest";
+
+import { assertPositiveBigintArray } from "../value-guards";
+
+const U64_MAX = 18446744073709551615n;
+const ABOVE_U64_MAX = 18446744073709551616n;
+const RANDOM_VECTOR_SEED = 0x5eedc0de;
+const RANDOM_VECTOR_COUNT = 256;
+const MAX_RANDOM_ARRAY_LENGTH = 4;
+const U32_MODULUS = 0x100000000;
+const RANDOM_VECTOR_SHAPES = 10;
+
+function outcome(guard: (values: unknown, label: string) => bigint[]) {
+  return (values: unknown): bigint[] | string => {
+    try {
+      return guard(values, "peginAmounts");
+    } catch (error) {
+      return (error as Error).message;
+    }
+  };
+}
+
+function mulberry32(seed: number): () => number {
+  let state = seed >>> 0;
+  return () => {
+    state = (state + 0x6d2b79f5) >>> 0;
+    let t = state;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / U32_MODULUS;
+  };
+}
+
+function randomU64(next: () => number): bigint {
+  const high = BigInt(Math.floor(next() * U32_MODULUS));
+  const low = BigInt(Math.floor(next() * U32_MODULUS));
+  return (high << 32n) | low;
+}
+
+function randomElement(next: () => number): unknown {
+  const pool: unknown[] = [
+    randomU64(next),
+    (randomU64(next) % 100_000n) + 1n,
+    0n,
+    -randomU64(next) - 1n,
+    1n,
+    U64_MAX,
+    ABOVE_U64_MAX,
+    ABOVE_U64_MAX + randomU64(next),
+    Number(randomU64(next) % 100_000n),
+    String(randomU64(next)),
+    undefined,
+    null,
+  ];
+  return pool[Math.floor(next() * pool.length)];
+}
+
+function randomVector(next: () => number): unknown {
+  const shape = Math.floor(next() * RANDOM_VECTOR_SHAPES);
+  if (shape === 0) return undefined;
+  if (shape === 1) return "not an array";
+  if (shape === 2) return { 0: 1n, length: 1 };
+  if (shape === 3) return [];
+  const length = 1 + Math.floor(next() * MAX_RANDOM_ARRAY_LENGTH);
+  return Array.from({ length }, () => randomElement(next));
+}
+
+describe("assertPositiveBigintArray", () => {
+  it("returns the narrowed array for valid satoshi amounts", () => {
+    expect(assertPositiveBigintArray([1n, U64_MAX], "peginAmounts")).toEqual([
+      1n,
+      U64_MAX,
+    ]);
+  });
+
+  it("rejects a non-array with the label and the received type", () => {
+    expect(() => assertPositiveBigintArray("nope", "peginAmounts")).toThrow(
+      "peginAmounts must be an array of positive bigints (got string).",
+    );
+  });
+
+  it("rejects an empty array", () => {
+    expect(() => assertPositiveBigintArray([], "peginAmounts")).toThrow(
+      "peginAmounts must not be empty.",
+    );
+  });
+
+  it("rejects a non-bigint element at its index", () => {
+    expect(() => assertPositiveBigintArray([1n, 2], "peginAmounts")).toThrow(
+      "peginAmounts[1] must be a bigint (got number); " +
+        "refusing to feed it into satoshi math.",
+    );
+  });
+
+  it("rejects a non-positive element at its index", () => {
+    expect(() => assertPositiveBigintArray([0n], "peginAmounts")).toThrow(
+      "peginAmounts[0] must be > 0 (got 0).",
+    );
+  });
+
+  it("rejects an amount that BigUint64Array would wrap mod 2^64", () => {
+    expect(() =>
+      assertPositiveBigintArray([1n, ABOVE_U64_MAX], "peginAmounts"),
+    ).toThrow(
+      "peginAmounts[1] must fit in a u64 (got 18446744073709551616); " +
+        "refusing to feed it into satoshi math.",
+    );
+  });
+
+  it("behaves identically to the WASM package's copy on boundary vectors", () => {
+    const vectors: unknown[] = [
+      [1n],
+      [1n, 2n, 100_000n],
+      [U64_MAX],
+      [0n],
+      [-1n],
+      [1n, 0n],
+      [ABOVE_U64_MAX],
+      [1n, ABOVE_U64_MAX],
+      [1],
+      ["1"],
+      [undefined],
+      [],
+      undefined,
+      "not an array",
+      { 0: 1n, length: 1 },
+    ];
+    const local = outcome(assertPositiveBigintArray);
+    const wasm = outcome(wasmAssertPositiveBigintArray);
+
+    for (const vector of vectors) {
+      expect(local(vector)).toEqual(wasm(vector));
+    }
+  });
+
+  it("behaves identically to the WASM package's copy on seeded random vectors", () => {
+    const next = mulberry32(RANDOM_VECTOR_SEED);
+    const local = outcome(assertPositiveBigintArray);
+    const wasm = outcome(wasmAssertPositiveBigintArray);
+
+    for (let index = 0; index < RANDOM_VECTOR_COUNT; index += 1) {
+      const vector = randomVector(next);
+      expect(
+        local(vector),
+        `seed ${RANDOM_VECTOR_SEED}, vector ${index}: ${String(vector)}`,
+      ).toEqual(wasm(vector));
+    }
+  });
+});

--- a/packages/babylon-ts-sdk/src/tbv/core/wasm/constants.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/wasm/constants.ts
@@ -2,7 +2,7 @@
  * Protocol constants that do not require loading the vault WASM module.
  *
  * Keeping these values local lets Bitcoin builders construct PSBT metadata
- * without resolving or evaluating the optional WASM peer at module-import
+ * without resolving or evaluating the WASM engine at module-import
  * time. The hex value is the BIP-341 nothing-up-my-sleeve internal key and is
  * pinned by the vault protocol.
  */

--- a/packages/babylon-ts-sdk/src/tbv/core/wasm/constants.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/wasm/constants.ts
@@ -1,0 +1,24 @@
+/**
+ * Protocol constants that do not require loading the vault WASM module.
+ *
+ * Keeping these values local lets Bitcoin builders construct PSBT metadata
+ * without resolving or evaluating the optional WASM peer at module-import
+ * time. The hex value is the BIP-341 nothing-up-my-sleeve internal key and is
+ * pinned by the vault protocol.
+ */
+export const TAP_INTERNAL_KEY =
+  "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0";
+
+const HEX_CHARS_PER_BYTE = 2;
+
+export const tapInternalPubkey = Uint8Array.from(
+  { length: TAP_INTERNAL_KEY.length / HEX_CHARS_PER_BYTE },
+  (_, index) =>
+    Number.parseInt(
+      TAP_INTERNAL_KEY.slice(
+        index * HEX_CHARS_PER_BYTE,
+        index * HEX_CHARS_PER_BYTE + HEX_CHARS_PER_BYTE,
+      ),
+      16,
+    ),
+);

--- a/packages/babylon-ts-sdk/src/tbv/core/wasm/index.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/wasm/index.ts
@@ -1,8 +1,8 @@
 /**
- * Explicit lazy boundary around the optional vault-WASM package.
+ * Explicit lazy boundary around the vault-WASM engine package.
  *
  * Importing the SDK (including its legacy root barrels) does not resolve the
- * WASM package or generated binary. The peer is loaded only when a caller
+ * WASM package or generated binary. The engine is loaded only when a caller
  * invokes an operation that actually needs the Bitcoin transaction graph.
  * ETH-only entry points never import this module.
  *
@@ -35,14 +35,16 @@ type RawTbvWasmModule =
   typeof import("@babylonlabs-io/babylon-tbv-rust-wasm/raw");
 let rawWasmModulePromise: Promise<RawTbvWasmModule> | undefined;
 
-/** Load the optional WASM peer on first use and share the in-flight import. */
+/** Load the WASM engine on first use and share the in-flight import. */
 export function loadTbvWasm(): Promise<TbvWasmModule> {
   wasmModulePromise ??= import("@babylonlabs-io/babylon-tbv-rust-wasm").catch(
     (error: unknown) => {
       wasmModulePromise = undefined;
       throw new Error(
-        "This operation requires the optional " +
-          "@babylonlabs-io/babylon-tbv-rust-wasm peer dependency.",
+        "The vault-WASM engine @babylonlabs-io/babylon-tbv-rust-wasm failed " +
+          "to load. The module could not be resolved, or it threw while " +
+          "evaluating, commonly a missing or stale generated WASM build. " +
+          "See the cause for the underlying error.",
         { cause: error },
       );
     },
@@ -59,7 +61,9 @@ export function loadRawTbvWasm(): Promise<RawTbvWasmModule> {
     .catch((error: unknown) => {
       rawWasmModulePromise = undefined;
       throw new Error(
-        "This operation requires the optional raw vault-WASM peer entry.",
+        "The raw vault-WASM entry @babylonlabs-io/babylon-tbv-rust-wasm/raw " +
+          "failed to load. The module could not be resolved, or it threw " +
+          "while evaluating. See the cause for the underlying error.",
         { cause: error },
       );
     })
@@ -69,7 +73,7 @@ export function loadRawTbvWasm(): Promise<RawTbvWasmModule> {
       } catch (error: unknown) {
         rawWasmModulePromise = undefined;
         throw new Error(
-          "The raw vault-WASM peer entry resolved but its WebAssembly " +
+          "The raw vault-WASM entry resolved but its WebAssembly " +
             "binary failed to initialize.",
           { cause: error },
         );
@@ -79,17 +83,40 @@ export function loadRawTbvWasm(): Promise<RawTbvWasmModule> {
   return rawWasmModulePromise;
 }
 
-export async function initWasm(): Promise<void> {
-  const wasm = await loadTbvWasm();
-  await wasm.initWasm();
-}
-
+/**
+ * Creates an unfunded Pre-PegIn transaction with no inputs and HTLC output(s).
+ *
+ * The HTLC output value (htlcValue) covers the peg-in amount, depositor claim value,
+ * and minimum pegin fee — all computed internally from the provided contract parameters.
+ *
+ * After building the Pre-PegIn transaction, the caller must:
+ * 1. Select UTXOs covering htlcValue + network fees
+ * 2. Fund the transaction (add inputs and change output)
+ * 3. Call reconstructFromFundedTx() with the funded tx hex
+ * 4. Call buildPeginTx() to derive the PegIn transaction
+ * 5. Sign the PegIn input using the HTLC hashlock leaf (leaf 0)
+ *
+ * @param params - Pre-PegIn parameters from contract and depositor wallet
+ * @returns Unfunded transaction details with HTLC output information
+ */
 export async function createPrePeginTransaction(
   params: PrePeginParams,
 ): Promise<PrePeginResult> {
   return (await loadTbvWasm()).createPrePeginTransaction(params);
 }
 
+/**
+ * Derives the PegIn transaction from a funded Pre-PegIn transaction.
+ *
+ * The PegIn transaction has a single input spending the Pre-PegIn HTLC output
+ * at `htlcVout` via the hashlock + all-party script (leaf 0).
+ *
+ * @param params - Same PrePeginParams used to create the Pre-PegIn transaction
+ * @param timelockPegin - CSV timelock in blocks for the PegIn vault output
+ * @param fundedPrePeginTxHex - Hex-encoded funded Pre-PegIn transaction
+ * @param htlcVout - Index of the HTLC output to spend
+ * @returns PegIn transaction details including vault output information
+ */
 export async function buildPeginTxFromPrePegin(
   params: PrePeginParams,
   timelockPegin: number,
@@ -104,12 +131,28 @@ export async function buildPeginTxFromPrePegin(
   );
 }
 
+/**
+ * Returns HTLC connector script info for signing the PegIn transaction input.
+ *
+ * The depositor signs PegIn input 0 using the hashlock leaf (leaf 0) of the
+ * Pre-PegIn HTLC output. Use getHashlockScript() and getHashlockControlBlock()
+ * to construct the tapLeafScript entry in the PSBT.
+ *
+ * @param params - HTLC connector parameters (subset of PrePeginParams)
+ * @returns Hashlock and refund script info for PSBT construction
+ */
 export async function getPrePeginHtlcConnectorInfo(
   params: HtlcConnectorParams,
 ): Promise<HtlcConnectorInfo> {
   return (await loadTbvWasm()).getPrePeginHtlcConnectorInfo(params);
 }
 
+/**
+ * Compute the minimum depositor claim value (PegIn output 1) in satoshis.
+ *
+ * This covers the full downstream tx graph cost (Claim → Assert → Payout)
+ * based on the protocol parameters.
+ */
 export async function computeMinClaimValue(
   txGraphVersion: number,
   numLocalChallengers: number,
@@ -128,6 +171,16 @@ export async function computeMinClaimValue(
   );
 }
 
+/**
+ * Compute the minimum PegIn (activation) transaction fee in satoshis.
+ *
+ * `minPeginFee = peginTxVsize(numVks, numUcs) × minPeginFeeRate`. Each HTLC
+ * the depositor funds in the Pre-PegIn tx must reserve at least this fee
+ * inside its value (`htlcValue = peginAmount + depositorClaimValue +
+ * minPeginFee`), otherwise the VP cannot afford to broadcast the PegIn at
+ * activation. The vsize comes from a Taproot script-path-spend weight
+ * prediction whose witness shape depends on the VK + UC signer count.
+ */
 export async function computeMinPeginFee(
   txGraphVersion: number,
   numVks: number,
@@ -142,6 +195,18 @@ export async function computeMinPeginFee(
   );
 }
 
+/**
+ * Floor of the Payout transaction fee under `txGraphVersion`: the minimum of
+ * `estimatedVsize * feeRate` across every output-sizing model a deployed
+ * vault provider is known to have used (fixed-34, intermediate,
+ * script-aware). A VP-built payout paying less than this is provably not
+ * produced by any known VP build. `out0Len` must be the TRUSTED length of the
+ * pinned outs[0] script (1..=128); `out1Len` is the measured, UNTRUSTED
+ * commission-script length — safe here because padding cannot raise the floor
+ * (the fixed-34 model saturates the minimum) and shortening only lowers it.
+ * Pass `undefined` for `out1Len` on 2-output (non-VP-claimer) payouts.
+ * `feeRate` is the vault's version-locked `offchainParams.feeRate`.
+ */
 export async function computePayoutFeeFloor(
   txGraphVersion: number,
   numVaultKeepers: number,
@@ -164,16 +229,39 @@ export async function computePayoutFeeFloor(
   );
 }
 
+/**
+ * Tx graph versions the shipped vault-wasm binary can build. Callers must
+ * preflight the required version (fresh: active; resume: stamped) against
+ * this list and fail closed instead of hitting per-call errors mid-flow.
+ *
+ * Note: the facade constructors themselves fail closed on unsupported
+ * versions, and derived objects carry the version they were built with —
+ * value-level cross-checks live in `assertWasmPeginSizing` and the golden
+ * byte-parity tests, not in a per-call version echo.
+ */
 export async function supportedTxGraphVersions(): Promise<number[]> {
   return (await loadTbvWasm()).supportedTxGraphVersions();
 }
 
+/**
+ * The PegIn transaction's P2A (pay-to-anchor) output for a graph version, or
+ * `null` when that version's PegIn carries no anchor (v1). The facade returns
+ * one record per version — never a zero-valued placeholder — so an absent
+ * anchor can't be mistaken for a real output. For v2/v3: 240 sats at vout 2,
+ * script `51024e73`.
+ */
 export async function peginP2aAnchorOutput(
   txGraphVersion: number,
 ): Promise<PeginP2aAnchorInfo | null> {
   return (await loadTbvWasm()).peginP2aAnchorOutput(txGraphVersion);
 }
 
+/**
+ * Validate a PegIn transaction's P2A anchor against a graph version's rules:
+ * v2 and v3 require the exact anchor (240 sats, vout 2, P2A script) and v1
+ * requires that NO output carries the P2A script. Throws on any mismatch — a
+ * v2 PegIn checked as v1 fails closed, and vice versa.
+ */
 export async function validatePeginP2aAnchor(
   txGraphVersion: number,
   txHex: string,
@@ -181,6 +269,16 @@ export async function validatePeginP2aAnchor(
   return (await loadTbvWasm()).validatePeginP2aAnchor(txGraphVersion, txHex);
 }
 
+/**
+ * Creates a payout connector for vault transactions.
+ *
+ * The payout connector generates the necessary taproot scripts and information
+ * required for signing payout transactions (both optimistic and regular payout paths).
+ *
+ * @param params - Parameters for creating the payout connector
+ * @param network - Bitcoin network
+ * @returns Payout connector information including scripts, hashes, and address
+ */
 export async function createPayoutConnector(
   params: PayoutConnectorParams,
   network: Network,
@@ -188,18 +286,30 @@ export async function createPayoutConnector(
   return (await loadTbvWasm()).createPayoutConnector(params, network);
 }
 
-export async function getPeginPayoutScriptInfo(
-  params: PayoutConnectorParams,
-): Promise<{ payoutScript: string; payoutControlBlock: string }> {
-  return (await loadTbvWasm()).getPeginPayoutScriptInfo(params);
-}
-
+/**
+ * Get the Payout script and control block for the depositor's Assert output.
+ *
+ * Used to build the depositor's Payout PSBT (depositor-as-claimer path).
+ *
+ * @param params - Assert Payout/NoPayout connector parameters
+ * @returns Payout script and control block (hex encoded)
+ */
 export async function getAssertPayoutScriptInfo(
   params: AssertPayoutNoPayoutConnectorParams,
 ): Promise<AssertPayoutScriptInfo> {
   return (await loadTbvWasm()).getAssertPayoutScriptInfo(params);
 }
 
+/**
+ * Get the NoPayout script and control block for a specific challenger.
+ *
+ * Used to build the depositor's NoPayout PSBT (depositor-as-claimer path).
+ * Each challenger has a distinct NoPayout script.
+ *
+ * @param params - Assert Payout/NoPayout connector parameters
+ * @param challengerPubkey - The challenger's x-only public key (hex encoded)
+ * @returns NoPayout script and control block (hex encoded)
+ */
 export async function getAssertNoPayoutScriptInfo(
   params: AssertPayoutNoPayoutConnectorParams,
   challengerPubkey: string,
@@ -210,16 +320,42 @@ export async function getAssertNoPayoutScriptInfo(
   );
 }
 
+/**
+ * Get the ChallengeAssert script and control block.
+ *
+ * Used to build ChallengeAssert PSBTs for the depositor-as-claimer path.
+ * Each challenger has 3 ChallengeAssert transactions, and this connector
+ * generates the spending scripts using WOTS public keys from the VP.
+ *
+ * @param params - ChallengeAssert connector parameters
+ * @returns Script and control block (hex encoded)
+ */
 export async function getChallengeAssertScriptInfo(
   params: ChallengeAssertConnectorParams,
 ): Promise<ChallengeAssertScriptInfo> {
   return (await loadTbvWasm()).getChallengeAssertScriptInfo(params);
 }
 
+/**
+ * Derive 32-byte `authAnchor` (OP_RETURN preimage → VP bearer token).
+ * @stability frozen — forwards the frozen expander in `@babylonlabs-io/babylon-tbv-rust-wasm`; see CLAUDE.md §4.
+ */
+/**
+ * Derive 32-byte `authAnchor` (OP_RETURN preimage → VP bearer token).
+ * @stability frozen — owned by btc-vault Rust via the vault-wasm pin (`VAULT_WASM_COMMIT`); rotation breaks VP auth for existing deposits.
+ */
 export async function expandAuthAnchor(root: Uint8Array): Promise<Uint8Array> {
   return (await loadTbvWasm()).expandAuthAnchor(root);
 }
 
+/**
+ * Derive 32-byte `hashlockSecret` for HTLC `htlcVout` (preimage → `activateVaultWithSecret`).
+ * @stability frozen — forwards the frozen expander in `@babylonlabs-io/babylon-tbv-rust-wasm`; see CLAUDE.md §4.
+ */
+/**
+ * Derive 32-byte `hashlockSecret` for HTLC `htlcVout` (preimage → `activateVaultWithSecret`).
+ * @stability frozen — owned by btc-vault Rust; rotation means affected vaults can never activate.
+ */
 export async function expandHashlockSecret(
   root: Uint8Array,
   htlcVout: number,
@@ -227,6 +363,14 @@ export async function expandHashlockSecret(
   return (await loadTbvWasm()).expandHashlockSecret(root, htlcVout);
 }
 
+/**
+ * Derive 64-byte `wotsSeed` for HTLC `htlcVout` (→ WOTS keys, hashed as `depositorWotsPkHash`).
+ * @stability frozen — forwards the frozen expander in `@babylonlabs-io/babylon-tbv-rust-wasm`; see CLAUDE.md §4.
+ */
+/**
+ * Derive 64-byte `wotsSeed` for HTLC `htlcVout` (→ WOTS keys, hashed as `depositorWotsPkHash`).
+ * @stability frozen — owned by btc-vault Rust; rotation breaks existing `depositorWotsPkHash` → no claim path.
+ */
 export async function expandWotsSeed(
   root: Uint8Array,
   htlcVout: number,
@@ -234,6 +378,16 @@ export async function expandWotsSeed(
   return (await loadTbvWasm()).expandWotsSeed(root, htlcVout);
 }
 
+/**
+ * Derives the vault ID from a PegIn transaction hash and depositor ETH address.
+ *
+ * Vault ID = keccak256(abi.encode(peginTxHash, depositor))
+ * This matches the Solidity-side derivation in BTCVaultRegistry.
+ *
+ * @param peginTxHash - 32-byte PegIn tx hash in display order (big-endian), hex encoded
+ * @param depositor - 20-byte Ethereum address of the depositor, hex encoded
+ * @returns Hex-encoded vault ID (32 bytes)
+ */
 export async function deriveVaultId(
   peginTxHash: string,
   depositor: string,

--- a/packages/babylon-ts-sdk/src/tbv/core/wasm/index.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/wasm/index.ts
@@ -1,0 +1,259 @@
+/**
+ * Explicit lazy boundary around the optional vault-WASM package.
+ *
+ * Importing the SDK (including its legacy root barrels) does not resolve the
+ * WASM package or generated binary. The peer is loaded only when a caller
+ * invokes an operation that actually needs the Bitcoin transaction graph.
+ * ETH-only entry points never import this module.
+ *
+ * @module tbv/core/wasm
+ */
+
+import type {
+  AssertNoPayoutScriptInfo,
+  AssertPayoutNoPayoutConnectorParams,
+  AssertPayoutScriptInfo,
+  ChallengeAssertConnectorParams,
+  ChallengeAssertScriptInfo,
+  HtlcConnectorInfo,
+  HtlcConnectorParams,
+  Network,
+  PayoutConnectorInfo,
+  PayoutConnectorParams,
+  PeginP2aAnchorInfo,
+  PeginTxResult,
+  PrePeginParams,
+  PrePeginResult,
+} from "@babylonlabs-io/babylon-tbv-rust-wasm";
+
+export { TAP_INTERNAL_KEY, tapInternalPubkey } from "./constants";
+
+type TbvWasmModule = typeof import("@babylonlabs-io/babylon-tbv-rust-wasm");
+
+let wasmModulePromise: Promise<TbvWasmModule> | undefined;
+type RawTbvWasmModule =
+  typeof import("@babylonlabs-io/babylon-tbv-rust-wasm/raw");
+let rawWasmModulePromise: Promise<RawTbvWasmModule> | undefined;
+
+/** Load the optional WASM peer on first use and share the in-flight import. */
+export function loadTbvWasm(): Promise<TbvWasmModule> {
+  wasmModulePromise ??= import("@babylonlabs-io/babylon-tbv-rust-wasm").catch(
+    (error: unknown) => {
+      wasmModulePromise = undefined;
+      throw new Error(
+        "This operation requires the optional " +
+          "@babylonlabs-io/babylon-tbv-rust-wasm peer dependency.",
+        { cause: error },
+      );
+    },
+  );
+  return wasmModulePromise;
+}
+
+/**
+ * Load the explicit raw-class entry for the one SDK primitive that must
+ * reconstruct a stateful WASM transaction object (refund construction).
+ */
+export function loadRawTbvWasm(): Promise<RawTbvWasmModule> {
+  rawWasmModulePromise ??= import("@babylonlabs-io/babylon-tbv-rust-wasm/raw")
+    .catch((error: unknown) => {
+      rawWasmModulePromise = undefined;
+      throw new Error(
+        "This operation requires the optional raw vault-WASM peer entry.",
+        { cause: error },
+      );
+    })
+    .then(async (wasm) => {
+      try {
+        await wasm.initWasm();
+      } catch (error: unknown) {
+        rawWasmModulePromise = undefined;
+        throw new Error(
+          "The raw vault-WASM peer entry resolved but its WebAssembly " +
+            "binary failed to initialize.",
+          { cause: error },
+        );
+      }
+      return wasm;
+    });
+  return rawWasmModulePromise;
+}
+
+export async function initWasm(): Promise<void> {
+  const wasm = await loadTbvWasm();
+  await wasm.initWasm();
+}
+
+export async function createPrePeginTransaction(
+  params: PrePeginParams,
+): Promise<PrePeginResult> {
+  return (await loadTbvWasm()).createPrePeginTransaction(params);
+}
+
+export async function buildPeginTxFromPrePegin(
+  params: PrePeginParams,
+  timelockPegin: number,
+  fundedPrePeginTxHex: string,
+  htlcVout: number,
+): Promise<PeginTxResult> {
+  return (await loadTbvWasm()).buildPeginTxFromPrePegin(
+    params,
+    timelockPegin,
+    fundedPrePeginTxHex,
+    htlcVout,
+  );
+}
+
+export async function getPrePeginHtlcConnectorInfo(
+  params: HtlcConnectorParams,
+): Promise<HtlcConnectorInfo> {
+  return (await loadTbvWasm()).getPrePeginHtlcConnectorInfo(params);
+}
+
+export async function computeMinClaimValue(
+  txGraphVersion: number,
+  numLocalChallengers: number,
+  numUniversalChallengers: number,
+  councilQuorum: number,
+  councilSize: number,
+  feeRate: bigint,
+): Promise<bigint> {
+  return (await loadTbvWasm()).computeMinClaimValue(
+    txGraphVersion,
+    numLocalChallengers,
+    numUniversalChallengers,
+    councilQuorum,
+    councilSize,
+    feeRate,
+  );
+}
+
+export async function computeMinPeginFee(
+  txGraphVersion: number,
+  numVks: number,
+  numUcs: number,
+  minPeginFeeRate: bigint,
+): Promise<bigint> {
+  return (await loadTbvWasm()).computeMinPeginFee(
+    txGraphVersion,
+    numVks,
+    numUcs,
+    minPeginFeeRate,
+  );
+}
+
+export async function computePayoutFeeFloor(
+  txGraphVersion: number,
+  numVaultKeepers: number,
+  numUniversalChallengers: number,
+  numLocalChallengers: number,
+  councilSize: number,
+  out0Len: number,
+  out1Len: number | null | undefined,
+  feeRate: bigint,
+): Promise<bigint> {
+  return (await loadTbvWasm()).computePayoutFeeFloor(
+    txGraphVersion,
+    numVaultKeepers,
+    numUniversalChallengers,
+    numLocalChallengers,
+    councilSize,
+    out0Len,
+    out1Len,
+    feeRate,
+  );
+}
+
+export async function supportedTxGraphVersions(): Promise<number[]> {
+  return (await loadTbvWasm()).supportedTxGraphVersions();
+}
+
+export async function peginP2aAnchorOutput(
+  txGraphVersion: number,
+): Promise<PeginP2aAnchorInfo | null> {
+  return (await loadTbvWasm()).peginP2aAnchorOutput(txGraphVersion);
+}
+
+export async function validatePeginP2aAnchor(
+  txGraphVersion: number,
+  txHex: string,
+): Promise<void> {
+  return (await loadTbvWasm()).validatePeginP2aAnchor(txGraphVersion, txHex);
+}
+
+export async function createPayoutConnector(
+  params: PayoutConnectorParams,
+  network: Network,
+): Promise<PayoutConnectorInfo> {
+  return (await loadTbvWasm()).createPayoutConnector(params, network);
+}
+
+export async function getPeginPayoutScriptInfo(
+  params: PayoutConnectorParams,
+): Promise<{ payoutScript: string; payoutControlBlock: string }> {
+  return (await loadTbvWasm()).getPeginPayoutScriptInfo(params);
+}
+
+export async function getAssertPayoutScriptInfo(
+  params: AssertPayoutNoPayoutConnectorParams,
+): Promise<AssertPayoutScriptInfo> {
+  return (await loadTbvWasm()).getAssertPayoutScriptInfo(params);
+}
+
+export async function getAssertNoPayoutScriptInfo(
+  params: AssertPayoutNoPayoutConnectorParams,
+  challengerPubkey: string,
+): Promise<AssertNoPayoutScriptInfo> {
+  return (await loadTbvWasm()).getAssertNoPayoutScriptInfo(
+    params,
+    challengerPubkey,
+  );
+}
+
+export async function getChallengeAssertScriptInfo(
+  params: ChallengeAssertConnectorParams,
+): Promise<ChallengeAssertScriptInfo> {
+  return (await loadTbvWasm()).getChallengeAssertScriptInfo(params);
+}
+
+export async function expandAuthAnchor(root: Uint8Array): Promise<Uint8Array> {
+  return (await loadTbvWasm()).expandAuthAnchor(root);
+}
+
+export async function expandHashlockSecret(
+  root: Uint8Array,
+  htlcVout: number,
+): Promise<Uint8Array> {
+  return (await loadTbvWasm()).expandHashlockSecret(root, htlcVout);
+}
+
+export async function expandWotsSeed(
+  root: Uint8Array,
+  htlcVout: number,
+): Promise<Uint8Array> {
+  return (await loadTbvWasm()).expandWotsSeed(root, htlcVout);
+}
+
+export async function deriveVaultId(
+  peginTxHash: string,
+  depositor: string,
+): Promise<string> {
+  return (await loadTbvWasm()).deriveVaultId(peginTxHash, depositor);
+}
+
+export type {
+  AssertNoPayoutScriptInfo,
+  AssertPayoutNoPayoutConnectorParams,
+  AssertPayoutScriptInfo,
+  ChallengeAssertConnectorParams,
+  ChallengeAssertScriptInfo,
+  HtlcConnectorInfo,
+  HtlcConnectorParams,
+  Network,
+  PayoutConnectorInfo,
+  PayoutConnectorParams,
+  PeginP2aAnchorInfo,
+  PeginTxResult,
+  PrePeginParams,
+  PrePeginResult,
+};

--- a/packages/babylon-ts-sdk/src/tbv/core/wasm/value-guards.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/wasm/value-guards.ts
@@ -10,8 +10,11 @@
  * {@link assertPositiveBigintArray} validates such inputs before the
  * typed-array construction.
  *
- * Mirrors `value-guards.ts` in `@babylonlabs-io/babylon-tbv-rust-wasm`; the two
- * are pinned to identical behaviour by `__tests__/value-guards.test.ts`.
+ * Mirrors the `assertPositiveBigintArray` half of `value-guards.ts` in
+ * `@babylonlabs-io/babylon-tbv-rust-wasm`; that one function is pinned to the
+ * engine's source copy by `__tests__/value-guards.test.ts`. The engine's other
+ * guard, `assertWasmBigint`, has no counterpart here: the engine applies it to
+ * its own WASM return values before they reach this package.
  */
 
 /** Largest value BigUint64Array stores without wrapping mod 2^64 (2^64 − 1). */

--- a/packages/babylon-ts-sdk/src/tbv/core/wasm/value-guards.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/wasm/value-guards.ts
@@ -1,0 +1,60 @@
+/**
+ * Runtime guard for satoshi amounts crossing into the WASM FFI boundary.
+ *
+ * `new BigUint64Array(values)` is the only way satoshi amounts are handed to
+ * the constructor, and a runtime cast (`as readonly bigint[]`) lets a caller
+ * pass a non-bigint or non-positive element that `BigUint64Array` would either
+ * reject cryptically or, in its length-arg form, silently zero-fill. Values
+ * above the u64 maximum are worse still: `BigUint64Array` wraps them mod 2^64
+ * without complaint, turning an oversized amount into a small one.
+ * {@link assertPositiveBigintArray} validates such inputs before the
+ * typed-array construction.
+ *
+ * Mirrors `value-guards.ts` in `@babylonlabs-io/babylon-tbv-rust-wasm`; the two
+ * are pinned to identical behaviour by `__tests__/value-guards.test.ts`.
+ */
+
+/** Largest value BigUint64Array stores without wrapping mod 2^64 (2^64 − 1). */
+const U64_MAX = (1n << 64n) - 1n;
+
+/**
+ * Assert a value is a non-empty array of strictly-positive `bigint`s and return
+ * it narrowed, ready to feed into `new BigUint64Array(...)`.
+ *
+ * @param values - The candidate array of satoshi amounts.
+ * @param label - Human-readable name used in the thrown error.
+ * @throws If `values` is not an array, is empty, or contains any element that is
+ *   not a `bigint`, is not strictly greater than 0, or exceeds the u64 maximum
+ *   (which `BigUint64Array` would otherwise wrap mod 2^64).
+ */
+export function assertPositiveBigintArray(
+  values: unknown,
+  label: string,
+): bigint[] {
+  if (!Array.isArray(values)) {
+    throw new Error(
+      `${label} must be an array of positive bigints (got ${typeof values}).`,
+    );
+  }
+  if (values.length === 0) {
+    throw new Error(`${label} must not be empty.`);
+  }
+  values.forEach((value, index) => {
+    if (typeof value !== "bigint") {
+      throw new Error(
+        `${label}[${index}] must be a bigint (got ${typeof value}); ` +
+          `refusing to feed it into satoshi math.`,
+      );
+    }
+    if (value <= 0n) {
+      throw new Error(`${label}[${index}] must be > 0 (got ${value}).`);
+    }
+    if (value > U64_MAX) {
+      throw new Error(
+        `${label}[${index}] must fit in a u64 (got ${value}); ` +
+          `refusing to feed it into satoshi math.`,
+      );
+    }
+  });
+  return values as bigint[];
+}

--- a/packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/__tests__/query.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/integrations/aave/clients/__tests__/query.test.ts
@@ -8,7 +8,7 @@
  * reported as "no position" would be a silent wrong answer.
  */
 
-import { type Address, type Hex, type PublicClient } from "viem";
+import type { Address, Hex, PublicClient } from "viem";
 import { describe, expect, it, vi } from "vitest";
 
 import { getPosition } from "../query.js";

--- a/packages/babylon-ts-sdk/vite.config.ts
+++ b/packages/babylon-ts-sdk/vite.config.ts
@@ -30,6 +30,10 @@ export default defineConfig({
           __dirname,
           "src/tbv/core/clients/index.ts",
         ),
+        "tbv/core/wasm/index": path.resolve(
+          __dirname,
+          "src/tbv/core/wasm/index.ts",
+        ),
         "tbv/core/services/index": path.resolve(
           __dirname,
           "src/tbv/core/services/index.ts",
@@ -60,6 +64,7 @@ export default defineConfig({
         "bitcoinjs-lib",
         "@bitcoin-js/tiny-secp256k1-asmjs",
         "@babylonlabs-io/babylon-tbv-rust-wasm",
+        "@babylonlabs-io/babylon-tbv-rust-wasm/raw",
         "viem",
         "buffer",
       ],

--- a/packages/babylon-ts-sdk/vite.config.ts
+++ b/packages/babylon-ts-sdk/vite.config.ts
@@ -30,6 +30,10 @@ export default defineConfig({
           __dirname,
           "src/tbv/core/clients/index.ts",
         ),
+        "tbv/core/clients/vault-provider/status/index": path.resolve(
+          __dirname,
+          "src/tbv/core/clients/vault-provider/status/index.ts",
+        ),
         "tbv/core/wasm/index": path.resolve(
           __dirname,
           "src/tbv/core/wasm/index.ts",


### PR DESCRIPTION
## Result

Merged as part 1 of #2231. #2231 stays open.

This release shipped as Bitcoin engine 0.17.0 and SDK 0.71.0.

## Change

- The Bitcoin engine loads on first use.
- One SDK facade owns normal engine access.
- Raw engine classes moved to an explicit subpath.
- Existing derivation values and generated engine bytes stayed unchanged.
- Build checks protect the lazy import boundary.

## Post-merge audit

- #2356: a failed browser engine download cannot retry without reload.
- #2361: the published raw loader lets callers bypass SDK value checks.
- #2333: the browser entry and some facade values lack direct tests.
- #2345: small review cleanup remains.
- #2358: the safer per-call connector has a low-priority performance cost.

## Verification at merge

Workspace build, lint, and unit checks passed. Those checks did not run the real browser engine entry.

Tracks #2231. #2231 stays open.