### PR TITLE
feat(ts-sdk, ledger-vault): validate deposit terms before the derive …

### DIFF
--- a/packages/babylon-ts-sdk/docs/api/deposit-terms.md
+++ b/packages/babylon-ts-sdk/docs/api/deposit-terms.md
@@ -336,6 +336,35 @@ signature — this is a UX optimization, never an authorization.
 
 `Promise`\<`boolean`\>
 
+##### validateDepositTerms()?
+
+```ts
+optional validateDepositTerms(terms): Promise<void>;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts)
+
+OPTIONAL validate-only pre-check (#2110): reject terms the device
+envelope would refuse, with the same `{ name:
+"DepositTermsRejectedError", reason: "device-envelope", message }` shape
+as `approveDepositTerms`, WITHOUT any device I/O and WITHOUT touching a
+held approval — the SDK calls it before the first derive screen, so a
+side effect here would cost or invalidate a physical ceremony. Success
+is NOT an approval: `approveDepositTerms` still runs its own envelope
+gate before the ceremony. Callers may pass provisional terms whose
+`prepeginTxid` is a placeholder (the real txid exists only post-derive),
+so implementations MUST NOT validate or bind `prepeginTxid` here.
+
+###### Parameters
+
+###### terms
+
+[`DepositTerms`](#depositterms)
+
+###### Returns
+
+`Promise`\<`void`\>
+
 ***
 
 ### PrePeginChangeSource
@@ -564,6 +593,24 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/prePeginApproval
 ###### Returns
 
 `Promise`\<`boolean`\>
+
+##### validateDepositTerms()?
+
+```ts
+optional validateDepositTerms(terms): Promise<void>;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/deposit-terms/prePeginApproval.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/prePeginApproval.ts)
+
+###### Parameters
+
+###### terms
+
+[`DepositTerms`](#depositterms)
+
+###### Returns
+
+`Promise`\<`void`\>
 
 ***
 

--- a/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/__tests__/depositTerms.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/__tests__/depositTerms.test.ts
@@ -76,4 +76,20 @@ describe("forwardDepositApproval", () => {
     );
     expect(withProbe.holdsApprovedDepositTerms).toHaveBeenCalledOnce();
   });
+
+  it("forwards validateDepositTerms only when the wallet implements it", async () => {
+    const withoutValidate = Object.assign(Object.create({}), base, {
+      approveDepositTerms: vi.fn(async () => {}),
+    });
+    expect(
+      forwardDepositApproval(withoutValidate).validateDepositTerms,
+    ).toBeUndefined();
+
+    const withValidate = Object.assign(Object.create({}), withoutValidate, {
+      validateDepositTerms: vi.fn(async () => {}),
+    });
+    const fwd = forwardDepositApproval(withValidate);
+    await fwd.validateDepositTerms!({} as never);
+    expect(withValidate.validateDepositTerms).toHaveBeenCalledOnce();
+  });
 });

--- a/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/__tests__/prePeginApproval.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/__tests__/prePeginApproval.test.ts
@@ -209,6 +209,56 @@ describe("ensurePrePeginTermsApproval", () => {
     expect(wallet.approveDepositTerms).toHaveBeenCalledTimes(1);
   });
 
