### PR TITLE
fix(vault): stop the visual harness photographing the mobile layout

### DIFF
--- a/services/vault/e2e/visual/capture.ts
+++ b/services/vault/e2e/visual/capture.ts
@@ -41,6 +41,27 @@ import {
 const MIN_CAPTURE_BYTES = 1000;
 
 /**
+ * The width at or above which the app must render its desktop tree.
+ *
+ * The default breakpoint of core-ui's `useIsMobile`
+ * (packages/babylon-core-ui/src/hooks/useIsMobile.ts), which is what every
+ * responsive branch in the vault shell reads.
+ */
+const DESKTOP_LAYOUT_MIN_WIDTH_PX = 768;
+
+/**
+ * The hamburger button core-ui's Header renders on its mobile branch, and
+ * only there.
+ *
+ * Read rather than added: this is the accessible name core-ui already ships,
+ * and the `nav-*` testids next to it are real-wallet E2E hooks this harness
+ * must not disturb. It is also the one marker that works on every screen -
+ * the sidebar cannot be used, because the disconnected `/` route is the entry
+ * layout and legitimately has no sidebar at any width.
+ */
+const MOBILE_MENU_BUTTON = 'button[aria-label="Open menu"]';
+
+/**
  * Name of the manifest each capture writes beside its PNGs, listing the
  * screens that side INTENDED to produce. Read by `scripts/visual-diff.mjs`
  * (`--expected-baseline` / `--expected-candidate`) and referenced by name in
@@ -121,6 +142,52 @@ export async function assertNoErrorSurface(
       `booted and then failed - usually a read the recorded backend cannot ` +
       `answer. Photographing it would bake "Something went wrong" in as the ` +
       `expected look, and it diffs clean against itself forever.`,
+  ).toHaveCount(0);
+}
+
+/**
+ * Refuse to photograph the mobile layout at a desktop width.
+ *
+ * A category gate, not a fix for one bug. `installVisualDeterminism` freezes
+ * `Date.now()` for the life of the page, and that is load-bearing for
+ * clock-derived copy - `stabilize.ts` explains why `clock.install()` is not an
+ * option instead. The cost is that any throttled or debounced listener in app
+ * code is reduced to a single leading-edge call for the whole capture run: it
+ * takes whatever the first event carried and never revises it. A resize
+ * listener that reads one spurious width therefore keeps it forever.
+ *
+ * That is exactly what happened. A full-page screenshot of a page taller than
+ * the viewport briefly emulates a 1x1 viewport, core-ui's `useIsMobile` took
+ * the 1x1 resize on its leading edge, and five 1280px-wide screens were
+ * photographed as the mobile tree. `stabilize.ts` no longer fires that event,
+ * which closes the instance; this closes the category, because the next
+ * listener to arrive will not have that history to warn it.
+ *
+ * Checked here rather than by the poll for the same reason as
+ * {@link assertNoErrorSurface}: the wrong layout is stable, so no amount of
+ * waiting can see it. Only a claim about what the frame must CONTAIN can.
+ *
+ * Below {@link DESKTOP_LAYOUT_MIN_WIDTH_PX} the gate does nothing - the mobile
+ * layout is the correct answer there, and the spurious width 1 lands on the
+ * same side of the breakpoint as the real one.
+ */
+async function assertLayoutMatchesViewport(
+  page: Page,
+  label: string,
+): Promise<void> {
+  const viewport = page.viewportSize();
+  if (!viewport || viewport.width < DESKTOP_LAYOUT_MIN_WIDTH_PX) return;
+
+  await expect(
+    page.locator(MOBILE_MENU_BUTTON),
+    `${label} captured the mobile layout at a ${viewport.width}px viewport. ` +
+      `The app decided it is mobile and never revised that decision, which is ` +
+      `what a resize listener does when it takes a spurious width on its ` +
+      `leading edge and the frozen capture clock stops its trailing edge from ` +
+      `ever firing. The result is a desktop-width photograph of the mobile ` +
+      `tree, and it is perfectly static, so it diffs clean against itself ` +
+      `forever. Find what resized the page during the capture rather than ` +
+      `accepting this as a baseline.`,
   ).toHaveCount(0);
 }
 
@@ -209,6 +276,8 @@ export async function capture(
   // Per photograph, not per walk - see {@link assertNoErrorSurface}. Settled
   // is not the same as rendered: an error fallback is perfectly stable.
   await assertNoErrorSurface(page, fileName);
+  // Nor is settled the same as correct: a latched mobile layout is stable too.
+  await assertLayoutMatchesViewport(page, fileName);
   const buffer = await page.screenshot({ fullPage: true });
   expect(
     buffer.byteLength,

--- a/services/vault/e2e/visual/stabilize.ts
+++ b/services/vault/e2e/visual/stabilize.ts
@@ -24,6 +24,25 @@
  * - **Everything else** (late data, lazy route chunks, layout shift) is
  *   covered by `waitForVisualStability`, which polls until the rendered
  *   frame stops changing rather than guessing a fixed delay.
+ *
+ * The stability poll photographs the VIEWPORT, never the full page. A
+ * full-page screenshot of a page taller than the viewport makes Playwright
+ * take Chromium's `captureBeyondViewport` path, and Chromium emulates a
+ * 1x1 viewport for a moment while it does. The page gets a real `resize`
+ * event with `window.innerWidth === 1`, then a restore ~10-250ms later.
+ * Any throttled or debounced resize listener in app code takes the 1x1
+ * edge and keeps it: `setFixedTime` above freezes `Date.now()` for the
+ * life of the page, lodash.throttle derives its window from `Date.now()`,
+ * so the trailing edge never fires and the restore is discarded. That is
+ * how core-ui's `useIsMobile` latched to `true` and five desktop routes
+ * were photographed as the mobile tree. The wrong layout is then perfectly
+ * static, so a pixel poll cannot tell it from a correct one.
+ *
+ * A viewport screenshot fires no resize event, so the poll stops causing
+ * the defect it is meant to detect. It also stops seeing below the fold,
+ * which two screens genuinely need, so the poll folds the document size
+ * into the signal as well - see {@link readFrameSignature}. The capture
+ * itself stays full-page; it is taken once, after the page has settled.
  */
 
 import type { Page } from "@playwright/test";
@@ -73,6 +92,56 @@ export async function installVisualDeterminism(page: Page): Promise<void> {
 }
 
 /**
+ * What one poll iteration compares. Two parts, because neither alone is
+ * enough:
+ *
+ * - `pixels` is the viewport only. It sees everything above the fold and
+ *   nothing below it, and it is the half that must not be full-page (see
+ *   the header comment).
+ * - `documentWidth` / `documentHeight` cover what the crop hides. A list
+ *   that grows below the fold, a lazy chunk that lands off-screen and a
+ *   collapsing skeleton all move the document box, so growth the pixels
+ *   cannot show still reads as "not settled".
+ *
+ * A change to EITHER part means the screen is still moving.
+ */
+interface FrameSignature {
+  readonly pixels: Buffer;
+  readonly documentWidth: number;
+  readonly documentHeight: number;
+}
+
+/**
+ * Read one {@link FrameSignature} from the live page.
+ *
+ * The document box is measured BEFORE the pixels, and the order is not a
+ * style choice. Reading `scrollWidth` forces a synchronous style and
+ * layout flush. Ask for it right after a screenshot and the flush lands
+ * between that raster and the next one, which moves the antialiasing of a
+ * rounded corner by one grey level: the deposit dialog's amount card came
+ * out two different ways across 12 runs of the same commit. Measure
+ * first, photograph the layout that measurement settled, and every run
+ * agrees again.
+ */
+async function readFrameSignature(page: Page): Promise<FrameSignature> {
+  const { documentWidth, documentHeight } = await page.evaluate(() => ({
+    documentWidth: document.documentElement.scrollWidth,
+    documentHeight: document.documentElement.scrollHeight,
+  }));
+  const pixels = await page.screenshot();
+  return { pixels, documentWidth, documentHeight };
+}
+
+/** True only when both halves of the signal are unchanged. */
+function isSameFrame(a: FrameSignature, b: FrameSignature): boolean {
+  return (
+    a.documentWidth === b.documentWidth &&
+    a.documentHeight === b.documentHeight &&
+    a.pixels.equals(b.pixels)
+  );
+}
+
+/**
  * Block until the page stops changing, then return.
  *
  * Polls the actual rendered bytes instead of waiting on `networkidle`
@@ -104,14 +173,14 @@ export async function waitForVisualStability(page: Page): Promise<void> {
   });
 
   const deadline = Date.now() + STABILITY_TIMEOUT_MS;
-  let previous = await page.screenshot({ fullPage: true });
+  let previous = await readFrameSignature(page);
   let matches = 0;
 
   while (Date.now() < deadline) {
     await page.waitForTimeout(STABILITY_QUIET_MS);
-    const current = await page.screenshot({ fullPage: true });
+    const current = await readFrameSignature(page);
 
-    if (current.equals(previous)) {
+    if (isSameFrame(current, previous)) {
       matches += 1;
       if (matches >= STABILITY_CONSECUTIVE_MATCHES) return;
     } else {


### PR DESCRIPTION
## What

Stops the visual-regression harness from photographing the mobile layout at a desktop viewport.

## Why

PR #2302 changed a Telegram URL and two lines of footer markup. Its visual check reported the
`/vaults` desktop screen as changed. Re-running the same commits reported four screens changed
instead of one, and on `loans` it was the merge-base side that had flipped, not the candidate. The
Storybook footer diffs in the same runs reproduced exactly, which is what a real change looks like.

The harness was causing the failure it reported.

`page.screenshot({ fullPage: true })` on a page taller than the viewport takes Chromium's
`captureBeyondViewport` path, and Chromium emulates a **1x1 viewport** for a moment while it does.
The page receives a real `resize` event carrying `window.innerWidth === 1`, then a restore about
10-250 ms later. core-ui's `useIsMobile` reads that width through `throttle(checkMobile, 100)` and
takes the 1x1 event on the leading edge.

It never recovers, because `installVisualDeterminism` freezes `Date.now()` for the life of the page
and `lodash.throttle` derives its window from `Date.now()`. The trailing edge never fires, so a
throttled listener invokes exactly once and keeps whatever the first event carried. The restore to
1280 is discarded permanently.

The result is a 1280px-wide photograph of the mobile React tree. It is also perfectly static, so
`waitForVisualStability` cannot tell it from a correct frame: it waits for pixels to stop moving,
and they have.

That explains every symptom. Only desktop is affected, because at the 390px target the spurious
width of 1 falls on the same side of the breakpoint. Only routes that overflow 800px are exposed at
all. Which ones lose the race is scheduling luck, so the set moves between runs and either side can
flip.

## How

Two changes, both in the harness.

- **The stability poll photographs the viewport, not the full page.** That removes the resize the
  poll was firing at itself. Cropping would blind the poll to a screen still settling below the
  fold, and `overview--mobile` (1415px) and `explore--mobile` (1129px) really are taller than their
  viewport, so the document box now travels with the pixels as one signal. A frame counts as
  settled only when both are unchanged.
- **`capture()` refuses to photograph the mobile shell at a desktop width.** The frozen clock stays
  - it is load-bearing for clock-derived copy, and the file already records why `clock.install()`
  is not an option. So the next throttled listener to arrive can latch the same way. This turns
  that into a red build with a message that names the mechanism, instead of a silent wrong
  baseline.

The final photograph stays full-page. A change below the fold is still a change.

## Verification

Reproduced and fixed under `Emulation.setCPUThrottlingRate`, which is the only way to see this on a
fast machine - unthrottled it is 0 in 28.

- **Unfixed, 6x and 20x:** all five desktop routes latch to the mobile tree. Byte-identical failure
  at both rates.
- **Fixed, 6x and 20x:** every desktop capture byte-identical to the clean baseline.
- **Fixed, unthrottled:** all 18 screens byte-identical to the clean baseline, 8 runs in a row.
- **The new gate has teeth:** with `useIsMobile` forced to latch, all six desktop captures fail with
  the diagnostic and no desktop PNG reaches disk. All five mobile captures still pass, so the gate
  stands down below the breakpoint as intended.
- prettier, eslint and `tsc --noEmit` clean.

## Review notes

- **The measure-before-photograph order in `readFrameSignature` is load-bearing, not style.**
  Reading `scrollWidth` forces a synchronous layout flush. Placed after the raster, that flush lands
  between two frames and shifts a rounded corner's antialiasing by one grey level - the deposit
  dialog's amount card came out two different ways across 12 runs of the same commit. The comment
  says so, because it looks arbitrary and invites tidying.
- The gate reads core-ui's existing `aria-label="Open menu"` rather than adding a `data-testid`. No
  `nav-*` testid is touched. The trade-off: that string is UI copy, so a rename in core-ui would
  disarm the gate silently. If a reviewer wants a hard guarantee, the answer is a `data-testid` on
  that button and a gate that asserts it.
- It keys on the Header's mobile branch rather than the sidebar on purpose. `/` at 1280 while
  disconnected is the entry layout and legitimately has no sidebar, so a sidebar check would have
  turned the suite red on `overview--desktop`.
- **`useIsMobile` is untouched and still wrong.** A throttled leading-edge read of a transient width
  will latch again for anything else that freezes the clock. It is shared by about a dozen
  consumers, so it wants its own PR and its own review, not a rider on a flake fix. With a live
  clock the trailing edge corrects the transient about 100 ms later, so users are not affected.
- Out of scope, seen while working here: `liquidations` fails at both viewports on `main` because
  the recorded backend has no `GetAavePriceFeedSource` for reserve 3. That currently costs the
  harness two of its twelve screens.
