### PR TITLE
feat(ledger-vault): injectable DMK transport and Speculos presign cov…

### DIFF
--- a/packages/babylon-ledger-vault-signer/package.json
+++ b/packages/babylon-ledger-vault-signer/package.json
@@ -44,7 +44,10 @@
     "rxjs": "7.8.2"
   },
   "devDependencies": {
+    "@babylonlabs-io/babylon-tbv-rust-wasm": "workspace:*",
+    "@babylonlabs-io/ts-sdk": "workspace:*",
     "@internal/eslint-config": "workspace:*",
+    "@ledgerhq/device-transport-kit-speculos": "1.2.1",
     "prettier": "^3.6.2",
     "prettier-plugin-organize-imports": "^4.1.0",
     "typescript": "^5.8.3",

--- a/packages/babylon-ledger-vault-signer/src/__tests__/dmkSession.test.ts
+++ b/packages/babylon-ledger-vault-signer/src/__tests__/dmkSession.test.ts
@@ -4,6 +4,7 @@
  * lifecycle policy, not Ledger's transport.
  */
 
+import type { TransportFactory } from "@ledgerhq/device-management-kit";
 import { of } from "rxjs";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -11,9 +12,16 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 // these mocks via CONCURRENT dynamic imports, and the registry's interception
 // races when the first resolution happens in parallel.
 import "@ledgerhq/device-management-kit";
-import "@ledgerhq/device-transport-kit-web-hid";
+import { webHidTransportFactory } from "@ledgerhq/device-transport-kit-web-hid";
 
-const built = vi.hoisted(() => ({ count: 0 }));
+const built = vi.hoisted(() => ({
+  count: 0,
+  transports: [] as unknown[],
+  instances: [] as object[],
+  closed: [] as object[],
+  /** Fires inside a build, after its dynamic imports and before `build()`. */
+  onBuilding: undefined as (() => void) | undefined,
+}));
 const dmkStub = vi.hoisted(() => ({
   startDiscovering: vi.fn(),
   connect: vi.fn(),
@@ -25,12 +33,18 @@ const dmkStub = vi.hoisted(() => ({
 
 vi.mock("@ledgerhq/device-management-kit", () => ({
   DeviceManagementKitBuilder: class {
-    addTransport() {
+    addTransport(factory: unknown) {
+      built.transports.push(factory);
+      built.onBuilding?.();
       return this;
     }
     build() {
       built.count += 1;
-      return dmkStub;
+      // Per-build identity, methods falling through to dmkStub's fns — the
+      // race tests must tell the orphaned instance from the survivor.
+      const instance: object = Object.create(dmkStub);
+      built.instances.push(instance);
+      return instance;
     }
   },
   GetAppAndVersionCommand: class {},
@@ -48,15 +62,39 @@ vi.mock("@ledgerhq/device-transport-kit-web-hid", () => ({
   webHidIdentifier: "WEB-HID",
 }));
 
-import { closeDmk, connectDmkSession, disconnectDmkSession, isSessionAlive } from "../dmkSession";
+import {
+  closeDmk,
+  connectDmkSession,
+  disconnectDmkSession,
+  isSessionAlive,
+  setDmkTransportOverride,
+} from "../dmkSession";
 
 const DEVICE = { id: "device-1" };
 
+/** A closed DMK is disposed; using one is a bug a no-op `close()` would hide. */
+function assertNotDisposed(instance: object, call: string): void {
+  if (built.closed.includes(instance)) throw new Error(`DMK.${call} called after close()`);
+}
+
 beforeEach(() => {
   built.count = 0;
+  built.transports.length = 0;
+  built.instances.length = 0;
+  built.closed.length = 0;
+  built.onBuilding = undefined;
   vi.clearAllMocks();
-  dmkStub.startDiscovering.mockReturnValue(of(DEVICE));
-  dmkStub.connect.mockResolvedValue("session-1");
+  dmkStub.close.mockImplementation(function (this: object) {
+    built.closed.push(this);
+  });
+  dmkStub.startDiscovering.mockImplementation(function (this: object) {
+    assertNotDisposed(this, "startDiscovering");
+    return of(DEVICE);
+  });
+  dmkStub.connect.mockImplementation(async function (this: object) {
+    assertNotDisposed(this, "connect");
+    return "session-1";
+  });
   dmkStub.sendCommand.mockResolvedValue({
     status: "SUCCESS",
     data: { name: "Babylon Vault Testnet", version: "0.9.4" },
@@ -64,7 +102,9 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  // closeDmk first: the setter refuses to touch a live singleton.
   closeDmk();
+  setDmkTransportOverride(undefined);
 });
 
 describe("connectDmkSession", () => {
@@ -195,5 +235,133 @@ describe("disconnectDmkSession", () => {
 
     expect(dmkStub.close).not.toHaveBeenCalled();
     expect(built.count).toBe(1);
+  });
+});
+
+describe("setDmkTransportOverride", () => {
+  // The mock DMK never invokes the factory; identity is all these tests need.
+  const fakeTransportFactory: TransportFactory = () => {
+    throw new Error("unit tests never invoke the transport factory");
+  };
+  const FAKE_IDENTIFIER = "FAKE-SPECULOS";
+
+  it("builds the DMK over the injected factory and discovers on its identifier", async () => {
+    setDmkTransportOverride({ transportFactory: fakeTransportFactory, transportIdentifier: FAKE_IDENTIFIER });
+
+    await connectDmkSession();
+
+    expect(built.transports).toEqual([fakeTransportFactory]);
+    expect(dmkStub.startDiscovering).toHaveBeenCalledWith({ transport: FAKE_IDENTIFIER });
+  });
+
+  it("keeps the web-hid factory and identifier when nothing is injected", async () => {
+    // Pins the default path: the seam must not perturb production behavior.
+    await connectDmkSession();
+
+    expect(built.transports).toEqual([webHidTransportFactory]);
+    expect(dmkStub.startDiscovering).toHaveBeenCalledWith({ transport: "WEB-HID" });
+  });
+
+  it("throws once the DMK singleton exists — transports register at build time", async () => {
+    await connectDmkSession();
+
+    expect(() =>
+      setDmkTransportOverride({ transportFactory: fakeTransportFactory, transportIdentifier: FAKE_IDENTIFIER }),
+    ).toThrow(/closeDmk/);
+  });
+
+  it("throws while a build is still in flight — the promise memo is claimed synchronously", async () => {
+    const pending = connectDmkSession();
+
+    expect(() =>
+      setDmkTransportOverride({ transportFactory: fakeTransportFactory, transportIdentifier: FAKE_IDENTIFIER }),
+    ).toThrow(/closeDmk/);
+
+    await pending;
+  });
+
+  it("clearing the override after closeDmk restores the web-hid default", async () => {
+    setDmkTransportOverride({ transportFactory: fakeTransportFactory, transportIdentifier: FAKE_IDENTIFIER });
+    await connectDmkSession();
+    closeDmk();
+    built.transports.length = 0;
+
+    setDmkTransportOverride(undefined);
+    await connectDmkSession();
+
+    expect(built.transports).toEqual([webHidTransportFactory]);
+    expect(dmkStub.startDiscovering).toHaveBeenLastCalledWith({ transport: "WEB-HID" });
+  });
+});
+
+describe("closeDmk landing inside a build's await window", () => {
+  // closeDmk() clears the promise memo, which lifts the setter's guard — so a
+  // transport swap can land while a build is still suspended on its imports.
+  const lateTransportFactory: TransportFactory = () => {
+    throw new Error("unit tests never invoke the transport factory");
+  };
+  const LATE_IDENTIFIER = "LATE-SPECULOS";
+
+  it("fails the abandoned connect, and the next one builds and discovers over the late-injected transport", async () => {
+    const abandoned = connectDmkSession();
+
+    closeDmk();
+    setDmkTransportOverride({ transportFactory: lateTransportFactory, transportIdentifier: LATE_IDENTIFIER });
+    // A torn-down DMK cannot serve this caller — handing it back would run
+    // discovery on a disposed instance.
+    await expect(abandoned).rejects.toThrow(/closeDmk/);
+
+    const handle = await connectDmkSession();
+
+    // Per-build snapshot, stated positively: the late override is the NEXT
+    // build's transport, and that build discovers on its own identifier.
+    expect(built.transports).toEqual([webHidTransportFactory, lateTransportFactory]);
+    expect(dmkStub.startDiscovering).toHaveBeenCalledWith({ transport: LATE_IDENTIFIER });
+    expect(handle.sessionId).toBe("session-1");
+  });
+
+  it("never closes the abandoned build's DMK — it holds no transport, and close() would construct one", async () => {
+    const abandoned = connectDmkSession();
+
+    closeDmk();
+    setDmkTransportOverride({ transportFactory: lateTransportFactory, transportIdentifier: LATE_IDENTIFIER });
+    await expect(abandoned).rejects.toThrow(/closeDmk/);
+
+    // `build()` only stores the factory, and the orphan never reached a use
+    // case — so it has nothing to release and close() would only add listeners.
+    expect(built.closed).toHaveLength(0);
+
+    const liveHandle = await connectDmkSession();
+    expect(built.count).toBe(2);
+    expect(liveHandle.dmk).not.toBe(built.instances[0]);
+
+    closeDmk();
+
+    // …and closeDmk() still reaches the LIVE instance, which does hold one.
+    expect(built.closed).toHaveLength(1);
+    expect(built.closed[0]).toBe(liveHandle.dmk);
+  });
+
+  it("an abandoned build's failure leaves the memo of the build that replaced it intact", async () => {
+    // Replace the memo from INSIDE the first build, once it is past its
+    // dynamic imports: two builds importing concurrently trips vitest's own
+    // mock registry, and that race is not the behavior under test.
+    let live: ReturnType<typeof connectDmkSession> | undefined;
+    built.onBuilding = () => {
+      built.onBuilding = undefined;
+      closeDmk();
+      live = connectDmkSession();
+    };
+
+    const abandoned = connectDmkSession();
+
+    await expect(abandoned).rejects.toThrow(/closeDmk/);
+    const liveHandle = await live;
+
+    // The build's catch clears the memo only while it still owns it, so the
+    // abandoned one must not wipe its successor's: a third connect reuses it.
+    const reused = await connectDmkSession();
+    expect(built.count).toBe(2);
+    expect(reused.dmk).toBe(liveHandle?.dmk);
   });
 });

--- a/packages/babylon-ledger-vault-signer/src/__tests__/e2e/depositorGraphFixture.ts
+++ b/packages/babylon-ledger-vault-signer/src/__tests__/e2e/depositorGraphFixture.ts
@@ -19,23 +19,20 @@
  *    (`test_sign_psbt_validate.py:2997`) because `_validate_nopayout` resolves
  *    the vault group by matching that txid (`sign_psbt_validate.c:2196-2219`).
  *  The suite pins the divergence: production shape rejected, firmware shape signs.
+ *  When Ledger fixes that routing (KB Q16, asked 2026-08-25) the production
+ *  shape MUST sign and `firmwareShapedPsbtHex` is deleted.
  *
  * Conscious call on the §7 audit boundary: importing the SDK/WASM builders here
- * makes them devDependencies, so `build`/`test` for this package now need them
- * built first (they never enter `dist` — the vite lib build excludes tests).
- * The alternative — committing pre-generated vectors — was rejected because a
- * stale vector would silently stop matching what the dApp actually sends.
+ * makes them devDependencies, so `build` (its typecheck) needs them built first
+ * (they never enter `dist` — the vite lib build excludes tests). `test` does
+ * not: the imports are lazy, so the ungated unit run loads this file without
+ * their dist output. The alternative — committing pre-generated vectors — was
+ * rejected because a stale vector would silently stop matching what the dApp
+ * actually sends.
  *
  * @module ledger-vault-signer/__tests__/e2e/depositorGraphFixture
  */
 
-import {
-  computePayoutFeeFloor,
-  getAssertNoPayoutScriptInfo,
-  getAssertPayoutScriptInfo,
-  type AssertPayoutNoPayoutConnectorParams,
-} from "@babylonlabs-io/babylon-tbv-rust-wasm";
-import { buildNoPayoutPsbt, buildPayoutPsbt } from "@babylonlabs-io/ts-sdk/tbv/core/primitives";
 import * as ecc from "@bitcoin-js/tiny-secp256k1-asmjs";
 import { crypto as bcrypto, initEccLib, payments, Psbt, Transaction } from "bitcoinjs-lib";
 import { Buffer } from "buffer";
@@ -55,6 +52,12 @@ import {
 
 // `payments.p2tr` (challenger sink) needs the ecc backend; idempotent.
 initEccLib(ecc);
+
+// Lazy on purpose: both resolve dist output the ungated unit run may lack, and
+// `nx/enforce-module-boundaries` forbids static imports of lazily loaded libraries.
+const loadWasm = () => import("@babylonlabs-io/babylon-tbv-rust-wasm");
+const loadSdkPrimitives = () => import("@babylonlabs-io/ts-sdk/tbv/core/primitives");
+type ConnectorParams = Parameters<Awaited<ReturnType<typeof loadWasm>>["getAssertPayoutScriptInfo"]>[0];
 
 /** BIP-341 tapscript leaf version — matches `TAPSCRIPT_LEAF_VERSION` in the SDK builders. */
 const TAPSCRIPT_LEAF_VERSION = 0xc0;
@@ -131,7 +134,7 @@ export interface DepositorGraphFixture {
   readonly payoutPsbtHex: string;
   /** Input 0's Vault-UTXO leaf hash — the single yield the firmware produces. */
   readonly payoutInput0LeafHashHex: string;
-  /** Input 1's Assert:0 payout leaf hash — the yield the HOST table also expects. */
+  /** Input 1's Assert:0 payout leaf hash (WASM-built) — display-only on-device, never signed (#2321). */
   readonly payoutInput1LeafHashHex: string;
   readonly perChallenger: readonly NoPayoutChallengerFixture[];
 }
@@ -175,9 +178,13 @@ function buildParentTx(prevoutFill: number, outputs: readonly { script: Buffer; 
  *   Vault-UTXO prevout the firmware recomputes from the intent)
  */
 export async function buildDepositorGraphFixture(peginTxHex: string): Promise<DepositorGraphFixture> {
+  const [
+    { computePayoutFeeFloor, getAssertNoPayoutScriptInfo, getAssertPayoutScriptInfo },
+    { buildNoPayoutPsbt, buildPayoutPsbt },
+  ] = await Promise.all([loadWasm(), loadSdkPrimitives()]);
   const peginTx = Transaction.fromHex(peginTxHex);
 
-  const connectorParams: AssertPayoutNoPayoutConnectorParams = {
+  const connectorParams: ConnectorParams = {
     txGraphVersion: VAULT_CORE_VERSION,
     claimer: DEPOSITOR_XONLY_HEX,
     // Depositor-as-claimer local challengers = keepers only (VP excluded).

--- a/packages/babylon-ledger-vault-signer/src/__tests__/e2e/depositorGraphFixture.ts
+++ b/packages/babylon-ledger-vault-signer/src/__tests__/e2e/depositorGraphFixture.ts
@@ -1,0 +1,333 @@
+/**
+ * Depositor-graph (Payout + NoPayout) fixtures for the Speculos e2e suite,
+ * built with the PRODUCTION SDK builders (`buildPayoutPsbt`,
+ * `buildNoPayoutPsbt` — the constructors `signDepositorGraph` drives) over
+ * VP-shaped parent transactions, so the device sees exactly the PSBTs the
+ * dApp would hand it.
+ *
+ * Roster, amounts and timelocks equal the intent `peginFixture.ts` approves.
+ * The WASM connector scripts were pre-verified byte-identical to the firmware
+ * leaf builders at the ELF tip: vault-UTXO leaf and Assert:0 payout leaf match
+ * fw `tests/test_sign_psbt_validate.py` `_vault_utxo_leaf` / `_assert0_payout_leaf`
+ * (@ 29beb88d5), and every control block commits to one Assert:0 spk.
+ *
+ * The NoPayout comes in TWO shapes per challenger:
+ *  - `productionPsbtHex`: input 0 spends Assert:0 — btc-vault
+ *    `transactions/nopayout.rs:146-155` and HLD v22 §4.9.8 ("Prevout Assert:0").
+ *  - `firmwareShapedPsbtHex`: identical except input 0's prevout txid is the
+ *    computed PegIn txid — the shape the firmware's own tests build
+ *    (`test_sign_psbt_validate.py:2997`) because `_validate_nopayout` resolves
+ *    the vault group by matching that txid (`sign_psbt_validate.c:2196-2219`).
+ *  The suite pins the divergence: production shape rejected, firmware shape signs.
+ *
+ * Conscious call on the §7 audit boundary: importing the SDK/WASM builders here
+ * makes them devDependencies, so `build`/`test` for this package now need them
+ * built first (they never enter `dist` — the vite lib build excludes tests).
+ * The alternative — committing pre-generated vectors — was rejected because a
+ * stale vector would silently stop matching what the dApp actually sends.
+ *
+ * @module ledger-vault-signer/__tests__/e2e/depositorGraphFixture
+ */
+
+import {
+  computePayoutFeeFloor,
+  getAssertNoPayoutScriptInfo,
+  getAssertPayoutScriptInfo,
+  type AssertPayoutNoPayoutConnectorParams,
+} from "@babylonlabs-io/babylon-tbv-rust-wasm";
+import { buildNoPayoutPsbt, buildPayoutPsbt } from "@babylonlabs-io/ts-sdk/tbv/core/primitives";
+import * as ecc from "@bitcoin-js/tiny-secp256k1-asmjs";
+import { crypto as bcrypto, initEccLib, payments, Psbt, Transaction } from "bitcoinjs-lib";
+import { Buffer } from "buffer";
+
+import { bip86OutputScript } from "../../expectedSignatures";
+import { tapLeafHash } from "../../tapLeafHash";
+import {
+  CHALLENGER_KEY_HEX,
+  DEPOSITOR_XONLY_HEX,
+  HTLC_VOUT,
+  KEEPER_KEY_HEX,
+  PAYOUT_TIMELOCK,
+  PEGIN_CSV_TIMELOCK,
+  VAULT_AMOUNT_SATS,
+  VP_KEY_HEX,
+} from "./peginFixture";
+
+// `payments.p2tr` (challenger sink) needs the ecc backend; idempotent.
+initEccLib(ecc);
+
+/** BIP-341 tapscript leaf version — matches `TAPSCRIPT_LEAF_VERSION` in the SDK builders. */
+const TAPSCRIPT_LEAF_VERSION = 0xc0;
+
+/** The graph the fixture PSBTs are built under (peginFixture terms `vaultCoreVersion: 2`). */
+const VAULT_CORE_VERSION = 2;
+
+/** Intent `base_fee_rate` (peginFixture BASE_FEE_RATE) as the SDK's bigint rate. */
+const PROTOCOL_FEE_RATE = 1n;
+
+/**
+ * Fixture security council (size 1, quorum 1). The council leaf only shapes
+ * the Assert:0 taptree — the device never reconstructs it, it rides the
+ * control block as a sibling hash (`sign_psbt_validate.c:664-...` commitment
+ * walk). Key = BIP-340 test-vector pubkey 1, a known-valid x-only point.
+ */
+const COUNCIL_MEMBERS = ["f9308a019258c31049344f85f89d5229b531c845836f99b08601f113bce036f9"];
+const COUNCIL_QUORUM = 1;
+
+/**
+ * Assert:0 funding: DUST + council-NoPayout fee at rate 1 (btc-vault funds
+ * Assert:0 at `DUST_AMOUNT + council_nopayout_fee`; 386 vB fixture vsize per
+ * the KB H3 row). Inside the device band [546, 546 + rate×500]
+ * (`sign_psbt_validate.c:1646-1658` payout, `:2114-2126` nopayout).
+ */
+const ASSERT0_VALUE_SATS = 546 + 386;
+
+/** Non-VP payout Out1 must be exactly DUST (`sign_psbt_validate.c:1898-1904`). */
+const PAYOUT_ANCHOR_VALUE_SATS = 546;
+
+/** ChallengeAssert connector value: device requires ≤ DUST (`sign_psbt_validate.c:2149-2167`). */
+const CHALLENGE_ASSERT_CONNECTOR_VALUE_SATS = 546;
+
+/** Fixture `timelock_challenge_assert` (nopayout.rs:157-176 CAX/CAY sequences); device reads no NoPayout sequence. */
+const CHALLENGE_ASSERT_TIMELOCK = 72;
+
+/** Fixture NoPayout fee; the device validates the output's spk, never its value (`sign_psbt_validate.c:2169-2188`). */
+const NOPAYOUT_FEE_SATS = 400;
+
+/** btc-vault tx literals: Payout/NoPayout are version 2, locktime 0 (payout.rs / nopayout.rs). */
+const GRAPH_TX_VERSION = 2;
+const GRAPH_TX_LOCKTIME = 0;
+
+/** NoPayout Assert-input sequence (nopayout.rs:153 `Sequence::MAX`). */
+const SEQUENCE_MAX = 0xffffffff;
+
+/** SDK fee-floor shape inputs: out0 is the 34-byte BIP-86 P2TR, out1 absent (2-output layout). */
+const BIP86_P2TR_SCRIPT_LEN = 34;
+
+/** Parent-tx prevout fill bytes — distinct, arbitrary; the device never fetches parents. */
+const ASSERT_PARENT_PREVOUT_FILL = 0xaa;
+const CHALLENGE_ASSERT_PREVOUT_FILL_BASE = 0xb0;
+
+const hexToBuffer = (hex: string): Buffer => Buffer.from(hex, "hex");
+
+/**
+ * Depositor-graph challenger roster: local ∪ universal. Depositor-as-claimer
+ * local challengers = vault keepers only, VP excluded (SDK
+ * `deriveLocalChallengers`, btc-vault `graph.rs derive_challengers_for`).
+ */
+export const DEPOSITOR_GRAPH_CHALLENGERS: readonly string[] = [KEEPER_KEY_HEX, CHALLENGER_KEY_HEX];
+
+interface NoPayoutChallengerFixture {
+  readonly challengerXOnlyHex: string;
+  /** btc-vault shape — input 0 spends Assert:0 (nopayout.rs:146-155). */
+  readonly productionPsbtHex: string;
+  /** fw-test shape — input 0's prevout txid = PegIn txid (test_sign_psbt_validate.py:2997). */
+  readonly firmwareShapedPsbtHex: string;
+  /** TapLeaf hash of the 68-byte `<D> OP_CHECKSIGVERIFY <Cj> OP_CHECKSIG` leaf. */
+  readonly noPayoutLeafHashHex: string;
+}
+
+export interface DepositorGraphFixture {
+  readonly payoutPsbtHex: string;
+  /** Input 0's Vault-UTXO leaf hash — the single yield the firmware produces. */
+  readonly payoutInput0LeafHashHex: string;
+  /** Input 1's Assert:0 payout leaf hash — the yield the HOST table also expects. */
+  readonly payoutInput1LeafHashHex: string;
+  readonly perChallenger: readonly NoPayoutChallengerFixture[];
+}
+
+/** BIP-341 output script from a tapscript leaf + its control block (internal key + sibling path). */
+function taprootSpkFromLeafScript(scriptHex: string, controlBlockHex: string): Buffer {
+  const controlBlock = hexToBuffer(controlBlockHex);
+  const internalKey = controlBlock.subarray(1, 33);
+  let node = tapLeafHash(TAPSCRIPT_LEAF_VERSION, hexToBuffer(scriptHex));
+  for (let offset = 33; offset < controlBlock.length; offset += 32) {
+    const sibling = controlBlock.subarray(offset, offset + 32);
+    const [left, right] = Buffer.compare(node, sibling) <= 0 ? [node, sibling] : [sibling, node];
+    node = bcrypto.taggedHash("TapBranch", Buffer.concat([left, right]));
+  }
+  const tweak = bcrypto.taggedHash("TapTweak", Buffer.concat([internalKey, node]));
+  const tweaked = ecc.xOnlyPointAddTweak(internalKey, tweak);
+  if (tweaked === null) {
+    throw new Error("control block internal key has no taproot output key");
+  }
+  return Buffer.concat([Buffer.from([0x51, 0x20]), Buffer.from(tweaked.xOnlyPubkey)]);
+}
+
+/** Minimal VP-side parent transaction: one dummy input, the given outputs. */
+function buildParentTx(prevoutFill: number, outputs: readonly { script: Buffer; value: number }[]): Transaction {
+  const tx = new Transaction();
+  tx.version = GRAPH_TX_VERSION;
+  tx.locktime = GRAPH_TX_LOCKTIME;
+  tx.addInput(Buffer.alloc(32, prevoutFill), 0, SEQUENCE_MAX);
+  for (const output of outputs) {
+    tx.addOutput(output.script, output.value);
+  }
+  return tx;
+}
+
+/**
+ * Build the depositor-as-claimer graph fixture bound to the suite's signed
+ * PegIn: Payout PSBT + per-challenger NoPayout PSBTs (both shapes), via the
+ * production SDK builders.
+ *
+ * @param peginTxHex the fixture PegIn's raw unsigned tx (its txid is the
+ *   Vault-UTXO prevout the firmware recomputes from the intent)
+ */
+export async function buildDepositorGraphFixture(peginTxHex: string): Promise<DepositorGraphFixture> {
+  const peginTx = Transaction.fromHex(peginTxHex);
+
+  const connectorParams: AssertPayoutNoPayoutConnectorParams = {
+    txGraphVersion: VAULT_CORE_VERSION,
+    claimer: DEPOSITOR_XONLY_HEX,
+    // Depositor-as-claimer local challengers = keepers only (VP excluded).
+    localChallengers: [KEEPER_KEY_HEX],
+    universalChallengers: [CHALLENGER_KEY_HEX],
+    timelockAssert: PAYOUT_TIMELOCK,
+    councilMembers: COUNCIL_MEMBERS,
+    councilQuorum: COUNCIL_QUORUM,
+  };
+
+  // Assert:0 — the one output every graph leaf's control block commits to.
+  const payoutLeafInfo = await getAssertPayoutScriptInfo(connectorParams);
+  const assert0Spk = taprootSpkFromLeafScript(payoutLeafInfo.payoutScript, payoutLeafInfo.payoutControlBlock);
+  const assertTx = buildParentTx(ASSERT_PARENT_PREVOUT_FILL, [{ script: assert0Spk, value: ASSERT0_VALUE_SATS }]);
+
+  // --- Payout transaction, as the VP builds it (payout.rs; fee = SDK floor,
+  // inside both bands: floor ≤ fee ≤ rate×(500+55×(N+M)) — fw
+  // `sign_psbt_validate.c:1949-1973`, SDK assertPayoutFeeBand).
+  const payoutFeeSats = Number(
+    await computePayoutFeeFloor(
+      VAULT_CORE_VERSION,
+      connectorParams.localChallengers.length,
+      connectorParams.universalChallengers.length,
+      connectorParams.localChallengers.length,
+      COUNCIL_MEMBERS.length,
+      BIP86_P2TR_SCRIPT_LEN,
+      undefined,
+      PROTOCOL_FEE_RATE,
+    ),
+  );
+  const depositorBip86Spk = bip86OutputScript(DEPOSITOR_XONLY_HEX);
+  const payoutTx = new Transaction();
+  payoutTx.version = GRAPH_TX_VERSION;
+  payoutTx.locktime = GRAPH_TX_LOCKTIME;
+  payoutTx.addInput(peginTx.getHash(), HTLC_VOUT, PEGIN_CSV_TIMELOCK);
+  payoutTx.addInput(assertTx.getHash(), 0, PAYOUT_TIMELOCK);
+  // Depositor claimer: Out0 = V + assert0 − fee − DUST to BIP-86(D), Out1 =
+  // DUST CPFP anchor to BIP-86(D) — both script-verified on-device
+  // (`sign_psbt_validate.c:1817-1831, 1864-1916`).
+  payoutTx.addOutput(
+    depositorBip86Spk,
+    VAULT_AMOUNT_SATS + ASSERT0_VALUE_SATS - payoutFeeSats - PAYOUT_ANCHOR_VALUE_SATS,
+  );
+  payoutTx.addOutput(depositorBip86Spk, PAYOUT_ANCHOR_VALUE_SATS);
+
+  const { psbtHex: payoutPsbtHex } = await buildPayoutPsbt({
+    vaultCoreVersion: VAULT_CORE_VERSION,
+    payoutTxHex: payoutTx.toHex(),
+    assertTxHex: assertTx.toHex(),
+    peginTxHex,
+    depositorBtcPubkey: DEPOSITOR_XONLY_HEX,
+    vaultProviderBtcPubkey: VP_KEY_HEX,
+    vaultKeeperBtcPubkeys: [KEEPER_KEY_HEX],
+    universalChallengerBtcPubkeys: [CHALLENGER_KEY_HEX],
+    timelockPegin: PEGIN_CSV_TIMELOCK,
+    timelockAssert: PAYOUT_TIMELOCK,
+    network: "signet",
+    claimerBtcPubkey: DEPOSITOR_XONLY_HEX,
+    registeredPayoutScriptPubKey: depositorBip86Spk.toString("hex"),
+    commissionBps: 1, // inert for the depositor-as-claimer role (signDepositorGraph.ts:67-70)
+    protocolFeeRate: PROTOCOL_FEE_RATE,
+    councilMembers: COUNCIL_MEMBERS,
+    councilQuorum: COUNCIL_QUORUM,
+    vkClaimerPayoutScriptPubKeys: {},
+    vpCommissionScriptPubKey: depositorBip86Spk.toString("hex"), // unused for this role
+  });
+
+  // --- NoPayout per challenger, both shapes.
+  const perChallenger: NoPayoutChallengerFixture[] = [];
+  for (const [challengerIndex, challengerXOnlyHex] of DEPOSITOR_GRAPH_CHALLENGERS.entries()) {
+    const noPayoutInfo = await getAssertNoPayoutScriptInfo(connectorParams, challengerXOnlyHex);
+    // Same taptree ⇒ same Assert:0 spk as the payout leaf's — fail loudly on drift.
+    const noPayoutSpk = taprootSpkFromLeafScript(noPayoutInfo.noPayoutScript, noPayoutInfo.noPayoutControlBlock);
+    if (!noPayoutSpk.equals(assert0Spk)) {
+      throw new Error(`NoPayout control block for ${challengerXOnlyHex} binds a different Assert:0 spk`);
+    }
+
+    // Placeholder connector spk (fw test_sign_psbt_validate.py:2991): the
+    // device checks connector VALUES only, never their scripts.
+    const connectorSpk = Buffer.concat([Buffer.from([0x51, 0x20]), Buffer.alloc(32)]);
+    const challengeAssertX = buildParentTx(CHALLENGE_ASSERT_PREVOUT_FILL_BASE + 2 * challengerIndex, [
+      { script: connectorSpk, value: CHALLENGE_ASSERT_CONNECTOR_VALUE_SATS },
+    ]);
+    const challengeAssertY = buildParentTx(CHALLENGE_ASSERT_PREVOUT_FILL_BASE + 2 * challengerIndex + 1, [
+      { script: connectorSpk, value: CHALLENGE_ASSERT_CONNECTOR_VALUE_SATS },
+    ]);
+
+    // Output 0 pays P2TR(key-path tweak of Cj) — `sign_psbt_validate.c:2169-2188`.
+    const challengerSink = payments.p2tr({ internalPubkey: hexToBuffer(challengerXOnlyHex) }).output!;
+    const totalInSats =
+      ASSERT0_VALUE_SATS + CHALLENGE_ASSERT_CONNECTOR_VALUE_SATS + CHALLENGE_ASSERT_CONNECTOR_VALUE_SATS;
+
+    const buildNoPayoutTx = (input0PrevoutTxid: Buffer): Transaction => {
+      const tx = new Transaction();
+      tx.version = GRAPH_TX_VERSION;
+      tx.locktime = GRAPH_TX_LOCKTIME;
+      tx.addInput(input0PrevoutTxid, 0, SEQUENCE_MAX);
+      tx.addInput(challengeAssertX.getHash(), 0, CHALLENGE_ASSERT_TIMELOCK);
+      tx.addInput(challengeAssertY.getHash(), 0, CHALLENGE_ASSERT_TIMELOCK);
+      tx.addOutput(challengerSink, totalInSats - NOPAYOUT_FEE_SATS);
+      return tx;
+    };
+
+    const prevouts = [
+      { script_pubkey: assert0Spk.toString("hex"), value: ASSERT0_VALUE_SATS },
+      { script_pubkey: connectorSpk.toString("hex"), value: CHALLENGE_ASSERT_CONNECTOR_VALUE_SATS },
+      { script_pubkey: connectorSpk.toString("hex"), value: CHALLENGE_ASSERT_CONNECTOR_VALUE_SATS },
+    ];
+    const [productionPsbtHex, firmwareShapedPsbtHex] = await Promise.all([
+      buildNoPayoutPsbt({
+        noPayoutTxHex: buildNoPayoutTx(assertTx.getHash()).toHex(),
+        challengerPubkey: challengerXOnlyHex,
+        prevouts,
+        connectorParams,
+      }),
+      buildNoPayoutPsbt({
+        noPayoutTxHex: buildNoPayoutTx(peginTx.getHash()).toHex(),
+        challengerPubkey: challengerXOnlyHex,
+        prevouts,
+        connectorParams,
+      }),
+    ]);
+
+    perChallenger.push({
+      challengerXOnlyHex,
+      productionPsbtHex,
+      firmwareShapedPsbtHex,
+      noPayoutLeafHashHex: tapLeafHash(TAPSCRIPT_LEAF_VERSION, hexToBuffer(noPayoutInfo.noPayoutScript)).toString(
+        "hex",
+      ),
+    });
+  }
+
+  return {
+    payoutPsbtHex,
+    // Input 0's Vault-UTXO leaf is derived inside buildPayoutPsbt — read it
+    // off the built PSBT rather than re-deriving.
+    payoutInput0LeafHashHex: leafHashOfPsbtInput(payoutPsbtHex, 0),
+    payoutInput1LeafHashHex: tapLeafHash(TAPSCRIPT_LEAF_VERSION, hexToBuffer(payoutLeafInfo.payoutScript)).toString(
+      "hex",
+    ),
+    perChallenger,
+  };
+}
+
+/** TapLeaf hash of the single tapLeafScript the SDK attached to `inputIndex`. */
+function leafHashOfPsbtInput(psbtHex: string, inputIndex: number): string {
+  const leaves = Psbt.fromHex(psbtHex).data.inputs[inputIndex].tapLeafScript;
+  if (leaves === undefined || leaves.length !== 1) {
+    throw new Error(`payout PSBT input ${inputIndex} must carry exactly one tapLeafScript`);
+  }
+  return tapLeafHash(TAPSCRIPT_LEAF_VERSION, leaves[0].script).toString("hex");
+}

--- a/packages/babylon-ledger-vault-signer/src/__tests__/e2e/depositorGraphFixture.ts
+++ b/packages/babylon-ledger-vault-signer/src/__tests__/e2e/depositorGraphFixture.ts
@@ -336,5 +336,5 @@ function leafHashOfPsbtInput(psbtHex: string, inputIndex: number): string {
   if (leaves === undefined || leaves.length !== 1) {
     throw new Error(`payout PSBT input ${inputIndex} must carry exactly one tapLeafScript`);
   }
-  return tapLeafHash(TAPSCRIPT_LEAF_VERSION, leaves[0].script).toString("hex");
+  return tapLeafHash(leaves[0].leafVersion, leaves[0].script).toString("hex");
 }

--- a/packages/babylon-ledger-vault-signer/src/__tests__/e2e/dmkTransport.e2e.test.ts
+++ b/packages/babylon-ledger-vault-signer/src/__tests__/e2e/dmkTransport.e2e.test.ts
@@ -7,7 +7,7 @@
  * the only coverage of the transport seam actually carrying APDUs.
  *
  * Runs against the same container as that suite, and is skipped unless
- * SPECULOS_URL is set:
+ * SPECULOS_URL is set (SPECULOS_REQUIRED turns that skip into a failure — CI):
  *
  *   SPECULOS_URL=http://127.0.0.1:5055 pnpm exec vitest run src/__tests__/e2e/
  *
@@ -23,8 +23,9 @@ import { speculosIdentifier, speculosTransportFactory } from "@ledgerhq/device-t
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { closeDmk, connectDmkSession, disconnectDmkSession, setDmkTransportOverride } from "../../dmkSession";
+import { readSpeculosUrl } from "./speculosClient";
 
-const SPECULOS_URL = process.env.SPECULOS_URL ?? "";
+const SPECULOS_URL = readSpeculosUrl();
 
 /**
  * `isE2E` skips SpeculosTransport's disconnect watcher — a 2 s `setInterval`

--- a/packages/babylon-ledger-vault-signer/src/__tests__/e2e/dmkTransport.e2e.test.ts
+++ b/packages/babylon-ledger-vault-signer/src/__tests__/e2e/dmkTransport.e2e.test.ts
@@ -1,0 +1,74 @@
+/**
+ * DMK-transport end-to-end test: the production {@link connectDmkSession} path
+ * — discovery, connect with the refresher disabled, and the
+ * GET_APP_AND_VERSION preflight — driven over a REAL DMK transport instead of
+ * the unit suite's mocked one. The sibling `speculos.e2e.test.ts` speaks to
+ * Speculos over its REST API directly and never exercises DMK; this file is
+ * the only coverage of the transport seam actually carrying APDUs.
+ *
+ * Runs against the same container as that suite, and is skipped unless
+ * SPECULOS_URL is set:
+ *
+ *   SPECULOS_URL=http://127.0.0.1:5055 pnpm exec vitest run src/__tests__/e2e/
+ *
+ * That container is a single device holding one ceremony session, so this file
+ * must never run alongside `speculos.e2e.test.ts` — vitest.config.ts drops
+ * `fileParallelism` whenever SPECULOS_URL is set, which is what keeps them apart.
+ *
+ * @module ledger-vault-signer/__tests__/e2e/dmkTransport.e2e.test
+ */
+
+import { DeviceModelId } from "@ledgerhq/device-management-kit";
+import { speculosIdentifier, speculosTransportFactory } from "@ledgerhq/device-transport-kit-speculos";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { closeDmk, connectDmkSession, disconnectDmkSession, setDmkTransportOverride } from "../../dmkSession";
+
+const SPECULOS_URL = process.env.SPECULOS_URL ?? "";
+
+/**
+ * `isE2E` skips SpeculosTransport's disconnect watcher — a 2 s `setInterval`
+ * that `disconnect()` never clears, only a failed `sendApdu` does
+ * (SpeculosTransport.js `listenForDisconnect`), so it would outlive the suite.
+ */
+const SPECULOS_IS_E2E = true;
+/** The container runs `speculos.py --model nanosp`; the factory would otherwise claim STAX. */
+const SPECULOS_DEVICE_MODEL = DeviceModelId.NANO_SP;
+
+/** Discovery + connect + one preflight APDU over HTTP. */
+const CONNECT_TIMEOUT_MS = 30_000;
+
+describe.skipIf(SPECULOS_URL === "")("DMK session over the Speculos transport", () => {
+  // Per-test, not per-file: the setter refuses while a DMK exists, so a second
+  // `it` sharing one armed override would fail as if the seam were broken.
+  beforeEach(() => {
+    setDmkTransportOverride({
+      transportFactory: speculosTransportFactory(SPECULOS_URL, SPECULOS_IS_E2E, SPECULOS_DEVICE_MODEL),
+      transportIdentifier: speculosIdentifier,
+    });
+  });
+
+  afterEach(() => {
+    // Release this file's live HTTP-backed DMK; close first, since the setter
+    // refuses to clear while one is built.
+    closeDmk();
+    setDmkTransportOverride(undefined);
+  });
+
+  it(
+    "discovers, connects, and reports the running vault app from the connect preflight",
+    async () => {
+      const handle = await connectDmkSession();
+
+      expect(handle.sessionId.length).toBeGreaterThan(0);
+      // Same preflight the sibling suite reads over REST, here proving the DMK
+      // command path — transport framing included — reaches the vault app.
+      expect(handle.appName).toContain("Babylon Vault");
+      expect(handle.appVersion).toMatch(/^\d+\.\d+\.\d+$/);
+      console.log(`[dmk-transport-e2e] app: ${handle.appName} v${handle.appVersion}`);
+
+      await disconnectDmkSession(handle);
+    },
+    CONNECT_TIMEOUT_MS,
+  );
+});

--- a/packages/babylon-ledger-vault-signer/src/__tests__/e2e/peginFixture.test.ts
+++ b/packages/babylon-ledger-vault-signer/src/__tests__/e2e/peginFixture.test.ts
@@ -1,0 +1,20 @@
+/**
+ * Ungated (no Speculos) guards for the e2e fixtures — regressions here must
+ * fail in CI without the emulator.
+ *
+ * @module ledger-vault-signer/__tests__/e2e/peginFixture.test
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { assertBip86Path } from "../../bip86Path";
+import { DEPOSITOR_PATH } from "./peginFixture";
+
+describe("peginFixture DEPOSITOR_PATH", () => {
+  it("passes the production BIP-86 path gate (assertBip86Path)", () => {
+    // Rot-catcher for the `HARDENED | 86` class of bug: bitwise OR yields
+    // negative int32 levels, which the production gate rejects and which made
+    // e2e stages 5/6/10 unrunnable from #2281 until the 2026-08-25 fix.
+    expect(() => assertBip86Path("DEPOSITOR_PATH", DEPOSITOR_PATH)).not.toThrow();
+  });
+});

--- a/packages/babylon-ledger-vault-signer/src/__tests__/e2e/peginFixture.ts
+++ b/packages/babylon-ledger-vault-signer/src/__tests__/e2e/peginFixture.ts
@@ -83,8 +83,12 @@ export const DERIVE_CONTEXT = Uint8Array.from(Array.from({ length: 72 }, (_, i) 
 export const VAULT_APP_NAME = "babylon-btc-vault";
 
 const HARDENED = 0x80000000;
-/** m/86'/1'/0'/0/0 — depositor_path(coin_type=1) (vault_client.py:279). */
-export const DEPOSITOR_PATH: readonly number[] = [HARDENED | 86, HARDENED | 1, HARDENED | 0, 0, 0];
+/**
+ * m/86'/1'/0'/0/0 — depositor_path(coin_type=1) (vault_client.py:279). Levels
+ * use `+` (unsigned, provider.ts:205-212): `|` yields negative int32s that
+ * `assertBip86Path` rejects; the wire bytes are identical (`>>> 0` serializers).
+ */
+export const DEPOSITOR_PATH: readonly number[] = [86 + HARDENED, 1 + HARDENED, 0 + HARDENED, 0, 0];
 const TESTNET_COIN_TYPE = 1;
 
 /** P2A anchor scriptPubKey `51 02 4e 73` (test_sign_psbt_validate.py:349). */

--- a/packages/babylon-ledger-vault-signer/src/__tests__/e2e/speculos.e2e.test.ts
+++ b/packages/babylon-ledger-vault-signer/src/__tests__/e2e/speculos.e2e.test.ts
@@ -14,8 +14,9 @@
  *   10. BIP-322 PoP, last among the intent stages, so it signs while the
  *       intent is still loaded — the path that exercises the firmware's
  *       intent-key check (`sign_psbt_validate.c:2764-2769`).
- *   11. depositor-graph presign (T7 stage a): Payout + NoPayout against a
- *       production-SDK-built graph fixture, still under the stage-4 intent.
+ *   11. depositor-graph presign (T7 stage a): Payout (under the production
+ *       `signInputIndexes: [0]`) + NoPayout against a production-SDK-built
+ *       graph fixture, still under the stage-4 intent.
  *   12. abort/dispatcher recovery (T7 stage b): interrupt SIGN_PSBT mid-loop,
  *       pin the eaten-APDU behavior and the full re-ceremony recovery. Runs
  *       LAST — it re-derives, which resets the vault session.
@@ -26,7 +27,8 @@
  * Requires a running container with the vault app (nanosp, testnet build,
  * firmware-test mnemonic) built from ELF commit `29beb88d5` (stages 1-10 also
  * pass at `e2d0c45b`; stages 11-12 cite `29beb88d5` line numbers). Skipped
- * unless SPECULOS_URL is set:
+ * unless SPECULOS_URL is set (SPECULOS_REQUIRED turns that skip into a
+ * failure — CI):
  *
  *   SPECULOS_URL=http://127.0.0.1:5055 pnpm exec vitest run src/__tests__/e2e/
  *
@@ -34,26 +36,19 @@
  * between runs.
  */
 
-import { assertScriptPathSchnorrSignature } from "@babylonlabs-io/ts-sdk/tbv/core/primitives";
 import { Psbt, Transaction } from "bitcoinjs-lib";
 import { Buffer } from "buffer";
-import { describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it } from "vitest";
 
 import { getExtendedPublicKey, getMasterFingerprintHex } from "../../derivation";
 import { assertDepositTermsDeviceCompatible } from "../../envelope";
-import {
-  isLedgerDeviceError,
-  isLedgerSignPsbtAbortedError,
-  isLedgerSignPsbtIncompleteError,
-  type LedgerSignPsbtAbortedError,
-  type LedgerSignPsbtIncompleteError,
-} from "../../errors";
+import { isLedgerDeviceError, isLedgerSignPsbtAbortedError, type LedgerSignPsbtAbortedError } from "../../errors";
 import { bip86OutputScript } from "../../expectedSignatures";
 import { augmentPsbtForWalletPolicy, deriveChangeXOnlyHex } from "../../policyPsbt";
 import { bip322ToSpendTxid, buildPopPsbtHex } from "../../popPsbt";
 import { SW_CAP_EXCEEDED } from "../../rawApdu";
 import { signPreparedVaultPsbt, signVaultPsbt, type SignVaultPsbtResult } from "../../signPsbt";
-import { getPreparedSignPsbtState, prepareSignPsbt, type PreparedSignPsbt } from "../../signPsbtPrepare";
+import { prepareSignPsbt, type PreparedSignPsbt } from "../../signPsbtPrepare";
 import { approveVaultIntent, deriveContextHash } from "../../vaultCommands";
 import { buildDefaultTaprootPolicy, type DefaultTaprootWalletPolicy } from "../../walletPolicy";
 import { buildDepositorGraphFixture, type DepositorGraphFixture } from "./depositorGraphFixture";
@@ -81,10 +76,21 @@ import {
   createSpeculosRawApduSender,
   getAppAndVersion,
   readScreenText,
+  readSpeculosUrl,
   sleep,
 } from "./speculosClient";
 
-const SPECULOS_URL = process.env.SPECULOS_URL ?? "";
+const SPECULOS_URL = readSpeculosUrl();
+
+/**
+ * The SDK's script-path verifier, loaded inside the gated suite only: it
+ * resolves the ts-sdk dist, which the ungated unit run must not need (same
+ * boundary as `depositorGraphFixture.ts`; nx forbids a static import here).
+ */
+async function loadSdkVerifier() {
+  return (await import("@babylonlabs-io/ts-sdk/tbv/core/primitives")).assertScriptPathSchnorrSignature;
+}
+type SdkVerifier = Awaited<ReturnType<typeof loadSdkVerifier>>;
 
 /** Live-verified nanosp review-screen texts (reference driver `lsk_ceremony2.py`). */
 const DERIVE_APPROVAL_TEXT = "Allow derivation";
@@ -107,6 +113,15 @@ const SCHNORR_SIG_BYTES = 64;
 
 /** Depositor-graph challengers = VKs + UCs (VP excluded): 1 keeper + 1 universal in the fixture roster. */
 const DEPOSITOR_GRAPH_CHALLENGER_COUNT = 2;
+/**
+ * Payout input 0 (Vault UTXO) is the one the depositor signs — production
+ * narrows the table to it (ts-sdk `signDepositorGraph` DEPOSITOR_SIGNED_INPUT_COUNT
+ * → `signInputIndexes: [0]`, #2321); input 1 (Assert:0) is display-only.
+ */
+const PAYOUT_VAULT_UTXO_INPUT = 0;
+const PAYOUT_ASSERT_INPUT = 1;
+/** NoPayout input 0 spends Assert:0 (btc-vault nopayout.rs:146-155) — the one prevout the two fixture shapes differ in. */
+const NOPAYOUT_ASSERT_INPUT = 0;
 /** Stage 12 aborts after the FIRST yield — validation (and the Pre-PegIn cap bump) is over, signing is not. */
 const ABORT_AFTER_YIELD_COUNT = 1;
 
@@ -467,11 +482,17 @@ describe.skipIf(SPECULOS_URL === "")("Speculos end-to-end vault signing", () => 
 
   describe("(11) depositor-graph presign (Payout + NoPayout) under the loaded intent", () => {
     let graph: DepositorGraphFixture | undefined;
+    let assertScriptPathSchnorrSignature: SdkVerifier | undefined;
+
+    beforeAll(async () => {
+      assertScriptPathSchnorrSignature = await loadSdkVerifier();
+    });
 
     it(
       "builds the graph fixture with the production SDK builders, bound to the signed PegIn",
       async () => {
         expect(fixture, "PegIn stage must have built its fixture").toBeDefined();
+        expect(assertScriptPathSchnorrSignature, "the SDK verifier must have loaded").toBeDefined();
         const peginTxHex = Transaction.fromBuffer(
           Psbt.fromHex((fixture as PeginPsbtFixture).psbtHex).data.globalMap.unsignedTx.toBuffer(),
         ).toHex();
@@ -482,46 +503,87 @@ describe.skipIf(SPECULOS_URL === "")("Speculos end-to-end vault signing", () => 
     );
 
     it(
-      "Payout: the device yields ONE signature (input 0, Vault-UTXO leaf) — the host table also expects input 1, pinning the completion gap",
+      "NoPayout fixture shapes differ ONLY in input 0's prevout txid — the firmware reject below is attributable to group routing alone",
+      () => {
+        expect(graph, "fixture stage must have built the graph").toBeDefined();
+        for (const challenger of (graph as DepositorGraphFixture).perChallenger) {
+          const production = Psbt.fromHex(challenger.productionPsbtHex);
+          const firmwareShaped = Psbt.fromHex(challenger.firmwareShapedPsbtHex);
+          const productionTx = Transaction.fromBuffer(production.data.globalMap.unsignedTx.toBuffer());
+          const firmwareShapedTx = Transaction.fromBuffer(firmwareShaped.data.globalMap.unsignedTx.toBuffer());
+          expect(
+            firmwareShapedTx.ins[NOPAYOUT_ASSERT_INPUT].hash.equals(productionTx.ins[NOPAYOUT_ASSERT_INPUT].hash),
+          ).toBe(false);
+          // Normalise the one intended difference, then demand byte-identity of
+          // the unsigned tx and field-identity of every map (the prevout lives
+          // nowhere but the tx — no non-witness UTXOs are attached).
+          firmwareShapedTx.ins[NOPAYOUT_ASSERT_INPUT].hash = productionTx.ins[NOPAYOUT_ASSERT_INPUT].hash;
+          expect(firmwareShapedTx.toBuffer().equals(productionTx.toBuffer())).toBe(true);
+          expect(firmwareShaped.data.inputs).toEqual(production.data.inputs);
+          expect(firmwareShaped.data.outputs).toEqual(production.data.outputs);
+          expect(firmwareShaped.data.globalMap.unknownKeyVals).toEqual(production.data.globalMap.unknownKeyVals);
+        }
+      },
+      SANITY_TIMEOUT_MS,
+    );
+
+    it(
+      "Payout: the device signs input 0 alone under signInputIndexes [0]; input 1 stays classified but unsigned",
       async () => {
         expect(graph, "fixture stage must have built the graph").toBeDefined();
         const g = graph as DepositorGraphFixture;
-        const prepared = prepareSignPsbt({ psbtHex: g.payoutPsbtHex, depositorXOnlyHex: DEPOSITOR_XONLY_HEX });
-        // The host table counts every leaf-carrying input (expectedSignatures.ts
-        // buildExpectedSignatureTable) — inputs 0 AND 1 here…
-        expect(prepared.table.expectedYieldCount).toBe(2);
-        const { collector } = getPreparedSignPsbtState(prepared);
-        const failure = await signPreparedVaultPsbt(sendRaw, prepared, {
-          signal: AbortSignal.timeout(SIGNING_ABORT_MS),
-        }).then(
-          () => null,
-          (error: unknown) => error,
-        );
-        // …but the firmware signs Payout input 0 ONLY and answers SW_OK
-        // (`sign_custom_inputs.c:345-424`; fw test_sign_psbt_payout_vk asserts a
-        // single sig for the depositor claimer). Input 1 belongs to the separate
-        // PayoutFinalize flow. The host's set-equal completion therefore fails
-        // AFTER the device signed — package gap to fix before the payout stage
-        // ships; this stage pins both sides.
-        expect(isLedgerSignPsbtIncompleteError(failure)).toBe(true);
-        expect((failure as LedgerSignPsbtIncompleteError).missing).toEqual([`1:${g.payoutInput1LeafHashHex}`]);
+        // #2321: the table is narrowed to what the firmware signs — the literal
+        // input 0 (`fw:sign_custom_inputs.c:347,413` @ 29beb88d5), never input 1.
+        const prepared = prepareSignPsbt({
+          psbtHex: g.payoutPsbtHex,
+          depositorXOnlyHex: DEPOSITOR_XONLY_HEX,
+          signInputIndexes: [PAYOUT_VAULT_UTXO_INPUT],
+        });
+        expect(prepared.table.expectedYieldCount).toBe(1);
+        expect([...prepared.table.byInput.keys()]).toEqual([PAYOUT_VAULT_UTXO_INPUT]);
+        // Input 1 is still classified and gated: a zero-I/O prepare requesting
+        // it passes the same structural gates, and its SDK-attached leaf is the
+        // WASM payout leaf (the SDK↔WASM cross-check).
+        const assertInput = prepareSignPsbt({
+          psbtHex: g.payoutPsbtHex,
+          depositorXOnlyHex: DEPOSITOR_XONLY_HEX,
+          signInputIndexes: [PAYOUT_ASSERT_INPUT],
+        }).table.byInput.get(PAYOUT_ASSERT_INPUT);
+        expect(assertInput?.kind).toBe("tapscript");
+        if (assertInput?.kind !== "tapscript") throw new Error("unreachable");
+        expect([...assertInput.expectedLeafHashHexes]).toEqual([g.payoutInput1LeafHashHex]);
 
-        expect(collector.yields).toHaveLength(1);
-        const yielded = collector.yields[0];
+        // Payout signing is silent on-device under the loaded intent.
+        const result = await signPreparedVaultPsbt(sendRaw, prepared, {
+          signal: AbortSignal.timeout(SIGNING_ABORT_MS),
+        });
+        expect(result.yields).toHaveLength(1);
+        const yielded = result.yields[0];
         expect(yielded.kind).toBe("tapscript");
         if (yielded.kind !== "tapscript") throw new Error("unreachable");
-        expect(yielded.inputIndex).toBe(0);
+        expect(yielded.inputIndex).toBe(PAYOUT_VAULT_UTXO_INPUT);
         expect(yielded.signerXOnlyHex).toBe(DEPOSITOR_XONLY_HEX);
         expect(yielded.leafHashHex).toBe(g.payoutInput0LeafHashHex);
         expect(yielded.signature).toHaveLength(SCHNORR_SIG_BYTES);
         // Far side, via the SDK's own verifier: recompute the BIP-341
         // script-path sighash from the PSBT WE built and check the Schnorr.
-        assertScriptPathSchnorrSignature({
+        (assertScriptPathSchnorrSignature as SdkVerifier)({
           requestedPsbtHex: g.payoutPsbtHex,
           signatureHex: Buffer.from(yielded.signature).toString("hex"),
           signerXOnlyPubkeyHex: DEPOSITOR_XONLY_HEX,
-          inputIndex: 0,
+          inputIndex: PAYOUT_VAULT_UTXO_INPUT,
         });
+
+        // Merge writes input 0's tapScriptSig for the depositor key and leaves
+        // input 1 untouched.
+        const merged = Psbt.fromHex(result.signedPsbtHex);
+        const tapScriptSig = merged.data.inputs[PAYOUT_VAULT_UTXO_INPUT].tapScriptSig;
+        expect(tapScriptSig).toHaveLength(1);
+        const entry = (tapScriptSig ?? [])[0];
+        expect(entry.pubkey.toString("hex")).toBe(DEPOSITOR_XONLY_HEX);
+        expect(entry.leafHash.toString("hex")).toBe(g.payoutInput0LeafHashHex);
+        expect(entry.signature).toHaveLength(SCHNORR_SIG_BYTES);
+        expect(merged.data.inputs[PAYOUT_ASSERT_INPUT].tapScriptSig).toBeUndefined();
       },
       SIGNING_TIMEOUT_MS,
     );
@@ -545,6 +607,8 @@ describe.skipIf(SPECULOS_URL === "")("Speculos end-to-end vault signing", () => 
           // protocol's NoPayout spends Assert:0 (btc-vault nopayout.rs:146-155;
           // HLD v22 §4.9.8 "Prevout Assert:0"), whose txid the device cannot
           // compute — so every honest NoPayout dies here at this tip.
+          // When Ledger fixes the routing (KB Q16, asked 2026-08-25) this MUST
+          // flip to a verified sign, and `firmwareShapedPsbtHex` + its stages go.
           expect(isLedgerDeviceError(failure)).toBe(true);
           expect((failure as { statusWord: number }).statusWord).toBe(SW_INCORRECT_DATA);
         }
@@ -572,11 +636,11 @@ describe.skipIf(SPECULOS_URL === "")("Speculos end-to-end vault signing", () => 
     /**
      * Sign the firmware-shaped NoPayout — the shape the firmware's own tests
      * build (test_sign_psbt_validate.py:2997), differing from production ONLY
-     * in input 0's prevout txid. Its completing isolates the production-shape
-     * rejection to the prevout routing alone: leaf, control block, witness
-     * band and sink all pass. NOT an endorsed scenario: a signature over the
-     * PegIn-txid prevout is unusable on the real Assert:0 (sighash commits
-     * the outpoint).
+     * in input 0's prevout txid (asserted host-side above). Its completing
+     * isolates the production-shape rejection to the prevout routing alone:
+     * leaf, control block, witness band and sink all pass. NOT an endorsed
+     * scenario: a signature over the PegIn-txid prevout is unusable on the real
+     * Assert:0 (sighash commits the outpoint). Deleted with the Q16 fix.
      */
     async function signAndVerifyFirmwareShapedNoPayout(
       challenger: DepositorGraphFixture["perChallenger"][number],
@@ -590,14 +654,14 @@ describe.skipIf(SPECULOS_URL === "")("Speculos end-to-end vault signing", () => 
       const yielded = result.yields[0];
       expect(yielded.kind).toBe("tapscript");
       if (yielded.kind !== "tapscript") throw new Error("unreachable");
-      expect(yielded.inputIndex).toBe(0);
+      expect(yielded.inputIndex).toBe(NOPAYOUT_ASSERT_INPUT);
       expect(yielded.signerXOnlyHex).toBe(DEPOSITOR_XONLY_HEX);
       expect(yielded.leafHashHex).toBe(challenger.noPayoutLeafHashHex);
-      assertScriptPathSchnorrSignature({
+      (assertScriptPathSchnorrSignature as SdkVerifier)({
         requestedPsbtHex: challenger.firmwareShapedPsbtHex,
         signatureHex: Buffer.from(yielded.signature).toString("hex"),
         signerXOnlyPubkeyHex: DEPOSITOR_XONLY_HEX,
-        inputIndex: 0,
+        inputIndex: NOPAYOUT_ASSERT_INPUT,
       });
     }
   });

--- a/packages/babylon-ledger-vault-signer/src/__tests__/e2e/speculos.e2e.test.ts
+++ b/packages/babylon-ledger-vault-signer/src/__tests__/e2e/speculos.e2e.test.ts
@@ -279,8 +279,8 @@ describe.skipIf(SPECULOS_URL === "")("Speculos end-to-end vault signing", () => 
       );
       // A terminal status word from the loop is classified into LedgerDeviceError
       // (`rawApdu.ts classifyStatusWord`, `signPsbtLoop.ts:159-171`).
-      expect(isLedgerDeviceError(failure)).toBe(true);
-      expect((failure as { statusWord: number }).statusWord).toBe(SW_INCORRECT_DATA);
+      if (!isLedgerDeviceError(failure)) throw new Error("expected a LedgerDeviceError");
+      expect(failure.statusWord).toBe(SW_INCORRECT_DATA);
       // Session and intent survive a validation failure: the next stage signs
       // the same Pre-PegIn under the same intent.
       expect(await getMasterFingerprintHex(send)).toBe(masterFingerprintHex);
@@ -609,8 +609,8 @@ describe.skipIf(SPECULOS_URL === "")("Speculos end-to-end vault signing", () => 
           // compute — so every honest NoPayout dies here at this tip.
           // When Ledger fixes the routing (KB Q16, asked 2026-08-25) this MUST
           // flip to a verified sign, and `firmwareShapedPsbtHex` + its stages go.
-          expect(isLedgerDeviceError(failure)).toBe(true);
-          expect((failure as { statusWord: number }).statusWord).toBe(SW_INCORRECT_DATA);
+          if (!isLedgerDeviceError(failure)) throw new Error("expected a LedgerDeviceError");
+          expect(failure.statusWord).toBe(SW_INCORRECT_DATA);
         }
         // Intent-survival proof, not a liveness probe: `_validate_nopayout` runs
         // only in VAULT_STATE_INTENT_LOADED (`sign_psbt_validate.c:2000-2003`),
@@ -699,8 +699,8 @@ describe.skipIf(SPECULOS_URL === "")("Speculos end-to-end vault signing", () => 
           () => null,
           (error: unknown) => error,
         );
-        expect(isLedgerDeviceError(eaten)).toBe(true);
-        expect((eaten as { statusWord: number }).statusWord).toBe(SW_INCORRECT_DATA);
+        if (!isLedgerDeviceError(eaten)) throw new Error("expected a LedgerDeviceError");
+        expect(eaten.statusWord).toBe(SW_INCORRECT_DATA);
         // …and exactly one: the same read now answers normally.
         expect(await getMasterFingerprintHex(send)).toBe(masterFingerprintHex);
       },
@@ -720,8 +720,8 @@ describe.skipIf(SPECULOS_URL === "")("Speculos end-to-end vault signing", () => 
           () => null,
           (error: unknown) => error,
         );
-        expect(isLedgerDeviceError(failure)).toBe(true);
-        expect((failure as { statusWord: number }).statusWord).toBe(SW_CAP_EXCEEDED);
+        if (!isLedgerDeviceError(failure)) throw new Error("expected a LedgerDeviceError");
+        expect(failure.statusWord).toBe(SW_CAP_EXCEEDED);
       },
       SIGNING_TIMEOUT_MS,
     );

--- a/packages/babylon-ledger-vault-signer/src/__tests__/e2e/speculos.e2e.test.ts
+++ b/packages/babylon-ledger-vault-signer/src/__tests__/e2e/speculos.e2e.test.ts
@@ -11,16 +11,22 @@
  *   5. Pre-PegIn with an UNMARKED change output → device rejection, intent intact
  *   6. Pre-PegIn under the default wallet policy → one key-path yield per input
  *   7-9. PegIn (spends the real Pre-PegIn txid), sighash check, finalize
- *   10. BIP-322 PoP, last, so it signs while the intent is still loaded — the
- *       path that exercises the firmware's intent-key check
- *       (`sign_psbt_validate.c:2764-2769`).
+ *   10. BIP-322 PoP, last among the intent stages, so it signs while the
+ *       intent is still loaded — the path that exercises the firmware's
+ *       intent-key check (`sign_psbt_validate.c:2764-2769`).
+ *   11. depositor-graph presign (T7 stage a): Payout + NoPayout against a
+ *       production-SDK-built graph fixture, still under the stage-4 intent.
+ *   12. abort/dispatcher recovery (T7 stage b): interrupt SIGN_PSBT mid-loop,
+ *       pin the eaten-APDU behavior and the full re-ceremony recovery. Runs
+ *       LAST — it re-derives, which resets the vault session.
  *
  * Stage 5 MUST precede stage 6: a successful Pre-PegIn sign arms the one-shot
  * cap and the next one answers SW_CAP_EXCEEDED (`sign_psbt_validate.c:539-543`).
  *
  * Requires a running container with the vault app (nanosp, testnet build,
- * firmware-test mnemonic) built from ELF commit `e2d0c45b`. Skipped unless
- * SPECULOS_URL is set:
+ * firmware-test mnemonic) built from ELF commit `29beb88d5` (stages 1-10 also
+ * pass at `e2d0c45b`; stages 11-12 cite `29beb88d5` line numbers). Skipped
+ * unless SPECULOS_URL is set:
  *
  *   SPECULOS_URL=http://127.0.0.1:5055 pnpm exec vitest run src/__tests__/e2e/
  *
@@ -28,20 +34,29 @@
  * between runs.
  */
 
+import { assertScriptPathSchnorrSignature } from "@babylonlabs-io/ts-sdk/tbv/core/primitives";
 import { Psbt, Transaction } from "bitcoinjs-lib";
 import { Buffer } from "buffer";
 import { describe, expect, it } from "vitest";
 
 import { getExtendedPublicKey, getMasterFingerprintHex } from "../../derivation";
 import { assertDepositTermsDeviceCompatible } from "../../envelope";
-import { isLedgerDeviceError } from "../../errors";
+import {
+  isLedgerDeviceError,
+  isLedgerSignPsbtAbortedError,
+  isLedgerSignPsbtIncompleteError,
+  type LedgerSignPsbtAbortedError,
+  type LedgerSignPsbtIncompleteError,
+} from "../../errors";
 import { bip86OutputScript } from "../../expectedSignatures";
 import { augmentPsbtForWalletPolicy, deriveChangeXOnlyHex } from "../../policyPsbt";
 import { bip322ToSpendTxid, buildPopPsbtHex } from "../../popPsbt";
+import { SW_CAP_EXCEEDED } from "../../rawApdu";
 import { signPreparedVaultPsbt, signVaultPsbt, type SignVaultPsbtResult } from "../../signPsbt";
-import { prepareSignPsbt } from "../../signPsbtPrepare";
+import { getPreparedSignPsbtState, prepareSignPsbt, type PreparedSignPsbt } from "../../signPsbtPrepare";
 import { approveVaultIntent, deriveContextHash } from "../../vaultCommands";
 import { buildDefaultTaprootPolicy, type DefaultTaprootWalletPolicy } from "../../walletPolicy";
+import { buildDepositorGraphFixture, type DepositorGraphFixture } from "./depositorGraphFixture";
 import {
   buildDepositTerms,
   buildPeginPsbt,
@@ -90,7 +105,16 @@ const SIGNING_ABORT_MS = SIGNING_TIMEOUT_MS - 10_000;
 
 const SCHNORR_SIG_BYTES = 64;
 
-/** SW_INCORRECT_DATA — `_validate_prepegin`'s catch-all output reject (`sign_psbt_validate.c:507-510`). */
+/** Depositor-graph challengers = VKs + UCs (VP excluded): 1 keeper + 1 universal in the fixture roster. */
+const DEPOSITOR_GRAPH_CHALLENGER_COUNT = 2;
+/** Stage 12 aborts after the FIRST yield — validation (and the Pre-PegIn cap bump) is over, signing is not. */
+const ABORT_AFTER_YIELD_COUNT = 1;
+
+/**
+ * SW_INCORRECT_DATA — `_validate_prepegin`'s catch-all output reject
+ * (`sign_psbt_validate.c:507-510`); also what the dispatcher answers for the
+ * one eaten APDU after an abandoned CONTINUE loop (`base:dispatcher.c:107-111`).
+ */
 const SW_INCORRECT_DATA = 0x6a80;
 
 /** `<eth>:<chainId>:pegin:<registry>` — grammar is the device's boundary, not ours. */
@@ -440,6 +464,279 @@ describe.skipIf(SPECULOS_URL === "")("Speculos end-to-end vault signing", () => 
       SIGNING_TIMEOUT_MS,
     );
   });
+
+  describe("(11) depositor-graph presign (Payout + NoPayout) under the loaded intent", () => {
+    let graph: DepositorGraphFixture | undefined;
+
+    it(
+      "builds the graph fixture with the production SDK builders, bound to the signed PegIn",
+      async () => {
+        expect(fixture, "PegIn stage must have built its fixture").toBeDefined();
+        const peginTxHex = Transaction.fromBuffer(
+          Psbt.fromHex((fixture as PeginPsbtFixture).psbtHex).data.globalMap.unsignedTx.toBuffer(),
+        ).toHex();
+        graph = await buildDepositorGraphFixture(peginTxHex);
+        expect(graph.perChallenger).toHaveLength(DEPOSITOR_GRAPH_CHALLENGER_COUNT);
+      },
+      SANITY_TIMEOUT_MS,
+    );
+
+    it(
+      "Payout: the device yields ONE signature (input 0, Vault-UTXO leaf) — the host table also expects input 1, pinning the completion gap",
+      async () => {
+        expect(graph, "fixture stage must have built the graph").toBeDefined();
+        const g = graph as DepositorGraphFixture;
+        const prepared = prepareSignPsbt({ psbtHex: g.payoutPsbtHex, depositorXOnlyHex: DEPOSITOR_XONLY_HEX });
+        // The host table counts every leaf-carrying input (expectedSignatures.ts
+        // buildExpectedSignatureTable) — inputs 0 AND 1 here…
+        expect(prepared.table.expectedYieldCount).toBe(2);
+        const { collector } = getPreparedSignPsbtState(prepared);
+        const failure = await signPreparedVaultPsbt(sendRaw, prepared, {
+          signal: AbortSignal.timeout(SIGNING_ABORT_MS),
+        }).then(
+          () => null,
+          (error: unknown) => error,
+        );
+        // …but the firmware signs Payout input 0 ONLY and answers SW_OK
+        // (`sign_custom_inputs.c:345-424`; fw test_sign_psbt_payout_vk asserts a
+        // single sig for the depositor claimer). Input 1 belongs to the separate
+        // PayoutFinalize flow. The host's set-equal completion therefore fails
+        // AFTER the device signed — package gap to fix before the payout stage
+        // ships; this stage pins both sides.
+        expect(isLedgerSignPsbtIncompleteError(failure)).toBe(true);
+        expect((failure as LedgerSignPsbtIncompleteError).missing).toEqual([`1:${g.payoutInput1LeafHashHex}`]);
+
+        expect(collector.yields).toHaveLength(1);
+        const yielded = collector.yields[0];
+        expect(yielded.kind).toBe("tapscript");
+        if (yielded.kind !== "tapscript") throw new Error("unreachable");
+        expect(yielded.inputIndex).toBe(0);
+        expect(yielded.signerXOnlyHex).toBe(DEPOSITOR_XONLY_HEX);
+        expect(yielded.leafHashHex).toBe(g.payoutInput0LeafHashHex);
+        expect(yielded.signature).toHaveLength(SCHNORR_SIG_BYTES);
+        // Far side, via the SDK's own verifier: recompute the BIP-341
+        // script-path sighash from the PSBT WE built and check the Schnorr.
+        assertScriptPathSchnorrSignature({
+          requestedPsbtHex: g.payoutPsbtHex,
+          signatureHex: Buffer.from(yielded.signature).toString("hex"),
+          signerXOnlyPubkeyHex: DEPOSITOR_XONLY_HEX,
+          inputIndex: 0,
+        });
+      },
+      SIGNING_TIMEOUT_MS,
+    );
+
+    it(
+      "NoPayout, production shape (input 0 spends Assert:0 per btc-vault/HLD): rejected per challenger, intent survives — challenger 0's firmware-shaped sign succeeds with no re-ceremony (FIRMWARE DIVERGENCE PIN)",
+      async () => {
+        expect(graph, "fixture stage must have built the graph").toBeDefined();
+        for (const challenger of (graph as DepositorGraphFixture).perChallenger) {
+          const failure = await signVaultPsbt(sendRaw, {
+            psbtHex: challenger.productionPsbtHex,
+            depositorXOnlyHex: DEPOSITOR_XONLY_HEX,
+            signal: AbortSignal.timeout(SIGNING_ABORT_MS),
+          }).then(
+            () => null,
+            (error: unknown) => error,
+          );
+          // DIVERGENCE PINNED (raise with Ledger): `_validate_nopayout` resolves
+          // the vault group by matching input 0's PREVIOUS_TXID against
+          // vault_compute_pegin_txid (`sign_psbt_validate.c:2196-2219`), but the
+          // protocol's NoPayout spends Assert:0 (btc-vault nopayout.rs:146-155;
+          // HLD v22 §4.9.8 "Prevout Assert:0"), whose txid the device cannot
+          // compute — so every honest NoPayout dies here at this tip.
+          expect(isLedgerDeviceError(failure)).toBe(true);
+          expect((failure as { statusWord: number }).statusWord).toBe(SW_INCORRECT_DATA);
+        }
+        // Intent-survival proof, not a liveness probe: `_validate_nopayout` runs
+        // only in VAULT_STATE_INTENT_LOADED (`sign_psbt_validate.c:2000-2003`),
+        // so a completed sign under the SAME intent — no derive/intent re-run —
+        // proves the rejects above left the session loaded (their SEND_SW path
+        // carries no vault_context_invalidate).
+        await signAndVerifyFirmwareShapedNoPayout((graph as DepositorGraphFixture).perChallenger[0]);
+      },
+      SIGNING_TIMEOUT_MS,
+    );
+
+    it(
+      "NoPayout, firmware shape for challenger 1 (FIRMWARE DIVERGENCE PIN — non-protocol shape, input 0 prevout swapped to the PegIn txid): signs and verifies",
+      async () => {
+        expect(graph, "fixture stage must have built the graph").toBeDefined();
+        // Challenger 0's slot was consumed by the survival proof above (per-slot
+        // dedup, `sign_psbt_validate.c:2221-2234`); this completes the roster.
+        await signAndVerifyFirmwareShapedNoPayout((graph as DepositorGraphFixture).perChallenger[1]);
+      },
+      SIGNING_TIMEOUT_MS,
+    );
+
+    /**
+     * Sign the firmware-shaped NoPayout — the shape the firmware's own tests
+     * build (test_sign_psbt_validate.py:2997), differing from production ONLY
+     * in input 0's prevout txid. Its completing isolates the production-shape
+     * rejection to the prevout routing alone: leaf, control block, witness
+     * band and sink all pass. NOT an endorsed scenario: a signature over the
+     * PegIn-txid prevout is unusable on the real Assert:0 (sighash commits
+     * the outpoint).
+     */
+    async function signAndVerifyFirmwareShapedNoPayout(
+      challenger: DepositorGraphFixture["perChallenger"][number],
+    ): Promise<void> {
+      const result = await signVaultPsbt(sendRaw, {
+        psbtHex: challenger.firmwareShapedPsbtHex,
+        depositorXOnlyHex: DEPOSITOR_XONLY_HEX,
+        signal: AbortSignal.timeout(SIGNING_ABORT_MS),
+      });
+      expect(result.yields).toHaveLength(1);
+      const yielded = result.yields[0];
+      expect(yielded.kind).toBe("tapscript");
+      if (yielded.kind !== "tapscript") throw new Error("unreachable");
+      expect(yielded.inputIndex).toBe(0);
+      expect(yielded.signerXOnlyHex).toBe(DEPOSITOR_XONLY_HEX);
+      expect(yielded.leafHashHex).toBe(challenger.noPayoutLeafHashHex);
+      assertScriptPathSchnorrSignature({
+        requestedPsbtHex: challenger.firmwareShapedPsbtHex,
+        signatureHex: Buffer.from(yielded.signature).toString("hex"),
+        signerXOnlyPubkeyHex: DEPOSITOR_XONLY_HEX,
+        inputIndex: 0,
+      });
+    }
+  });
+
+  describe("(12) SIGN_PSBT abort mid-loop: eaten APDU, consumed cap, re-ceremony recovery", () => {
+    it(
+      "an abort after the first yield leaves the device awaiting CONTINUE: exactly one APDU is eaten with 0x6a80",
+      async () => {
+        expect(prePegin, "policy-context stage must have built the Pre-PegIn").toBeDefined();
+        const root = await rearmIntentCeremony();
+        // Same context ⇒ same root: the re-derivation is deterministic.
+        expect(Buffer.from(root).equals(Buffer.from(contextRoot as Uint8Array))).toBe(true);
+
+        const abort = new AbortController();
+        const prepared = prepareAugmentedPrePegin();
+        const failure = await signPreparedVaultPsbt(sendRaw, prepared, {
+          signal: abort.signal,
+          onProgress: ({ yieldedCount }) => {
+            // Abort BEFORE the loop sends this round's CONTINUE — the device is
+            // left mid-interruption with the first signature already yielded.
+            if (yieldedCount === ABORT_AFTER_YIELD_COUNT) abort.abort();
+          },
+        }).then(
+          () => null,
+          (error: unknown) => error,
+        );
+        expect(isLedgerSignPsbtAbortedError(failure)).toBe(true);
+        expect((failure as LedgerSignPsbtAbortedError).yieldedCount).toBe(ABORT_AFTER_YIELD_COUNT);
+
+        // Probe IMMEDIATELY — the 50-tick ≈ 5 s deadline (base:io_ext.h:28)
+        // resets the app on further host silence. The dispatcher answers a
+        // non-CONTINUE APDU with SW_INCORRECT_DATA and drops the interrupted
+        // handler (base:dispatcher.c:107-111 @ e400d8d8): one eaten APDU…
+        const eaten = await getMasterFingerprintHex(send).then(
+          () => null,
+          (error: unknown) => error,
+        );
+        expect(isLedgerDeviceError(eaten)).toBe(true);
+        expect((eaten as { statusWord: number }).statusWord).toBe(SW_INCORRECT_DATA);
+        // …and exactly one: the same read now answers normally.
+        expect(await getMasterFingerprintHex(send)).toBe(masterFingerprintHex);
+      },
+      CEREMONY_TIMEOUT_MS,
+    );
+
+    it(
+      "the aborted sign consumed the one-per-intent Pre-PegIn cap: the retry answers SW_CAP_EXCEEDED",
+      async () => {
+        // `pre_pegin_signed++` runs at the END of validation, BEFORE any yield
+        // ("a failed attempt counts as used", sign_psbt_validate.c:648-656) —
+        // the abort above came after yield 1, so the slot is already burnt.
+        // Pins the fw-reverify delta note: recovery REQUIRES the re-ceremony.
+        const failure = await signPreparedVaultPsbt(sendRaw, prepareAugmentedPrePegin(), {
+          signal: AbortSignal.timeout(SIGNING_ABORT_MS),
+        }).then(
+          () => null,
+          (error: unknown) => error,
+        );
+        expect(isLedgerDeviceError(failure)).toBe(true);
+        expect((failure as { statusWord: number }).statusWord).toBe(SW_CAP_EXCEEDED);
+      },
+      SIGNING_TIMEOUT_MS,
+    );
+
+    it(
+      "a full re-ceremony (derive → intent → sign) recovers: the Pre-PegIn completes with two verifiable yields",
+      async () => {
+        // SW_CAP_EXCEEDED nullified the session — this re-ceremony is exactly
+        // T3's post-cancel recovery path, pinned here on real firmware.
+        const root = await rearmIntentCeremony();
+        expect(Buffer.from(root).equals(Buffer.from(contextRoot as Uint8Array))).toBe(true);
+
+        const result = await signPreparedVaultPsbt(sendRaw, prepareAugmentedPrePegin(), {
+          signal: AbortSignal.timeout(SIGNING_ABORT_MS),
+        });
+        expect(result.yields).toHaveLength(2);
+        const depositorSpk = bip86OutputScript(DEPOSITOR_XONLY_HEX);
+        const tx = Transaction.fromBuffer(
+          Psbt.fromHex((prePegin as PrePeginPsbtFixture).psbtHex).data.globalMap.unsignedTx.toBuffer(),
+        );
+        for (const yielded of result.yields) {
+          expect(yielded.kind).toBe("taproot-keypath");
+          expect(yielded.signature).toHaveLength(SCHNORR_SIG_BYTES);
+          const sighash = tx.hashForWitnessV1(
+            yielded.inputIndex,
+            [depositorSpk, depositorSpk],
+            [PREPEGIN_INPUT_VALUE_SATS, PREPEGIN_INPUT_VALUE_SATS],
+            Transaction.SIGHASH_DEFAULT,
+          );
+          expect(
+            verifySchnorrSignature(
+              sighash,
+              depositorSpk.subarray(P2TR_WITNESS_PROGRAM_OFFSET).toString("hex"),
+              yielded.signature,
+            ),
+          ).toBe(true);
+        }
+      },
+      CEREMONY_TIMEOUT_MS,
+    );
+  });
+
+  /** Re-run the device ceremony (derive → intent) over the same deterministic fixture; returns the re-derived root. */
+  async function rearmIntentCeremony(): Promise<Uint8Array> {
+    await waitForIdleScreen();
+    const rootPending = deriveContextHash(send, {
+      appName: VAULT_APP_NAME,
+      derivationPath: DEPOSITOR_PATH,
+      context: DERIVE_CONTEXT,
+    });
+    rootPending.catch(() => undefined); // handled at the await below
+    await approveOnScreen(SPECULOS_URL, DERIVE_APPROVAL_TEXT);
+    const root = await rootPending;
+
+    const terms = buildDepositTerms((prePegin as PrePeginPsbtFixture).txidInternal);
+    const intent = termsToIntent(terms);
+    await waitForIdleScreen();
+    const approvePending = approveVaultIntent(send, intent);
+    approvePending.catch(() => undefined); // handled at the await below
+    await approveOnScreen(SPECULOS_URL, INTENT_APPROVAL_TEXT);
+    await approvePending;
+    return root;
+  }
+
+  /** Stage-6-shaped Pre-PegIn (change marked internal), freshly prepared — prepared objects are single-use. */
+  function prepareAugmentedPrePegin(): PreparedSignPsbt {
+    const augmented = augmentPsbtForWalletPolicy({
+      psbtHex: (prePegin as PrePeginPsbtFixture).psbtHex,
+      depositorXOnlyHex: DEPOSITOR_XONLY_HEX,
+      walletPolicy: policy as DefaultTaprootWalletPolicy,
+      depositorPath: DEPOSITOR_PATH,
+      change: { addressIndex: CHANGE_ADDRESS_INDEX },
+    });
+    return prepareSignPsbt({
+      psbtHex: augmented,
+      depositorXOnlyHex: DEPOSITOR_XONLY_HEX,
+      walletPolicy: policy as DefaultTaprootWalletPolicy,
+    });
+  }
 
   /** Best-effort settle back to the dashboard between the ceremony's two approval flows. */
   async function waitForIdleScreen(): Promise<void> {

--- a/packages/babylon-ledger-vault-signer/src/__tests__/e2e/speculosClient.test.ts
+++ b/packages/babylon-ledger-vault-signer/src/__tests__/e2e/speculosClient.test.ts
@@ -21,12 +21,45 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { LEDGER_USER_REFUSED_ERROR_NAME } from "../../errors";
 import type { Apdu, RawApduSender } from "../../rawApdu";
-import { createSpeculosApduSender, createSpeculosRawApduSender, getAppAndVersion, SW_OK } from "./speculosClient";
+import {
+  createSpeculosApduSender,
+  createSpeculosRawApduSender,
+  getAppAndVersion,
+  readSpeculosUrl,
+  SW_OK,
+} from "./speculosClient";
 
 /** A sender that answers success with the given response body. */
 function senderReturning(dataHex: string): RawApduSender {
   return async () => ({ sw: SW_OK, data: Buffer.from(dataHex, "hex") });
 }
+
+describe("readSpeculosUrl", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("returns an empty string when SPECULOS_URL is unset, so the e2e files skip", () => {
+    vi.stubEnv("SPECULOS_URL", "");
+    vi.stubEnv("SPECULOS_REQUIRED", "");
+
+    expect(readSpeculosUrl()).toBe("");
+  });
+
+  it("returns SPECULOS_URL when it is set", () => {
+    vi.stubEnv("SPECULOS_URL", "http://127.0.0.1:5055");
+    vi.stubEnv("SPECULOS_REQUIRED", "1");
+
+    expect(readSpeculosUrl()).toBe("http://127.0.0.1:5055");
+  });
+
+  it("throws when SPECULOS_REQUIRED is set but SPECULOS_URL is empty, instead of letting the e2e files skip", () => {
+    vi.stubEnv("SPECULOS_URL", "");
+    vi.stubEnv("SPECULOS_REQUIRED", "1");
+
+    expect(() => readSpeculosUrl()).toThrow(/SPECULOS_REQUIRED is set but SPECULOS_URL is empty/);
+  });
+});
 
 describe("getAppAndVersion", () => {
   it("asks for the BOLOS GET_APP_AND_VERSION with no data", async () => {

--- a/packages/babylon-ledger-vault-signer/src/__tests__/e2e/speculosClient.ts
+++ b/packages/babylon-ledger-vault-signer/src/__tests__/e2e/speculosClient.ts
@@ -37,6 +37,19 @@ const EVENTS_POLL_TIMEOUT_MS = 10_000;
 /** The vault app's idle dashboard shows this line ("… app is ready"). */
 const IDLE_SCREEN_TEXT = "app is ready";
 
+/**
+ * SPECULOS_URL, or "" when unset — the value the e2e files' `skipIf` gates on.
+ * Under SPECULOS_REQUIRED (CI) an empty URL throws at module load instead, so
+ * a missing emulator fails the run rather than silently skipping it.
+ */
+export function readSpeculosUrl(): string {
+  const url = process.env.SPECULOS_URL ?? "";
+  if (url === "" && (process.env.SPECULOS_REQUIRED ?? "") !== "") {
+    throw new Error("SPECULOS_REQUIRED is set but SPECULOS_URL is empty — the Speculos e2e files cannot run");
+  }
+  return url;
+}
+
 function toHex(bytes: Uint8Array): string {
   return Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
 }

--- a/packages/babylon-ledger-vault-signer/src/dmkSession.ts
+++ b/packages/babylon-ledger-vault-signer/src/dmkSession.ts
@@ -2,11 +2,19 @@
  * DMK session lifecycle: discovery → connect → state gate → dispose behind a
  * Promise API, so everything above this file is device-free and testable.
  * Verified against the installed DMK 1.7.1 types, not the published docs.
+ * The transport is web-hid, swappable pre-build through the test-only
+ * {@link setDmkTransportOverride} seam.
  *
  * @module ledger-vault-signer/dmkSession
  */
 
-import type { DeviceManagementKit, DeviceSessionId, DiscoveredDevice } from "@ledgerhq/device-management-kit";
+import type {
+  DeviceManagementKit,
+  DeviceSessionId,
+  DiscoveredDevice,
+  TransportFactory,
+  TransportIdentifier,
+} from "@ledgerhq/device-management-kit";
 
 /**
  * The refresher injects `GET_APP_AND_VERSION` mid-ceremony, and whether that
@@ -29,37 +37,111 @@ export interface DmkSessionHandle {
 
 /**
  * One DMK per application, as a module-level lazy singleton (the connector is
- * not a React tree here). Two instances would register duplicate transport
- * listeners.
+ * not a React tree here). Two USED instances would each construct a transport,
+ * duplicating its listener pair — and DMK never destroys one.
  */
 let dmkInstance: DeviceManagementKit | undefined;
-let dmkPromise: Promise<DeviceManagementKit> | undefined;
+let dmkPromise: Promise<DmkBuild> | undefined;
+
+/** A DMK paired with the transport identifier its OWN build registered. */
+interface DmkBuild {
+  readonly dmk: DeviceManagementKit;
+  readonly transportIdentifier: TransportIdentifier;
+}
+
+/** Transport pair injected in place of the web-hid default. Test/E2E only. */
+export interface DmkTransportOverride {
+  readonly transportFactory: TransportFactory;
+  /** Must match what the factory's transport reports via `getIdentifier()`. */
+  readonly transportIdentifier: TransportIdentifier;
+}
+
+let transportOverride: DmkTransportOverride | undefined;
+
+/**
+ * TEST/E2E SEAM — replace the web-hid transport before the DMK is built. For
+ * Speculos, pass `speculosTransportFactory(url)` + `speculosIdentifier` from
+ * `@ledgerhq/device-transport-kit-speculos` (LedgerHQ/device-sdk-ts, tag
+ * `@ledgerhq/device-transport-kit-speculos@1.2.1`, api/SpeculosTransport.ts).
+ * The injector passes the factory in; this module never imports that package,
+ * so production bundles stay speculos-free.
+ *
+ * Package-internal for now: deliberately NOT re-exported from `index.ts`, so
+ * the only callers are this package's own tests. The env-gated dApp seam that
+ * needs it publicly is a separate task and re-exports it with its consumer.
+ *
+ * The override persists across {@link closeDmk}; pass `undefined` to restore
+ * the web-hid default.
+ *
+ * @throws while a DMK singleton exists (built or building): each build captures
+ * the factory it was given, so a late swap would leave discovery pointed at a
+ * transport that DMK does not hold. Call {@link closeDmk} first.
+ */
+export function setDmkTransportOverride(override: DmkTransportOverride | undefined): void {
+  if (dmkPromise !== undefined) {
+    throw new Error("setDmkTransportOverride: DMK already built or building — closeDmk() before changing transports");
+  }
+  transportOverride = override;
+}
 
 /**
  * Build (or reuse) the DMK instance. Memoised as a PROMISE, not the instance:
- * a check-then-act across the dynamic imports would let two concurrent
- * connects build two DMKs, and the loser's transport keeps live WebHID
- * listeners forever. A failed build clears the memo (identity-guarded) so
- * the next connect retries.
+ * a check-then-act across the dynamic imports would let two concurrent connects
+ * build two DMKs, and once both were USED each would hold its own transport and
+ * listener pair, with no way to destroy either. A failed build clears the memo
+ * (identity-guarded) so the next connect retries. Each build snapshots its
+ * transport and resolves the identifier alongside the DMK; one abandoned
+ * mid-flight by {@link closeDmk} rejects its callers, leaving its never-used
+ * instance to be garbage-collected unclosed (see {@link publish}).
  *
  * Every `@ledgerhq/device-*` import is dynamic so a provider that ships
  * disabled stays off the bundle's critical path — DMK pulls in xstate,
  * inversify, reflect-metadata and purify-ts.
  */
-function getDmk(): Promise<DeviceManagementKit> {
+function getDmk(): Promise<DmkBuild> {
   if (!dmkPromise) {
-    const build = (async () => {
-      const [{ DeviceManagementKitBuilder }, { webHidTransportFactory }] = await Promise.all([
+    // ONE read of the override per build: closeDmk() lifts the setter's guard,
+    // so a swap can land while this build is suspended on its imports.
+    const override = transportOverride;
+
+    /**
+     * Adopt as the singleton — or, if closeDmk() got here first, fail this
+     * build's callers. Deliberately NOT closed: `build()` only stores the
+     * factory, and DMK constructs transports when a use case first resolves
+     * TransportService — so `close()` would CONSTRUCT this orphan's transport
+     * (registering a WebHID listener pair) and then release nothing, since
+     * `CloseSessionsUseCase` only iterates existing sessions and never calls
+     * `destroy()`. Same fact as wallet-connector `provider.ts:305-309`.
+     */
+    function publish(built: DmkBuild): DmkBuild {
+      if (dmkPromise !== build) {
+        throw new Error(
+          "connectDmkSession: closeDmk() tore down this DMK while it was still building — retry to connect over a fresh one",
+        );
+      }
+      dmkInstance = built.dmk;
+      return built;
+    }
+
+    const build: Promise<DmkBuild> = (async () => {
+      // No .addLogger() on either path: DMK's own send/error logs include
+      // full APDU payload bytes.
+      if (override) {
+        const { DeviceManagementKitBuilder } = await import("@ledgerhq/device-management-kit");
+        const dmk = new DeviceManagementKitBuilder().addTransport(override.transportFactory).build();
+        return publish({ dmk, transportIdentifier: override.transportIdentifier });
+      }
+      const [{ DeviceManagementKitBuilder }, { webHidTransportFactory, webHidIdentifier }] = await Promise.all([
         import("@ledgerhq/device-management-kit"),
         import("@ledgerhq/device-transport-kit-web-hid"),
       ]);
-      // No .addLogger(): DMK's own send/error logs include full APDU payload bytes.
-      dmkInstance = new DeviceManagementKitBuilder().addTransport(webHidTransportFactory).build();
-      return dmkInstance;
+      const dmk = new DeviceManagementKitBuilder().addTransport(webHidTransportFactory).build();
+      return publish({ dmk, transportIdentifier: webHidIdentifier });
     })().catch((error) => {
       if (dmkPromise === build) dmkPromise = undefined;
       throw error;
     });
+
     dmkPromise = build;
   }
   return dmkPromise;
@@ -74,15 +156,15 @@ function getDmk(): Promise<DeviceManagementKit> {
  * @throws If no device is selected or the connection fails
  */
 export async function connectDmkSession(): Promise<DmkSessionHandle> {
-  const dmk = await getDmk();
-  const [{ firstValueFrom }, { webHidIdentifier }] = await Promise.all([
-    import("rxjs"),
-    import("@ledgerhq/device-transport-kit-web-hid"),
-  ]);
+  // The identifier comes from the build, never from a re-read of the override:
+  // discovery must target the transport THIS DMK registered.
+  const { dmk, transportIdentifier } = await getDmk();
+  const { firstValueFrom } = await import("rxjs");
 
   // The browser picker guarantees a single device, so the first emission is
-  // the selection; unsubscribing immediately stops discovery.
-  const device: DiscoveredDevice = await firstValueFrom(dmk.startDiscovering({ transport: webHidIdentifier }));
+  // the selection; unsubscribing immediately stops discovery. (Speculos'
+  // startDiscovering likewise emits its single device.)
+  const device: DiscoveredDevice = await firstValueFrom(dmk.startDiscovering({ transport: transportIdentifier }));
 
   const sessionId = await dmk.connect({
     device,

--- a/packages/babylon-ledger-vault-signer/vitest.config.ts
+++ b/packages/babylon-ledger-vault-signer/vitest.config.ts
@@ -5,5 +5,9 @@ export default defineConfig({
     globals: true,
     environment: "node",
     exclude: ["**/node_modules/**", "**/dist/**"],
+    // Only with an emulator attached: the e2e files share ONE Speculos device,
+    // and an APDU arriving mid-UX-flow answers 0x6901 (sdk `status_words.h:56`).
+    // Predicate matches the suites' own skipIf, which treats "" as unset.
+    fileParallelism: (process.env.SPECULOS_URL ?? "") === "",
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -315,9 +315,18 @@ importers:
         specifier: 7.8.2
         version: 7.8.2
     devDependencies:
+      '@babylonlabs-io/babylon-tbv-rust-wasm':
+        specifier: workspace:*
+        version: link:../babylon-tbv-rust-wasm
+      '@babylonlabs-io/ts-sdk':
+        specifier: workspace:*
+        version: link:../babylon-ts-sdk
       '@internal/eslint-config':
         specifier: workspace:*
         version: link:../../tools/eslint-config
+      '@ledgerhq/device-transport-kit-speculos':
+        specifier: 1.2.1
+        version: 1.2.1(@ledgerhq/device-management-kit@1.7.1(bufferutil@4.0.9)(rxjs@7.8.2)(utf-8-validate@5.0.10))(rxjs@7.8.2)
       prettier:
         specifier: ^3.6.2
         version: 3.6.2
@@ -2935,6 +2944,12 @@ packages:
   '@ledgerhq/device-management-kit@1.7.1':
     resolution: {integrity: sha512-O1/H1BWPjrZre+/czkuDcP7fpbjq+PaTwquUtFxEXdVMM+6buvYAtlRUyGR6kjBy/tOsiSKQmHCnOabi/KBozw==}
     peerDependencies:
+      rxjs: 7.8.2
+
+  '@ledgerhq/device-transport-kit-speculos@1.2.1':
+    resolution: {integrity: sha512-lowqaGWtum+KrLgayz5Fu35Ep0AgtBMKo9FJoQ82ilNGli/PxSa4RqLLeWh/+L3CQtpyW8/89pBqSURQyldaYw==}
+    peerDependencies:
+      '@ledgerhq/device-management-kit': ^1.5.1
       rxjs: 7.8.2
 
   '@ledgerhq/device-transport-kit-web-hid@1.2.4':
@@ -13300,6 +13315,13 @@ snapshots:
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
+
+  '@ledgerhq/device-transport-kit-speculos@1.2.1(@ledgerhq/device-management-kit@1.7.1(bufferutil@4.0.9)(rxjs@7.8.2)(utf-8-validate@5.0.10))(rxjs@7.8.2)':
+    dependencies:
+      '@ledgerhq/device-management-kit': 1.7.1(bufferutil@4.0.9)(rxjs@7.8.2)(utf-8-validate@5.0.10)
+      '@sentry/minimal': 6.19.7
+      purify-ts: 2.1.0
+      rxjs: 7.8.2
 
   '@ledgerhq/device-transport-kit-web-hid@1.2.4(@ledgerhq/device-management-kit@1.7.1(bufferutil@4.0.9)(rxjs@7.8.2)(utf-8-validate@5.0.10))(rxjs@7.8.2)':
     dependencies:


### PR DESCRIPTION
Adds a transport-factory seam to dmkSession (web-hid stays the default) so the DMK path can be driven against Speculos, plus two package e2e stages: depositor-graph presign (Payout + per-challenger NoPayout, fixtures built by the production SDK builders) and abort/dispatcher recovery, which firmware-pins the behaviour T3's cancel recovery assumes. Run live against fix/audit-findings @ 29beb88d5 — existing stages 24/24.
Two findings came out of the live run and are not fixed here: a firmware bug where _validate_nopayout routes the vault group by PegIn txid while protocol NoPayout spends Assert:0 (raised with Ledger; stage 11 pins both shapes), and a host gap where the expected-signature table demands a payout input-1 yield the device never produces under a loaded intent.

Also fixes a latent test-fixture bug: DEPOSITOR_PATH was built with a bitwise OR, yielding a negative int32 that production's assertBip86Path rejects — wire-identical, so live-run-only impact, now pinned by an offline unit test.