+  it("runs validateDepositTerms before the derive on the ceremony path", async () => {
+    const { hex, txid } = makeFundedTx();
+    const order: string[] = [];
+    const wallet: PrePeginApprovalWallet = {
+      validateDepositTerms: vi.fn(async () => {
+        order.push("validate");
+      }),
+      deriveContextHash: vi.fn(async () => {
+        order.push("derive");
+        return "ab".repeat(32);
+      }),
+      approveDepositTerms: vi.fn(async () => {
+        order.push("approve");
+      }),
+    };
+    const terms = makeTerms(txid);
+
+    await ensurePrePeginTermsApproval({
+      wallet,
+      depositTerms: terms,
+      fundedPrePeginTxHex: hex,
+      depositorBtcPubkey: DEPOSITOR_PUBKEY,
+    });
+
+    expect(order).toEqual(["validate", "derive", "approve"]);
+    expect(wallet.validateDepositTerms).toHaveBeenCalledWith(terms);
+  });
+
+  it("stops before the derive when validateDepositTerms rejects", async () => {
+    const { hex, txid } = makeFundedTx();
+    const wallet: PrePeginApprovalWallet = {
+      validateDepositTerms: vi.fn(async () => {
+        throw new Error("Deposit terms outside the device-supported range");
+      }),
+      deriveContextHash: vi.fn(),
+      approveDepositTerms: vi.fn(),
+    };
+
+    await expect(
+      ensurePrePeginTermsApproval({
+        wallet,
+        depositTerms: makeTerms(txid),
+        fundedPrePeginTxHex: hex,
+        depositorBtcPubkey: DEPOSITOR_PUBKEY,
+      }),
+    ).rejects.toThrow(/device-supported range/);
+    expect(wallet.deriveContextHash).not.toHaveBeenCalled();
+    expect(wallet.approveDepositTerms).not.toHaveBeenCalled();
+  });
+
   it("skips derive and approve when the wallet still holds the approved terms", async () => {
     const { hex, txid } = makeFundedTx();
     const wallet: PrePeginApprovalWallet = {

--- a/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/depositTerms.ts
@@ -119,6 +119,19 @@ export interface DepositTermsApprover {
    * signature — this is a UX optimization, never an authorization.
    */
   holdsApprovedDepositTerms?(terms: DepositTerms): Promise<boolean>;
+  /**
+   * OPTIONAL validate-only pre-check (#2110): reject terms the device
+   * envelope would refuse, with the same `{ name:
+   * "DepositTermsRejectedError", reason: "device-envelope", message }` shape
+   * as `approveDepositTerms`, WITHOUT any device I/O and WITHOUT touching a
+   * held approval — the SDK calls it before the first derive screen, so a
+   * side effect here would cost or invalidate a physical ceremony. Success
+   * is NOT an approval: `approveDepositTerms` still runs its own envelope
+   * gate before the ceremony. Callers may pass provisional terms whose
+   * `prepeginTxid` is a placeholder (the real txid exists only post-derive),
+   * so implementations MUST NOT validate or bind `prepeginTxid` here.
+   */
+  validateDepositTerms?(terms: DepositTerms): Promise<void>;
 }
 
 /**
@@ -183,11 +196,12 @@ export function forwardDepositApproval(
     return {};
   }
   const holdsApprovedDepositTerms = wallet.holdsApprovedDepositTerms;
+  const validateDepositTerms = wallet.validateDepositTerms;
   const getChangeAddress = (wallet as Partial<PrePeginChangeSource>)
     .getChangeAddress;
   return {
     approveDepositTerms: (terms) => wallet.approveDepositTerms(terms),
-    // Both optional in the seam: forward only what the provider implements, so
+    // All optional in the seam: forward only what the provider implements, so
     // wrapper consumers can keep probing by typeof.
     ...(typeof getChangeAddress === "function"
       ? { getChangeAddress: () => getChangeAddress.call(wallet) }
@@ -196,6 +210,12 @@ export function forwardDepositApproval(
       ? {
           holdsApprovedDepositTerms: (terms: DepositTerms) =>
             holdsApprovedDepositTerms.call(wallet, terms),
+        }
+      : {}),
+    ...(typeof validateDepositTerms === "function"
+      ? {
+          validateDepositTerms: (terms: DepositTerms) =>
+            validateDepositTerms.call(wallet, terms),
         }
       : {}),
   };

--- a/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/prePeginApproval.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/deposit-terms/prePeginApproval.ts
@@ -32,6 +32,7 @@ export interface PrePeginApprovalWallet {
   deriveContextHash?(appName: string, context: string): Promise<string>;
   approveDepositTerms?(terms: DepositTerms): Promise<void>;
   holdsApprovedDepositTerms?(terms: DepositTerms): Promise<boolean>;
+  validateDepositTerms?(terms: DepositTerms): Promise<void>;
 }
 
 export interface EnsurePrePeginTermsApprovalParams {
@@ -131,6 +132,12 @@ export async function ensurePrePeginTermsApproval(
     if (holdsApproval) {
       return;
     }
+  }
+
+  // #2110 T4: envelope violations fail here, before the derive costs a
+  // physical approval. Validate-only per DepositTermsApprover — no device I/O.
+  if (typeof wallet.validateDepositTerms === "function") {
+    await wallet.validateDepositTerms(depositTerms);
   }
 
   // Same funding outpoints preparePegin derived over, via the shared

--- a/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts
@@ -120,6 +120,27 @@ const NO_REFERRAL_CODE = 0;
 const SIZING_PASS_PLACEHOLDER_BYTES32_HEX = "00".repeat(32);
 
 /**
+ * Placeholder `prepeginTxid` for the provisional deposit terms validated
+ * before the derive (#2110 T4) — the real txid exists only post-derive, and
+ * the terms carrying this value are validate-only: they never reach a device
+ * (the envelope gate reads no txid; see ledger-vault-signer `envelope.ts`).
+ */
+const PROVISIONAL_TERMS_PLACEHOLDER_TXID_HEX = "00".repeat(32);
+
+/**
+ * Sizing-pass output. The WASM-computed `depositorClaimValue` / `minPeginFee`
+ * feed the provisional (validate-only) deposit terms; the commit pass asserts
+ * it reproduces them before building the terms the wallet approves.
+ */
+interface PeginSizing {
+  selectedUTXOs: UTXO[];
+  fee: bigint;
+  changeAmount: bigint;
+  depositorClaimValue: bigint;
+  minPeginFee: bigint;
+}
+
+/**
  * Configuration for the PeginManager.
  */
 export interface PeginManagerConfig {
@@ -714,6 +735,24 @@ export class PeginManager {
     // UTXO selection and fees match the commit pass.
     const sizing = await this.prepareSizing(depositorBtcPubkey, params);
 
+    // #2110 T4: an envelope violation must fail HERE, before the derive costs
+    // a physical device approval. Validate-only by contract — no device I/O.
+    if (supportsDepositApproval(this.config.btcWallet)) {
+      const { validateDepositTerms } = this.config.btcWallet;
+      if (typeof validateDepositTerms === "function") {
+        await validateDepositTerms.call(
+          this.config.btcWallet,
+          this.buildPeginDepositTerms({
+            params,
+            prepeginTxid: PROVISIONAL_TERMS_PLACEHOLDER_TXID_HEX,
+            prepeginMaxFee: sizing.fee,
+            depositorClaimValue: sizing.depositorClaimValue,
+            peginMaxFee: sizing.minPeginFee,
+          }),
+        );
+      }
+    }
+
     const fundingOutpoints: FundingOutpoint[] = sizing.selectedUTXOs.map(
       (u) => ({
         txid: hexToUint8Array(u.txid),
@@ -821,7 +860,7 @@ export class PeginManager {
   private async prepareSizing(
     depositorBtcPubkey: string,
     params: PreparePeginParams,
-  ): Promise<{ selectedUTXOs: UTXO[]; fee: bigint; changeAmount: bigint }> {
+  ): Promise<PeginSizing> {
     const placeholderHashlocks = params.amounts.map(
       () => SIZING_PASS_PLACEHOLDER_BYTES32_HEX,
     );
@@ -857,7 +896,43 @@ export class PeginManager {
       selectedUTXOs: selection.selectedUTXOs,
       fee: selection.fee,
       changeAmount: selection.changeAmount,
+      depositorClaimValue: prePegin.depositorClaimValue,
+      minPeginFee: prePegin.minPeginFee,
     };
+  }
+
+  /**
+   * One projection for both the provisional (pre-derive, placeholder-txid)
+   * terms and the final approved terms, so the fields the pre-check validated
+   * cannot drift from the fields the device later displays (#2110 T4).
+   */
+  private buildPeginDepositTerms(args: {
+    params: PreparePeginParams;
+    prepeginTxid: string;
+    prepeginMaxFee: bigint;
+    depositorClaimValue: bigint;
+    peginMaxFee: bigint;
+  }): DepositTerms {
+    const { params } = args;
+    return buildDepositTerms({
+      vaultCoreVersion: params.vaultCoreVersion,
+      protocolFeeRate: params.protocolFeeRate,
+      timelockPegin: params.timelockPegin,
+      timelockAssert: params.timelockAssert,
+      timelockRefund: params.timelockRefund,
+      prepeginTxid: args.prepeginTxid,
+      prepeginMaxFee: args.prepeginMaxFee,
+      vaultProviderBtcPubkey: stripHexPrefix(params.vaultProviderBtcPubkey),
+      vaultKeeperBtcPubkeys: params.vaultKeeperBtcPubkeys.map(stripHexPrefix),
+      universalChallengerBtcPubkeys:
+        params.universalChallengerBtcPubkeys.map(stripHexPrefix),
+      maxAcceptableCommissionBps: capMaxAcceptableCommissionBps(
+        params.commissionBps,
+      ),
+      peginAmounts: params.amounts,
+      depositorClaimValue: args.depositorClaimValue,
+      peginMaxFee: args.peginMaxFee,
+    });
   }
 
   /** Build PegIn txs and batch-sign their inputs with real hashlocks. */
@@ -866,7 +941,7 @@ export class PeginManager {
     depositorBtcPubkey: string;
     hashlocks: readonly string[];
     authAnchorHash: string;
-    sizing: { selectedUTXOs: UTXO[]; fee: bigint; changeAmount: bigint };
+    sizing: PeginSizing;
     params: PreparePeginParams;
   }): Promise<{
     fundedPrePeginTxHex: string;
@@ -933,6 +1008,21 @@ export class PeginManager {
     };
 
     const prePeginResult = await buildPrePeginPsbt(prePeginParams);
+
+    // The pre-derive check (#2110 T4) validated the sizing-build values; the
+    // wallet approves these commit-build ones — assert agreement, not assume.
+    if (
+      prePeginResult.depositorClaimValue !== sizing.depositorClaimValue ||
+      prePeginResult.minPeginFee !== sizing.minPeginFee
+    ) {
+      throw new Error(
+        `Pre-PegIn sizing/commit divergence: depositorClaimValue ` +
+          `${sizing.depositorClaimValue} -> ${prePeginResult.depositorClaimValue}, ` +
+          `minPeginFee ${sizing.minPeginFee} -> ${prePeginResult.minPeginFee}. ` +
+          `The provisional deposit terms validated before derivation would not ` +
+          `match the terms sent for approval; refusing to continue.`,
+      );
+    }
 
     const network = getNetwork(this.config.btcNetwork);
     const fundedPrePeginTxHex = fundPeginTransaction({
@@ -1005,21 +1095,10 @@ export class PeginManager {
     // wallet capability; only approval-capable wallets need the call below.
     // peginMaxFee reuses assertWasmPeginSizing's already-asserted minPeginFee
     // (via prePeginResult) instead of recomputing it.
-    const depositTerms = buildDepositTerms({
-      vaultCoreVersion: params.vaultCoreVersion,
-      protocolFeeRate: params.protocolFeeRate,
-      timelockPegin: params.timelockPegin,
-      timelockAssert: params.timelockAssert,
-      timelockRefund: params.timelockRefund,
+    const depositTerms = this.buildPeginDepositTerms({
+      params,
       prepeginTxid: prePeginTxid,
       prepeginMaxFee: sizing.fee,
-      vaultProviderBtcPubkey,
-      vaultKeeperBtcPubkeys,
-      universalChallengerBtcPubkeys,
-      maxAcceptableCommissionBps: capMaxAcceptableCommissionBps(
-        params.commissionBps,
-      ),
-      peginAmounts: params.amounts,
       depositorClaimValue: prePeginResult.depositorClaimValue,
       peginMaxFee: prePeginResult.minPeginFee,
     });

--- a/packages/babylon-ts-sdk/src/tbv/core/managers/__tests__/PeginManager.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/__tests__/PeginManager.test.ts
@@ -86,8 +86,8 @@ vi.mock("../../primitives/psbt/verifyKeyPathSchnorrSignature", () => ({
 
 // Passthrough observer: records each per-vault PegIn build so the seam test can
 // assert the htlcVout bind-checks run BEFORE deposit-terms approval. The
-// prePeginTamper hook lets one test corrupt the Pre-PegIn result to prove the
-// funded-fee cross-check fires; it must be reset to null afterwards.
+// prePeginTamper hook lets tests corrupt the Pre-PegIn commit pass to prove
+// the sizing/commit and funded-fee cross-checks fire; each resets it to null.
 const peginBuildLog = vi.hoisted(() => [] as string[]);
 const prePeginTamper = vi.hoisted(
   () =>
@@ -845,6 +845,225 @@ describe("PeginManager", () => {
         expect(vault.peginMaxFee).toBe(expectedPeginMaxFee);
         expect(vault.depositorClaimValue).toBe(expectedClaimValue);
       });
+    });
+
+    it("rejects before any device call when validateDepositTerms refuses the provisional terms", async () => {
+      // T4 (#2110): an envelope violation must cost zero device ceremonies —
+      // today it is discovered only after the physical Screen-1 approval.
+      const btcWallet = new MockBitcoinWallet({
+        publicKeyHex: TEST_KEYS.DEPOSITOR,
+      });
+      const deriveSpy = vi.fn(btcWallet.deriveContextHash.bind(btcWallet));
+      const signPsbtSpy = vi.fn(btcWallet.signPsbt.bind(btcWallet));
+      const signPsbtsSpy = vi.fn(btcWallet.signPsbts.bind(btcWallet));
+      const approveSpy = vi.fn(async () => {});
+      const capableWallet = Object.assign(btcWallet, {
+        deriveContextHash: deriveSpy,
+        signPsbt: signPsbtSpy,
+        signPsbts: signPsbtsSpy,
+        approveDepositTerms: approveSpy,
+        validateDepositTerms: vi.fn(async () => {
+          throw new DepositTermsRejectedError(
+            "Deposit terms outside the device-supported range: protocolFeeRate",
+          );
+        }),
+        getChangeAddress: async () => TEST_CHANGE_ADDRESS,
+      });
+      const manager = new PeginManager({
+        btcNetwork: "signet",
+        btcWallet: capableWallet,
+        ethWallet: new MockEthereumWallet() as any,
+        ethChain: TEST_CHAIN,
+        publicClient: TEST_PUBLIC_CLIENT,
+        vaultContracts: { btcVaultRegistry: TEST_CONTRACT_ADDRESS },
+        mempoolApiUrl: MEMPOOL_API_URLS.signet,
+      });
+
+      await expect(
+        manager.preparePegin({
+          amounts: [TEST_AMOUNTS.PEGIN],
+          ...BASE_PREPARE_PEGIN_PARAMS,
+        }),
+      ).rejects.toMatchObject({
+        name: "DepositTermsRejectedError",
+        reason: "device-envelope",
+      });
+
+      expect(capableWallet.validateDepositTerms).toHaveBeenCalledOnce();
+      expect(deriveSpy).not.toHaveBeenCalled();
+      expect(approveSpy).not.toHaveBeenCalled();
+      expect(signPsbtSpy).not.toHaveBeenCalled();
+      expect(signPsbtsSpy).not.toHaveBeenCalled();
+    });
+
+    it("validates provisional terms before the derive and approves the final terms identical except the txid", async () => {
+      const callOrder: string[] = [];
+      let validatedTerms: DepositTerms | undefined;
+      let approvedTerms: DepositTerms | undefined;
+      const btcWallet = new MockBitcoinWallet({
+        publicKeyHex: TEST_KEYS.DEPOSITOR,
+      });
+      const originalDerive = btcWallet.deriveContextHash.bind(btcWallet);
+      const capableWallet = Object.assign(btcWallet, {
+        deriveContextHash: async (appName: string, context: string) => {
+          callOrder.push("deriveContextHash");
+          return originalDerive(appName, context);
+        },
+        validateDepositTerms: vi.fn(async (terms: DepositTerms) => {
+          callOrder.push("validateDepositTerms");
+          validatedTerms = terms;
+        }),
+        approveDepositTerms: vi.fn(async (terms: DepositTerms) => {
+          callOrder.push("approveDepositTerms");
+          approvedTerms = terms;
+        }),
+        getChangeAddress: async () => TEST_CHANGE_ADDRESS,
+      });
+      const manager = new PeginManager({
+        btcNetwork: "signet",
+        btcWallet: capableWallet,
+        ethWallet: new MockEthereumWallet() as any,
+        ethChain: TEST_CHAIN,
+        publicClient: TEST_PUBLIC_CLIENT,
+        vaultContracts: { btcVaultRegistry: TEST_CONTRACT_ADDRESS },
+        mempoolApiUrl: MEMPOOL_API_URLS.signet,
+      });
+
+      const result = await manager.preparePegin({
+        amounts: [TEST_AMOUNTS.PEGIN],
+        ...BASE_PREPARE_PEGIN_PARAMS,
+      });
+
+      // The validate-only pre-check runs BEFORE the first device screen.
+      expect(capableWallet.validateDepositTerms).toHaveBeenCalledOnce();
+      const validateIdx = callOrder.indexOf("validateDepositTerms");
+      const deriveIdx = callOrder.indexOf("deriveContextHash");
+      expect(validateIdx).toBeGreaterThanOrEqual(0);
+      expect(deriveIdx).toBeGreaterThan(validateIdx);
+
+      // The provisional txid is the all-zero placeholder and never reaches the
+      // device: approveDepositTerms (the only device-bound terms call) gets
+      // the real Pre-PegIn txid instead.
+      expect(validatedTerms?.prepeginTxid).toBe("00".repeat(32));
+      expect(approvedTerms?.prepeginTxid).toBe(
+        result.transaction.prePeginTxid.replace(/^0x/i, "").toLowerCase(),
+      );
+      expect(approvedTerms?.prepeginTxid).not.toBe(
+        validatedTerms?.prepeginTxid,
+      );
+
+      // Every other field of the validated provisional terms must equal the
+      // approved terms — the pre-check validated what the device later shows.
+      expect({
+        ...validatedTerms,
+        prepeginTxid: approvedTerms!.prepeginTxid,
+      }).toEqual(approvedTerms);
+    });
+
+    it("keeps the provisional terms identical to the approved terms except the txid across a 2-vault batch", async () => {
+      let validatedTerms: DepositTerms | undefined;
+      let approvedTerms: DepositTerms | undefined;
+      const btcWallet = new MockBitcoinWallet({
+        publicKeyHex: TEST_KEYS.DEPOSITOR,
+      });
+      const capableWallet = Object.assign(btcWallet, {
+        validateDepositTerms: vi.fn(async (terms: DepositTerms) => {
+          validatedTerms = terms;
+        }),
+        approveDepositTerms: vi.fn(async (terms: DepositTerms) => {
+          approvedTerms = terms;
+        }),
+        getChangeAddress: async () => TEST_CHANGE_ADDRESS,
+      });
+      const manager = new PeginManager({
+        btcNetwork: "signet",
+        btcWallet: capableWallet,
+        ethWallet: new MockEthereumWallet() as any,
+        ethChain: TEST_CHAIN,
+        publicClient: TEST_PUBLIC_CLIENT,
+        vaultContracts: { btcVaultRegistry: TEST_CONTRACT_ADDRESS },
+        mempoolApiUrl: MEMPOOL_API_URLS.signet,
+      });
+
+      await manager.preparePegin({
+        // Distinct amounts so a per-vault projection swap is observable.
+        amounts: [TEST_AMOUNTS.PEGIN, TEST_AMOUNTS.PEGIN_MEDIUM],
+        ...BASE_PREPARE_PEGIN_PARAMS,
+      });
+
+      // The per-vault projection (vault groups, commission fees, htlcVout
+      // ordering) must already be final in the provisional terms.
+      expect(validatedTerms?.prepeginTxid).toBe("00".repeat(32));
+      expect(validatedTerms?.vaults.map((v) => v.peginAmount)).toEqual([
+        TEST_AMOUNTS.PEGIN,
+        TEST_AMOUNTS.PEGIN_MEDIUM,
+      ]);
+      expect({
+        ...validatedTerms,
+        prepeginTxid: approvedTerms!.prepeginTxid,
+      }).toEqual(approvedTerms);
+    });
+
+    it("throws when the commit pass diverges from the sizing pass on depositorClaimValue", async () => {
+      // The provisional pre-check validated the sizing-build value; a commit
+      // pass that computes a different one must fail, not ship unvalidated.
+      const manager = new PeginManager({
+        btcNetwork: "signet",
+        btcWallet: new MockBitcoinWallet({ publicKeyHex: TEST_KEYS.DEPOSITOR }),
+        ethWallet: new MockEthereumWallet() as any,
+        ethChain: TEST_CHAIN,
+        publicClient: TEST_PUBLIC_CLIENT,
+        vaultContracts: { btcVaultRegistry: TEST_CONTRACT_ADDRESS },
+        mempoolApiUrl: MEMPOOL_API_URLS.signet,
+      });
+
+      let prePeginCalls = 0;
+      prePeginTamper.fn = (result) => {
+        prePeginCalls += 1;
+        return prePeginCalls === 2
+          ? { ...result, depositorClaimValue: result.depositorClaimValue + 1n }
+          : result;
+      };
+      try {
+        await expect(
+          manager.preparePegin({
+            amounts: [TEST_AMOUNTS.PEGIN],
+            ...BASE_PREPARE_PEGIN_PARAMS,
+          }),
+        ).rejects.toThrow(/sizing\/commit divergence/i);
+      } finally {
+        prePeginTamper.fn = null;
+      }
+    });
+
+    it("throws when the commit pass diverges from the sizing pass on minPeginFee", async () => {
+      const manager = new PeginManager({
+        btcNetwork: "signet",
+        btcWallet: new MockBitcoinWallet({ publicKeyHex: TEST_KEYS.DEPOSITOR }),
+        ethWallet: new MockEthereumWallet() as any,
+        ethChain: TEST_CHAIN,
+        publicClient: TEST_PUBLIC_CLIENT,
+        vaultContracts: { btcVaultRegistry: TEST_CONTRACT_ADDRESS },
+        mempoolApiUrl: MEMPOOL_API_URLS.signet,
+      });
+
+      let prePeginCalls = 0;
+      prePeginTamper.fn = (result) => {
+        prePeginCalls += 1;
+        return prePeginCalls === 2
+          ? { ...result, minPeginFee: result.minPeginFee + 1n }
+          : result;
+      };
+      try {
+        await expect(
+          manager.preparePegin({
+            amounts: [TEST_AMOUNTS.PEGIN],
+            ...BASE_PREPARE_PEGIN_PARAMS,
+          }),
+        ).rejects.toThrow(/sizing\/commit divergence/i);
+      } finally {
+        prePeginTamper.fn = null;
+      }
     });
 
     it("is a no-op for wallets without approveDepositTerms", async () => {

--- a/packages/babylon-ts-sdk/src/tbv/core/services/deposit/__tests__/runDepositorPresignFlow.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/deposit/__tests__/runDepositorPresignFlow.test.ts
@@ -650,6 +650,63 @@ describe("runDepositorPresignFlow", () => {
       expect(wallet.approveDepositTerms).toHaveBeenCalledWith(DEPOSIT_TERMS);
     });
 
+    it("validates then approves, in that order, when the wallet exposes validateDepositTerms", async () => {
+      const callLog: string[] = [];
+      const wallet = Object.assign(
+        createCapabilityWallet(() => callLog.push("approve")),
+        {
+          validateDepositTerms: vi.fn(async () => {
+            callLog.push("validate");
+          }),
+        },
+      );
+      const reader = createMockStatusReader([
+        DaemonStatus.PENDING_DEPOSITOR_SIGNATURES,
+      ]);
+
+      await runDepositorPresignFlow({
+        statusReader: reader,
+        presignClient: createMockPresignClient(),
+        btcWallet: wallet,
+        peginTxid: VALID_TXID,
+        depositorPk: DEPOSITOR_PK,
+        signingContext: createSigningContext(),
+        depositTerms: DEPOSIT_TERMS,
+      });
+
+      expect(callLog).toEqual(["validate", "approve"]);
+      expect(wallet.validateDepositTerms).toHaveBeenCalledWith(DEPOSIT_TERMS);
+    });
+
+    it("stops before the approval ceremony when validateDepositTerms rejects", async () => {
+      const wallet = Object.assign(createCapabilityWallet(), {
+        validateDepositTerms: vi.fn(async () => {
+          throw new Error("Deposit terms outside the device-supported range");
+        }),
+      });
+      const reader = createMockStatusReader([
+        DaemonStatus.PENDING_DEPOSITOR_SIGNATURES,
+      ]);
+      const presignClient = createMockPresignClient();
+
+      await expect(
+        runDepositorPresignFlow({
+          statusReader: reader,
+          presignClient,
+          btcWallet: wallet,
+          peginTxid: VALID_TXID,
+          depositorPk: DEPOSITOR_PK,
+          signingContext: createSigningContext(),
+          depositTerms: DEPOSIT_TERMS,
+        }),
+      ).rejects.toThrow(/device-supported range/);
+
+      expect(wallet.approveDepositTerms).not.toHaveBeenCalled();
+      expect(
+        presignClient.requestDepositorPresignTransactions,
+      ).not.toHaveBeenCalled();
+    });
+
     it("throws for capability wallets when no depositTerms is provided", async () => {
       const wallet = createCapabilityWallet();
       const reader = createMockStatusReader([

--- a/packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/deposit/runDepositorPresignFlow.ts
@@ -459,6 +459,11 @@ export async function runDepositorPresignFlow(
           "must rebuild them from on-chain state (the vault app's rebuildDepositTerms).",
       );
     }
+    // #2110 T4: providers exposing the validate-only pre-check fail an
+    // envelope violation here, before the approval ceremony starts.
+    if (typeof btcWallet.validateDepositTerms === "function") {
+      await btcWallet.validateDepositTerms(depositTerms);
+    }
     // The provider validates its own device envelope inside
     // approveDepositTerms (DepositTermsApprover contract, #2109).
     await btcWallet.approveDepositTerms(depositTerms);

--- a/packages/babylon-wallet-connector/src/core/wallets/btc/ledger-vault/__tests__/provider.test.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/ledger-vault/__tests__/provider.test.ts
@@ -1053,6 +1053,52 @@ describe("LedgerVaultProvider", () => {
     expect(h.sent).toHaveLength(0);
   });
 
+  describe("validateDepositTerms (#2110 T4)", () => {
+    it("rejects out-of-envelope terms with the seam's shape and zero device I/O", async () => {
+      // Validate-only: works even unconnected — nothing may touch the device.
+      const provider = new LedgerVaultProvider(Network.SIGNET);
+
+      await expect(provider.validateDepositTerms({ ...TERMS, protocolFeeRate: 0n })).rejects.toMatchObject({
+        name: "DepositTermsRejectedError",
+        reason: "device-envelope",
+        message: expect.stringMatching(/protocolFeeRate/),
+      });
+      expect(h.sent).toHaveLength(0);
+      expect(dmkSessionMock.connectDmkSession).not.toHaveBeenCalled();
+    });
+
+    it("accepts in-envelope terms carrying a placeholder txid, without device I/O", async () => {
+      // The SDK pre-check runs before the real txid exists; the envelope never
+      // reads prepeginTxid (ledger-vault-signer envelope.ts has no reference).
+      const provider = new LedgerVaultProvider(Network.SIGNET);
+
+      await expect(provider.validateDepositTerms({ ...TERMS, prepeginTxid: "00".repeat(32) })).resolves.toBeUndefined();
+      expect(h.sent).toHaveLength(0);
+      expect(dmkSessionMock.connectDmkSession).not.toHaveBeenCalled();
+    });
+
+    it("is not an approval: after validate, the full approve ceremony still runs", async () => {
+      const provider = await derived();
+
+      await provider.validateDepositTerms(TERMS);
+
+      expect(await provider.holdsApprovedDepositTerms(TERMS)).toBe(false);
+      h.sent.length = 0;
+      await provider.approveDepositTerms(TERMS);
+      expect(approveApdus().map((s) => s.p1)).toEqual([0x00, 0x01, 0x02]);
+    });
+
+    it("leaves a held approval intact — validate is read-only on the mirror", async () => {
+      const provider = await derived();
+      await provider.approveDepositTerms(TERMS);
+      expect(await provider.holdsApprovedDepositTerms(TERMS)).toBe(true);
+
+      await provider.validateDepositTerms(TERMS);
+
+      expect(await provider.holdsApprovedDepositTerms(TERMS)).toBe(true);
+    });
+  });
+
   it("classifies both approve-time state conflicts as DEVICE_CEREMONY_INVALID", async () => {
     // The UX routes restart-from-derivation on this code, not on message text.
     const loaded = await derived();

--- a/packages/babylon-wallet-connector/src/core/wallets/btc/ledger-vault/provider.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/ledger-vault/provider.ts
@@ -479,6 +479,16 @@ export class LedgerVaultProvider implements IBTCProvider {
   };
 
   /**
+   * DepositTermsApprover.validateDepositTerms (#2110 T4): the envelope gate
+   * alone — no device I/O, no state, callable before the first approval
+   * screen. The envelope never reads `prepeginTxid`, so provisional terms
+   * with a placeholder txid validate correctly.
+   */
+  validateDepositTerms = async (terms: DepositTerms): Promise<void> => {
+    assertDepositTermsDeviceCompatible(terms);
+  };
+
+  /**
    * Validate the terms against the device envelope, then run the ceremony.
    * The envelope gate runs BEFORE any device I/O — the firmware answers an
    * out-of-range intent with an opaque status word and a dead session.


### PR DESCRIPTION
Adds validateDepositTerms to DepositTermsApprover (optional, validate-only); the Ledger provider implements it as the existing envelope assert. preparePegin and both resume paths call it before any device ceremony, so out-of-envelope terms fail instantly. Provisional and approved terms share one projection, and a new assert pins sizing-pass/commit-pass agreement. Software wallets are unaffected (test-pinned byte-identical path). #2110 T4.