### PR TITLE
feat(ts-sdk, vault): reclaim the stranded depositor-claim reserve after settlement

### DIFF
--- a/packages/babylon-ts-sdk/docs/api/primitives.md
+++ b/packages/babylon-ts-sdk/docs/api/primitives.md
@@ -446,6 +446,60 @@ Per-input connector params (one per input/segment, determines the taproot script
 
 ***
 
+### DepositorClaimDescriptor
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/depositorClaim.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/depositorClaim.ts)
+
+The single-leaf taptree's spend material for one depositor key.
+
+#### Properties
+
+##### scriptPubKey
+
+```ts
+scriptPubKey: Buffer;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/depositorClaim.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/depositorClaim.ts)
+
+P2TR scriptPubKey the PegIn pays at [PEGIN\_DEPOSITOR\_CLAIM\_VOUT](#pegin_depositor_claim_vout).
+
+##### leafScript
+
+```ts
+leafScript: Buffer;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/depositorClaim.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/depositorClaim.ts)
+
+The one tapleaf: `<depositor> OP_CHECKSIG`, 34 bytes.
+
+##### controlBlock
+
+```ts
+controlBlock: Buffer;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/depositorClaim.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/depositorClaim.ts)
+
+Control block for that leaf: `[leafVersion | outputKeyParity] || NUMS`,
+33 bytes. The tree has a single leaf at depth 0, so it carries no sibling
+hashes.
+
+##### internalKey
+
+```ts
+internalKey: Buffer;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/depositorClaim.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/depositorClaim.ts)
+
+The NUMS internal key the taptree commits to — the PSBT's `tapInternalKey`.
+Carried here so an input's internal key and control block provably come
+from the same derivation.
+
+***
+
 ### NoPayoutParams
 
 Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/noPayout.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/noPayout.ts)
@@ -1282,6 +1336,148 @@ PSBT hex for the depositor to sign
 
 ***
 
+### ReclaimReserve
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/reclaim.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/reclaim.ts)
+
+One depositor-claim reserve to sweep, with the material to bind it.
+
+#### Properties
+
+##### depositorSignedPeginTxHex
+
+```ts
+depositorSignedPeginTxHex: string;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/reclaim.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/reclaim.ts)
+
+The contract's own copy of the depositor-signed PegIn transaction
+(`VaultProtocolInfo.depositorSignedPeginTx`). Authoritative: its SegWit
+txid equals the broadcast PegIn's, and its `outs[1]` carries the reserve's
+script and value at no extra RPC cost.
+
+##### observed
+
+```ts
+observed: object;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/reclaim.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/reclaim.ts)
+
+Independent chain observation of `peginTxid:1` (esplora UTXO lookup).
+
+###### scriptPubKey
+
+```ts
+scriptPubKey: string;
+```
+
+scriptPubKey hex, with or without `0x` prefix.
+
+###### value
+
+```ts
+value: bigint;
+```
+
+Output value in satoshis.
+
+##### expectedValue
+
+```ts
+expectedValue: bigint;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/reclaim.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/reclaim.ts)
+
+The reserve value recomputed from this vault's protocol parameters via
+`computeMinClaimValue`. Bound so a doctored PegIn that agrees with itself
+and with a compromised indexer still fails.
+
+***
+
+### BuildReclaimPsbtParams
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/reclaim.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/reclaim.ts)
+
+#### Properties
+
+##### depositorPubkey
+
+```ts
+depositorPubkey: string;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/reclaim.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/reclaim.ts)
+
+The **connected wallet's live** x-only pubkey, 64-char hex. Never the
+indexer's `depositorBtcPubkey`: re-deriving from the live key is what
+proves the wallet about to sign is the wallet that can spend, and rejects
+the wrong-wallet case with an error instead of an unspendable broadcast.
+
+##### inputs
+
+```ts
+inputs: ReclaimReserve[];
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/reclaim.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/reclaim.ts)
+
+Reserves to sweep. An array so batching several vaults into one
+transaction is a later change rather than a rewrite; today the app passes
+exactly one.
+
+##### feeSats
+
+```ts
+feeSats: bigint;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/reclaim.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/reclaim.ts)
+
+Absolute fee in satoshis. The caller sizes it; see `reclaimVsize`.
+
+***
+
+### BuildReclaimPsbtResult
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/reclaim.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/reclaim.ts)
+
+#### Properties
+
+##### psbtHex
+
+```ts
+psbtHex: string;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/reclaim.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/reclaim.ts)
+
+PSBT hex ready for depositor signing.
+
+##### outputValue
+
+```ts
+outputValue: bigint;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/reclaim.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/reclaim.ts)
+
+Value of the single output — what the depositor actually receives.
+
+##### totalInputValue
+
+```ts
+totalInputValue: bigint;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/reclaim.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/reclaim.ts)
+
+Sum of the swept reserves, before fee.
+
+***
+
 ### BuildRefundPsbtParams
 
 Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/refund.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/refund.ts)
@@ -2057,6 +2253,63 @@ If two inputs reference the same Assert output index
 
 ***
 
+### deriveDepositorClaimDescriptor()
+
+```ts
+function deriveDepositorClaimDescriptor(depositorPubkey): DepositorClaimDescriptor;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/depositorClaim.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/depositorClaim.ts)
+
+Derive the depositor-claim output's spend material in JS, independently of
+WASM — the Rust `SingleKeyConnector` has no WASM wrapper, so this is the
+only derivation available on the JS side.
+
+Takes no graph version: the connector is identical across v1/v2/v3. A future
+`VAULT_WASM_COMMIT` bump that changed it would break `assertPeginTxShape` at
+peg-in build time, which is where that regression should surface.
+
+#### Parameters
+
+##### depositorPubkey
+
+`string`
+
+x-only depositor pubkey, 64-char hex (no 0x prefix)
+
+#### Returns
+
+[`DepositorClaimDescriptor`](#depositorclaimdescriptor)
+
+#### Throws
+
+If bitcoinjs cannot derive the P2TR output or its control block
+
+***
+
+### deriveDepositorClaimScriptPubKey()
+
+```ts
+function deriveDepositorClaimScriptPubKey(depositorPubkey): Buffer;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/depositorClaim.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/depositorClaim.ts)
+
+The depositor-claim output's scriptPubKey alone — the peg-in validation path,
+which has no need of the spend material.
+
+#### Parameters
+
+##### depositorPubkey
+
+`string`
+
+#### Returns
+
+`Buffer`
+
+***
+
 ### buildNoPayoutPsbt()
 
 ```ts
@@ -2421,6 +2674,92 @@ Non-finalized signed PSBT hex (returned by wallet with autoFinalized: false)
 `string`
 
 Depositor-signed PegIn transaction hex with full taproot witness stack
+
+***
+
+### reclaimVsize()
+
+```ts
+function reclaimVsize(numInputs): number;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/reclaim.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/reclaim.ts)
+
+Virtual size of an N-in/1-out reclaim transaction.
+
+`REFUND_VSIZE = 160` does not generalise to N inputs, and
+`computePeginBaseFeeSats` is wrong for this shape entirely — its
+`P2TR_INPUT_SIZE = 58` is a *key-path* input and under-fees a script-path
+spend by roughly a quarter.
+
+N=1 → 129 vB; each additional input adds 75 vB.
+
+#### Parameters
+
+##### numInputs
+
+`number`
+
+#### Returns
+
+`number`
+
+***
+
+### estimateReclaimFeeSats()
+
+```ts
+function estimateReclaimFeeSats(feeRateSatsVb, numInputs): bigint;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/reclaim.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/reclaim.ts)
+
+Absolute fee in satoshis for an N-in/1-out reclaim at a given rate.
+
+#### Parameters
+
+##### feeRateSatsVb
+
+`number`
+
+##### numInputs
+
+`number`
+
+#### Returns
+
+`bigint`
+
+***
+
+### buildReclaimPsbt()
+
+```ts
+function buildReclaimPsbt(params): BuildReclaimPsbtResult;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/reclaim.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/reclaim.ts)
+
+Build the N-in/1-out reclaim PSBT.
+
+Every input is bound three ways before it reaches the PSBT: the contract's
+PegIn bytes, the chain observation, and a JS re-derivation from the live
+wallet key must agree on both script and value. Any disagreement throws.
+
+#### Parameters
+
+##### params
+
+[`BuildReclaimPsbtParams`](#buildreclaimpsbtparams)
+
+#### Returns
+
+[`BuildReclaimPsbtResult`](#buildreclaimpsbtresult)
+
+#### Throws
+
+If `inputs` is empty, the fee is non-positive, any input fails its
+  script or value bind, or the resulting output would be at or below dust.
 
 ***
 
@@ -3144,3 +3483,19 @@ Where the value came from, for the error message
 #### Returns
 
 `void`
+
+## Variables
+
+### PEGIN\_DEPOSITOR\_CLAIM\_VOUT
+
+```ts
+const PEGIN_DEPOSITOR_CLAIM_VOUT: 1 = 1;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/depositorClaim.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/depositorClaim.ts)
+
+Vout of the depositor-claim output in every PegIn version (btc-vault: vault
+at 0, depositor claim at 1, optional P2A anchor appended after).
+
+Version-invariant: the graph version dispatches only the trailing P2A anchor
+(absent in v1, 240 sats at vout 2 in v2/v3). Nothing touches vout 1.

--- a/packages/babylon-ts-sdk/docs/api/services.md
+++ b/packages/babylon-ts-sdk/docs/api/services.md
@@ -177,6 +177,83 @@ Error.constructor
 
 ***
 
+### ReclaimUneconomicalError
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/reclaim/errors.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/reclaim/errors.ts)
+
+Thrown when the fee would consume too much of the swept reserve — either the
+per-vbyte rate exceeds the safety ceiling, or the absolute fee exceeds the
+fraction cap.
+
+Distinct from a generic error because the caller's response differs: nothing
+is at risk and nothing expires. The reserve simply stays where it is until
+fee rates fall, and the UI should say so rather than presenting a failure.
+
+#### Extends
+
+- `Error`
+
+#### Constructors
+
+##### Constructor
+
+```ts
+new ReclaimUneconomicalError(
+   message, 
+   feeSats, 
+   sweptTotalSats): ReclaimUneconomicalError;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/reclaim/errors.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/reclaim/errors.ts)
+
+###### Parameters
+
+###### message
+
+`string`
+
+###### feeSats
+
+`bigint`
+
+###### sweptTotalSats
+
+`bigint`
+
+###### Returns
+
+[`ReclaimUneconomicalError`](#reclaimuneconomicalerror)
+
+###### Overrides
+
+```ts
+Error.constructor
+```
+
+#### Properties
+
+##### feeSats
+
+```ts
+readonly feeSats: bigint;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/reclaim/errors.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/reclaim/errors.ts)
+
+Fee the reclaim would have paid, in satoshis.
+
+##### sweptTotalSats
+
+```ts
+readonly sweptTotalSats: bigint;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/reclaim/errors.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/reclaim/errors.ts)
+
+Sum of the reserves the reclaim would have swept, in satoshis.
+
+***
+
 ### BIP68NotMatureError
 
 Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/errors.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/refund/errors.ts)
@@ -2367,6 +2444,150 @@ drift.
 
 ***
 
+### ReclaimVaultData
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/reclaim/buildAndBroadcastReclaim.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/reclaim/buildAndBroadcastReclaim.ts)
+
+One reserve to sweep, as the caller resolves it.
+
+#### Properties
+
+##### depositorSignedPeginTxHex
+
+```ts
+depositorSignedPeginTxHex: string;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/reclaim/buildAndBroadcastReclaim.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/reclaim/buildAndBroadcastReclaim.ts)
+
+The contract's own copy of the depositor-signed PegIn transaction
+(`VaultProtocolInfo.depositorSignedPeginTx`). Must come from the chain —
+never the indexer. Its `outs[1]` is one leg of the three-way bind.
+
+##### observed
+
+```ts
+observed: object;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/reclaim/buildAndBroadcastReclaim.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/reclaim/buildAndBroadcastReclaim.ts)
+
+Independent chain observation of `peginTxid:1`.
+
+###### scriptPubKey
+
+```ts
+scriptPubKey: string;
+```
+
+###### value
+
+```ts
+value: bigint;
+```
+
+##### expectedClaimValue
+
+```ts
+expectedClaimValue: bigint;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/reclaim/buildAndBroadcastReclaim.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/reclaim/buildAndBroadcastReclaim.ts)
+
+This vault's reserve value, recomputed via `computeMinClaimValue`.
+
+***
+
+### ReclaimInput
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/reclaim/buildAndBroadcastReclaim.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/reclaim/buildAndBroadcastReclaim.ts)
+
+#### Type Parameters
+
+##### R
+
+`R` *extends* [`BtcBroadcastResult`](#btcbroadcastresult) = [`BtcBroadcastResult`](#btcbroadcastresult)
+
+#### Properties
+
+##### vaultIds
+
+```ts
+vaultIds: `0x${string}`[];
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/reclaim/buildAndBroadcastReclaim.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/reclaim/buildAndBroadcastReclaim.ts)
+
+##### depositorBtcPubkey
+
+```ts
+depositorBtcPubkey: string;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/reclaim/buildAndBroadcastReclaim.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/reclaim/buildAndBroadcastReclaim.ts)
+
+The **connected wallet's live** BTC pubkey — compressed sec1 or x-only.
+Never the indexer's `depositorBtcPubkey`: re-deriving the claim script
+from the live key is what proves the wallet about to sign is the wallet
+that can spend.
+
+##### readVaults()
+
+```ts
+readVaults: () => Promise<ReclaimVaultData[]>;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/reclaim/buildAndBroadcastReclaim.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/reclaim/buildAndBroadcastReclaim.ts)
+
+Resolve the reserves to sweep, in the same order as `vaultIds`. The SDK
+passes no arguments — the caller closes over whatever context it needs.
+
+###### Returns
+
+`Promise`\<[`ReclaimVaultData`](#reclaimvaultdata)[]\>
+
+##### feeRate
+
+```ts
+feeRate: number;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/reclaim/buildAndBroadcastReclaim.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/reclaim/buildAndBroadcastReclaim.ts)
+
+Mempool-derived sat/vB fee rate. Caller fetches it before invoking.
+
+##### signPsbt
+
+```ts
+signPsbt: ReclaimPsbtSigner;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/reclaim/buildAndBroadcastReclaim.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/reclaim/buildAndBroadcastReclaim.ts)
+
+BTC wallet signer; receives a PSBT hex + taproot script-path options.
+
+##### broadcastTx
+
+```ts
+broadcastTx: BtcBroadcaster<R>;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/reclaim/buildAndBroadcastReclaim.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/reclaim/buildAndBroadcastReclaim.ts)
+
+Broadcast callback — returns whatever shape the caller needs.
+
+##### signal?
+
+```ts
+optional signal: AbortSignal;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/reclaim/buildAndBroadcastReclaim.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/reclaim/buildAndBroadcastReclaim.ts)
+
+Checked at every async boundary.
+
+***
+
 ### VaultBatchEntry
 
 Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts)
@@ -2823,6 +3044,30 @@ type KeyResolutionMode =
 Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/participants/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/participants/types.ts)
 
 How a [ParticipantKeySet](#participantkeyset) was resolved. Carried for diagnostics.
+
+***
+
+### ReclaimPsbtSigner()
+
+```ts
+type ReclaimPsbtSigner = (psbtHex, opts) => Promise<string>;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/reclaim/buildAndBroadcastReclaim.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/reclaim/buildAndBroadcastReclaim.ts)
+
+#### Parameters
+
+##### psbtHex
+
+`string`
+
+##### opts
+
+[`SignPsbtOptions`](managers.md#signpsbtoptions)
+
+#### Returns
+
+`Promise`\<`string`\>
 
 ***
 
@@ -3886,6 +4131,49 @@ thresholds) are a consumer-side concern.
 
 ***
 
+### buildAndBroadcastReclaim()
+
+```ts
+function buildAndBroadcastReclaim<R>(input): Promise<R>;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/reclaim/buildAndBroadcastReclaim.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/reclaim/buildAndBroadcastReclaim.ts)
+
+Build, sign, and broadcast a reclaim transaction sweeping one or more
+depositor-claim reserves back to the depositor's BIP-86 address.
+
+#### Type Parameters
+
+##### R
+
+`R` *extends* [`BtcBroadcastResult`](#btcbroadcastresult) = [`BtcBroadcastResult`](#btcbroadcastresult)
+
+#### Parameters
+
+##### input
+
+[`ReclaimInput`](#reclaiminput)\<`R`\>
+
+#### Returns
+
+`Promise`\<`R`\>
+
+whatever the injected `broadcastTx` returns (generic pass-through)
+
+#### Throws
+
+[ReclaimUneconomicalError](#reclaimuneconomicalerror) if the fee breaches either cap
+
+#### Throws
+
+`Error` if any validation or script/value bind fails
+
+#### Throws
+
+anything `readVaults`, `signPsbt`, or `broadcastTx` throws
+
+***
+
 ### estimateRefundFeeSats()
 
 ```ts
@@ -4203,6 +4491,64 @@ by a client bug), and costs ~1.6 min at 12s slots. Deliberately not the
 benefit. This is a liveness guard against an orphaned registration, not a
 theft mitigation — every Pre-PegIn HTLC spend path requires the depositor's
 own BTC key regardless.
+
+***
+
+### RECLAIM\_MAX\_FEE\_RATE\_SATS\_VB
+
+```ts
+const RECLAIM_MAX_FEE_RATE_SATS_VB: 2000 = 2000;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/reclaim/buildAndBroadcastReclaim.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/reclaim/buildAndBroadcastReclaim.ts)
+
+Hard upper bound on the per-vbyte fee rate the SDK will sign a reclaim at.
+Same reasoning and value as the refund's cap: a compromised mempool endpoint
+can legally return up to 10,000 sat/vB, and 2000 leaves margin over the
+worst historical `halfHourFee` while still blocking that by 5×.
+
+***
+
+### RECLAIM\_MAX\_FEE\_FRACTION\_NUMERATOR
+
+```ts
+const RECLAIM_MAX_FEE_FRACTION_NUMERATOR: 25n = 25n;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/reclaim/buildAndBroadcastReclaim.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/reclaim/buildAndBroadcastReclaim.ts)
+
+Hard upper bound on the absolute fee as a fraction of the **swept total**.
+
+> ⚠️ The basis here is deliberately different from the refund's. There the
+> basis is `vault.amount` and the swept amount is far larger, so a 10% cap is
+> generous. Here the basis *is* the swept amount — roughly 33k sats — and a
+> 10% cap would block every reclaim above about 25 sat/vB. Do not "fix" this
+> into symmetry with `REFUND_MAX_FEE_FRACTION_*`; it would silently change
+> behaviour. The matching comment lives at the UI cap site.
+
+***
+
+### RECLAIM\_MAX\_FEE\_FRACTION\_DENOMINATOR
+
+```ts
+const RECLAIM_MAX_FEE_FRACTION_DENOMINATOR: 100n = 100n;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/reclaim/buildAndBroadcastReclaim.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/reclaim/buildAndBroadcastReclaim.ts)
+
+***
+
+### RECLAIM\_WARN\_FEE\_FRACTION\_NUMERATOR
+
+```ts
+const RECLAIM_WARN_FEE_FRACTION_NUMERATOR: 10n = 10n;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/reclaim/buildAndBroadcastReclaim.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/reclaim/buildAndBroadcastReclaim.ts)
+
+Fraction of the swept total above which the UI warns but still allows the
+reclaim. Exported so the review screen derives its threshold from the same
+constant the SDK enforces against, rather than restating it.
 
 ***
 

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/index.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/index.ts
@@ -133,6 +133,24 @@ export type {
   BuildRefundPsbtResult,
 } from "./psbt/refund";
 
+export {
+  PEGIN_DEPOSITOR_CLAIM_VOUT,
+  deriveDepositorClaimDescriptor,
+  deriveDepositorClaimScriptPubKey,
+} from "./psbt/depositorClaim";
+export type { DepositorClaimDescriptor } from "./psbt/depositorClaim";
+
+export {
+  buildReclaimPsbt,
+  estimateReclaimFeeSats,
+  reclaimVsize,
+} from "./psbt/reclaim";
+export type {
+  BuildReclaimPsbtParams,
+  BuildReclaimPsbtResult,
+  ReclaimReserve,
+} from "./psbt/reclaim";
+
 export { buildPayoutPsbt, extractPayoutSignature } from "./psbt/payout";
 export type { PayoutParams, PayoutPsbtResult } from "./psbt/payout";
 

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/__tests__/depositorClaim.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/__tests__/depositorClaim.test.ts
@@ -150,6 +150,10 @@ describe("deriveDepositorClaimDescriptor", () => {
     );
   });
 
+  // Each key costs three secp256k1 operations across the two implementations,
+  // and the asmjs build is slow — ~1s locally but ~5s on a CI runner, which
+  // overran vitest's 5s default. Critical path #9 wants the randomised sweep,
+  // so the timeout gives way rather than the coverage.
   it("matches the independent BIP-341 derivation across 64 randomised keys", () => {
     for (let seed = 1; seed <= 64; seed++) {
       const depositor = xOnlyKeyFromSeed(seed);
@@ -168,7 +172,7 @@ describe("deriveDepositorClaimDescriptor", () => {
         expected.controlBlock.toString("hex"),
       );
     }
-  });
+  }, 30_000);
 
   it("produces a distinct script per depositor key", () => {
     const a = deriveDepositorClaimScriptPubKey(xOnlyKeyFromSeed(1));

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/__tests__/depositorClaim.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/__tests__/depositorClaim.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Depositor-claim descriptor tests.
+ *
+ * CLAUDE.md critical path #9: this derivation mints the script a real Bitcoin
+ * transaction is signed against, and it has no Rust counterpart to compare
+ * with — btc-vault's `SingleKeyConnector` is not exposed through WASM. So the
+ * differential oracle here is a second, independent JS implementation: the
+ * hand-rolled BIP-341 construction below, which mirrors the Ledger firmware
+ * test's `p2trFromSingleLeaf` (test_sign_psbt_validate.py:188) and shares no
+ * code with `payments.p2tr`.
+ *
+ * The differential runs over pinned golden vectors *and* randomised keys — a
+ * single hardcoded vector pins one input, not the function.
+ */
+
+import * as ecc from "@bitcoin-js/tiny-secp256k1-asmjs";
+import { Buffer } from "buffer";
+import { crypto as bcrypto } from "bitcoinjs-lib";
+import { describe, expect, it } from "vitest";
+
+import { TAPSCRIPT_LEAF_VERSION } from "../../utils/bitcoin";
+import {
+  PEGIN_DEPOSITOR_CLAIM_VOUT,
+  deriveDepositorClaimDescriptor,
+  deriveDepositorClaimScriptPubKey,
+} from "../depositorClaim";
+
+/** NUMS point from btc-vault `crates/vault/src/lib.rs:157-177`. */
+const NUMS_XONLY = Buffer.from(
+  "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0",
+  "hex",
+);
+
+const OP_1 = 0x51;
+const PUSH_32 = 0x20;
+const OP_CHECKSIG = 0xac;
+
+// --- Independent BIP-341 oracle (no bitcoinjs payments involvement) ---
+
+function oracleLeafScript(depositorPk: Buffer): Buffer {
+  return Buffer.concat([
+    Buffer.from([PUSH_32]),
+    depositorPk,
+    Buffer.from([OP_CHECKSIG]),
+  ]);
+}
+
+function oracleTapLeafHash(leaf: Buffer): Buffer {
+  // BIP-341 leaf hash: tagged("TapLeaf", version || compactSize(len) || script).
+  // Every leaf here is 34 bytes, so the compact size is a single byte.
+  return bcrypto.taggedHash(
+    "TapLeaf",
+    Buffer.concat([
+      Buffer.from([TAPSCRIPT_LEAF_VERSION, leaf.length]),
+      leaf,
+    ]),
+  );
+}
+
+function oracleTweakNums(merkleRoot: Buffer): { parity: 0 | 1; xOnly: Buffer } {
+  const tweak = bcrypto.taggedHash(
+    "TapTweak",
+    Buffer.concat([NUMS_XONLY, merkleRoot]),
+  );
+  const tweaked = ecc.xOnlyPointAddTweak(NUMS_XONLY, tweak);
+  if (tweaked === null) throw new Error("NUMS taptweak produced no point");
+  return {
+    parity: tweaked.parity as 0 | 1,
+    xOnly: Buffer.from(tweaked.xOnlyPubkey),
+  };
+}
+
+function oracleDerive(depositorPubkeyHex: string): {
+  scriptPubKey: Buffer;
+  leafScript: Buffer;
+  controlBlock: Buffer;
+} {
+  const leafScript = oracleLeafScript(Buffer.from(depositorPubkeyHex, "hex"));
+  const { parity, xOnly } = oracleTweakNums(oracleTapLeafHash(leafScript));
+  return {
+    scriptPubKey: Buffer.concat([Buffer.from([OP_1, PUSH_32]), xOnly]),
+    leafScript,
+    // Single leaf at depth 0 — no sibling hashes follow the internal key.
+    controlBlock: Buffer.concat([
+      Buffer.from([TAPSCRIPT_LEAF_VERSION | parity]),
+      NUMS_XONLY,
+    ]),
+  };
+}
+
+/** Deterministic valid x-only keys, so a failure is reproducible. */
+function xOnlyKeyFromSeed(seed: number): string {
+  const priv = Buffer.alloc(32);
+  priv.writeUInt32BE(seed >>> 0, 28);
+  priv[0] = 0x01; // keep it comfortably inside the curve order
+  const pub = ecc.pointFromScalar(priv, true);
+  if (pub === null) throw new Error(`seed ${seed} produced no point`);
+  return Buffer.from(pub).subarray(1).toString("hex");
+}
+
+describe("deriveDepositorClaimDescriptor", () => {
+  it("builds the leaf script as <depositor> OP_CHECKSIG in 34 bytes", () => {
+    const depositor =
+      "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798";
+    const { leafScript } = deriveDepositorClaimDescriptor(depositor);
+
+    expect(leafScript.length).toBe(34);
+    expect(leafScript.toString("hex")).toBe(`20${depositor}ac`);
+  });
+
+  it("builds a 33-byte control block of leaf version, parity and the NUMS key", () => {
+    const { controlBlock } = deriveDepositorClaimDescriptor(
+      "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+    );
+
+    expect(controlBlock.length).toBe(33);
+    // No merkle path: everything after the first byte is the internal key.
+    expect(controlBlock.subarray(1).toString("hex")).toBe(
+      NUMS_XONLY.toString("hex"),
+    );
+    expect(controlBlock[0] & 0xfe).toBe(TAPSCRIPT_LEAF_VERSION);
+  });
+
+  it("commits to the NUMS internal key, so the key path is unspendable", () => {
+    const { internalKey } = deriveDepositorClaimDescriptor(
+      "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+    );
+
+    expect(internalKey.toString("hex")).toBe(NUMS_XONLY.toString("hex"));
+  });
+
+  it("puts the depositor-claim reserve at PegIn vout 1", () => {
+    expect(PEGIN_DEPOSITOR_CLAIM_VOUT).toBe(1);
+  });
+
+  it("matches an independent BIP-341 derivation on a pinned golden vector", () => {
+    const depositor =
+      "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798";
+    const actual = deriveDepositorClaimDescriptor(depositor);
+    const expected = oracleDerive(depositor);
+
+    expect(actual.scriptPubKey.toString("hex")).toBe(
+      expected.scriptPubKey.toString("hex"),
+    );
+    expect(actual.leafScript.toString("hex")).toBe(
+      expected.leafScript.toString("hex"),
+    );
+    expect(actual.controlBlock.toString("hex")).toBe(
+      expected.controlBlock.toString("hex"),
+    );
+  });
+
+  it("matches the independent BIP-341 derivation across 64 randomised keys", () => {
+    for (let seed = 1; seed <= 64; seed++) {
+      const depositor = xOnlyKeyFromSeed(seed);
+      const actual = deriveDepositorClaimDescriptor(depositor);
+      const expected = oracleDerive(depositor);
+
+      expect(actual.scriptPubKey.toString("hex")).toBe(
+        expected.scriptPubKey.toString("hex"),
+      );
+      expect(actual.leafScript.toString("hex")).toBe(
+        expected.leafScript.toString("hex"),
+      );
+      // Parity flips with the key, so this also exercises both control-block
+      // first bytes rather than only the one the golden vector happens to hit.
+      expect(actual.controlBlock.toString("hex")).toBe(
+        expected.controlBlock.toString("hex"),
+      );
+    }
+  });
+
+  it("produces a distinct script per depositor key", () => {
+    const a = deriveDepositorClaimScriptPubKey(xOnlyKeyFromSeed(1));
+    const b = deriveDepositorClaimScriptPubKey(xOnlyKeyFromSeed(2));
+
+    expect(a.toString("hex")).not.toBe(b.toString("hex"));
+  });
+
+  it("derives the same script regardless of graph version, having no version input", () => {
+    // The reserve's connector is identical across v1/v2/v3 — only the trailing
+    // P2A anchor is version-shaped. If a VAULT_WASM_COMMIT bump ever changed
+    // that, this function's signature would have to change with it, and this
+    // assertion is what makes that a deliberate act rather than a silent one.
+    expect(deriveDepositorClaimDescriptor).toHaveLength(1);
+  });
+
+  it("rejects a pubkey that is not 32 bytes", () => {
+    expect(() => deriveDepositorClaimDescriptor("deadbeef")).toThrow();
+  });
+});

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/__tests__/reclaim.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/__tests__/reclaim.test.ts
@@ -1,0 +1,341 @@
+/**
+ * Reclaim PSBT builder tests.
+ *
+ * The builder signs away a real UTXO, so every assertion it makes gets a
+ * rejection test here: one per bind, plus value conservation and the dust
+ * floor. The vsize model is measured against a real transaction rather than
+ * asserted against the arithmetic that produced it.
+ */
+
+import { Buffer } from "buffer";
+import { Psbt, Transaction } from "bitcoinjs-lib";
+import { describe, expect, it } from "vitest";
+
+import {
+  PEGIN_DEPOSITOR_CLAIM_VOUT,
+  deriveDepositorClaimDescriptor,
+} from "../depositorClaim";
+import {
+  buildReclaimPsbt,
+  estimateReclaimFeeSats,
+  reclaimVsize,
+  type ReclaimReserve,
+} from "../reclaim";
+
+const DEPOSITOR =
+  "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798";
+const OTHER_DEPOSITOR =
+  "c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5";
+
+const CLAIM_VALUE = 33_000n;
+
+/**
+ * A PegIn transaction shaped like the real one: vault output at vout 0, the
+ * depositor-claim reserve at vout 1.
+ */
+function makePeginTxHex({
+  depositorPubkey = DEPOSITOR,
+  claimValue = CLAIM_VALUE,
+  omitClaimOutput = false,
+  // Varies the funding outpoint so each call yields a distinct PegIn txid,
+  // the way two real vaults would.
+  seed = 7,
+}: {
+  depositorPubkey?: string;
+  claimValue?: bigint;
+  omitClaimOutput?: boolean;
+  seed?: number;
+} = {}): string {
+  const tx = new Transaction();
+  tx.version = 2;
+  tx.addInput(Buffer.alloc(32, seed), 0);
+  // vout 0 — the vault output. Contents are irrelevant to the reclaim.
+  tx.addOutput(Buffer.concat([Buffer.from([0x51, 0x20]), Buffer.alloc(32, 1)]), 500_000);
+  if (!omitClaimOutput) {
+    const { scriptPubKey } = deriveDepositorClaimDescriptor(depositorPubkey);
+    tx.addOutput(scriptPubKey, Number(claimValue));
+  }
+  return tx.toHex();
+}
+
+function makeInput(
+  overrides: Partial<ReclaimReserve> = {},
+  seed = 7,
+): ReclaimReserve {
+  const { scriptPubKey } = deriveDepositorClaimDescriptor(DEPOSITOR);
+  return {
+    depositorSignedPeginTxHex: makePeginTxHex({ seed }),
+    observed: {
+      scriptPubKey: scriptPubKey.toString("hex"),
+      value: CLAIM_VALUE,
+    },
+    expectedValue: CLAIM_VALUE,
+    ...overrides,
+  };
+}
+
+/** N distinct reserves, as a real multi-vault batch would look. */
+function makeInputs(count: number): ReclaimReserve[] {
+  return Array.from({ length: count }, (_, i) => makeInput({}, 7 + i));
+}
+
+describe("buildReclaimPsbt", () => {
+  it("sweeps the reserve to the depositor's BIP-86 address", () => {
+    const { psbtHex, outputValue, totalInputValue } = buildReclaimPsbt({
+      depositorPubkey: DEPOSITOR,
+      inputs: [makeInput()],
+      feeSats: 645n,
+    });
+
+    expect(totalInputValue).toBe(CLAIM_VALUE);
+    expect(outputValue).toBe(CLAIM_VALUE - 645n);
+
+    const psbt = Psbt.fromHex(psbtHex);
+    expect(psbt.txOutputs).toHaveLength(1);
+    expect(BigInt(psbt.txOutputs[0].value)).toBe(CLAIM_VALUE - 645n);
+  });
+
+  it("spends PegIn vout 1 and pins the claim leaf into the input", () => {
+    const { psbtHex } = buildReclaimPsbt({
+      depositorPubkey: DEPOSITOR,
+      inputs: [makeInput()],
+      feeSats: 645n,
+    });
+
+    const psbt = Psbt.fromHex(psbtHex);
+    const descriptor = deriveDepositorClaimDescriptor(DEPOSITOR);
+
+    expect(psbt.txInputs[0].index).toBe(PEGIN_DEPOSITOR_CLAIM_VOUT);
+    const leaf = psbt.data.inputs[0].tapLeafScript?.[0];
+    expect(leaf?.script.toString("hex")).toBe(
+      descriptor.leafScript.toString("hex"),
+    );
+    expect(leaf?.controlBlock.toString("hex")).toBe(
+      descriptor.controlBlock.toString("hex"),
+    );
+    expect(psbt.data.inputs[0].tapInternalKey?.toString("hex")).toBe(
+      descriptor.internalKey.toString("hex"),
+    );
+  });
+
+  it("marks the input RBF-enabled with no relative timelock", () => {
+    const { psbtHex } = buildReclaimPsbt({
+      depositorPubkey: DEPOSITOR,
+      inputs: [makeInput()],
+      feeSats: 645n,
+    });
+
+    // The claim leaf has no OP_CSV, so this is a fee-bump signal only.
+    expect(Psbt.fromHex(psbtHex).txInputs[0].sequence).toBe(0xfffffffd);
+  });
+
+  it("rejects a reserve that pays a different wallet's claim script", () => {
+    // The PegIn belongs to OTHER_DEPOSITOR; the connected wallet is DEPOSITOR.
+    const input = makeInput({
+      depositorSignedPeginTxHex: makePeginTxHex({
+        depositorPubkey: OTHER_DEPOSITOR,
+      }),
+    });
+
+    expect(() =>
+      buildReclaimPsbt({
+        depositorPubkey: DEPOSITOR,
+        inputs: [input],
+        feeSats: 645n,
+      }),
+    ).toThrow(/belongs to a different wallet/);
+  });
+
+  it("rejects when the observed UTXO script disagrees with the contract's PegIn", () => {
+    const input = makeInput({
+      observed: {
+        scriptPubKey: deriveDepositorClaimDescriptor(
+          OTHER_DEPOSITOR,
+        ).scriptPubKey.toString("hex"),
+        value: CLAIM_VALUE,
+      },
+    });
+
+    expect(() =>
+      buildReclaimPsbt({
+        depositorPubkey: DEPOSITOR,
+        inputs: [input],
+        feeSats: 645n,
+      }),
+    ).toThrow(/chain state disagrees with the contract's PegIn/);
+  });
+
+  it("rejects when the observed value disagrees with the contract's PegIn", () => {
+    const input = makeInput({
+      observed: {
+        scriptPubKey: deriveDepositorClaimDescriptor(
+          DEPOSITOR,
+        ).scriptPubKey.toString("hex"),
+        value: CLAIM_VALUE - 1n,
+      },
+    });
+
+    expect(() =>
+      buildReclaimPsbt({
+        depositorPubkey: DEPOSITOR,
+        inputs: [input],
+        feeSats: 645n,
+      }),
+    ).toThrow(/observed UTXO carries/);
+  });
+
+  it("rejects when the reserve value disagrees with the recomputed claim value", () => {
+    const input = makeInput({ expectedValue: CLAIM_VALUE + 1n });
+
+    expect(() =>
+      buildReclaimPsbt({
+        depositorPubkey: DEPOSITOR,
+        inputs: [input],
+        feeSats: 645n,
+      }),
+    ).toThrow(/depositor-claim value of/);
+  });
+
+  it("rejects a PegIn with no output at vout 1", () => {
+    const input = makeInput({
+      depositorSignedPeginTxHex: makePeginTxHex({ omitClaimOutput: true }),
+    });
+
+    expect(() =>
+      buildReclaimPsbt({
+        depositorPubkey: DEPOSITOR,
+        inputs: [input],
+        feeSats: 645n,
+      }),
+    ).toThrow(/no depositor-claim reserve to reclaim/);
+  });
+
+  it("rejects an output at or below the dust threshold", () => {
+    expect(() =>
+      buildReclaimPsbt({
+        depositorPubkey: DEPOSITOR,
+        inputs: [makeInput()],
+        // Leaves exactly the 546-sat dust threshold.
+        feeSats: CLAIM_VALUE - 546n,
+      }),
+    ).toThrow(/at or below the dust threshold/);
+  });
+
+  it("rejects a fee that consumes the whole reserve", () => {
+    expect(() =>
+      buildReclaimPsbt({
+        depositorPubkey: DEPOSITOR,
+        inputs: [makeInput()],
+        feeSats: CLAIM_VALUE,
+      }),
+    ).toThrow(/not less than the swept total/);
+  });
+
+  it("rejects a non-positive fee", () => {
+    expect(() =>
+      buildReclaimPsbt({
+        depositorPubkey: DEPOSITOR,
+        inputs: [makeInput()],
+        feeSats: 0n,
+      }),
+    ).toThrow(/fee must be positive/);
+  });
+
+  it("rejects an empty input set", () => {
+    expect(() =>
+      buildReclaimPsbt({
+        depositorPubkey: DEPOSITOR,
+        inputs: [],
+        feeSats: 645n,
+      }),
+    ).toThrow(/at least one input/);
+  });
+
+  it("conserves value across a two-reserve batch", () => {
+    const { psbtHex, outputValue, totalInputValue } = buildReclaimPsbt({
+      depositorPubkey: DEPOSITOR,
+      inputs: makeInputs(2),
+      feeSats: 1_015n,
+    });
+
+    expect(totalInputValue).toBe(CLAIM_VALUE * 2n);
+    expect(outputValue).toBe(CLAIM_VALUE * 2n - 1_015n);
+    // Still a single consolidating output, whatever the input count.
+    expect(Psbt.fromHex(psbtHex).txOutputs).toHaveLength(1);
+  });
+
+  it("rejects a batch that names the same reserve twice", () => {
+    expect(() =>
+      buildReclaimPsbt({
+        depositorPubkey: DEPOSITOR,
+        inputs: [makeInput(), makeInput()],
+        feeSats: 1_015n,
+      }),
+    ).toThrow(/repeats outpoint/);
+  });
+});
+
+describe("reclaimVsize", () => {
+  it("matches the virtual size of a real script-path spend", () => {
+    // Measured, not asserted against the arithmetic that produced it: build the
+    // transaction the PSBT describes and give each input the witness it will
+    // carry — a 64-byte BIP-340 signature under SIGHASH_DEFAULT, the 34-byte
+    // leaf, and the 33-byte control block.
+    const descriptor = deriveDepositorClaimDescriptor(DEPOSITOR);
+
+    for (const numInputs of [1, 2, 3, 4]) {
+      const { psbtHex } = buildReclaimPsbt({
+        depositorPubkey: DEPOSITOR,
+        inputs: makeInputs(numInputs),
+        feeSats: 645n,
+      });
+      const psbt = Psbt.fromHex(psbtHex);
+
+      const tx = new Transaction();
+      tx.version = 2;
+      tx.locktime = 0;
+      psbt.txInputs.forEach((input) => {
+        tx.addInput(input.hash, input.index, input.sequence);
+      });
+      psbt.txOutputs.forEach((output) => {
+        tx.addOutput(output.script, output.value);
+      });
+      psbt.txInputs.forEach((_input, i) => {
+        tx.setWitness(i, [
+          Buffer.alloc(64),
+          descriptor.leafScript,
+          descriptor.controlBlock,
+        ]);
+      });
+
+      expect(reclaimVsize(numInputs)).toBe(tx.virtualSize());
+    }
+  });
+
+  it("sizes a single-input sweep at 129 vB", () => {
+    expect(reclaimVsize(1)).toBe(129);
+  });
+
+  it("adds 75 vB per additional input", () => {
+    expect(reclaimVsize(2) - reclaimVsize(1)).toBe(74);
+    expect(reclaimVsize(3) - reclaimVsize(2)).toBe(75);
+    expect(reclaimVsize(4) - reclaimVsize(3)).toBe(75);
+  });
+
+  it("rejects a non-positive input count", () => {
+    expect(() => reclaimVsize(0)).toThrow(/positive integer/);
+  });
+});
+
+describe("estimateReclaimFeeSats", () => {
+  it("rounds the rate times vsize up to the next satoshi", () => {
+    // 129 vB at 5 sat/vB.
+    expect(estimateReclaimFeeSats(5, 1)).toBe(645n);
+    // 129 vB at 1.5 sat/vB = 193.5, rounded up.
+    expect(estimateReclaimFeeSats(1.5, 1)).toBe(194n);
+  });
+
+  it("rejects a non-positive fee rate", () => {
+    expect(() => estimateReclaimFeeSats(0, 1)).toThrow(/positive number/);
+  });
+});

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/depositorClaim.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/depositorClaim.ts
@@ -1,0 +1,132 @@
+/**
+ * Depositor-claim output descriptor
+ *
+ * The PegIn transaction's vout 1 carries `depositorClaimValue` — the reserve
+ * that funds the depositor's own `claim_tx`, their recourse if the vault
+ * provider fails during peg-out.
+ *
+ * It is btc-vault's `SingleKeyConnector` (`crates/vault/src/connectors/mod.rs`):
+ * a Taproot output with the NUMS internal key (key path provably unspendable)
+ * and exactly one tapleaf at depth 0, `<depositor> OP_CHECKSIG`. No timelock,
+ * no counterparty key — the depositor's Schnorr signature alone spends it.
+ *
+ * Two call sites need this, and they must not drift:
+ *  - `assertPeginTxShape` (./pegin) validates the encoded PegIn output against
+ *    the scriptPubKey before the depositor signs the peg-in.
+ *  - `buildReclaimPsbt` (./reclaim) spends that same output, and needs the leaf
+ *    script and control block to populate the PSBT's `tapLeafScript`.
+ *
+ * Keeping one definition here is what makes the reclaim's script binding
+ * meaningful: the bytes the reclaim signs against are the same bytes the
+ * peg-in validated.
+ *
+ * @module primitives/psbt/depositorClaim
+ */
+
+import { tapInternalPubkey } from "@babylonlabs-io/babylon-tbv-rust-wasm";
+import { Buffer } from "buffer";
+import { payments, script as bscript, opcodes } from "bitcoinjs-lib";
+
+import {
+  TAPSCRIPT_LEAF_VERSION,
+  hexToUint8Array,
+  stripHexPrefix,
+} from "../utils/bitcoin";
+
+/**
+ * Vout of the depositor-claim output in every PegIn version (btc-vault: vault
+ * at 0, depositor claim at 1, optional P2A anchor appended after).
+ *
+ * Version-invariant: the graph version dispatches only the trailing P2A anchor
+ * (absent in v1, 240 sats at vout 2 in v2/v3). Nothing touches vout 1.
+ */
+export const PEGIN_DEPOSITOR_CLAIM_VOUT = 1;
+
+/** The single-leaf taptree's spend material for one depositor key. */
+export interface DepositorClaimDescriptor {
+  /** P2TR scriptPubKey the PegIn pays at {@link PEGIN_DEPOSITOR_CLAIM_VOUT}. */
+  scriptPubKey: Buffer;
+  /** The one tapleaf: `<depositor> OP_CHECKSIG`, 34 bytes. */
+  leafScript: Buffer;
+  /**
+   * Control block for that leaf: `[leafVersion | outputKeyParity] || NUMS`,
+   * 33 bytes. The tree has a single leaf at depth 0, so it carries no sibling
+   * hashes.
+   */
+  controlBlock: Buffer;
+  /**
+   * The NUMS internal key the taptree commits to — the PSBT's `tapInternalKey`.
+   * Carried here so an input's internal key and control block provably come
+   * from the same derivation.
+   */
+  internalKey: Buffer;
+}
+
+/**
+ * Derive the depositor-claim output's spend material in JS, independently of
+ * WASM — the Rust `SingleKeyConnector` has no WASM wrapper, so this is the
+ * only derivation available on the JS side.
+ *
+ * Takes no graph version: the connector is identical across v1/v2/v3. A future
+ * `VAULT_WASM_COMMIT` bump that changed it would break `assertPeginTxShape` at
+ * peg-in build time, which is where that regression should surface.
+ *
+ * @param depositorPubkey - x-only depositor pubkey, 64-char hex (no 0x prefix)
+ * @throws If bitcoinjs cannot derive the P2TR output or its control block
+ */
+export function deriveDepositorClaimDescriptor(
+  depositorPubkey: string,
+): DepositorClaimDescriptor {
+  // Validate before compiling: `bscript.compile` happily emits a shorter push
+  // for a truncated key, yielding a well-formed script that is not the claim
+  // leaf. Downstream that becomes a scriptPubKey nobody can spend, so reject
+  // here rather than deriving something plausible. Mirrors the same check in
+  // `deriveBip86ScriptPubKeyHex`.
+  const cleanPubkey = stripHexPrefix(depositorPubkey);
+  if (!/^[0-9a-fA-F]{64}$/.test(cleanPubkey)) {
+    throw new Error(
+      "Invalid depositor pubkey for the depositor-claim script: must be an " +
+        "x-only key of 64 hex characters (32 bytes).",
+    );
+  }
+
+  const leafScript = bscript.compile([
+    Buffer.from(hexToUint8Array(cleanPubkey)),
+    opcodes.OP_CHECKSIG,
+  ]);
+
+  const internalKey = Buffer.from(tapInternalPubkey);
+  const redeem = { output: leafScript, redeemVersion: TAPSCRIPT_LEAF_VERSION };
+  const { output, witness } = payments.p2tr({
+    internalPubkey: internalKey,
+    scriptTree: { output: leafScript },
+    redeem,
+  });
+
+  if (!output) {
+    throw new Error(
+      "Failed to derive the depositor-claim P2TR scriptPubKey for PegIn output validation",
+    );
+  }
+  // bitcoinjs appends the control block last in the script-path witness stack
+  // ([...redeemWitness, script, controlBlock]); with `redeem` supplied it is
+  // always present, but a missing entry must fail rather than sign unspendably.
+  const controlBlock = witness?.[witness.length - 1];
+  if (!controlBlock) {
+    throw new Error(
+      "Failed to derive the depositor-claim tapleaf control block; refusing to build an unspendable input",
+    );
+  }
+
+  return { scriptPubKey: output, leafScript, controlBlock, internalKey };
+}
+
+/**
+ * The depositor-claim output's scriptPubKey alone — the peg-in validation path,
+ * which has no need of the spend material.
+ */
+export function deriveDepositorClaimScriptPubKey(
+  depositorPubkey: string,
+): Buffer {
+  return deriveDepositorClaimDescriptor(depositorPubkey).scriptPubKey;
+}

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts
@@ -19,24 +19,22 @@ import {
   computeMinClaimValue,
   createPrePeginTransaction,
   peginP2aAnchorOutput,
-  tapInternalPubkey,
   validatePeginP2aAnchor,
   type Network,
 } from "@babylonlabs-io/babylon-tbv-rust-wasm";
-import { Buffer } from "buffer";
-import { payments, script as bscript, Transaction, opcodes } from "bitcoinjs-lib";
+import { Transaction } from "bitcoinjs-lib";
 
 import { parseUnfundedWasmTransaction } from "../../utils/transaction/fundPeginTransaction";
-import {
-  hexToUint8Array,
-  stripHexPrefix,
-  uint8ArrayToHex,
-} from "../utils/bitcoin";
+import { stripHexPrefix, uint8ArrayToHex } from "../utils/bitcoin";
 
 import {
   assertEncodedHtlcOutputsMatch,
   assertWasmPeginSizing,
 } from "./assertWasmPeginSizing";
+import {
+  PEGIN_DEPOSITOR_CLAIM_VOUT,
+  deriveDepositorClaimScriptPubKey,
+} from "./depositorClaim";
 
 /**
  * Parameters for building an unfunded Pre-PegIn PSBT
@@ -330,12 +328,6 @@ export async function buildPeginTxFromFundedPrePegin(
 const PEGIN_BASE_OUTPUT_COUNT = 2;
 
 /**
- * Vout of the depositor-claim output in every PegIn version (btc-vault:
- * vault at 0, depositor claim at 1, optional P2A anchor appended after).
- */
-const PEGIN_DEPOSITOR_CLAIM_VOUT = 1;
-
-/**
  * Cross-check the WASM-built PegIn transaction's bytes against the request
  * and the version's expected output layout before the depositor signs it.
  *
@@ -483,26 +475,3 @@ async function assertPeginTxShape(
   }
 }
 
-/**
- * Independently derive the PegIn depositor-claim output's scriptPubKey in
- * JS: a Taproot output with the NUMS internal key and a single
- * `<depositor> OP_CHECKSIG` leaf — btc-vault's `SingleKeyConnector`
- * (`crates/vault/src/connectors/mod.rs`, identical across graph versions).
- * Uses the same `tapInternalPubkey` NUMS constant the HTLC connector pins.
- */
-function deriveDepositorClaimScriptPubKey(depositorPubkey: string): Buffer {
-  const claimLeafScript = bscript.compile([
-    Buffer.from(hexToUint8Array(depositorPubkey)),
-    opcodes.OP_CHECKSIG,
-  ]);
-  const { output } = payments.p2tr({
-    internalPubkey: Buffer.from(tapInternalPubkey),
-    scriptTree: { output: claimLeafScript },
-  });
-  if (!output) {
-    throw new Error(
-      "Failed to derive the depositor-claim P2TR scriptPubKey for PegIn output validation",
-    );
-  }
-  return output;
-}

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/reclaim.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/reclaim.ts
@@ -1,0 +1,312 @@
+/**
+ * Reclaim PSBT Builder Primitive
+ *
+ * Builds an unsigned PSBT that sweeps the depositor-claim reserve — PegIn
+ * vout 1 — back to the depositor's own BIP-86 address.
+ *
+ * The reserve funds the depositor's `claim_tx`, their recourse if the vault
+ * provider fails during peg-out. When the vault provider claims instead and
+ * the depositor withdraws normally, nothing ever spends it. This primitive is
+ * the only thing in the repository that can.
+ *
+ * Spend path: the single `<depositor> OP_CHECKSIG` tapleaf (see
+ * ./depositorClaim). No timelock, no counterparty signature — the depositor's
+ * Schnorr signature alone. That is also why the *caller* must gate: this
+ * builder will happily sweep a reserve whose vault is still live, which would
+ * permanently void the depositor's pre-signed recourse graph. Eligibility is
+ * enforced upstream, in the service.
+ *
+ * @module primitives/psbt/reclaim
+ */
+
+import { Buffer } from "buffer";
+import { Psbt, Transaction } from "bitcoinjs-lib";
+
+import { DUST_THRESHOLD } from "../../utils/fee/constants";
+import {
+  TAPSCRIPT_LEAF_VERSION,
+  deriveBip86ScriptPubKeyHex,
+  hexToUint8Array,
+  stripHexPrefix,
+  uint8ArrayToHex,
+} from "../utils/bitcoin";
+import {
+  PEGIN_DEPOSITOR_CLAIM_VOUT,
+  deriveDepositorClaimDescriptor,
+} from "./depositorClaim";
+
+/**
+ * nVersion for the reclaim transaction. Plain v2, not TRUC: the reserve is only
+ * offered once its PegIn is deeply confirmed, so the v2/v3 PegIn's nVersion-3
+ * topology limits no longer constrain its children.
+ */
+const RECLAIM_TX_VERSION = 2;
+
+/**
+ * nSequence for every reclaim input: RBF-enabled, no relative timelock. The
+ * claim leaf carries no CSV, so this is a fee-bumping signal only.
+ */
+const RECLAIM_INPUT_SEQUENCE = 0xfffffffd;
+
+/**
+ * Weight units of the reclaim transaction's skeleton — everything except the
+ * inputs. Non-witness `version(4) + inCount(1) + outCount(1) + locktime(4) +
+ * output(8 + 1 + 34)` = 53 B × 4, plus the 2 WU SegWit marker and flag.
+ */
+const RECLAIM_SKELETON_WEIGHT_UNITS = 214;
+
+/**
+ * Weight units each script-path input adds. Non-witness `outpoint(36) +
+ * scriptSigLen(1) + sequence(4)` = 41 B × 4 = 164, plus a witness of
+ * `stackCount(1) + sig(1 + 64) + leafScript(1 + 34) + controlBlock(1 + 33)` =
+ * 135 WU.
+ *
+ * Exact rather than conservative: every element is fixed-length here — a
+ * 64-byte BIP-340 signature under SIGHASH_DEFAULT, the 34-byte leaf, and a
+ * 33-byte control block with no merkle path.
+ */
+const RECLAIM_INPUT_WEIGHT_UNITS = 299;
+
+/** Weight units per virtual byte. */
+const WEIGHT_UNITS_PER_VBYTE = 4;
+
+/**
+ * Virtual size of an N-in/1-out reclaim transaction.
+ *
+ * `REFUND_VSIZE = 160` does not generalise to N inputs, and
+ * `computePeginBaseFeeSats` is wrong for this shape entirely — its
+ * `P2TR_INPUT_SIZE = 58` is a *key-path* input and under-fees a script-path
+ * spend by roughly a quarter.
+ *
+ * N=1 → 129 vB; each additional input adds 75 vB.
+ */
+export function reclaimVsize(numInputs: number): number {
+  if (!Number.isInteger(numInputs) || numInputs < 1) {
+    throw new Error(
+      `Reclaim input count must be a positive integer, got ${numInputs}.`,
+    );
+  }
+  return Math.ceil(
+    (RECLAIM_SKELETON_WEIGHT_UNITS +
+      RECLAIM_INPUT_WEIGHT_UNITS * numInputs) /
+      WEIGHT_UNITS_PER_VBYTE,
+  );
+}
+
+/** Absolute fee in satoshis for an N-in/1-out reclaim at a given rate. */
+export function estimateReclaimFeeSats(
+  feeRateSatsVb: number,
+  numInputs: number,
+): bigint {
+  if (!Number.isFinite(feeRateSatsVb) || feeRateSatsVb <= 0) {
+    throw new Error(
+      `Reclaim fee rate must be a positive number, got ${feeRateSatsVb}.`,
+    );
+  }
+  return BigInt(Math.ceil(feeRateSatsVb * reclaimVsize(numInputs)));
+}
+
+/** One depositor-claim reserve to sweep, with the material to bind it. */
+export interface ReclaimReserve {
+  /**
+   * The contract's own copy of the depositor-signed PegIn transaction
+   * (`VaultProtocolInfo.depositorSignedPeginTx`). Authoritative: its SegWit
+   * txid equals the broadcast PegIn's, and its `outs[1]` carries the reserve's
+   * script and value at no extra RPC cost.
+   */
+  depositorSignedPeginTxHex: string;
+  /** Independent chain observation of `peginTxid:1` (esplora UTXO lookup). */
+  observed: {
+    /** scriptPubKey hex, with or without `0x` prefix. */
+    scriptPubKey: string;
+    /** Output value in satoshis. */
+    value: bigint;
+  };
+  /**
+   * The reserve value recomputed from this vault's protocol parameters via
+   * `computeMinClaimValue`. Bound so a doctored PegIn that agrees with itself
+   * and with a compromised indexer still fails.
+   */
+  expectedValue: bigint;
+}
+
+export interface BuildReclaimPsbtParams {
+  /**
+   * The **connected wallet's live** x-only pubkey, 64-char hex. Never the
+   * indexer's `depositorBtcPubkey`: re-deriving from the live key is what
+   * proves the wallet about to sign is the wallet that can spend, and rejects
+   * the wrong-wallet case with an error instead of an unspendable broadcast.
+   */
+  depositorPubkey: string;
+  /**
+   * Reserves to sweep. An array so batching several vaults into one
+   * transaction is a later change rather than a rewrite; today the app passes
+   * exactly one.
+   */
+  inputs: ReclaimReserve[];
+  /** Absolute fee in satoshis. The caller sizes it; see `reclaimVsize`. */
+  feeSats: bigint;
+}
+
+export interface BuildReclaimPsbtResult {
+  /** PSBT hex ready for depositor signing. */
+  psbtHex: string;
+  /** Value of the single output — what the depositor actually receives. */
+  outputValue: bigint;
+  /** Sum of the swept reserves, before fee. */
+  totalInputValue: bigint;
+}
+
+/**
+ * Build the N-in/1-out reclaim PSBT.
+ *
+ * Every input is bound three ways before it reaches the PSBT: the contract's
+ * PegIn bytes, the chain observation, and a JS re-derivation from the live
+ * wallet key must agree on both script and value. Any disagreement throws.
+ *
+ * @throws If `inputs` is empty, the fee is non-positive, any input fails its
+ *   script or value bind, or the resulting output would be at or below dust.
+ */
+export function buildReclaimPsbt(
+  params: BuildReclaimPsbtParams,
+): BuildReclaimPsbtResult {
+  const { depositorPubkey, inputs, feeSats } = params;
+
+  if (inputs.length === 0) {
+    throw new Error("Reclaim requires at least one input; got none.");
+  }
+  if (feeSats <= 0n) {
+    throw new Error(
+      `Reclaim fee must be positive, got ${feeSats} sat. Refusing to build a ` +
+        `transaction that would not relay.`,
+    );
+  }
+
+  // One derivation, reused for every input's bind and for the destination.
+  const descriptor = deriveDepositorClaimDescriptor(depositorPubkey);
+  const expectedScriptPubKey = uint8ArrayToHex(
+    new Uint8Array(descriptor.scriptPubKey),
+  ).toLowerCase();
+
+  const psbt = new Psbt();
+  psbt.setVersion(RECLAIM_TX_VERSION);
+  psbt.setLocktime(0);
+
+  let totalInputValue = 0n;
+  const seenOutpoints = new Set<string>();
+
+  inputs.forEach((input, i) => {
+    const peginTx = Transaction.fromHex(
+      stripHexPrefix(input.depositorSignedPeginTxHex),
+    );
+    const peginTxid = peginTx.getId();
+
+    const claimOut = peginTx.outs[PEGIN_DEPOSITOR_CLAIM_VOUT];
+    if (!claimOut) {
+      throw new Error(
+        `PegIn ${peginTxid} has no output at vout ` +
+          `${PEGIN_DEPOSITOR_CLAIM_VOUT} (tx has ${peginTx.outs.length}); ` +
+          `there is no depositor-claim reserve to reclaim.`,
+      );
+    }
+
+    // Bind 1: the contract's PegIn bytes against the JS re-derivation from the
+    // live wallet key. This is the assertion that proves the connected wallet
+    // can actually spend the output we are about to sign for.
+    const contractScriptPubKey = uint8ArrayToHex(
+      new Uint8Array(claimOut.script),
+    ).toLowerCase();
+    if (contractScriptPubKey !== expectedScriptPubKey) {
+      throw new Error(
+        `Input ${i}: PegIn ${peginTxid} vout ${PEGIN_DEPOSITOR_CLAIM_VOUT} pays ` +
+          `${contractScriptPubKey}, but the connected wallet's depositor-claim ` +
+          `script is ${expectedScriptPubKey}. Reclaim refused — this reserve ` +
+          `belongs to a different wallet.`,
+      );
+    }
+
+    // Bind 2: the independent chain observation must agree with both.
+    const observedScriptPubKey = stripHexPrefix(
+      input.observed.scriptPubKey,
+    ).toLowerCase();
+    if (observedScriptPubKey !== expectedScriptPubKey) {
+      throw new Error(
+        `Input ${i}: the observed UTXO ${peginTxid}:${PEGIN_DEPOSITOR_CLAIM_VOUT} ` +
+          `pays ${observedScriptPubKey}, expected ${expectedScriptPubKey}. ` +
+          `Reclaim refused — chain state disagrees with the contract's PegIn.`,
+      );
+    }
+
+    // Value bind, same three ways.
+    const contractValue = BigInt(claimOut.value);
+    if (contractValue !== input.observed.value) {
+      throw new Error(
+        `Input ${i}: PegIn ${peginTxid} vout ${PEGIN_DEPOSITOR_CLAIM_VOUT} ` +
+          `carries ${contractValue} sat, but the observed UTXO carries ` +
+          `${input.observed.value} sat. Reclaim refused.`,
+      );
+    }
+    if (contractValue !== input.expectedValue) {
+      throw new Error(
+        `Input ${i}: PegIn ${peginTxid} vout ${PEGIN_DEPOSITOR_CLAIM_VOUT} ` +
+          `carries ${contractValue} sat, but this vault's parameters compute a ` +
+          `depositor-claim value of ${input.expectedValue} sat. Reclaim refused.`,
+      );
+    }
+
+    // A batch that names the same vault twice would otherwise double-count the
+    // swept total and then fail deep inside bitcoinjs. Reject it here, where
+    // the message can say which input is the duplicate.
+    const outpoint = `${peginTxid}:${PEGIN_DEPOSITOR_CLAIM_VOUT}`;
+    if (seenOutpoints.has(outpoint)) {
+      throw new Error(
+        `Input ${i} repeats outpoint ${outpoint}, which is already being ` +
+          `swept by an earlier input. Reclaim refused.`,
+      );
+    }
+    seenOutpoints.add(outpoint);
+
+    totalInputValue += contractValue;
+
+    psbt.addInput({
+      hash: peginTxid,
+      index: PEGIN_DEPOSITOR_CLAIM_VOUT,
+      sequence: RECLAIM_INPUT_SEQUENCE,
+      witnessUtxo: { script: claimOut.script, value: claimOut.value },
+      tapLeafScript: [
+        {
+          leafVersion: TAPSCRIPT_LEAF_VERSION,
+          script: descriptor.leafScript,
+          controlBlock: descriptor.controlBlock,
+        },
+      ],
+      tapInternalKey: descriptor.internalKey,
+    });
+  });
+
+  if (feeSats >= totalInputValue) {
+    throw new Error(
+      `Reclaim fee ${feeSats} sat is not less than the swept total ` +
+        `${totalInputValue} sat. Refusing to build a transaction with no output.`,
+    );
+  }
+
+  const outputValue = totalInputValue - feeSats;
+  if (outputValue <= DUST_THRESHOLD) {
+    throw new Error(
+      `Reclaim output ${outputValue} sat is at or below the dust threshold ` +
+        `${DUST_THRESHOLD} sat. The reserve is not at risk — it stays where it ` +
+        `is until fee rates fall.`,
+    );
+  }
+
+  const destination = stripHexPrefix(
+    deriveBip86ScriptPubKeyHex(depositorPubkey),
+  );
+  psbt.addOutput({
+    script: Buffer.from(hexToUint8Array(destination)),
+    value: Number(outputValue),
+  });
+
+  return { psbtHex: psbt.toHex(), outputValue, totalInputValue };
+}

--- a/packages/babylon-ts-sdk/src/tbv/core/services/index.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/index.ts
@@ -11,3 +11,4 @@ export * from "./htlc";
 export * from "./participants";
 export * from "./pegout";
 export * from "./refund";
+export * from "./reclaim";

--- a/packages/babylon-ts-sdk/src/tbv/core/services/reclaim/__tests__/buildAndBroadcastReclaim.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/reclaim/__tests__/buildAndBroadcastReclaim.test.ts
@@ -1,0 +1,237 @@
+/**
+ * Reclaim orchestration tests.
+ *
+ * The PSBT builder and its binds have their own suite; here the contract under
+ * test is the orchestration — fee caps, call order, per-input signature
+ * verification, and abort handling.
+ */
+
+import type { Hex } from "viem";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  RECLAIM_MAX_FEE_FRACTION_DENOMINATOR,
+  RECLAIM_MAX_FEE_FRACTION_NUMERATOR,
+  RECLAIM_MAX_FEE_RATE_SATS_VB,
+  ReclaimUneconomicalError,
+  buildAndBroadcastReclaim,
+  type ReclaimVaultData,
+} from "../index";
+
+vi.mock("../../../primitives/psbt/reclaim", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../../../primitives/psbt/reclaim")>();
+  return {
+    ...actual,
+    buildReclaimPsbt: vi.fn().mockReturnValue({
+      psbtHex: "70736274ffmock",
+      outputValue: 32_355n,
+      totalInputValue: 33_000n,
+    }),
+  };
+});
+
+vi.mock("../../../primitives/psbt/assertPsbtUnsignedTxMatches", () => ({
+  assertPsbtUnsignedTxMatches: vi.fn(),
+}));
+
+vi.mock("../../../primitives/psbt/payout", () => ({
+  extractPayoutSignature: vi.fn().mockReturnValue("aa".repeat(64)),
+}));
+
+vi.mock("../../../primitives/psbt/verifyScriptPathSchnorrSignature", () => ({
+  assertScriptPathSchnorrSignature: vi.fn(),
+}));
+
+vi.mock("bitcoinjs-lib", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("bitcoinjs-lib")>();
+  return {
+    ...actual,
+    Psbt: {
+      ...actual.Psbt,
+      fromHex: vi.fn().mockReturnValue({
+        finalizeAllInputs: vi.fn(),
+        extractTransaction: () => ({ toHex: () => "signedtxhex" }),
+      }),
+    },
+  };
+});
+
+const { buildReclaimPsbt } = await import("../../../primitives/psbt/reclaim");
+const { assertScriptPathSchnorrSignature } = await import(
+  "../../../primitives/psbt/verifyScriptPathSchnorrSignature"
+);
+const { extractPayoutSignature } = await import(
+  "../../../primitives/psbt/payout"
+);
+
+const VAULT_ID = `0x${"11".repeat(32)}` as Hex;
+const DEPOSITOR_PUBKEY =
+  "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798";
+const CLAIM_VALUE = 33_000n;
+
+function makeVaultData(
+  overrides: Partial<ReclaimVaultData> = {},
+): ReclaimVaultData {
+  return {
+    depositorSignedPeginTxHex: "0200000000",
+    observed: { scriptPubKey: "5120" + "ab".repeat(32), value: CLAIM_VALUE },
+    expectedClaimValue: CLAIM_VALUE,
+    ...overrides,
+  };
+}
+
+function makeInput(overrides: Record<string, unknown> = {}) {
+  return {
+    vaultIds: [VAULT_ID],
+    depositorBtcPubkey: DEPOSITOR_PUBKEY,
+    readVaults: vi.fn().mockResolvedValue([makeVaultData()]),
+    feeRate: 5,
+    signPsbt: vi.fn().mockResolvedValue("70736274ffsigned"),
+    broadcastTx: vi.fn().mockResolvedValue({ txId: "abc123" }),
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("buildAndBroadcastReclaim", () => {
+  it("returns the broadcast result on the happy path", async () => {
+    const input = makeInput();
+
+    await expect(buildAndBroadcastReclaim(input)).resolves.toEqual({
+      txId: "abc123",
+    });
+    expect(input.broadcastTx).toHaveBeenCalledWith("signedtxhex");
+  });
+
+  it("sizes the fee from the rate and the input count", async () => {
+    await buildAndBroadcastReclaim(makeInput({ feeRate: 5 }));
+
+    // 129 vB at 5 sat/vB.
+    expect(vi.mocked(buildReclaimPsbt).mock.calls[0][0].feeSats).toBe(645n);
+  });
+
+  it("rejects a fee rate above the safety cap before reading any vault", async () => {
+    const input = makeInput({ feeRate: RECLAIM_MAX_FEE_RATE_SATS_VB + 1 });
+
+    await expect(buildAndBroadcastReclaim(input)).rejects.toBeInstanceOf(
+      ReclaimUneconomicalError,
+    );
+    // Fails closed ahead of any I/O — no wallet prompt, no chain read.
+    expect(input.readVaults).not.toHaveBeenCalled();
+    expect(input.signPsbt).not.toHaveBeenCalled();
+  });
+
+  it("rejects a fee above the fraction cap of the swept total", async () => {
+    // The cap is 25% of 33,000 = 8,250 sats. At 129 vB that binds around
+    // 64 sat/vB, so 100 sat/vB is comfortably over.
+    const input = makeInput({ feeRate: 100 });
+
+    await expect(buildAndBroadcastReclaim(input)).rejects.toBeInstanceOf(
+      ReclaimUneconomicalError,
+    );
+    expect(input.signPsbt).not.toHaveBeenCalled();
+  });
+
+  it("allows a fee just under the fraction cap", async () => {
+    const capSats =
+      (CLAIM_VALUE * RECLAIM_MAX_FEE_FRACTION_NUMERATOR) /
+      RECLAIM_MAX_FEE_FRACTION_DENOMINATOR;
+    // Highest whole sat/vB whose 129 vB fee stays at or under the cap.
+    const feeRate = Math.floor(Number(capSats) / 129);
+
+    await expect(
+      buildAndBroadcastReclaim(makeInput({ feeRate })),
+    ).resolves.toEqual({ txId: "abc123" });
+  });
+
+  it("reports the fee and swept total on an uneconomical rejection", async () => {
+    try {
+      await buildAndBroadcastReclaim(makeInput({ feeRate: 100 }));
+      expect.unreachable("should have thrown");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ReclaimUneconomicalError);
+      const typed = error as ReclaimUneconomicalError;
+      expect(typed.sweptTotalSats).toBe(CLAIM_VALUE);
+      expect(typed.feeSats).toBe(12_900n);
+    }
+  });
+
+  it("verifies a signature for every input, not just the first", async () => {
+    const input = makeInput({
+      vaultIds: [VAULT_ID, `0x${"22".repeat(32)}` as Hex],
+      readVaults: vi
+        .fn()
+        .mockResolvedValue([makeVaultData(), makeVaultData()]),
+    });
+
+    await buildAndBroadcastReclaim(input);
+
+    expect(vi.mocked(extractPayoutSignature).mock.calls.map((c) => c[2])).toEqual(
+      [0, 1],
+    );
+    expect(
+      vi
+        .mocked(assertScriptPathSchnorrSignature)
+        .mock.calls.map((c) => c[0].inputIndex),
+    ).toEqual([0, 1]);
+  });
+
+  it("refuses when readVaults returns a different number of reserves than requested", async () => {
+    const input = makeInput({
+      vaultIds: [VAULT_ID, `0x${"22".repeat(32)}` as Hex],
+      readVaults: vi.fn().mockResolvedValue([makeVaultData()]),
+    });
+
+    await expect(buildAndBroadcastReclaim(input)).rejects.toThrow(
+      /does not match the request/,
+    );
+    expect(input.signPsbt).not.toHaveBeenCalled();
+  });
+
+  it("rejects an empty vault set", async () => {
+    await expect(
+      buildAndBroadcastReclaim(makeInput({ vaultIds: [] })),
+    ).rejects.toThrow(/at least one vault id/);
+  });
+
+  it("rejects a non-positive fee rate", async () => {
+    await expect(
+      buildAndBroadcastReclaim(makeInput({ feeRate: 0 })),
+    ).rejects.toThrow(/positive number/);
+  });
+
+  it("aborts before broadcasting when the signal fires", async () => {
+    const controller = new AbortController();
+    const input = makeInput({
+      signal: controller.signal,
+      signPsbt: vi.fn().mockImplementation(async () => {
+        controller.abort();
+        return "70736274ffsigned";
+      }),
+    });
+
+    await expect(buildAndBroadcastReclaim(input)).rejects.toThrow();
+    expect(input.broadcastTx).not.toHaveBeenCalled();
+  });
+
+  it("passes the swept reserves through to the builder in request order", async () => {
+    const first = makeVaultData({ depositorSignedPeginTxHex: "0200000001" });
+    const second = makeVaultData({ depositorSignedPeginTxHex: "0200000002" });
+    await buildAndBroadcastReclaim(
+      makeInput({
+        vaultIds: [VAULT_ID, `0x${"22".repeat(32)}` as Hex],
+        readVaults: vi.fn().mockResolvedValue([first, second]),
+      }),
+    );
+
+    const passed = vi.mocked(buildReclaimPsbt).mock.calls[0][0].inputs;
+    expect(passed.map((r) => r.depositorSignedPeginTxHex)).toEqual([
+      "0200000001",
+      "0200000002",
+    ]);
+  });
+});

--- a/packages/babylon-ts-sdk/src/tbv/core/services/reclaim/buildAndBroadcastReclaim.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/reclaim/buildAndBroadcastReclaim.ts
@@ -1,0 +1,257 @@
+/**
+ * Reclaim orchestration — sweep the depositor-claim reserve (PegIn vout 1)
+ * back to the depositor after their vault has terminally settled.
+ *
+ * The SDK owns the sequence: read → fee caps → PSBT build → sign → verify →
+ * finalize → broadcast. Interactive transports (`signPsbt`, `broadcastTx`) and
+ * the data read stay as injected callbacks, so the caller keeps its transport
+ * choice and error decoding. Mirrors `services/refund/buildAndBroadcastRefund`.
+ *
+ * > **Eligibility is the caller's job, and it is a safety control.** The claim
+ * > leaf carries no timelock, so this service will sweep a reserve whose vault
+ * > is still live. Doing that permanently voids the depositor's pre-signed
+ * > recourse graph: their `claim_tx` hard-codes `OutPoint(peginTxid, 1)` as its
+ * > only input, and every downstream Assert / Payout / NoPayout signature
+ * > commits to that tx's txid. There is no re-funding path. The caller must
+ * > confirm the vault's Payout has landed — PegIn vout 0 spent and deeply
+ * > confirmed — before calling this.
+ *
+ * @module services/reclaim
+ */
+
+import { Psbt } from "bitcoinjs-lib";
+import type { Hex } from "viem";
+
+import type { SignPsbtOptions } from "../../../../shared/wallets/interfaces/BitcoinWallet";
+import { assertPsbtUnsignedTxMatches } from "../../primitives/psbt/assertPsbtUnsignedTxMatches";
+import { extractPayoutSignature } from "../../primitives/psbt/payout";
+import {
+  buildReclaimPsbt,
+  estimateReclaimFeeSats,
+  type ReclaimReserve,
+} from "../../primitives/psbt/reclaim";
+import { assertScriptPathSchnorrSignature } from "../../primitives/psbt/verifyScriptPathSchnorrSignature";
+import { processPublicKeyToXOnly } from "../../primitives/utils/bitcoin";
+import { createTaprootScriptPathSignOptions } from "../../utils/signing";
+// The BTC broadcast transport types are shared with the refund service rather
+// than redeclared — `services/index.ts` re-exports both modules flat, so a
+// second declaration would collide on the barrel.
+import type {
+  BtcBroadcastResult,
+  BtcBroadcaster,
+} from "../refund/buildAndBroadcastRefund";
+
+import { ReclaimUneconomicalError } from "./errors";
+
+/**
+ * Hard upper bound on the per-vbyte fee rate the SDK will sign a reclaim at.
+ * Same reasoning and value as the refund's cap: a compromised mempool endpoint
+ * can legally return up to 10,000 sat/vB, and 2000 leaves margin over the
+ * worst historical `halfHourFee` while still blocking that by 5×.
+ */
+export const RECLAIM_MAX_FEE_RATE_SATS_VB = 2000;
+
+/**
+ * Hard upper bound on the absolute fee as a fraction of the **swept total**.
+ *
+ * > ⚠️ The basis here is deliberately different from the refund's. There the
+ * > basis is `vault.amount` and the swept amount is far larger, so a 10% cap is
+ * > generous. Here the basis *is* the swept amount — roughly 33k sats — and a
+ * > 10% cap would block every reclaim above about 25 sat/vB. Do not "fix" this
+ * > into symmetry with `REFUND_MAX_FEE_FRACTION_*`; it would silently change
+ * > behaviour. The matching comment lives at the UI cap site.
+ */
+export const RECLAIM_MAX_FEE_FRACTION_NUMERATOR = 25n;
+export const RECLAIM_MAX_FEE_FRACTION_DENOMINATOR = 100n;
+
+/**
+ * Fraction of the swept total above which the UI warns but still allows the
+ * reclaim. Exported so the review screen derives its threshold from the same
+ * constant the SDK enforces against, rather than restating it.
+ */
+export const RECLAIM_WARN_FEE_FRACTION_NUMERATOR = 10n;
+
+export type ReclaimPsbtSigner = (
+  psbtHex: string,
+  opts: SignPsbtOptions,
+) => Promise<string>;
+
+/** One reserve to sweep, as the caller resolves it. */
+export interface ReclaimVaultData {
+  /**
+   * The contract's own copy of the depositor-signed PegIn transaction
+   * (`VaultProtocolInfo.depositorSignedPeginTx`). Must come from the chain —
+   * never the indexer. Its `outs[1]` is one leg of the three-way bind.
+   */
+  depositorSignedPeginTxHex: string;
+  /** Independent chain observation of `peginTxid:1`. */
+  observed: { scriptPubKey: string; value: bigint };
+  /** This vault's reserve value, recomputed via `computeMinClaimValue`. */
+  expectedClaimValue: bigint;
+}
+
+export interface ReclaimInput<
+  R extends BtcBroadcastResult = BtcBroadcastResult,
+> {
+  vaultIds: Hex[];
+  /**
+   * The **connected wallet's live** BTC pubkey — compressed sec1 or x-only.
+   * Never the indexer's `depositorBtcPubkey`: re-deriving the claim script
+   * from the live key is what proves the wallet about to sign is the wallet
+   * that can spend.
+   */
+  depositorBtcPubkey: string;
+  /**
+   * Resolve the reserves to sweep, in the same order as `vaultIds`. The SDK
+   * passes no arguments — the caller closes over whatever context it needs.
+   */
+  readVaults: () => Promise<ReclaimVaultData[]>;
+  /** Mempool-derived sat/vB fee rate. Caller fetches it before invoking. */
+  feeRate: number;
+  /** BTC wallet signer; receives a PSBT hex + taproot script-path options. */
+  signPsbt: ReclaimPsbtSigner;
+  /** Broadcast callback — returns whatever shape the caller needs. */
+  broadcastTx: BtcBroadcaster<R>;
+  /** Checked at every async boundary. */
+  signal?: AbortSignal;
+}
+
+function finalizeAndExtract(signedPsbtHex: string): string {
+  const psbt = Psbt.fromHex(signedPsbtHex);
+  try {
+    psbt.finalizeAllInputs();
+  } catch (e: unknown) {
+    // Some wallets (e.g. Keystone) finalize during signPsbt; bitcoinjs then
+    // throws "Input is already finalized". Treat that case as a no-op.
+    const message = e instanceof Error ? e.message : String(e);
+    if (!message.includes("already finalized")) {
+      throw new Error(`Failed to finalize reclaim PSBT: ${message}`);
+    }
+  }
+  return psbt.extractTransaction().toHex();
+}
+
+/**
+ * Build, sign, and broadcast a reclaim transaction sweeping one or more
+ * depositor-claim reserves back to the depositor's BIP-86 address.
+ *
+ * @returns whatever the injected `broadcastTx` returns (generic pass-through)
+ * @throws {@link ReclaimUneconomicalError} if the fee breaches either cap
+ * @throws `Error` if any validation or script/value bind fails
+ * @throws anything `readVaults`, `signPsbt`, or `broadcastTx` throws
+ */
+export async function buildAndBroadcastReclaim<
+  R extends BtcBroadcastResult = BtcBroadcastResult,
+>(input: ReclaimInput<R>): Promise<R> {
+  const {
+    vaultIds,
+    depositorBtcPubkey,
+    readVaults,
+    feeRate,
+    signPsbt,
+    broadcastTx,
+    signal,
+  } = input;
+
+  signal?.throwIfAborted();
+
+  if (vaultIds.length === 0) {
+    throw new Error("Reclaim requires at least one vault id; got none.");
+  }
+  if (!Number.isFinite(feeRate) || feeRate <= 0) {
+    throw new Error(`feeRate must be a positive number, got ${feeRate}`);
+  }
+  // Rate cap first: fail closed before any PSBT construction or wallet prompt.
+  if (feeRate > RECLAIM_MAX_FEE_RATE_SATS_VB) {
+    throw new ReclaimUneconomicalError(
+      `Fee rate ${feeRate} sat/vB exceeds the reclaim safety cap of ` +
+        `${RECLAIM_MAX_FEE_RATE_SATS_VB} sat/vB; refusing to sign.`,
+      0n,
+      0n,
+    );
+  }
+
+  const vaults = await readVaults();
+  signal?.throwIfAborted();
+
+  if (vaults.length !== vaultIds.length) {
+    throw new Error(
+      `readVaults returned ${vaults.length} reserves for ${vaultIds.length} ` +
+        `vault id(s); refusing to sweep a set that does not match the request.`,
+    );
+  }
+
+  // x-only for script derivation and signature verification; the raw form is
+  // kept for the wallet's own sign call below.
+  const xOnlyDepositorPubkey = processPublicKeyToXOnly(depositorBtcPubkey);
+
+  const reserves: ReclaimReserve[] = vaults.map((vault) => ({
+    depositorSignedPeginTxHex: vault.depositorSignedPeginTxHex,
+    observed: vault.observed,
+    expectedValue: vault.expectedClaimValue,
+  }));
+
+  const feeSats = estimateReclaimFeeSats(feeRate, reserves.length);
+
+  // Fraction cap: bound the burn against the swept total. See the constant's
+  // note on why this basis differs from the refund's.
+  const sweptTotal = reserves.reduce((sum, r) => sum + r.expectedValue, 0n);
+  const maxFeeByFraction =
+    (sweptTotal * RECLAIM_MAX_FEE_FRACTION_NUMERATOR) /
+    RECLAIM_MAX_FEE_FRACTION_DENOMINATOR;
+  if (feeSats > maxFeeByFraction) {
+    throw new ReclaimUneconomicalError(
+      `Reclaim fee ${feeSats} sats exceeds ` +
+        `${RECLAIM_MAX_FEE_FRACTION_NUMERATOR}/${RECLAIM_MAX_FEE_FRACTION_DENOMINATOR} ` +
+        `of the swept total (${sweptTotal} sats, cap ${maxFeeByFraction} sats). ` +
+        `The reserve is not at risk — it stays where it is until fee rates fall.`,
+      feeSats,
+      sweptTotal,
+    );
+  }
+  signal?.throwIfAborted();
+
+  // Builds the three-way bind: contract PegIn bytes × chain observation × JS
+  // re-derivation from the live wallet key. Throws on any disagreement.
+  const { psbtHex } = buildReclaimPsbt({
+    depositorPubkey: xOnlyDepositorPubkey,
+    inputs: reserves,
+    feeSats,
+  });
+  signal?.throwIfAborted();
+
+  const signOptions = createTaprootScriptPathSignOptions(
+    depositorBtcPubkey,
+    reserves.length,
+  );
+  const signedPsbtHex = await signPsbt(psbtHex, signOptions);
+
+  assertPsbtUnsignedTxMatches({
+    requestedPsbtHex: psbtHex,
+    returnedPsbtHex: signedPsbtHex,
+  });
+
+  // CLAUDE.md critical path #8: `useTweakedSigner: false` / `autoFinalized:
+  // false` means wallet success is not evidence of a valid signature. Verify
+  // every input against a sighash recomputed from the PSBT we built, before
+  // finalizing — not just input 0, or a batch could broadcast with one good
+  // signature and the rest garbage.
+  reserves.forEach((_reserve, inputIndex) => {
+    const signature = extractPayoutSignature(
+      signedPsbtHex,
+      xOnlyDepositorPubkey,
+      inputIndex,
+    );
+    assertScriptPathSchnorrSignature({
+      requestedPsbtHex: psbtHex,
+      signatureHex: signature,
+      signerXOnlyPubkeyHex: xOnlyDepositorPubkey,
+      inputIndex,
+    });
+  });
+
+  const signedTxHex = finalizeAndExtract(signedPsbtHex);
+  signal?.throwIfAborted();
+
+  return broadcastTx(signedTxHex);
+}

--- a/packages/babylon-ts-sdk/src/tbv/core/services/reclaim/errors.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/reclaim/errors.ts
@@ -1,0 +1,28 @@
+/**
+ * Domain errors thrown by the reclaim service.
+ *
+ * @module services/reclaim/errors
+ */
+
+/**
+ * Thrown when the fee would consume too much of the swept reserve — either the
+ * per-vbyte rate exceeds the safety ceiling, or the absolute fee exceeds the
+ * fraction cap.
+ *
+ * Distinct from a generic error because the caller's response differs: nothing
+ * is at risk and nothing expires. The reserve simply stays where it is until
+ * fee rates fall, and the UI should say so rather than presenting a failure.
+ */
+export class ReclaimUneconomicalError extends Error {
+  /** Fee the reclaim would have paid, in satoshis. */
+  public readonly feeSats: bigint;
+  /** Sum of the reserves the reclaim would have swept, in satoshis. */
+  public readonly sweptTotalSats: bigint;
+
+  constructor(message: string, feeSats: bigint, sweptTotalSats: bigint) {
+    super(message);
+    this.name = "ReclaimUneconomicalError";
+    this.feeSats = feeSats;
+    this.sweptTotalSats = sweptTotalSats;
+  }
+}

--- a/packages/babylon-ts-sdk/src/tbv/core/services/reclaim/index.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/reclaim/index.ts
@@ -1,0 +1,18 @@
+/**
+ * Vault reclaim service — sweep the depositor-claim reserve (PegIn vout 1)
+ * back to the depositor after their vault has terminally settled.
+ *
+ * @module services/reclaim
+ */
+
+export { ReclaimUneconomicalError } from "./errors";
+export {
+  buildAndBroadcastReclaim,
+  RECLAIM_MAX_FEE_FRACTION_DENOMINATOR,
+  RECLAIM_MAX_FEE_FRACTION_NUMERATOR,
+  RECLAIM_MAX_FEE_RATE_SATS_VB,
+  RECLAIM_WARN_FEE_FRACTION_NUMERATOR,
+  type ReclaimInput,
+  type ReclaimPsbtSigner,
+  type ReclaimVaultData,
+} from "./buildAndBroadcastReclaim";

--- a/services/vault/src/clients/btc/outspend.ts
+++ b/services/vault/src/clients/btc/outspend.ts
@@ -16,6 +16,12 @@ export interface HtlcSpend {
   confirmed: boolean;
   /** Spending (refund) transaction id, when spent. */
   spendingTxid?: string;
+  /**
+   * Height of the block containing the spending tx, when confirmed. Used by
+   * the reclaim gate, which needs confirmation depth rather than a boolean —
+   * see `models/reclaimEligibility`.
+   */
+  blockHeight?: number;
 }
 
 /**
@@ -36,5 +42,6 @@ export async function fetchHtlcSpend(
     spent: res.spent === true,
     confirmed: res.spent === true && res.status?.confirmed === true,
     spendingTxid: res.txid,
+    blockHeight: res.status?.block_height,
   };
 }

--- a/services/vault/src/components/Activity/ActivityListWithRefund.tsx
+++ b/services/vault/src/components/Activity/ActivityListWithRefund.tsx
@@ -37,6 +37,7 @@ export function ActivityListWithRefund({
     ethAddress,
     broadcastModal,
     refundModal,
+    reclaimModal,
     emergencyWithdrawModal,
   } = usePendingDeposits();
 
@@ -89,6 +90,7 @@ export function ActivityListWithRefund({
       <PendingDepositModals
         broadcastModal={broadcastModal}
         refundModal={refundModal}
+        reclaimModal={reclaimModal}
         emergencyWithdrawModal={emergencyWithdrawModal}
         ethAddress={ethAddress}
       />

--- a/services/vault/src/components/deposit/ReclaimModal/ReclaimAlreadySettledContent.tsx
+++ b/services/vault/src/components/deposit/ReclaimModal/ReclaimAlreadySettledContent.tsx
@@ -1,0 +1,35 @@
+import { Button, Heading, Text } from "@babylonlabs-io/core-ui";
+
+import { COPY } from "@/copy";
+
+/**
+ * Terminal state for a reserve that turned out to be already spent — usually
+ * the same depositor sweeping from another device. Their money is where they
+ * wanted it, so this reads as a resolved outcome rather than a failure.
+ */
+export function ReclaimAlreadySettledContent({
+  onClose,
+}: {
+  onClose: () => void;
+}) {
+  return (
+    <div className="mx-auto flex w-full max-w-[564px] flex-col gap-10 rounded-3xl border border-secondary-strokeLight bg-surface px-6 pb-6 pt-10 dark:border-secondary-strokeDark">
+      <div className="flex w-full flex-col items-center gap-4 text-center">
+        <Heading variant="h5" className="text-accent-primary">
+          {COPY.reclaim.alreadySettled.heading}
+        </Heading>
+        <Text variant="body1" className="text-accent-secondary">
+          {COPY.reclaim.alreadySettled.body}
+        </Text>
+      </div>
+      <Button
+        variant="contained"
+        color="secondary"
+        className="w-full"
+        onClick={onClose}
+      >
+        {COPY.reclaim.alreadySettled.doneButton}
+      </Button>
+    </div>
+  );
+}

--- a/services/vault/src/components/deposit/ReclaimModal/ReclaimReviewContent.tsx
+++ b/services/vault/src/components/deposit/ReclaimModal/ReclaimReviewContent.tsx
@@ -60,12 +60,22 @@ export function ReclaimReviewContent({
   const [usingFallback, setUsingFallback] = useState(false);
 
   useEffect(() => {
-    if (feeRate !== null) return;
     if (defaultFeeRateSatsVb && defaultFeeRateSatsVb > 0) {
-      setFeeRate(defaultFeeRateSatsVb);
-      setUsingFallback(false);
+      // The real rate can arrive later than the first render — the preview
+      // refetches on window focus, so a failed fetch can succeed on a second
+      // pass. Adopt it then, and clear the gate. Returning early whenever
+      // `feeRate` was set would strand the fallback warning on screen with
+      // Confirm disabled until the depositor edited the field by hand.
+      //
+      // Only overwrite the field while it still holds the fallback seed; a
+      // rate the depositor typed is theirs to keep.
+      setUsingFallback((wasFallback) => {
+        if (wasFallback || feeRate === null) setFeeRate(defaultFeeRateSatsVb);
+        return false;
+      });
       return;
     }
+    if (feeRate !== null) return;
     setFeeRate(FALLBACK_FEE_RATE_SATS_VB);
     setUsingFallback(true);
   }, [defaultFeeRateSatsVb, feeRate]);

--- a/services/vault/src/components/deposit/ReclaimModal/ReclaimReviewContent.tsx
+++ b/services/vault/src/components/deposit/ReclaimModal/ReclaimReviewContent.tsx
@@ -1,0 +1,284 @@
+import { Button, Callout, Heading, Loader } from "@babylonlabs-io/core-ui";
+import { estimateReclaimFeeSats } from "@babylonlabs-io/ts-sdk/tbv/core/primitives";
+import {
+  RECLAIM_MAX_FEE_FRACTION_DENOMINATOR,
+  RECLAIM_MAX_FEE_FRACTION_NUMERATOR,
+  RECLAIM_MAX_FEE_RATE_SATS_VB,
+  RECLAIM_WARN_FEE_FRACTION_NUMERATOR,
+} from "@babylonlabs-io/ts-sdk/tbv/core/services";
+import { useEffect, useState } from "react";
+
+import { ReviewDetailRow } from "@/components/shared/DetailRow";
+import { FALLBACK_FEE_RATE_SATS_VB } from "@/constants";
+import { useBTCWallet } from "@/context/wallet";
+import { COPY } from "@/copy";
+import { usePrice } from "@/hooks/usePrices";
+import { satoshiToBtcNumber } from "@/utils/btcConversion";
+import {
+  formatBtcValue,
+  formatSats,
+  formatUsd,
+  getBtcSymbol,
+} from "@/utils/formatting";
+
+import { FeeRateField } from "../RefundModal/FeeRateField";
+
+// Bitcoin policy dust limit, matching the SDK builder's floor.
+const DUST_LIMIT_SATS = 546n;
+
+/** A single reclaim sweeps one reserve. */
+const RECLAIM_INPUT_COUNT = 1;
+
+interface ReclaimReviewContentProps {
+  /** Gross reserve value at PegIn vout 1. */
+  amountSats: bigint | null;
+  defaultFeeRateSatsVb: number | null;
+  previewError: string | null;
+  reclaiming: boolean;
+  error: string | null;
+  onConfirm: (feeRate: number) => void;
+}
+
+export function ReclaimReviewContent({
+  amountSats,
+  defaultFeeRateSatsVb,
+  previewError,
+  reclaiming,
+  error,
+  onConfirm,
+}: ReclaimReviewContentProps) {
+  const btcPriceUSD = usePrice("BTC");
+  const symbol = getBtcSymbol();
+  // Signing a BTC transaction, so a silently locked wallet must block confirm.
+  // This full-screen modal covers the navbar's unlock affordance.
+  const { locked: walletLocked } = useBTCWallet();
+
+  const [feeRate, setFeeRate] = useState<number | null>(null);
+  // True while the seeded rate came from the hard-coded floor because the
+  // mempool fetch failed. Confirm stays gated until the user edits the field
+  // or the real rate arrives.
+  const [usingFallback, setUsingFallback] = useState(false);
+
+  useEffect(() => {
+    if (feeRate !== null) return;
+    if (defaultFeeRateSatsVb && defaultFeeRateSatsVb > 0) {
+      setFeeRate(defaultFeeRateSatsVb);
+      setUsingFallback(false);
+      return;
+    }
+    setFeeRate(FALLBACK_FEE_RATE_SATS_VB);
+    setUsingFallback(true);
+  }, [defaultFeeRateSatsVb, feeRate]);
+
+  const handleFeeRateChange = (next: number) => {
+    setFeeRate(next);
+    setUsingFallback(false);
+  };
+
+  const amountBtc = amountSats !== null ? satoshiToBtcNumber(amountSats) : null;
+  const networkFeeSats =
+    feeRate !== null && feeRate > 0
+      ? estimateReclaimFeeSats(feeRate, RECLAIM_INPUT_COUNT)
+      : null;
+  const networkFeeBtc =
+    networkFeeSats !== null ? satoshiToBtcNumber(networkFeeSats) : null;
+  const youReceiveSats =
+    amountSats !== null && networkFeeSats !== null
+      ? amountSats - networkFeeSats
+      : null;
+  // Clamped so a fee above the reserve doesn't render a negative figure;
+  // confirm is gated by the dust check below.
+  const youReceiveBtc =
+    youReceiveSats !== null
+      ? satoshiToBtcNumber(youReceiveSats > 0n ? youReceiveSats : 0n)
+      : null;
+
+  const isDust = youReceiveSats !== null && youReceiveSats <= DUST_LIMIT_SATS;
+
+  // Mirror the SDK's two caps so the user can never confirm a fee the SDK is
+  // about to reject, which would dead-end the modal after a wallet prompt.
+  //
+  // > The fee-fraction basis here is the swept reserve itself, not the vault
+  // > deposit. That is why these constants differ from the refund's — a 10%
+  // > cap on ~33k sats would block every reclaim above roughly 25 sat/vB. The
+  // > matching note is on the SDK constants; do not align the two.
+  const exceedsRateCap =
+    feeRate !== null && feeRate > RECLAIM_MAX_FEE_RATE_SATS_VB;
+  const maxFeeByFractionSats =
+    amountSats !== null
+      ? (amountSats * RECLAIM_MAX_FEE_FRACTION_NUMERATOR) /
+        RECLAIM_MAX_FEE_FRACTION_DENOMINATOR
+      : null;
+  const exceedsFractionCap =
+    networkFeeSats !== null &&
+    maxFeeByFractionSats !== null &&
+    networkFeeSats > maxFeeByFractionSats;
+
+  // Between the warn and block thresholds the reclaim still goes through — the
+  // depositor may reasonably prefer paying now over waiting for cheaper fees.
+  const warnFeeThresholdSats =
+    amountSats !== null
+      ? (amountSats * RECLAIM_WARN_FEE_FRACTION_NUMERATOR) /
+        RECLAIM_MAX_FEE_FRACTION_DENOMINATOR
+      : null;
+  const isExpensive =
+    !exceedsFractionCap &&
+    networkFeeSats !== null &&
+    warnFeeThresholdSats !== null &&
+    networkFeeSats > warnFeeThresholdSats;
+
+  const canConfirm =
+    !reclaiming &&
+    !walletLocked &&
+    feeRate !== null &&
+    feeRate > 0 &&
+    youReceiveSats !== null &&
+    !isDust &&
+    !exceedsRateCap &&
+    !exceedsFractionCap &&
+    !usingFallback;
+
+  const capPercent = Number(
+    (RECLAIM_MAX_FEE_FRACTION_NUMERATOR * 100n) /
+      RECLAIM_MAX_FEE_FRACTION_DENOMINATOR,
+  );
+  const warnPercent = Number(
+    (RECLAIM_WARN_FEE_FRACTION_NUMERATOR * 100n) /
+      RECLAIM_MAX_FEE_FRACTION_DENOMINATOR,
+  );
+
+  const feeCapMessage = exceedsRateCap
+    ? COPY.reclaim.review.feeRateCapError(RECLAIM_MAX_FEE_RATE_SATS_VB)
+    : exceedsFractionCap
+      ? COPY.reclaim.review.feeFractionCapError(capPercent)
+      : null;
+
+  const handleConfirmClick = () => {
+    if (feeRate === null || feeRate <= 0) return;
+    onConfirm(feeRate);
+  };
+
+  return (
+    <div className="mx-auto w-full max-w-[540px]">
+      <div className="rounded-t-2xl border border-b-0 border-secondary-strokeLight bg-surface p-6">
+        <div className="flex flex-col gap-2">
+          <Heading variant="h5" className="text-accent-primary">
+            {COPY.reclaim.review.heading}
+          </Heading>
+          <p className="text-sm leading-[1.43] tracking-[0.17px] text-accent-secondary">
+            {COPY.reclaim.review.description}
+          </p>
+        </div>
+      </div>
+
+      <div className="rounded-b-2xl border border-secondary-strokeLight bg-surface p-6">
+        <div className="flex flex-col gap-6">
+          <ReviewDetailRow
+            label={COPY.reclaim.review.reclaimAmount}
+            // Whole sats, matching the row: ~33k sats reads as "0.00033 BTC"
+            // and loses all shape.
+            value={
+              amountSats !== null
+                ? COPY.reclaim.rowAmount(formatSats(amountSats))
+                : "—"
+            }
+            secondaryValue={
+              amountBtc !== null && btcPriceUSD > 0
+                ? `${formatUsd(amountBtc * btcPriceUSD)} USD`
+                : undefined
+            }
+          />
+
+          <ReviewDetailRow
+            label={COPY.reclaim.review.networkFeeRate}
+            value={
+              feeRate !== null ? (
+                <FeeRateField
+                  value={feeRate}
+                  onChange={handleFeeRateChange}
+                  disabled={reclaiming}
+                />
+              ) : (
+                <span className="text-base text-accent-secondary">—</span>
+              )
+            }
+          />
+
+          <ReviewDetailRow
+            label={COPY.reclaim.review.btcNetworkFee}
+            value={
+              networkFeeSats !== null
+                ? COPY.reclaim.rowAmount(formatSats(networkFeeSats))
+                : "—"
+            }
+            secondaryValue={
+              networkFeeBtc !== null && btcPriceUSD > 0
+                ? `${formatUsd(networkFeeBtc * btcPriceUSD)} USD`
+                : undefined
+            }
+          />
+
+          <div className="my-1 border-t border-secondary-strokeLight" />
+
+          <ReviewDetailRow
+            label={COPY.reclaim.review.youReceive}
+            value={
+              youReceiveBtc !== null
+                ? `${formatBtcValue(youReceiveBtc)} ${symbol}`
+                : "—"
+            }
+            secondaryValue={
+              youReceiveBtc !== null && btcPriceUSD > 0
+                ? `${formatUsd(youReceiveBtc * btcPriceUSD)} USD`
+                : undefined
+            }
+          />
+
+          {walletLocked && (
+            <Callout variant="error" title={COPY.wallet.locked.title}>
+              {COPY.wallet.locked.description}
+            </Callout>
+          )}
+          {previewError && <Callout variant="error">{previewError}</Callout>}
+          {!error && !isDust && usingFallback && (
+            <Callout variant="warning">
+              {COPY.reclaim.review.fallbackFeeWarning}
+            </Callout>
+          )}
+          {!error && isDust && (
+            <Callout variant="error">{COPY.reclaim.review.dustError}</Callout>
+          )}
+          {!error && !isDust && feeCapMessage && (
+            <Callout variant="error">{feeCapMessage}</Callout>
+          )}
+          {!error && !isDust && !feeCapMessage && isExpensive && (
+            <Callout variant="warning">
+              {COPY.reclaim.review.feeFractionWarning(warnPercent)}
+            </Callout>
+          )}
+          {error && <Callout variant="error">{error}</Callout>}
+
+          <Button
+            variant="contained"
+            color="secondary"
+            className="w-full"
+            onClick={handleConfirmClick}
+            disabled={!canConfirm}
+            data-testid="reclaim-confirm-button"
+          >
+            {reclaiming ? (
+              <span className="flex items-center justify-center gap-2">
+                <Loader size={16} className="text-accent-contrast" />
+                <span>{COPY.common.confirming}</span>
+              </span>
+            ) : error ? (
+              COPY.reclaim.review.retryButton
+            ) : (
+              COPY.reclaim.review.confirmButton
+            )}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/services/vault/src/components/deposit/ReclaimModal/ReclaimSuccessContent.tsx
+++ b/services/vault/src/components/deposit/ReclaimModal/ReclaimSuccessContent.tsx
@@ -1,0 +1,69 @@
+import { Button, Heading, Text } from "@babylonlabs-io/core-ui";
+
+import { getNetworkConfigBTC } from "@/config";
+import { COPY } from "@/copy";
+import { getBtcExplorerTxUrl } from "@/utils/explorer";
+import { formatSats } from "@/utils/formatting";
+
+const btcConfig = getNetworkConfigBTC();
+
+interface ReclaimSuccessContentProps {
+  reclaimTxId: string;
+  /** Gross reserve swept, for the confirmation sentence. */
+  amountSats: bigint | null;
+  onDone: () => void;
+}
+
+export function ReclaimSuccessContent({
+  reclaimTxId,
+  amountSats,
+  onDone,
+}: ReclaimSuccessContentProps) {
+  const explorerUrl = getBtcExplorerTxUrl(reclaimTxId);
+
+  return (
+    <div className="mx-auto flex w-full max-w-[564px] flex-col gap-10 rounded-3xl border border-secondary-strokeLight bg-surface px-6 pb-6 pt-10 dark:border-secondary-strokeDark">
+      <div className="flex flex-col items-center gap-6">
+        <img
+          src={btcConfig.icon}
+          alt={btcConfig.name}
+          className="h-[100px] w-[100px]"
+        />
+        <div className="flex w-full flex-col items-center gap-4 text-center">
+          <Heading variant="h5" className="text-accent-primary">
+            {COPY.reclaim.success.heading}
+          </Heading>
+          <Text variant="body1" className="text-accent-secondary">
+            {COPY.reclaim.success.body(
+              amountSats !== null
+                ? COPY.reclaim.rowAmount(formatSats(amountSats))
+                : COPY.reclaim.success.amountFallback,
+            )}
+          </Text>
+        </div>
+      </div>
+
+      <div className="flex w-full gap-4">
+        <Button
+          variant="outlined"
+          color="primary"
+          className="flex-1 whitespace-nowrap !border-secondary-strokeLight"
+          onClick={() => {
+            window.open(explorerUrl, "_blank", "noopener,noreferrer");
+          }}
+        >
+          {COPY.reclaim.success.explorerButton}
+        </Button>
+        <Button
+          variant="contained"
+          color="secondary"
+          className="flex-1 whitespace-nowrap"
+          onClick={onDone}
+          data-testid="reclaim-done-button"
+        >
+          {COPY.reclaim.success.doneButton}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/services/vault/src/components/deposit/ReclaimModal/__tests__/ReclaimModal.test.tsx
+++ b/services/vault/src/components/deposit/ReclaimModal/__tests__/ReclaimModal.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { type ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -53,20 +53,22 @@ const ACTIVITY = {
   providers: [],
 } as unknown as VaultActivity;
 
-function renderModal() {
+function renderModal(onBroadcast = vi.fn()) {
   const client = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
-  return render(
+  const result = render(
     <QueryClientProvider client={client}>
       <ReclaimModal
         open
         activity={ACTIVITY}
         onClose={vi.fn()}
         onSuccess={vi.fn()}
+        onBroadcast={onBroadcast}
       />
     </QueryClientProvider>,
   );
+  return { ...result, onBroadcast };
 }
 
 function mockReclaimState(overrides: Record<string, unknown> = {}) {
@@ -135,6 +137,27 @@ describe("ReclaimModal", () => {
     expect(
       await screen.findByText(COPY.reclaim.alreadySettled.heading),
     ).toBeInTheDocument();
+  });
+
+  it("marks the vault in flight only after this session broadcast a sweep", async () => {
+    mockReclaimState({ reclaimTxId: "deadbeef" });
+    const { onBroadcast } = renderModal();
+
+    fireEvent.click(await screen.findByTestId("reclaim-done-button"));
+
+    expect(onBroadcast).toHaveBeenCalledWith(ACTIVITY.id);
+  });
+
+  it("does not mark the vault in flight when the reserve was already spent", async () => {
+    // Someone else's sweep — claiming it as this session's in-flight reclaim
+    // would make the row show "Reclaiming" for work it did not do.
+    mockReclaimState({ alreadySettled: true });
+    const { onBroadcast } = renderModal();
+
+    await screen.findByText(COPY.reclaim.alreadySettled.heading);
+    fireEvent.click(screen.getByText(COPY.reclaim.alreadySettled.doneButton));
+
+    expect(onBroadcast).not.toHaveBeenCalled();
   });
 
   it("surfaces a preview failure on the review screen rather than blocking it", async () => {

--- a/services/vault/src/components/deposit/ReclaimModal/__tests__/ReclaimModal.test.tsx
+++ b/services/vault/src/components/deposit/ReclaimModal/__tests__/ReclaimModal.test.tsx
@@ -1,0 +1,148 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import { type ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { COPY } from "@/copy";
+import { useReclaimState } from "@/hooks/deposit/useReclaimState";
+import {
+  ReclaimAlreadySettledError,
+  getReclaimPreview,
+} from "@/services/vault/vaultReclaimService";
+import type { VaultActivity } from "@/types/activity";
+
+import { ReclaimModal } from "../index";
+
+// The shared v3 shell renders the app top bar, whose graph reaches
+// wallet-connector and can't be transformed here. This suite is about the
+// reclaim content inside it.
+vi.mock("@/components/shared/V3ModalShell", () => ({
+  V3ModalShell: ({ open, children }: { open: boolean; children: ReactNode }) =>
+    open ? <div>{children}</div> : null,
+}));
+
+vi.mock("@/services/vault/vaultReclaimService", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("@/services/vault/vaultReclaimService")
+    >();
+  return { ...actual, getReclaimPreview: vi.fn() };
+});
+
+vi.mock("@/hooks/deposit/useReclaimState", () => ({
+  useReclaimState: vi.fn(),
+}));
+
+vi.mock("@/clients/eth-contract/chainlink", () => ({
+  getTokenPrices: vi.fn(async () => ({
+    prices: { BTC: 50_000 },
+    metadata: { BTC: { isStale: false, fetchFailed: false } },
+  })),
+}));
+
+// The review screen reads the BTC wallet-lock state to gate confirm; the real
+// module's graph reaches wallet-connector and can't be transformed here.
+const mockBtcWalletState = vi.hoisted(() => ({ locked: false }));
+vi.mock("@/context/wallet", () => ({
+  useBTCWallet: () => mockBtcWalletState,
+}));
+
+const ACTIVITY = {
+  id: "0xvault",
+  collateral: { amount: "0.6", symbol: "BTC" },
+  providers: [],
+} as unknown as VaultActivity;
+
+function renderModal() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <ReclaimModal
+        open
+        activity={ACTIVITY}
+        onClose={vi.fn()}
+        onSuccess={vi.fn()}
+      />
+    </QueryClientProvider>,
+  );
+}
+
+function mockReclaimState(overrides: Record<string, unknown> = {}) {
+  vi.mocked(useReclaimState).mockReturnValue({
+    reclaiming: false,
+    reclaimTxId: null,
+    alreadySettled: false,
+    error: null,
+    handleReclaim: vi.fn(),
+    ...overrides,
+  } as ReturnType<typeof useReclaimState>);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockReclaimState();
+  vi.mocked(getReclaimPreview).mockResolvedValue({
+    reclaimableSats: 33_000n,
+    halfHourFeeSatsVb: 5,
+    peginTxid: "abc",
+  });
+});
+
+describe("ReclaimModal", () => {
+  it("shows the review screen once the preview resolves", async () => {
+    renderModal();
+
+    expect(
+      await screen.findByText(COPY.reclaim.review.heading),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(COPY.reclaim.review.description),
+    ).toBeInTheDocument();
+  });
+
+  it("shows the reserve amount in whole sats", async () => {
+    renderModal();
+
+    expect(await screen.findByText("33,000 sats")).toBeInTheDocument();
+  });
+
+  it("shows the success screen once a reclaim txid exists", async () => {
+    mockReclaimState({ reclaimTxId: "deadbeef" });
+    renderModal();
+
+    expect(
+      await screen.findByText(COPY.reclaim.success.heading),
+    ).toBeInTheDocument();
+  });
+
+  it("shows the already-settled screen when the sweep raced another device", async () => {
+    mockReclaimState({ alreadySettled: true });
+    renderModal();
+
+    expect(
+      await screen.findByText(COPY.reclaim.alreadySettled.heading),
+    ).toBeInTheDocument();
+  });
+
+  it("shows the already-settled screen when the preview finds the reserve spent", async () => {
+    vi.mocked(getReclaimPreview).mockRejectedValue(
+      new ReclaimAlreadySettledError(),
+    );
+    renderModal();
+
+    expect(
+      await screen.findByText(COPY.reclaim.alreadySettled.heading),
+    ).toBeInTheDocument();
+  });
+
+  it("surfaces a preview failure on the review screen rather than blocking it", async () => {
+    vi.mocked(getReclaimPreview).mockRejectedValue(new Error("indexer down"));
+    renderModal();
+
+    await waitFor(() => {
+      expect(screen.getByText("indexer down")).toBeInTheDocument();
+    });
+  });
+});

--- a/services/vault/src/components/deposit/ReclaimModal/index.tsx
+++ b/services/vault/src/components/deposit/ReclaimModal/index.tsx
@@ -1,0 +1,124 @@
+import { Loader } from "@babylonlabs-io/core-ui";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useCallback } from "react";
+
+import { V3ModalShell } from "@/components/shared/V3ModalShell";
+import { useReclaimState } from "@/hooks/deposit/useReclaimState";
+import { RECLAIM_STATUS_QUERY_KEY } from "@/hooks/useReclaimStatus";
+import {
+  ReclaimAlreadySettledError,
+  getReclaimPreview,
+} from "@/services/vault/vaultReclaimService";
+import type { VaultActivity } from "@/types/activity";
+
+import { ReclaimAlreadySettledContent } from "./ReclaimAlreadySettledContent";
+import { ReclaimReviewContent } from "./ReclaimReviewContent";
+import { ReclaimSuccessContent } from "./ReclaimSuccessContent";
+
+interface ReclaimModalProps {
+  open: boolean;
+  activity: VaultActivity;
+  onClose: () => void;
+  onSuccess: () => void;
+}
+
+const RECLAIM_PREVIEW_QUERY_KEY = "RECLAIM_PREVIEW";
+
+export function ReclaimModal({
+  open,
+  activity,
+  onClose,
+  onSuccess,
+}: ReclaimModalProps) {
+  const { reclaiming, reclaimTxId, alreadySettled, error, handleReclaim } =
+    useReclaimState({ activity });
+  const queryClient = useQueryClient();
+
+  // The reserve poll carries a 55s staleTime, so without this the row would
+  // sit on cached "unspent" data after the sweep. The in-session in-flight
+  // marker already disables the button; this makes the next tick fetch fresh
+  // so the row can settle back to its plain state as soon as the sweep mines.
+  const handleDone = useCallback(() => {
+    queryClient.invalidateQueries({ queryKey: [RECLAIM_STATUS_QUERY_KEY] });
+    onSuccess();
+    onClose();
+  }, [queryClient, onSuccess, onClose]);
+
+  const previewQuery = useQuery({
+    queryKey: [RECLAIM_PREVIEW_QUERY_KEY, activity.id],
+    queryFn: () => getReclaimPreview(activity.id),
+    enabled: open && !reclaimTxId,
+    retry: false,
+    // No staleTime: refetch on every open. The reserve's spend status can flip
+    // from another device between openings, and caching a stale "unspent"
+    // would send the user into a doomed wallet prompt. The fetch is cheap.
+  });
+
+  const previewAmountSats = previewQuery.data?.reclaimableSats ?? null;
+
+  // The reserve was already spent — either found by the preview probe or hit
+  // at broadcast. Same resolved outcome either way.
+  const settledDuringPreview =
+    previewQuery.error instanceof ReclaimAlreadySettledError;
+
+  const previewError =
+    previewQuery.error && !settledDuringPreview
+      ? previewQuery.error instanceof Error
+        ? previewQuery.error.message
+        : "Failed to load reclaim preview"
+      : null;
+
+  // Fire onSuccess only once the user acknowledges, so the parent refetch
+  // doesn't race the success screen.
+  if (reclaimTxId) {
+    return (
+      <V3ModalShell open={open} onClose={handleDone}>
+        <ReclaimSuccessContent
+          reclaimTxId={reclaimTxId}
+          amountSats={previewAmountSats}
+          onDone={handleDone}
+        />
+      </V3ModalShell>
+    );
+  }
+
+  if (alreadySettled || settledDuringPreview) {
+    return (
+      <V3ModalShell open={open} onClose={handleDone}>
+        <ReclaimAlreadySettledContent onClose={handleDone} />
+      </V3ModalShell>
+    );
+  }
+
+  // Hold a neutral loading state until the preview resolves — rendering the
+  // review form before the amount and fee rate are known would flash a screen
+  // full of em-dashes.
+  if (previewQuery.isLoading) {
+    return (
+      // The shell stretches its content box to full width; the spinner is a
+      // fixed-size inline element, so it needs centering of its own.
+      <V3ModalShell
+        open={open}
+        onClose={onClose}
+        contentClassName="flex justify-center"
+      >
+        <Loader />
+      </V3ModalShell>
+    );
+  }
+
+  // Close is blocked while a broadcast is in flight so the dialog cannot be
+  // dismissed mid-signing.
+  return (
+    <V3ModalShell open={open} onClose={reclaiming ? undefined : onClose}>
+      <ReclaimReviewContent
+        amountSats={previewAmountSats}
+        defaultFeeRateSatsVb={previewQuery.data?.halfHourFeeSatsVb ?? null}
+        previewError={previewError}
+        reclaiming={reclaiming}
+        error={error}
+        onConfirm={handleReclaim}
+      />
+    </V3ModalShell>
+  );
+}

--- a/services/vault/src/components/deposit/ReclaimModal/index.tsx
+++ b/services/vault/src/components/deposit/ReclaimModal/index.tsx
@@ -20,6 +20,11 @@ interface ReclaimModalProps {
   activity: VaultActivity;
   onClose: () => void;
   onSuccess: () => void;
+  /**
+   * Called once, only when this session actually broadcast a sweep. Not called
+   * on the already-settled path — that reserve was spent by someone else.
+   */
+  onBroadcast: (vaultId: string) => void;
 }
 
 const RECLAIM_PREVIEW_QUERY_KEY = "RECLAIM_PREVIEW";
@@ -29,6 +34,7 @@ export function ReclaimModal({
   activity,
   onClose,
   onSuccess,
+  onBroadcast,
 }: ReclaimModalProps) {
   const { reclaiming, reclaimTxId, alreadySettled, error, handleReclaim } =
     useReclaimState({ activity });
@@ -71,12 +77,16 @@ export function ReclaimModal({
   // Fire onSuccess only once the user acknowledges, so the parent refetch
   // doesn't race the success screen.
   if (reclaimTxId) {
+    const handleBroadcastDone = () => {
+      onBroadcast(activity.id);
+      handleDone();
+    };
     return (
-      <V3ModalShell open={open} onClose={handleDone}>
+      <V3ModalShell open={open} onClose={handleBroadcastDone}>
         <ReclaimSuccessContent
           reclaimTxId={reclaimTxId}
           amountSats={previewAmountSats}
-          onDone={handleDone}
+          onDone={handleBroadcastDone}
         />
       </V3ModalShell>
     );

--- a/services/vault/src/components/simple/PendingDepositModals.tsx
+++ b/services/vault/src/components/simple/PendingDepositModals.tsx
@@ -38,6 +38,7 @@ interface RefundModalState {
 interface ReclaimModalState {
   reclaimingActivity: VaultActivity | null;
   handleClose: () => void;
+  handleBroadcast: (vaultId: string) => void;
   handleSuccess: () => void;
 }
 
@@ -97,6 +98,7 @@ export function PendingDepositModals({
           activity={reclaimModal.reclaimingActivity}
           onClose={reclaimModal.handleClose}
           onSuccess={reclaimModal.handleSuccess}
+          onBroadcast={reclaimModal.handleBroadcast}
         />
       )}
 

--- a/services/vault/src/components/simple/PendingDepositModals.tsx
+++ b/services/vault/src/components/simple/PendingDepositModals.tsx
@@ -1,17 +1,18 @@
 /**
  * PendingDepositModals Component
  *
- * Renders the broadcast + refund + emergency-withdraw + success modals used
- * by the pending deposit section. The shared Pre-PegIn broadcast keeps a
- * dedicated modal (it's hoisted to a batch-level button); the recovery escape
- * hatches (HTLC refund, activate-and-redeem withdraw) each own a dedicated
- * modal; every other per-vault action (WOTS, payout signing, activation,
+ * Renders the broadcast + refund + reclaim + emergency-withdraw + success
+ * modals used by the pending deposit section. The shared Pre-PegIn broadcast
+ * keeps a dedicated modal (it's hoisted to a batch-level button); the recovery
+ * escape hatches (HTLC refund, depositor-claim reclaim, activate-and-redeem
+ * withdraw) each own a dedicated modal; every other per-vault action (WOTS, payout signing, activation,
  * artifact download) is owned by the deposit multistepper opened from the
  * card body.
  */
 
 import { BroadcastSuccessModal } from "@/components/deposit/BroadcastSuccessModal";
 import { EmergencyWithdrawModal } from "@/components/deposit/EmergencyWithdrawModal";
+import { ReclaimModal } from "@/components/deposit/ReclaimModal";
 import { RefundModal } from "@/components/deposit/RefundModal";
 import type { VaultActivity } from "@/types/activity";
 
@@ -34,6 +35,12 @@ interface RefundModalState {
   handleSuccess: () => void;
 }
 
+interface ReclaimModalState {
+  reclaimingActivity: VaultActivity | null;
+  handleClose: () => void;
+  handleSuccess: () => void;
+}
+
 interface EmergencyWithdrawModalState {
   withdrawing: {
     activity: VaultActivity;
@@ -46,6 +53,7 @@ interface EmergencyWithdrawModalState {
 interface PendingDepositModalsProps {
   broadcastModal: BroadcastModalState;
   refundModal: RefundModalState;
+  reclaimModal: ReclaimModalState;
   emergencyWithdrawModal: EmergencyWithdrawModalState;
   ethAddress: string | undefined;
 }
@@ -53,6 +61,7 @@ interface PendingDepositModalsProps {
 export function PendingDepositModals({
   broadcastModal,
   refundModal,
+  reclaimModal,
   emergencyWithdrawModal,
   ethAddress,
 }: PendingDepositModalsProps) {
@@ -78,6 +87,16 @@ export function PendingDepositModals({
           activity={refundModal.refundingActivity}
           onClose={refundModal.handleClose}
           onSuccess={refundModal.handleSuccess}
+        />
+      )}
+
+      {/* Reclaim Modal (depositor-claim reserve sweep, post-settlement) */}
+      {reclaimModal.reclaimingActivity && (
+        <ReclaimModal
+          open={!!reclaimModal.reclaimingActivity}
+          activity={reclaimModal.reclaimingActivity}
+          onClose={reclaimModal.handleClose}
+          onSuccess={reclaimModal.handleSuccess}
         />
       )}
 

--- a/services/vault/src/components/vaults/VaultsLifecycleSections.tsx
+++ b/services/vault/src/components/vaults/VaultsLifecycleSections.tsx
@@ -68,6 +68,20 @@ import { formatSats } from "@/utils/formatting";
 /** Step-progress bar fill — the pending amber, matching the status dot. */
 const PROGRESS_FILL_COLOR = "rgb(var(--risk-amber))";
 
+/**
+ * Real-wallet E2E hook for the reclaim action (e2e/real/actions/reclaim.ts).
+ * Shared by the enabled and in-flight renders so the harness finds the control
+ * in either state — carry it over if you move or rename the element.
+ */
+const RECLAIM_BUTTON_TEST_ID = "vault-reclaim-button";
+
+/**
+ * Reserve-figure cell width. Sits outside the fixed action slot, whose basis is
+ * what keeps every row's columns aligned, so it needs a width of its own; 82px
+ * is the design's, and fits "999,999 sats" at `text-sm`.
+ */
+const RECLAIM_METRIC_COLUMN_CLASS = "w-[82px]";
+
 /** Dot color per display variant. Danger keeps the error red explicitly —
  *  there is no "no dot" state in this compact row layout (v2's cards swap in
  *  a warning icon instead). */
@@ -427,7 +441,7 @@ function InactiveRow({
           columns aligned, and the design's amount + button pair is wider than
           that basis. Rendered on every inactive row — empty for refund rows —
           so both row kinds still line up. */}
-      <div className="flex w-[82px] shrink-0 flex-col">
+      <div className={`flex shrink-0 flex-col ${RECLAIM_METRIC_COLUMN_CLASS}`}>
         {reclaimableSats !== null && (
           <>
             <span className="text-sm leading-[1.43] tracking-[0.17px] text-accent-primary">
@@ -467,7 +481,7 @@ function InactiveRow({
             type="button"
             onClick={() => onReclaim(activity.id)}
             className={NEUTRAL_ROW_BUTTON_CLASS}
-            data-testid="vault-reclaim-button"
+            data-testid={RECLAIM_BUTTON_TEST_ID}
           >
             {COPY.reclaim.rowButton}
           </button>
@@ -480,7 +494,7 @@ function InactiveRow({
             type="button"
             disabled
             className={NEUTRAL_ROW_BUTTON_CLASS}
-            data-testid="vault-reclaim-button"
+            data-testid={RECLAIM_BUTTON_TEST_ID}
           >
             {COPY.reclaim.rowButton}
           </button>

--- a/services/vault/src/components/vaults/VaultsLifecycleSections.tsx
+++ b/services/vault/src/components/vaults/VaultsLifecycleSections.tsx
@@ -16,7 +16,7 @@
  */
 
 import { Heading, Hint, InfoIcon, Loader } from "@babylonlabs-io/core-ui";
-import { type ReactNode, useCallback, useState } from "react";
+import { useCallback, useMemo, useState, type ReactNode } from "react";
 import type { Address, Hex } from "viem";
 
 import { ApplicationLogo } from "@/components/ApplicationLogo";
@@ -46,8 +46,11 @@ import { PostDepositContinuationContent } from "@/components/simple/PostDepositC
 import { ProtocolParamsProvider } from "@/context/ProtocolParamsContext";
 import { useDepositPollingResult } from "@/context/deposit/PeginPollingContext";
 import { COPY } from "@/copy";
+import { useReclaimRowAction } from "@/hooks/deposit/useReclaimRowAction";
 import { useRefundRowAction } from "@/hooks/deposit/useRefundRowAction";
 import type { usePendingDeposits } from "@/hooks/usePendingDeposits";
+import { useReclaimStatus, type ReclaimStatus } from "@/hooks/useReclaimStatus";
+import { useReclaimVaultChainData } from "@/hooks/useReclaimVaultChainData";
 import {
   canPerformAction,
   getPeginDisplayStep,
@@ -60,6 +63,7 @@ import type { VaultProvider } from "@/types/vaultProvider";
 import { truncateHash } from "@/utils/addressUtils";
 import { getBatchSiblings } from "@/utils/batchedPegin";
 import { getBtcExplorerTxUrl } from "@/utils/explorer";
+import { formatSats } from "@/utils/formatting";
 
 /** Step-progress bar fill — the pending amber, matching the status dot. */
 const PROGRESS_FILL_COLOR = "rgb(var(--risk-amber))";
@@ -292,10 +296,21 @@ function InactiveRow({
   activity,
   vaultProviders,
   onRefund,
+  onReclaim,
+  reclaimStatus,
+  reclaimTipHeight,
+  reclaimOnChainStatus,
+  isReclaimInFlight,
 }: {
   activity: VaultActivity;
   vaultProviders: VaultProvider[];
   onRefund: (depositId: string) => void;
+  onReclaim: (depositId: string) => void;
+  /** Reserve state from the section's batched poll; undefined for expired rows. */
+  reclaimStatus: ReclaimStatus | undefined;
+  reclaimTipHeight: number | undefined;
+  reclaimOnChainStatus: number | undefined;
+  isReclaimInFlight: boolean;
 }) {
   const result = useDepositPollingResult(activity.id);
   const provider = findProvider(vaultProviders, activity.providers[0]?.id);
@@ -308,6 +323,30 @@ function InactiveRow({
   const { available: isRefundAvailable, blockedTooltip } = useRefundRowAction(
     activity.id,
   );
+  // Refund and reclaim are mutually exclusive by contract status — refund
+  // applies to EXPIRED vaults (no PegIn was ever broadcast), reclaim to
+  // DEPOSITOR_WITHDRAWN ones (the PegIn confirmed and the peg-out settled). A
+  // row therefore never carries both actions.
+  const {
+    available: isReclaimAvailable,
+    reclaiming: isReclaiming,
+    blockedTooltip: reclaimBlockedTooltip,
+    reclaimableSats,
+  } = useReclaimRowAction({
+    status: reclaimStatus,
+    tipHeight: reclaimTipHeight,
+    onChainStatus: reclaimOnChainStatus,
+    depositorBtcPubkey: activity.depositorBtcPubkey,
+    isReclaimInFlight,
+  });
+
+  // While a sweep is in flight the status cell reports the reserve action
+  // rather than the vault's own lifecycle state, the same way the refund path
+  // shows "Refunding" over an expired vault's label. It reverts to the vault's
+  // own label ("Redeemed") once the sweep confirms.
+  const statusLabel = isReclaiming
+    ? COPY.reclaim.rowStatusReclaiming
+    : peginState?.displayLabel;
 
   // Pre-PegIn first: an expired deposit never activated, so the Pre-PegIn tx
   // is the one that exists (active rows prefer the opposite).
@@ -342,9 +381,11 @@ function InactiveRow({
               className={`size-3 rounded-full ${DOT_CLASS[peginState.displayVariant]}`}
             />
             <span className="text-sm leading-[1.43] tracking-[0.17px] text-accent-primary">
-              {peginState.displayLabel}
+              {statusLabel}
             </span>
-            {peginState.message && (
+            {/* The vault's own hint describes its lifecycle state, which is not
+                what the cell is reporting while a sweep is in flight. */}
+            {!isReclaiming && peginState.message && (
               <Hint
                 tooltip={peginState.message}
                 icon={<InfoIcon size={16} className="text-accent-secondary" />}
@@ -381,7 +422,25 @@ function InactiveRow({
         )}
       </div>
 
-      {/* Reserved even when the refund is neither available nor blocked, so an
+      {/* Reclaimable reserve figure, sitting left of the action slot rather
+          than inside it: the slot's fixed basis is what keeps every row's
+          columns aligned, and the design's amount + button pair is wider than
+          that basis. Rendered on every inactive row — empty for refund rows —
+          so both row kinds still line up. */}
+      <div className="flex w-[82px] shrink-0 flex-col">
+        {reclaimableSats !== null && (
+          <>
+            <span className="text-sm leading-[1.43] tracking-[0.17px] text-accent-primary">
+              {COPY.reclaim.rowAmount(formatSats(reclaimableSats))}
+            </span>
+            <span className="text-xs leading-[1.4] tracking-[0.4px] text-accent-secondary">
+              {COPY.reclaim.rowMetricLabel}
+            </span>
+          </>
+        )}
+      </div>
+
+      {/* Reserved even when neither action is available nor blocked, so an
           actionless row still aligns with the rows that carry a button. */}
       <div className={LIST_ROW_ACTION_SLOT_CLASS}>
         {isRefundAvailable && (
@@ -397,6 +456,39 @@ function InactiveRow({
           <Hint tooltip={blockedTooltip} attachToChildren>
             <button type="button" disabled className={NEUTRAL_ROW_BUTTON_CLASS}>
               {COPY.vaults.actions.withdraw}
+            </button>
+          </Hint>
+        )}
+        {isReclaimAvailable && (
+          // This control's data-testid is a real-wallet E2E hook
+          // (e2e/real/actions/reclaim.ts) — carry it over if you move or
+          // rename the element.
+          <button
+            type="button"
+            onClick={() => onReclaim(activity.id)}
+            className={NEUTRAL_ROW_BUTTON_CLASS}
+            data-testid="vault-reclaim-button"
+          >
+            {COPY.reclaim.rowButton}
+          </button>
+        )}
+        {/* Sweep broadcast, awaiting confirmation. The button stays in place
+            but disabled — re-opening the modal would only reach the
+            "already reclaimed" screen. The status cell carries the "why". */}
+        {isReclaiming && (
+          <button
+            type="button"
+            disabled
+            className={NEUTRAL_ROW_BUTTON_CLASS}
+            data-testid="vault-reclaim-button"
+          >
+            {COPY.reclaim.rowButton}
+          </button>
+        )}
+        {reclaimBlockedTooltip && (
+          <Hint tooltip={reclaimBlockedTooltip} attachToChildren>
+            <button type="button" disabled className={NEUTRAL_ROW_BUTTON_CLASS}>
+              {COPY.reclaim.rowButton}
             </button>
           </Hint>
         )}
@@ -420,16 +512,52 @@ export function VaultsLifecycleSections({
   const {
     pendingActivities,
     expiredActivities,
+    reclaimableCandidates,
     allActivities,
     vaultProviders,
     ethAddress,
     broadcastModal,
     refundModal,
+    reclaimModal,
     emergencyWithdrawModal,
     demo,
   } = deposits;
 
-  const rows = [...pendingActivities, ...expiredActivities];
+  // Contract reads for the settled candidates: the authoritative PegIn txid and
+  // the live on-chain status. Cached long — a settled vault's row is immutable.
+  const candidateVaultIds = useMemo(
+    () => reclaimableCandidates.map((a) => a.id),
+    [reclaimableCandidates],
+  );
+  const reclaimChainData = useReclaimVaultChainData(candidateVaultIds);
+
+  // Bitcoin poll, one batch for the whole section. Only vaults whose contract
+  // read landed are probed — without it the gate fails closed anyway.
+  const reclaimOutpoints = useMemo(
+    () =>
+      reclaimableCandidates
+        .map((activity) => {
+          const chain = reclaimChainData.get(activity.id.toLowerCase());
+          return chain
+            ? { depositId: activity.id as string, peginTxid: chain.peginTxid }
+            : null;
+        })
+        .filter(
+          (o): o is { depositId: string; peginTxid: string } => o !== null,
+        ),
+    [reclaimableCandidates, reclaimChainData],
+  );
+  const { statusByDepositId, tipHeight } = useReclaimStatus(reclaimOutpoints);
+
+  // Settled vaults join the expired ones in the Inactive section rather than
+  // getting a section of their own, so the heading count and action-required
+  // label pick them up unchanged.
+  const inactiveActivities: VaultActivity[] = useMemo(
+    () => [...expiredActivities, ...reclaimableCandidates],
+    [expiredActivities, reclaimableCandidates],
+  );
+
+  const rows = [...pendingActivities, ...inactiveActivities];
 
   const handleOpenDetails = useCallback(
     (depositId: string) => {
@@ -471,6 +599,16 @@ export function VaultsLifecycleSections({
     },
     [allActivities, refundModal, handleOpenDetails],
   );
+  const handleReclaim = useCallback(
+    (depositId: string) => {
+      if (allActivities.some((a) => a.id === depositId)) {
+        reclaimModal.handleReclaimClick(depositId);
+        return;
+      }
+      handleOpenDetails(depositId);
+    },
+    [allActivities, reclaimModal, handleOpenDetails],
+  );
   const handleEmergencyWithdraw = useCallback(
     (depositId: string) => {
       if (allActivities.some((a) => a.id === depositId)) {
@@ -499,6 +637,7 @@ export function VaultsLifecycleSections({
     broadcastModal.broadcastingActivity ||
       broadcastModal.successOpen ||
       refundModal.refundingActivity ||
+      reclaimModal.reclaimingActivity ||
       emergencyWithdrawModal.withdrawing ||
       viewingBatch,
   );
@@ -542,7 +681,7 @@ export function VaultsLifecycleSections({
 
       {children}
 
-      {expiredActivities.length > 0 && (
+      {inactiveActivities.length > 0 && (
         <section className="w-full space-y-3">
           <Heading
             variant="h6"
@@ -551,16 +690,25 @@ export function VaultsLifecycleSections({
           >
             {COPY.vaults.sections.inactiveVaultsTitle}{" "}
             <span className="text-accent-secondary">
-              {COPY.vaults.sections.count(expiredActivities.length)}
+              {COPY.vaults.sections.count(inactiveActivities.length)}
             </span>
           </Heading>
           <div className="space-y-2">
-            {expiredActivities.map((activity) => (
+            {inactiveActivities.map((activity) => (
               <InactiveRow
                 key={activity.id}
                 activity={activity}
                 vaultProviders={vaultProviders}
                 onRefund={handleRefund}
+                onReclaim={handleReclaim}
+                reclaimStatus={statusByDepositId.get(activity.id.toLowerCase())}
+                reclaimTipHeight={tipHeight}
+                reclaimOnChainStatus={
+                  reclaimChainData.get(activity.id.toLowerCase())?.onChainStatus
+                }
+                isReclaimInFlight={reclaimModal.inFlightVaultIds.has(
+                  activity.id.toLowerCase(),
+                )}
               />
             ))}
           </div>
@@ -570,6 +718,7 @@ export function VaultsLifecycleSections({
       <PendingDepositModals
         broadcastModal={broadcastModal}
         refundModal={refundModal}
+        reclaimModal={reclaimModal}
         emergencyWithdrawModal={emergencyWithdrawModal}
         ethAddress={ethAddress}
       />

--- a/services/vault/src/context/wallet/VaultWalletConnectionProvider.tsx
+++ b/services/vault/src/context/wallet/VaultWalletConnectionProvider.tsx
@@ -40,7 +40,12 @@ const ALWAYS_DISABLED_WALLETS: string[] = [
 // Ledger's firmware being final. Opt-in rather than opt-out: the env disable
 // list defaults to empty, so a new provider would otherwise be visible in any
 // environment that has not listed it.
-const LEDGER_VAULT_WALLET_ID = "ledger_btc_vault";
+/**
+ * Wallet id of the Ledger BTC Vault app. Exported because the reclaim flow
+ * gates on it too — the device firmware cannot sign that transaction shape
+ * (see `models/reclaimEligibility`) — and both sites must agree on the id.
+ */
+export const LEDGER_VAULT_WALLET_ID = "ledger_btc_vault";
 
 const DISABLED_WALLETS: string[] = [
   ...ALWAYS_DISABLED_WALLETS,

--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -663,8 +663,13 @@ export const COPY = {
     form: {
       computingAllocation: "Computing allocation...",
       transactionReserveLabel: "Reserve Claimer UTXO",
+      // Describes the real mechanism, and deliberately shares wording with
+      // COPY.reclaim.review.description so the promise made at deposit time
+      // and the action offered after settlement read as the same thing. Until
+      // the reclaim flow shipped this said the reserve "is returned to you if
+      // unused", which nothing in the app could actually do.
       transactionReserveTooltip:
-        "A small portion of your deposit is reserved in a dedicated output to fund a future protocol claim transaction. It remains locked until claim conditions are met and is returned to you if unused.",
+        "A small portion of your deposit is reserved in a dedicated output to fund a future protocol claim transaction. If it goes unused, you can reclaim it from your BTC Vault once the vault has settled.",
       // The depositable maximum is labelled as the balance, with `maxTooltip`
       // explaining the fee buffer / cap adjustments.
       balanceLabel: "Balance",
@@ -1236,6 +1241,79 @@ export const COPY = {
     // anchor to the explorer home; `callout` is the plain lead-in.
     callout:
       "Explore BTC Vault activity, liquidity metrics, and protocol statistics in the",
+  },
+  // Reclaim of the depositor-claim reserve — the ~33k sats every peg-in sets
+  // aside to fund the depositor's own claim transaction. On the happy path the
+  // vault provider claims from its own wallet and the reserve is never spent,
+  // so it is swept back once the vault has terminally settled.
+  //
+  // "Reclaim", never "Withdraw": that word already means the peg-out, the
+  // inactive-row refund, and ACTIVATE_AND_REDEEM. A fourth sense would make
+  // the row labels unreadable.
+  reclaim: {
+    // Row action in the Inactive Vaults section.
+    rowButton: "Reclaim",
+    // Reserve figure on the row. Whole sats rather than BTC — the reserve is
+    // ~33,000 sats, which reads as "0.00033 BTC" and loses all shape.
+    rowAmount: (amount: string) => `${amount} sats`,
+    // Caption under the reclaimable amount on the row.
+    rowMetricLabel: "reclaimable",
+    // Status-cell label while a sweep is broadcast but not yet confirmed.
+    // Replaces the vault's own "Redeemed" for the duration, the same way the
+    // refund path shows "Refunding" before "Refunded".
+    rowStatusReclaiming: "Reclaiming",
+    review: {
+      heading: "Review Reclaim",
+      description:
+        "A small amount of BTC was reserved during peg-in as a fallback for the withdrawal. The reserve was not used and is now available to reclaim.",
+      reclaimAmount: "Reclaim Amount",
+      networkFeeRate: "Network Fee Rate",
+      btcNetworkFee: "BTC Network Fee",
+      youReceive: "You'll receive",
+      fallbackFeeWarning:
+        "Could not fetch the mempool fee rate. The minimum relay fee may not get your reclaim confirmed. Set a fee rate above to continue.",
+      dustError:
+        "Network fee is too high — the reclaimed amount would be below the Bitcoin dust limit. Your reserve is safe where it is; try again when fees are lower.",
+      feeRateCapError: (maxRateSatsVb: number) =>
+        `Network fee rate exceeds the safety cap of ${maxRateSatsVb} sat/vB. Lower the fee rate to continue.`,
+      // The basis here is the reclaimed amount itself, unlike the refund's cap
+      // which is a fraction of the much larger deposit. Say so plainly — the
+      // percentage is of the figure shown directly above it.
+      feeFractionCapError: (percent: number) =>
+        `Network fee would take more than ${percent}% of the reclaimed amount. Your reserve is safe where it is; try again when fees are lower.`,
+      feeFractionWarning: (percent: number) =>
+        `Network fee takes over ${percent}% of the reclaimed amount. You can continue, or wait for lower fees.`,
+      retryButton: "Retry",
+      confirmButton: "Confirm",
+    },
+    success: {
+      heading: "Reclaim submitted",
+      body: (amount: string) =>
+        `Your ${amount} reclaim transaction has been submitted. It may take a few minutes to be confirmed on the Bitcoin network. You'll receive the funds once the transaction is confirmed.`,
+      // Stands in for the amount when the chain read is unavailable at the
+      // moment of success — the sweep still happened, we just can't name the
+      // figure. Reads naturally in the body sentence above.
+      amountFallback: "reserve",
+      explorerButton: "View on blockchain explorer",
+      doneButton: "Done",
+    },
+    // Shown on a disabled row control, explaining why the reclaim is visible
+    // but not performable right now.
+    blocked: {
+      protocolPaused:
+        "Reclaim is paused while the protocol is under maintenance. Your reserve is safe and will remain reclaimable.",
+      // The Ledger vault app's firmware cannot sign this transaction shape.
+      // See models/reclaimEligibility.ts for the firmware reference.
+      ledgerUnsupported:
+        "The Ledger BTC Vault app cannot sign a reclaim yet. Connect the same wallet through another BTC wallet to reclaim your reserve.",
+    },
+    // Terminal state reached while the modal was open — the reserve turned out
+    // to be spent already, typically from another device or session.
+    alreadySettled: {
+      heading: "Reserve already reclaimed",
+      body: "This reserve has already been spent, so there is nothing left to reclaim.",
+      doneButton: "Done",
+    },
   },
   withdraw: {
     // Shared labels (review + initiated screens).

--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -1307,6 +1307,16 @@ export const COPY = {
       ledgerUnsupported:
         "The Ledger BTC Vault app cannot sign a reclaim yet. Connect the same wallet through another BTC wallet to reclaim your reserve.",
     },
+    // Failures surfaced on the review screen's error callout. Kept here rather
+    // than inline in the execution hook so the whole reclaim surface is
+    // editable from one place.
+    errors: {
+      walletNotConnected: "BTC wallet not connected",
+      missingVaultId: "Missing BTC Vault ID",
+      invalidFeeRate: "Fee rate must be a positive number",
+      // Fallback when the failure carries no message of its own.
+      generic: "Reclaim transaction failed",
+    },
     // Terminal state reached while the modal was open — the reserve turned out
     // to be spent already, typically from another device or session.
     alreadySettled: {

--- a/services/vault/src/hooks/deposit/useReclaimModal.ts
+++ b/services/vault/src/hooks/deposit/useReclaimModal.ts
@@ -39,14 +39,19 @@ export function useReclaimModal(options: {
     setReclaimingActivity(null);
   }, []);
 
+  /**
+   * A sweep was broadcast from this session. Separate from {@link handleClose}
+   * on purpose: the modal also reaches a terminal screen when the reserve turns
+   * out to be *already* spent — by another device, or long ago — and marking
+   * that as this session's in-flight reclaim would make the row claim credit
+   * for work it did not do.
+   */
+  const handleBroadcast = useCallback((vaultId: string) => {
+    setInFlightVaultIds((prev) => new Set(prev).add(vaultId.toLowerCase()));
+  }, []);
+
   const handleSuccess = useCallback(() => {
-    setReclaimingActivity((current) => {
-      if (current) {
-        const vaultId = current.id.toLowerCase();
-        setInFlightVaultIds((prev) => new Set(prev).add(vaultId));
-      }
-      return null;
-    });
+    setReclaimingActivity(null);
     onSuccess();
   }, [onSuccess]);
 
@@ -56,6 +61,7 @@ export function useReclaimModal(options: {
     inFlightVaultIds,
     handleReclaimClick,
     handleClose,
+    handleBroadcast,
     handleSuccess,
   };
 }

--- a/services/vault/src/hooks/deposit/useReclaimModal.ts
+++ b/services/vault/src/hooks/deposit/useReclaimModal.ts
@@ -1,0 +1,61 @@
+import { useCallback, useState } from "react";
+
+import type { VaultActivity } from "@/types/activity";
+
+/**
+ * Open/close state for the reclaim review modal. Sibling of `useRefundModal`;
+ * the execution machinery lives in `useReclaimState`.
+ *
+ * Also owns the in-session set of vaults whose sweep this session broadcast.
+ * The reserve poll runs on a 60s tick, so without it a row would keep offering
+ * an enabled Reclaim button for up to a minute after the depositor confirmed.
+ * In-session only, deliberately: the vault is terminal by now and its local
+ * storage entry has been cleared, and a page reload picks the state back up
+ * from the chain read (`spent && !confirmed`) anyway.
+ */
+export function useReclaimModal(options: {
+  allActivities: VaultActivity[];
+  onSuccess: () => void;
+}) {
+  const { allActivities, onSuccess } = options;
+
+  const [reclaimingActivity, setReclaimingActivity] =
+    useState<VaultActivity | null>(null);
+  const [inFlightVaultIds, setInFlightVaultIds] = useState<ReadonlySet<string>>(
+    () => new Set(),
+  );
+
+  const handleReclaimClick = useCallback(
+    (depositId: string) => {
+      const activity = allActivities.find((a) => a.id === depositId);
+      if (activity) {
+        setReclaimingActivity(activity);
+      }
+    },
+    [allActivities],
+  );
+
+  const handleClose = useCallback(() => {
+    setReclaimingActivity(null);
+  }, []);
+
+  const handleSuccess = useCallback(() => {
+    setReclaimingActivity((current) => {
+      if (current) {
+        const vaultId = current.id.toLowerCase();
+        setInFlightVaultIds((prev) => new Set(prev).add(vaultId));
+      }
+      return null;
+    });
+    onSuccess();
+  }, [onSuccess]);
+
+  return {
+    reclaimingActivity,
+    /** Vault ids (lowercased) whose sweep this session broadcast. */
+    inFlightVaultIds,
+    handleReclaimClick,
+    handleClose,
+    handleSuccess,
+  };
+}

--- a/services/vault/src/hooks/deposit/useReclaimRowAction.ts
+++ b/services/vault/src/hooks/deposit/useReclaimRowAction.ts
@@ -1,0 +1,127 @@
+/**
+ * useReclaimRowAction — whether a settled vault's row may offer the reclaim of
+ * its depositor-claim reserve.
+ *
+ * Sibling of `useRefundRowAction`, and the same three-state contract:
+ *
+ *  - `available` — the reclaim can be performed now.
+ *  - `blockedTooltip` — the reclaim is the row's action but is not performable;
+ *    the row shows a disabled control explaining why. Null when the reclaim is
+ *    not this row's action at all, which leaves the row with no action rather
+ *    than a permanently disabled button.
+ *  - `reclaimableSats` — the reserve's value, for the row's figure. Null until
+ *    the chain read lands.
+ *
+ * Refund and reclaim are mutually exclusive by contract status: refund applies
+ * to EXPIRED vaults (no PegIn was ever broadcast), reclaim to
+ * DEPOSITOR_WITHDRAWN ones (the PegIn confirmed and the peg-out settled). A row
+ * never offers both.
+ *
+ * The decision itself lives in `models/reclaimEligibility` — read the warning
+ * there before changing when this is offered.
+ */
+
+import { useChainConnector } from "@babylonlabs-io/wallet-connector";
+import { useMemo } from "react";
+
+import { isWithdrawBlocked } from "@/components/shared/protocolStatus";
+import { useBTCWallet } from "@/context/wallet";
+import { LEDGER_VAULT_WALLET_ID } from "@/context/wallet/VaultWalletConnectionProvider";
+import { useProtocolGateState } from "@/hooks/useProtocolGate";
+import type { ReclaimStatus } from "@/hooks/useReclaimStatus";
+import {
+  getReclaimEligibility,
+  type ReclaimEligibility,
+} from "@/models/reclaimEligibility";
+
+export interface ReclaimRowAction {
+  available: boolean;
+  /** A sweep is broadcast and unconfirmed: show the button, disabled. */
+  reclaiming: boolean;
+  blockedTooltip: string | null;
+  reclaimableSats: bigint | null;
+}
+
+export interface UseReclaimRowActionInput {
+  /** This vault's reserve state from the batched poller. */
+  status: ReclaimStatus | undefined;
+  /** Bitcoin tip height from the same poll. */
+  tipHeight: number | undefined;
+  /** Live `BTCVaultStatus` from the contract. */
+  onChainStatus: number | undefined;
+  /** The vault's depositor BTC pubkey, for the ownership check. */
+  depositorBtcPubkey: string | undefined;
+  /** True while this session's sweep for this vault is not yet observed. */
+  isReclaimInFlight: boolean;
+}
+
+/**
+ * Whether the vault's depositor key is the connected wallet's.
+ *
+ * Deliberately not `isVaultOwnedByWallet` from `utils/vaultWarnings`: that
+ * helper assumes ownership when either key is missing, which is right for a
+ * warning banner and wrong here. This gate fails closed — an unknown key means
+ * no action offered, rather than a button that can only fail at signing.
+ */
+function isOwnedByConnectedWallet(
+  vaultDepositorBtcPubkey: string | undefined,
+  connectedBtcPubkey: string | undefined,
+): boolean {
+  if (!vaultDepositorBtcPubkey || !connectedBtcPubkey) return false;
+  const normalize = (key: string) => key.replace(/^0x/i, "").toLowerCase();
+  return normalize(vaultDepositorBtcPubkey) === normalize(connectedBtcPubkey);
+}
+
+export function useReclaimRowAction({
+  status,
+  tipHeight,
+  onChainStatus,
+  depositorBtcPubkey,
+  isReclaimInFlight,
+}: UseReclaimRowActionInput): ReclaimRowAction {
+  const { publicKeyNoCoord } = useBTCWallet();
+  // The wallet id lives on the connector, not the BTC wallet context — same
+  // accessor `useRefundState` uses.
+  const btcConnector = useChainConnector("BTC");
+  const isLedgerWallet =
+    btcConnector?.connectedWallet?.id === LEDGER_VAULT_WALLET_ID;
+  const isOwnedByWallet = isOwnedByConnectedWallet(
+    depositorBtcPubkey,
+    publicKeyNoCoord,
+  );
+  // Reclaim is an exit, so it follows withdraw's pause semantics.
+  const withdrawBlocked = isWithdrawBlocked(useProtocolGateState());
+
+  const eligibility: ReclaimEligibility = useMemo(
+    () =>
+      getReclaimEligibility({
+        onChainStatus,
+        payoutSpend: status?.payoutSpend,
+        reserveSpend: status?.reserveSpend,
+        tipHeight,
+        isOwnedByWallet,
+        isLedgerWallet,
+        isWithdrawBlocked: withdrawBlocked,
+        isReclaimInFlight,
+      }),
+    [
+      onChainStatus,
+      status,
+      tipHeight,
+      isOwnedByWallet,
+      isLedgerWallet,
+      withdrawBlocked,
+      isReclaimInFlight,
+    ],
+  );
+
+  return {
+    available: eligibility.type === "available",
+    reclaiming: eligibility.type === "reclaiming",
+    blockedTooltip: eligibility.type === "blocked" ? eligibility.tooltip : null,
+    // Only meaningful once the row actually offers something; an absent row
+    // shows no figure.
+    reclaimableSats:
+      eligibility.type === "absent" ? null : (status?.reserveValueSats ?? null),
+  };
+}

--- a/services/vault/src/hooks/deposit/useReclaimState.ts
+++ b/services/vault/src/hooks/deposit/useReclaimState.ts
@@ -1,0 +1,156 @@
+import { useChainConnector } from "@babylonlabs-io/wallet-connector";
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { Hex } from "viem";
+
+import { logger } from "@/infrastructure";
+import {
+  ReclaimAlreadySettledError,
+  buildAndBroadcastReclaimTransaction,
+} from "@/services/vault/vaultReclaimService";
+import type { VaultActivity } from "@/types/activity";
+import {
+  shouldProbeWalletLiveness,
+  verifyBtcWalletLiveness,
+} from "@/utils/btc";
+
+export interface UseReclaimStateProps {
+  activity: VaultActivity;
+}
+
+export interface UseReclaimStateResult {
+  reclaiming: boolean;
+  reclaimTxId: string | null;
+  /** True when the reserve turned out to be already spent. */
+  alreadySettled: boolean;
+  error: string | null;
+  handleReclaim: (feeRate: number) => Promise<void>;
+}
+
+/**
+ * Execution machinery for the reclaim. Sibling of `useRefundState`, minus its
+ * local-storage bookkeeping: the vault is already terminal by the time a
+ * reclaim is offered, so its storage entry has been cleared and there is
+ * nothing to mark. The row disappears on the next poll once the sweep lands.
+ */
+export function useReclaimState({
+  activity,
+}: UseReclaimStateProps): UseReclaimStateResult {
+  const btcConnector = useChainConnector("BTC");
+  const btcWalletProvider = btcConnector?.connectedWallet?.provider;
+  const connectedBtcAddress = btcConnector?.connectedWallet?.account?.address;
+
+  const [reclaiming, setReclaiming] = useState(false);
+  const [reclaimTxId, setReclaimTxId] = useState<string | null>(null);
+  const [alreadySettled, setAlreadySettled] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Synchronous reentrancy guard: `reclaiming` updates async, so rapid
+  // double-confirms before the next render could race two wallet prompts.
+  const inFlightRef = useRef(false);
+  // Abort an in-flight reclaim on unmount (the user closing the modal
+  // mid-prompt). Deferred one tick so StrictMode's mount→cleanup→remount
+  // doesn't kill the controller we just created.
+  const abortRef = useRef<AbortController | null>(null);
+  const pendingAbortRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => {
+    if (pendingAbortRef.current !== null) {
+      clearTimeout(pendingAbortRef.current);
+      pendingAbortRef.current = null;
+    }
+    return () => {
+      pendingAbortRef.current = setTimeout(() => {
+        abortRef.current?.abort();
+        pendingAbortRef.current = null;
+      }, 0);
+    };
+  }, []);
+
+  const { id: vaultId } = activity;
+
+  const handleReclaim = useCallback(
+    async (feeRate: number) => {
+      if (inFlightRef.current || reclaiming) return;
+      inFlightRef.current = true;
+
+      try {
+        if (!btcWalletProvider || !connectedBtcAddress) {
+          setError("BTC wallet not connected");
+          return;
+        }
+        if (!vaultId) {
+          setError("Missing BTC Vault ID");
+          return;
+        }
+        if (!Number.isFinite(feeRate) || feeRate <= 0) {
+          setError("Fee rate must be a positive number");
+          return;
+        }
+
+        setReclaiming(true);
+        setError(null);
+
+        abortRef.current?.abort();
+        abortRef.current = new AbortController();
+
+        try {
+          await verifyBtcWalletLiveness(
+            btcWalletProvider,
+            connectedBtcAddress,
+            {
+              probeConnection: shouldProbeWalletLiveness(
+                btcConnector?.connectedWallet?.id,
+              ),
+            },
+          );
+
+          // The wallet's live key, not the indexer's copy: the SDK re-derives
+          // the claim script from this and aborts if it does not match the
+          // reserve's scriptPubKey, which is what proves this wallet can spend.
+          const depositorBtcPubkey = await btcWalletProvider.getPublicKeyHex();
+
+          const txId = await buildAndBroadcastReclaimTransaction({
+            vaultId: vaultId as Hex,
+            depositorBtcPubkey,
+            feeRate,
+            signPsbt: (psbtHex, opts) =>
+              btcWalletProvider.signPsbt(psbtHex, opts),
+            signal: abortRef.current.signal,
+          });
+          setReclaimTxId(txId);
+          setReclaiming(false);
+        } catch (err) {
+          if (err instanceof Error && err.name === "AbortError") {
+            setReclaiming(false);
+            return;
+          }
+          if (err instanceof ReclaimAlreadySettledError) {
+            // Someone else already swept it — usually this depositor on
+            // another device. Their money is where they wanted it, so this is
+            // a terminal success state, not a failure.
+            setAlreadySettled(true);
+            setReclaiming(false);
+            return;
+          }
+          logger.error(err instanceof Error ? err : new Error(String(err)), {
+            data: { context: "Reclaim failed", vaultId },
+          });
+          setError(
+            err instanceof Error ? err.message : "Reclaim transaction failed",
+          );
+          setReclaiming(false);
+        }
+      } finally {
+        inFlightRef.current = false;
+      }
+    },
+    [
+      reclaiming,
+      vaultId,
+      btcWalletProvider,
+      connectedBtcAddress,
+      btcConnector?.connectedWallet?.id,
+    ],
+  );
+
+  return { reclaiming, reclaimTxId, alreadySettled, error, handleReclaim };
+}

--- a/services/vault/src/hooks/deposit/useReclaimState.ts
+++ b/services/vault/src/hooks/deposit/useReclaimState.ts
@@ -2,6 +2,7 @@ import { useChainConnector } from "@babylonlabs-io/wallet-connector";
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { Hex } from "viem";
 
+import { COPY } from "@/copy";
 import { logger } from "@/infrastructure";
 import {
   ReclaimAlreadySettledError,
@@ -74,15 +75,15 @@ export function useReclaimState({
 
       try {
         if (!btcWalletProvider || !connectedBtcAddress) {
-          setError("BTC wallet not connected");
+          setError(COPY.reclaim.errors.walletNotConnected);
           return;
         }
         if (!vaultId) {
-          setError("Missing BTC Vault ID");
+          setError(COPY.reclaim.errors.missingVaultId);
           return;
         }
         if (!Number.isFinite(feeRate) || feeRate <= 0) {
-          setError("Fee rate must be a positive number");
+          setError(COPY.reclaim.errors.invalidFeeRate);
           return;
         }
 
@@ -135,7 +136,7 @@ export function useReclaimState({
             data: { context: "Reclaim failed", vaultId },
           });
           setError(
-            err instanceof Error ? err.message : "Reclaim transaction failed",
+            err instanceof Error ? err.message : COPY.reclaim.errors.generic,
           );
           setReclaiming(false);
         }

--- a/services/vault/src/hooks/usePendingDeposits.ts
+++ b/services/vault/src/hooks/usePendingDeposits.ts
@@ -6,6 +6,9 @@
  *  - expiredActivities: refundable expired deposits (contractStatus 7=EXPIRED with
  *    unsignedPrePeginTx — the only indexer-sourced field required to build the
  *    refund PSBT; hashlock and htlcVout come from the on-chain contract).
+ *  - reclaimableCandidates: settled deposits (contractStatus 6=DEPOSITOR_WITHDRAWN)
+ *    whose depositor-claim reserve may still be unspent. Candidates only —
+ *    eligibility is decided on Bitcoin, not from this status.
  * Provides wallet state and modal handlers for broadcast/refund actions on
  * pending and expired deposits. The post-broadcast actions (WOTS, payout
  * signing, activation, artifact download) are owned by the deposit
@@ -21,6 +24,7 @@ import { useBTCWallet, useETHWallet } from "@/context/wallet";
 import { useAllDepositProviders } from "@/hooks/deposit/useAllDepositProviders";
 import { useBroadcastModal } from "@/hooks/deposit/useBroadcastModal";
 import { useEmergencyWithdrawModal } from "@/hooks/deposit/useEmergencyWithdrawModal";
+import { useReclaimModal } from "@/hooks/deposit/useReclaimModal";
 import { useRefundModal } from "@/hooks/deposit/useRefundModal";
 import { useVaultDeposits } from "@/hooks/useVaultDeposits";
 import { ContractStatus } from "@/models/peginStateMachine";
@@ -65,6 +69,26 @@ export function usePendingDeposits() {
     return [...demo.expiredActivities, ...(demo.hideReal ? [] : real)];
   }, [activities, demo]);
 
+  // Settled vaults whose depositor-claim reserve may still be sitting at PegIn
+  // vout 1. Candidates only: this is the cheap pre-filter that decides which
+  // vaults are worth probing on Bitcoin. Whether the reserve is actually
+  // reclaimable is decided by `getReclaimEligibility` against the chain reads,
+  // and gating on the contract status alone would be unsafe — see the warning
+  // in `models/reclaimEligibility`.
+  //
+  // `depositorSignedPeginTx` here is the indexer's copy, used only to derive
+  // the txid the poller probes. The signing path re-reads it from the contract
+  // (`vaultReclaimService`); a wrong value here can at worst mislabel a row.
+  const reclaimableCandidates = useMemo(
+    () =>
+      activities.filter(
+        (a) =>
+          a.contractStatus === ContractStatus.DEPOSITOR_WITHDRAWN &&
+          !!a.depositorSignedPeginTx,
+      ),
+    [activities],
+  );
+
   const mergedVaultProviders = useMemo(
     () => (demo ? [demo.provider, ...vaultProviders] : vaultProviders),
     [demo, vaultProviders],
@@ -80,6 +104,11 @@ export function usePendingDeposits() {
     onSuccess: refetchActivities,
   });
 
+  const reclaimModal = useReclaimModal({
+    allActivities: activities,
+    onSuccess: refetchActivities,
+  });
+
   const emergencyWithdrawModal = useEmergencyWithdrawModal({
     allActivities: activities,
     onSuccess: refetchActivities,
@@ -88,6 +117,7 @@ export function usePendingDeposits() {
   return {
     pendingActivities,
     expiredActivities,
+    reclaimableCandidates,
     allActivities: activities,
     vaultProviders: mergedVaultProviders,
     btcAddress,
@@ -100,6 +130,7 @@ export function usePendingDeposits() {
     refetchActivities,
     broadcastModal,
     refundModal,
+    reclaimModal,
     emergencyWithdrawModal,
     // God-mode demo aggregate (null in production). Only the activation-walk
     // click routing reads it; every other consumer uses the real lists above.

--- a/services/vault/src/hooks/useReclaimStatus.ts
+++ b/services/vault/src/hooks/useReclaimStatus.ts
@@ -1,0 +1,166 @@
+// Centralized poller for the depositor-claim reserve. One batched query for
+// every candidate vault, mirroring `useBtcHtlcRefundStatus` — per-row queries
+// would fan out against mempool.space's rate limit.
+//
+// Two outpoints are probed per vault, and both matter:
+//   vout 0 — the vault UTXO. Its spend is the Payout, and that is the gate.
+//   vout 1 — the reserve itself, to know there is still something to sweep.
+// See `models/reclaimEligibility` for why the gate is on Bitcoin rather than
+// the Ethereum vault status.
+
+import {
+  getOutspend,
+  getTipHeight,
+  getUtxoInfo,
+} from "@babylonlabs-io/ts-sdk/tbv/core/clients";
+import { PEGIN_DEPOSITOR_CLAIM_VOUT } from "@babylonlabs-io/ts-sdk/tbv/core/primitives";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMemo } from "react";
+
+import { getMempoolApiUrl } from "@/clients/btc/config";
+import {
+  PEGIN_VAULT_VOUT,
+  type OutpointSpend,
+} from "@/models/reclaimEligibility";
+import { mapWithConcurrency } from "@/utils/concurrency";
+
+// A settled vault changes state on a ~10-min block, so a minute of latency is
+// immaterial. Matches the HTLC refund poller.
+const POLL_INTERVAL_MS = 60 * 1000;
+const STALE_TIME_MS = 55 * 1000;
+// Each vault costs three requests, so keep the vault-level fan-out low.
+const MAX_CONCURRENT_VAULTS = 2;
+
+export const RECLAIM_STATUS_QUERY_KEY = "depositorClaimOutspend";
+
+/** Per-vault reserve state, as observed on Bitcoin. */
+export interface ReclaimStatus {
+  payoutSpend: OutpointSpend;
+  reserveSpend: OutpointSpend;
+  /** The reserve's value, for the row's "reclaimable" figure. */
+  reserveValueSats: bigint;
+}
+
+/** One candidate vault to probe. */
+export interface ReclaimOutpoint {
+  /** Vault id (the result map's key). */
+  depositId: string;
+  /** PegIn txid, derived from the contract's depositor-signed PegIn tx. */
+  peginTxid: string;
+}
+
+export interface ReclaimStatusResult {
+  /** Vault id (lowercased) → reserve state. Missing = not yet polled. */
+  statusByDepositId: Map<string, ReclaimStatus>;
+  /** Current Bitcoin tip height, for the confirmation-depth check. */
+  tipHeight: number | undefined;
+}
+
+// Stable identity for the no-data render; a fresh Map per render would defeat
+// every downstream memo. Same reasoning as `EMPTY_REFUNDS`.
+const EMPTY_STATUSES = new Map<string, ReclaimStatus>();
+
+interface ReclaimBatch {
+  statuses: Map<string, ReclaimStatus>;
+  tipHeight: number | undefined;
+}
+
+function toOutpointSpend(res: {
+  spent?: boolean;
+  status?: { confirmed?: boolean; block_height?: number };
+}): OutpointSpend {
+  return {
+    spent: res.spent === true,
+    confirmed: res.spent === true && res.status?.confirmed === true,
+    blockHeight: res.status?.block_height,
+  };
+}
+
+export function useReclaimStatus(
+  outpoints: ReadonlyArray<ReclaimOutpoint>,
+): ReclaimStatusResult {
+  const queryClient = useQueryClient();
+
+  // Dedupe by vault id and sort so list churn doesn't refetch.
+  const stable = useMemo(() => {
+    const map = new Map<string, ReclaimOutpoint>();
+    for (const o of outpoints) {
+      if (!o.depositId || !o.peginTxid) continue;
+      const depositId = o.depositId.toLowerCase();
+      map.set(depositId, { ...o, depositId });
+    }
+    return Array.from(map.values()).sort((a, b) =>
+      a.depositId.localeCompare(b.depositId),
+    );
+  }, [outpoints]);
+
+  const enabled = stable.length > 0;
+  const queryKey = useMemo(
+    () =>
+      [
+        RECLAIM_STATUS_QUERY_KEY,
+        stable.map((o) => o.depositId).join(","),
+      ] as const,
+    [stable],
+  );
+
+  const query = useQuery({
+    queryKey,
+    enabled,
+    refetchInterval: POLL_INTERVAL_MS,
+    staleTime: STALE_TIME_MS,
+    placeholderData: (prev) => prev,
+    queryFn: async (): Promise<ReclaimBatch> => {
+      const apiUrl = getMempoolApiUrl();
+      const prior =
+        queryClient.getQueryData<ReclaimBatch>(queryKey)?.statuses ?? new Map();
+
+      // The tip is shared across the batch, and a failure to read it must not
+      // drop the whole poll — the gate treats an absent tip as "not yet known"
+      // and simply withholds the action.
+      const tipHeight = await getTipHeight(apiUrl).catch(() => undefined);
+
+      const entries = await mapWithConcurrency(
+        stable,
+        MAX_CONCURRENT_VAULTS,
+        async (o): Promise<[string, ReclaimStatus] | null> => {
+          try {
+            const [payout, reserve, reserveUtxo] = await Promise.all([
+              getOutspend(o.peginTxid, PEGIN_VAULT_VOUT, apiUrl),
+              getOutspend(o.peginTxid, PEGIN_DEPOSITOR_CLAIM_VOUT, apiUrl),
+              getUtxoInfo(o.peginTxid, PEGIN_DEPOSITOR_CLAIM_VOUT, apiUrl),
+            ]);
+            return [
+              o.depositId,
+              {
+                payoutSpend: toOutpointSpend(payout),
+                reserveSpend: toOutpointSpend(reserve),
+                reserveValueSats: BigInt(reserveUtxo.value),
+              },
+            ];
+          } catch {
+            // Carry the prior status forward so a transient 429 doesn't drop a
+            // row for a cycle. No prior means the row stays actionless, which
+            // is the fail-closed direction.
+            const priorStatus = prior.get(o.depositId);
+            return priorStatus !== undefined
+              ? [o.depositId, priorStatus]
+              : null;
+          }
+        },
+      );
+
+      return {
+        statuses: new Map(
+          entries.filter((e): e is [string, ReclaimStatus] => e !== null),
+        ),
+        tipHeight,
+      };
+    },
+  });
+
+  return {
+    statusByDepositId: query.data?.statuses ?? EMPTY_STATUSES,
+    tipHeight: query.data?.tipHeight,
+  };
+}

--- a/services/vault/src/hooks/useReclaimVaultChainData.ts
+++ b/services/vault/src/hooks/useReclaimVaultChainData.ts
@@ -21,6 +21,8 @@ import { mapWithConcurrency } from "@/utils/concurrency";
 // still re-reads if the user leaves the page open for a long time.
 const STALE_TIME_MS = 5 * 60 * 1000;
 const MAX_CONCURRENT_REQUESTS = 4;
+/** Retries before a failed batch gives up until the next focus or remount. */
+const MAX_READ_RETRIES = 3;
 
 export const RECLAIM_CHAIN_DATA_QUERY_KEY = "reclaimVaultChainData";
 
@@ -45,32 +47,33 @@ export function useReclaimVaultChainData(
     queryKey: [RECLAIM_CHAIN_DATA_QUERY_KEY, stable.join(",")] as const,
     enabled: stable.length > 0,
     staleTime: STALE_TIME_MS,
-    refetchOnWindowFocus: false,
+    // An errored query is always stale, so leaving focus refetching on is what
+    // lets a failed batch recover when the user comes back to the tab.
+    refetchOnWindowFocus: true,
+    retry: MAX_READ_RETRIES,
     placeholderData: (prev) => prev,
     queryFn: async () => {
       const entries = await mapWithConcurrency(
         stable,
         MAX_CONCURRENT_REQUESTS,
-        async (vaultId): Promise<[string, ReclaimVaultChainData] | null> => {
-          try {
-            const vault = await getVaultFromChain(vaultId as Hex);
-            return [
-              vaultId,
-              {
-                peginTxid: derivePeginTxid(vault.depositorSignedPeginTx),
-                onChainStatus: vault.status,
-              },
-            ];
-          } catch {
-            // Fails closed: without the contract read the gate withholds the
-            // action rather than trusting the indexer's status.
-            return null;
-          }
+        async (vaultId): Promise<[string, ReclaimVaultChainData]> => {
+          const vault = await getVaultFromChain(vaultId as Hex);
+          return [
+            vaultId,
+            {
+              peginTxid: derivePeginTxid(vault.depositorSignedPeginTx),
+              onChainStatus: vault.status,
+            },
+          ];
         },
       );
-      return new Map<string, ReclaimVaultChainData>(
-        entries.filter((e): e is [string, ReclaimVaultChainData] => e !== null),
-      );
+      // Deliberately not swallowed per-vault. Catching here would resolve the
+      // query *successfully* with the vault missing, and with a 5-minute
+      // staleTime nothing would refetch — one transient RPC blip would hide
+      // Reclaim for five minutes with no way back. Letting it throw keeps the
+      // gate fail-closed (no data, no action) while React Query retries with
+      // backoff and refetches on focus.
+      return new Map<string, ReclaimVaultChainData>(entries);
     },
   });
 

--- a/services/vault/src/hooks/useReclaimVaultChainData.ts
+++ b/services/vault/src/hooks/useReclaimVaultChainData.ts
@@ -1,0 +1,78 @@
+// On-chain data the reclaim gate needs, batched across candidate vaults.
+//
+// Split from the Bitcoin poll deliberately: a settled vault's contract row is
+// immutable — its status will not leave Redeemed and its PegIn transaction
+// cannot change — so this caches long, while the outspend poll keeps its 60s
+// tick. Re-reading the registry every minute for values that cannot move would
+// be pure RPC waste.
+//
+// This is also the *authoritative* source of the PegIn txid. `vaultId` is a
+// one-way hash of it, and the indexer's copy is display-grade only.
+
+import { useQuery } from "@tanstack/react-query";
+import { useMemo } from "react";
+import type { Hex } from "viem";
+
+import { getVaultFromChain } from "@/clients/eth-contract/btc-vault-registry/query";
+import { derivePeginTxid } from "@/services/vault/vaultReclaimService";
+import { mapWithConcurrency } from "@/utils/concurrency";
+
+// Settled vault rows are immutable; five minutes is well inside a session and
+// still re-reads if the user leaves the page open for a long time.
+const STALE_TIME_MS = 5 * 60 * 1000;
+const MAX_CONCURRENT_REQUESTS = 4;
+
+export const RECLAIM_CHAIN_DATA_QUERY_KEY = "reclaimVaultChainData";
+
+export interface ReclaimVaultChainData {
+  /** PegIn txid derived from the contract's depositor-signed PegIn tx. */
+  peginTxid: string;
+  /** Live `BTCVaultStatus` enum value from the registry. */
+  onChainStatus: number;
+}
+
+const EMPTY_CHAIN_DATA = new Map<string, ReclaimVaultChainData>();
+
+export function useReclaimVaultChainData(
+  vaultIds: ReadonlyArray<string>,
+): Map<string, ReclaimVaultChainData> {
+  const stable = useMemo(
+    () => Array.from(new Set(vaultIds.map((id) => id.toLowerCase()))).sort(),
+    [vaultIds],
+  );
+
+  const query = useQuery({
+    queryKey: [RECLAIM_CHAIN_DATA_QUERY_KEY, stable.join(",")] as const,
+    enabled: stable.length > 0,
+    staleTime: STALE_TIME_MS,
+    refetchOnWindowFocus: false,
+    placeholderData: (prev) => prev,
+    queryFn: async () => {
+      const entries = await mapWithConcurrency(
+        stable,
+        MAX_CONCURRENT_REQUESTS,
+        async (vaultId): Promise<[string, ReclaimVaultChainData] | null> => {
+          try {
+            const vault = await getVaultFromChain(vaultId as Hex);
+            return [
+              vaultId,
+              {
+                peginTxid: derivePeginTxid(vault.depositorSignedPeginTx),
+                onChainStatus: vault.status,
+              },
+            ];
+          } catch {
+            // Fails closed: without the contract read the gate withholds the
+            // action rather than trusting the indexer's status.
+            return null;
+          }
+        },
+      );
+      return new Map<string, ReclaimVaultChainData>(
+        entries.filter((e): e is [string, ReclaimVaultChainData] => e !== null),
+      );
+    },
+  });
+
+  return query.data ?? EMPTY_CHAIN_DATA;
+}

--- a/services/vault/src/models/__tests__/reclaimEligibility.test.ts
+++ b/services/vault/src/models/__tests__/reclaimEligibility.test.ts
@@ -1,0 +1,212 @@
+import { OnChainBtcVaultStatus } from "@babylonlabs-io/ts-sdk/tbv/core/clients";
+import { describe, expect, it } from "vitest";
+
+import { COPY } from "@/copy";
+import {
+  RECLAIM_MIN_PAYOUT_CONFIRMATIONS,
+  getReclaimEligibility,
+  type ReclaimEligibilityInput,
+} from "@/models/reclaimEligibility";
+
+const TIP_HEIGHT = 900_000;
+/** A Payout buried exactly at the required depth. */
+const DEEP_PAYOUT_HEIGHT = TIP_HEIGHT - RECLAIM_MIN_PAYOUT_CONFIRMATIONS + 1;
+
+function makeInput(
+  overrides: Partial<ReclaimEligibilityInput> = {},
+): ReclaimEligibilityInput {
+  return {
+    onChainStatus: OnChainBtcVaultStatus.REDEEMED,
+    payoutSpend: {
+      spent: true,
+      confirmed: true,
+      blockHeight: DEEP_PAYOUT_HEIGHT,
+    },
+    reserveSpend: { spent: false, confirmed: false },
+    tipHeight: TIP_HEIGHT,
+    isOwnedByWallet: true,
+    isLedgerWallet: false,
+    isWithdrawBlocked: false,
+    isReclaimInFlight: false,
+    ...overrides,
+  };
+}
+
+describe("getReclaimEligibility", () => {
+  it("offers the reclaim once the payout is deeply confirmed and the reserve is unspent", () => {
+    expect(getReclaimEligibility(makeInput())).toEqual({ type: "available" });
+  });
+
+  it("hides the reclaim when the contract says redeemed but the vault UTXO is unspent", () => {
+    // The case an Ethereum-status-only gate would wrongly allow: the contract
+    // sets Redeemed before any Bitcoin claim happens, so the depositor's claim
+    // right — funded by this very reserve — still matters here.
+    const result = getReclaimEligibility(
+      makeInput({ payoutSpend: { spent: false, confirmed: false } }),
+    );
+
+    expect(result).toEqual({ type: "absent" });
+  });
+
+  it("hides the reclaim while the payout spend is unconfirmed", () => {
+    expect(
+      getReclaimEligibility(
+        makeInput({ payoutSpend: { spent: true, confirmed: false } }),
+      ),
+    ).toEqual({ type: "absent" });
+  });
+
+  it("hides the reclaim while the payout is confirmed but not deep enough", () => {
+    expect(
+      getReclaimEligibility(
+        makeInput({
+          payoutSpend: {
+            spent: true,
+            confirmed: true,
+            blockHeight: DEEP_PAYOUT_HEIGHT + 1,
+          },
+        }),
+      ),
+    ).toEqual({ type: "absent" });
+  });
+
+  it("treats a confirmed payout with no block height as a single confirmation", () => {
+    // A partial esplora response delays the offer rather than waving it through.
+    expect(
+      getReclaimEligibility(
+        makeInput({ payoutSpend: { spent: true, confirmed: true } }),
+      ),
+    ).toEqual({ type: "absent" });
+  });
+
+  it("keeps the row actionless once the reserve spend has confirmed", () => {
+    expect(
+      getReclaimEligibility(
+        makeInput({ reserveSpend: { spent: true, confirmed: true } }),
+      ),
+    ).toEqual({ type: "absent" });
+  });
+
+  it("reports reclaiming while the sweep is broadcast but unconfirmed", () => {
+    expect(
+      getReclaimEligibility(
+        makeInput({ reserveSpend: { spent: true, confirmed: false } }),
+      ),
+    ).toEqual({ type: "reclaiming" });
+  });
+
+  it("reports reclaiming from the in-session marker before the poll sees the spend", () => {
+    // The 60s poll still shows the reserve unspent; without the marker the row
+    // would keep offering an enabled button for up to a minute after confirm.
+    expect(
+      getReclaimEligibility(makeInput({ isReclaimInFlight: true })),
+    ).toEqual({ type: "reclaiming" });
+  });
+
+  it("does not report reclaiming for a spend on a vault that never passed the gate", () => {
+    // An unconfirmed spend without a settled payout is a protocol claim_tx,
+    // not a reclaim — do not attribute it to this feature.
+    expect(
+      getReclaimEligibility(
+        makeInput({
+          payoutSpend: { spent: false, confirmed: false },
+          reserveSpend: { spent: true, confirmed: false },
+        }),
+      ),
+    ).toEqual({ type: "absent" });
+  });
+
+  it("ignores the in-session marker when the vault is not eligible anyway", () => {
+    expect(
+      getReclaimEligibility(
+        makeInput({
+          isReclaimInFlight: true,
+          payoutSpend: { spent: false, confirmed: false },
+        }),
+      ),
+    ).toEqual({ type: "absent" });
+  });
+
+  it("hides the reclaim for a vault that is not redeemed on chain", () => {
+    expect(
+      getReclaimEligibility(
+        makeInput({ onChainStatus: OnChainBtcVaultStatus.ACTIVE }),
+      ),
+    ).toEqual({ type: "absent" });
+  });
+
+  it("hides the reclaim for a vault the connected wallet does not own", () => {
+    expect(
+      getReclaimEligibility(makeInput({ isOwnedByWallet: false })),
+    ).toEqual({ type: "absent" });
+  });
+
+  it("hides the reclaim while the on-chain status has not loaded", () => {
+    expect(
+      getReclaimEligibility(makeInput({ onChainStatus: undefined })),
+    ).toEqual({ type: "absent" });
+  });
+
+  it("hides the reclaim while the payout spend read has not loaded", () => {
+    expect(
+      getReclaimEligibility(makeInput({ payoutSpend: undefined })),
+    ).toEqual({ type: "absent" });
+  });
+
+  it("hides the reclaim while the reserve spend read has not loaded", () => {
+    expect(
+      getReclaimEligibility(makeInput({ reserveSpend: undefined })),
+    ).toEqual({ type: "absent" });
+  });
+
+  it("hides the reclaim while the chain tip has not loaded", () => {
+    expect(getReclaimEligibility(makeInput({ tipHeight: undefined }))).toEqual({
+      type: "absent",
+    });
+  });
+
+  it("blocks with an explanation while the protocol has paused exits", () => {
+    expect(
+      getReclaimEligibility(makeInput({ isWithdrawBlocked: true })),
+    ).toEqual({
+      type: "blocked",
+      tooltip: COPY.reclaim.blocked.protocolPaused,
+    });
+  });
+
+  it("blocks with an explanation on the Ledger vault wallet", () => {
+    // Blocked rather than hidden: the device firmware cannot sign this shape,
+    // and a silent absence would mean Ledger users never learn the reserve
+    // exists.
+    expect(getReclaimEligibility(makeInput({ isLedgerWallet: true }))).toEqual({
+      type: "blocked",
+      tooltip: COPY.reclaim.blocked.ledgerUnsupported,
+    });
+  });
+
+  it("prefers the reclaiming state over the Ledger block once a sweep is in flight", () => {
+    // A sweep already broadcast from another wallet is in flight regardless of
+    // what this session is connected with.
+    expect(
+      getReclaimEligibility(
+        makeInput({
+          isLedgerWallet: true,
+          reserveSpend: { spent: true, confirmed: false },
+        }),
+      ),
+    ).toEqual({ type: "reclaiming" });
+  });
+
+  it("hides rather than blocks on Ledger when the vault is not eligible anyway", () => {
+    // The wallet check sits behind the eligibility checks, so an ineligible
+    // vault never advertises a reclaim the depositor could not perform.
+    expect(
+      getReclaimEligibility(
+        makeInput({
+          isLedgerWallet: true,
+          reserveSpend: { spent: true, confirmed: true },
+        }),
+      ),
+    ).toEqual({ type: "absent" });
+  });
+});

--- a/services/vault/src/models/reclaimEligibility.ts
+++ b/services/vault/src/models/reclaimEligibility.ts
@@ -1,0 +1,206 @@
+/**
+ * When the depositor-claim reserve may be reclaimed.
+ *
+ * Every peg-in reserves `depositorClaimValue` — roughly 33k sats — at PegIn
+ * vout 1 to fund the depositor's own `claim_tx`. On the happy path the vault
+ * provider claims from its own wallet instead, and that reserve is never spent
+ * by anyone. This module decides when the app may offer to sweep it back.
+ *
+ * A pure predicate over already-fetched data, mirroring
+ * `computeDepositPollingResult`: the reads live in the polling context, the
+ * decision lives here where it can be tested exhaustively.
+ *
+ * @module models/reclaimEligibility
+ */
+
+import { OnChainBtcVaultStatus } from "@babylonlabs-io/ts-sdk/tbv/core/clients";
+
+import { COPY } from "@/copy";
+
+/**
+ * Confirmations required on the Payout before the reserve is offered.
+ *
+ * Six is the conventional deep-confirmation depth; the point is that a reorg
+ * unwinding the Payout must not leave the depositor having already destroyed
+ * the recourse graph that Payout made redundant.
+ */
+export const RECLAIM_MIN_PAYOUT_CONFIRMATIONS = 6;
+
+/**
+ * Vout of the vault output in the PegIn transaction. Its spend is the Payout —
+ * the signal this gate turns on.
+ */
+export const PEGIN_VAULT_VOUT = 0;
+
+/** Spend status of a single PegIn output, as observed on Bitcoin. */
+export interface OutpointSpend {
+  spent: boolean;
+  confirmed: boolean;
+  /** Height of the block containing the spending tx, when confirmed. */
+  blockHeight?: number;
+}
+
+export interface ReclaimEligibilityInput {
+  /**
+   * Live `BTCVaultStatus` from the contract. Necessary but never sufficient —
+   * see the note below on why this cannot be the gate.
+   */
+  onChainStatus: number | undefined;
+  /** Spend status of `peginTxid:0` — the vault UTXO. */
+  payoutSpend: OutpointSpend | undefined;
+  /** Spend status of `peginTxid:1` — the reserve itself. */
+  reserveSpend: OutpointSpend | undefined;
+  /** Current Bitcoin tip height, for the confirmation-depth check. */
+  tipHeight: number | undefined;
+  /** Whether the vault belongs to the connected wallet. */
+  isOwnedByWallet: boolean;
+  /** Whether the connected BTC wallet is the Ledger vault app. */
+  isLedgerWallet: boolean;
+  /** Whether protocol status has paused exits. */
+  isWithdrawBlocked: boolean;
+  /**
+   * True when this session broadcast a sweep for this vault whose spend the
+   * poll has not observed yet. Bridges the ≤60s poll interval so the button
+   * disables the moment the depositor confirms.
+   */
+  isReclaimInFlight: boolean;
+}
+
+export type ReclaimEligibility =
+  /** Offer the action. */
+  | { type: "available" }
+  /**
+   * A sweep is broadcast but not yet confirmed. The row keeps its figure and
+   * its button, with the button disabled and the status reading "Reclaiming" —
+   * mirroring how the refund path shows "Refunding".
+   */
+  | { type: "reclaiming" }
+  /**
+   * The reclaim is this row's action but is not performable; the row shows a
+   * disabled control explaining why.
+   */
+  | { type: "blocked"; tooltip: string }
+  /** Not this row's action at all — render nothing. */
+  | { type: "absent" };
+
+/**
+ * Decide whether the reserve may be swept.
+ *
+ * > ⚠️ **The gate is on Bitcoin, not Ethereum, and that is deliberate.**
+ * >
+ * > The obvious implementation — offer it once the contract says `Redeemed` —
+ * > is wrong. `RedeemLogic.redeemForDepositor` sets that status *before* any
+ * > Bitcoin claim happens, and emits `VaultClaimableBy` for the vault provider
+ * > key *and* the depositor key. That is an authorization issued to both
+ * > parties, not a record of who acted; no on-chain state distinguishes them.
+ * >
+ * > The reserve is the only input to the depositor's pre-signed `claim_tx`, and
+ * > every downstream Assert / Payout / NoPayout signature commits to that tx's
+ * > txid. There is no re-funding path. Sweeping it while the vault is still
+ * > live permanently destroys the depositor's recourse.
+ * >
+ * > So the real gate is `peginTxid:0` spent and deeply confirmed: the vault
+ * > UTXO is consumed, a Payout landed, and the claim graph can no longer serve
+ * > any purpose. Do not "simplify" this back to a status read.
+ *
+ * Fails closed: any read still missing or errored yields `absent`.
+ */
+export function getReclaimEligibility(
+  input: ReclaimEligibilityInput,
+): ReclaimEligibility {
+  const {
+    onChainStatus,
+    payoutSpend,
+    reserveSpend,
+    tipHeight,
+    isOwnedByWallet,
+    isLedgerWallet,
+    isWithdrawBlocked,
+    isReclaimInFlight,
+  } = input;
+
+  // Necessary precondition. A vault that is not redeemed on Ethereum has no
+  // business offering this, whatever Bitcoin shows.
+  if (onChainStatus !== OnChainBtcVaultStatus.REDEEMED)
+    return { type: "absent" };
+
+  // Not the connected wallet's vault: the sweep is keyed on the connected
+  // wallet's pubkey, so there is nothing this wallet could sign.
+  if (!isOwnedByWallet) return { type: "absent" };
+
+  // Any read not yet in hand leaves the action hidden rather than offered.
+  if (!payoutSpend || !reserveSpend || tipHeight === undefined) {
+    return { type: "absent" };
+  }
+
+  // The gate. An unspent vault UTXO means the peg-out has not settled on
+  // Bitcoin and the depositor's claim right still matters.
+  const payoutSettled =
+    payoutSpend.spent &&
+    payoutSpend.confirmed &&
+    payoutConfirmations(payoutSpend, tipHeight) >=
+      RECLAIM_MIN_PAYOUT_CONFIRMATIONS;
+
+  if (reserveSpend.spent) {
+    // Spent but not yet mined, on a vault that had passed the gate: this is a
+    // sweep in flight. Only `<D> OP_CHECKSIG` can spend the output, so the
+    // spender is provably the depositor, and once the payout has settled the
+    // protocol claim_tx has no purpose left — so attributing it to a reclaim
+    // is right in every realistic case.
+    if (!reserveSpend.confirmed && payoutSettled) {
+      return { type: "reclaiming" };
+    }
+    // Confirmed spend (or a spend on a vault that never passed the gate, which
+    // would be a claim_tx): nothing left to reclaim, and nothing to attribute.
+    return { type: "absent" };
+  }
+
+  // A sweep we broadcast this session, before the 60s poll has observed it.
+  // Without this the row would keep offering an enabled button for up to a
+  // minute after the user confirmed.
+  if (isReclaimInFlight && payoutSettled) return { type: "reclaiming" };
+
+  if (!payoutSettled) return { type: "absent" };
+
+  // Past this point the reserve is genuinely reclaimable and the depositor
+  // should be told so even when they cannot act right now.
+
+  // Reclaim is an exit, so it follows withdraw's pause semantics.
+  if (isWithdrawBlocked) {
+    return { type: "blocked", tooltip: COPY.reclaim.blocked.protocolPaused };
+  }
+
+  // The Ledger vault app cannot sign this transaction. Its firmware routes any
+  // 34-byte `<D> OP_CHECKSIG` tapleaf to the claim validator
+  // (app-babylon-vault `src/sign_psbt_validate.c`), which hard-requires the
+  // protocol claim_tx shape of 1 input and 2 outputs; a 1-in/1-out sweep is
+  // rejected on the output count before any device I/O.
+  //
+  // Deliberately reclaim-specific: refund *is* reachable on the device
+  // (`_validate_display_refund`), so this must not become "no Bitcoin actions
+  // on Ledger". Supporting reclaim needs a new firmware validator with its own
+  // approval screen, plus host-side work in babylon-ledger-vault-signer.
+  //
+  // Shown as blocked rather than hidden so Ledger users still learn the
+  // reserve exists and can sweep it from another wallet.
+  if (isLedgerWallet) {
+    return { type: "blocked", tooltip: COPY.reclaim.blocked.ledgerUnsupported };
+  }
+
+  return { type: "available" };
+}
+
+/**
+ * Confirmation depth of the Payout, counting the containing block as one.
+ *
+ * A spend confirmed but missing its height is treated as one confirmation —
+ * enough to be real, not enough to clear the deep-confirmation bar — so a
+ * partial esplora response delays the offer instead of waving it through.
+ */
+function payoutConfirmations(
+  payoutSpend: OutpointSpend,
+  tipHeight: number,
+): number {
+  if (payoutSpend.blockHeight === undefined) return 1;
+  return tipHeight - payoutSpend.blockHeight + 1;
+}

--- a/services/vault/src/services/vault/vaultReclaimService.ts
+++ b/services/vault/src/services/vault/vaultReclaimService.ts
@@ -1,0 +1,305 @@
+/**
+ * Vault Reclaim Service — thin adapter over the SDK's
+ * `buildAndBroadcastReclaim`.
+ *
+ * Every peg-in reserves `depositorClaimValue` at PegIn vout 1 to fund the
+ * depositor's own `claim_tx`. When the vault provider claims from its own
+ * wallet instead and the depositor withdraws normally, nothing ever spends it.
+ * This adapter sweeps it back once the vault has terminally settled.
+ *
+ * Protocol logic (fee math, PSBT build, the three-way script bind, signature
+ * verification) lives in the SDK. This adapter resolves the vault's frozen
+ * protocol parameters, observes the reserve on Bitcoin, and provides the
+ * signing and broadcast transports.
+ *
+ * Eligibility is decided in `@/models/reclaimEligibility` and enforced by the
+ * caller — read the warning there before changing when this is offered.
+ */
+
+import type { SignPsbtOptions } from "@babylonlabs-io/ts-sdk/shared";
+import {
+  computeMinClaimValue,
+  getNetworkFees,
+  pushTx,
+  stripHexPrefix,
+} from "@babylonlabs-io/ts-sdk/tbv/core";
+import {
+  getOutspend,
+  getTipHeight,
+  getUtxoInfo,
+} from "@babylonlabs-io/ts-sdk/tbv/core/clients";
+import { PEGIN_DEPOSITOR_CLAIM_VOUT } from "@babylonlabs-io/ts-sdk/tbv/core/primitives";
+import {
+  buildAndBroadcastReclaim,
+  type ReclaimVaultData,
+} from "@babylonlabs-io/ts-sdk/tbv/core/services";
+import { calculateBtcTxHash } from "@babylonlabs-io/ts-sdk/tbv/core/utils";
+import type { Hex } from "viem";
+
+import { assertMinClaimValue } from "@/utils/wasm";
+
+import { getMempoolApiUrl } from "../../clients/btc/config";
+import { getVaultFromChain } from "../../clients/eth-contract/btc-vault-registry/query";
+import {
+  getProtocolParamsReader,
+  getUniversalChallengerReader,
+  getVaultKeeperReader,
+} from "../../clients/eth-contract/sdk-readers";
+import {
+  PEGIN_VAULT_VOUT,
+  type OutpointSpend,
+} from "../../models/reclaimEligibility";
+
+/**
+ * Thrown when the reserve turns out to be already spent — typically the
+ * depositor reclaimed from another device or session. A pure BTC sweep emits
+ * no Ethereum event, so this is detected by probing the outpoint, not from the
+ * indexer.
+ */
+export class ReclaimAlreadySettledError extends Error {
+  public readonly spendingTxid?: string;
+
+  constructor(spendingTxid?: string) {
+    super("Reclaim already settled: the depositor-claim reserve is spent.");
+    this.name = "ReclaimAlreadySettledError";
+    this.spendingTxid = spendingTxid;
+  }
+}
+
+// bitcoind sendrawtransaction rejection codes meaning "this already happened",
+// relayed verbatim by mempool.space. -27 = already in the UTXO set; -25 =
+// missing or already-spent inputs. Same classifiers the refund path uses.
+const ALREADY_IN_CHAIN_CODE_RE = /"code"\s*:\s*-27\b/;
+const MISSING_OR_SPENT_INPUTS_CODE_RE = /"code"\s*:\s*-25\b/;
+
+/** The vault's own PegIn txid plus the two outpoints the gate depends on. */
+export interface ReclaimChainState {
+  peginTxid: string;
+  /** Spend status of the vault UTXO — the Payout signal. */
+  payoutSpend: OutpointSpend;
+  /** Spend status of the reserve itself. */
+  reserveSpend: OutpointSpend;
+  /** Current Bitcoin tip height. */
+  tipHeight: number;
+  /** The reserve's value, as observed on chain. */
+  reserveValueSats: bigint;
+}
+
+/**
+ * Derive a vault's PegIn txid from the contract's own copy of the
+ * depositor-signed PegIn transaction.
+ *
+ * `vaultId` is a one-way hash of the txid, so it cannot be recovered from it.
+ * This is the authoritative source and the only one that may feed a signed
+ * transaction: the SegWit txid excludes witness data, so it equals the
+ * broadcast PegIn's even though the vault provider adds its own witness. The
+ * indexer's `peginTxHash` may drive display and polling, never this.
+ */
+export function derivePeginTxid(depositorSignedPeginTx: Hex): string {
+  return stripHexPrefix(calculateBtcTxHash(depositorSignedPeginTx));
+}
+
+function toOutpointSpend(res: {
+  spent?: boolean;
+  txid?: string;
+  status?: { confirmed?: boolean; block_height?: number };
+}): OutpointSpend {
+  return {
+    spent: res.spent === true,
+    confirmed: res.spent === true && res.status?.confirmed === true,
+    blockHeight: res.status?.block_height,
+  };
+}
+
+/**
+ * Read everything on Bitcoin the eligibility gate needs for one vault.
+ *
+ * Both outpoints are probed: vout 0 decides whether the Payout has landed
+ * (the gate), vout 1 whether the reserve is still there to sweep.
+ */
+export async function readReclaimChainState(
+  vaultId: Hex,
+): Promise<ReclaimChainState> {
+  const onChainVault = await getVaultFromChain(vaultId);
+  const peginTxid = derivePeginTxid(onChainVault.depositorSignedPeginTx);
+  const apiUrl = getMempoolApiUrl();
+
+  const [payoutOutspend, reserveOutspend, tipHeight, reserveUtxo] =
+    await Promise.all([
+      getOutspend(peginTxid, PEGIN_VAULT_VOUT, apiUrl),
+      getOutspend(peginTxid, PEGIN_DEPOSITOR_CLAIM_VOUT, apiUrl),
+      getTipHeight(apiUrl),
+      getUtxoInfo(peginTxid, PEGIN_DEPOSITOR_CLAIM_VOUT, apiUrl),
+    ]);
+
+  return {
+    peginTxid,
+    payoutSpend: toOutpointSpend(payoutOutspend),
+    reserveSpend: toOutpointSpend(reserveOutspend),
+    tipHeight,
+    reserveValueSats: BigInt(reserveUtxo.value),
+  };
+}
+
+/**
+ * Recompute this vault's reserve value from the protocol parameters frozen at
+ * its registration — not the currently active ones. Bound against the
+ * observed UTXO inside the SDK builder.
+ */
+async function readExpectedClaimValue(vaultId: Hex): Promise<bigint> {
+  const onChainVault = await getVaultFromChain(vaultId);
+
+  const [protocolReader, keeperReader, challengerReader] = await Promise.all([
+    getProtocolParamsReader(),
+    getVaultKeeperReader(),
+    getUniversalChallengerReader(),
+  ]);
+
+  const [offchainParams, vaultKeepers, universalChallengers] =
+    await Promise.all([
+      protocolReader.getOffchainParamsByVersion(
+        onChainVault.offchainParamsVersion,
+      ),
+      keeperReader.getVaultKeepersByVersion(
+        onChainVault.applicationEntryPoint,
+        onChainVault.appVaultKeepersVersion,
+      ),
+      challengerReader.getUniversalChallengersByVersion(
+        onChainVault.universalChallengersVersion,
+      ),
+    ]);
+
+  if (vaultKeepers.length === 0) {
+    throw new Error(
+      `No vault keepers found for version ${onChainVault.appVaultKeepersVersion}; ` +
+        `cannot recompute the depositor-claim value.`,
+    );
+  }
+  if (universalChallengers.length === 0) {
+    throw new Error(
+      `No universal challengers found for version ${onChainVault.universalChallengersVersion}; ` +
+        `cannot recompute the depositor-claim value.`,
+    );
+  }
+
+  const value = await computeMinClaimValue(
+    onChainVault.vaultCoreVersion,
+    vaultKeepers.length,
+    universalChallengers.length,
+    offchainParams.councilQuorum,
+    offchainParams.securityCouncilKeys.length,
+    offchainParams.feeRate,
+  );
+  return assertMinClaimValue(value);
+}
+
+export interface ReclaimPreview {
+  /** Gross reserve value before the network fee. */
+  reclaimableSats: bigint;
+  /** Mempool half-hour rate, or null when the fetch failed. */
+  halfHourFeeSatsVb: number | null;
+  peginTxid: string;
+}
+
+/**
+ * Data for the review screen. A failed fee fetch is surfaced as null rather
+ * than defaulted — the review screen blocks on it until the depositor sets a
+ * rate explicitly.
+ */
+export async function getReclaimPreview(vaultId: Hex): Promise<ReclaimPreview> {
+  const [chainState, fees] = await Promise.all([
+    readReclaimChainState(vaultId),
+    getNetworkFees(getMempoolApiUrl()).catch(() => null),
+  ]);
+
+  if (chainState.reserveSpend.spent) {
+    throw new ReclaimAlreadySettledError(undefined);
+  }
+
+  return {
+    reclaimableSats: chainState.reserveValueSats,
+    halfHourFeeSatsVb: fees?.halfHourFee ?? null,
+    peginTxid: chainState.peginTxid,
+  };
+}
+
+export interface BroadcastReclaimParams {
+  vaultId: Hex;
+  /**
+   * The connected wallet's live BTC pubkey. Never the indexer's copy — the
+   * SDK re-derives the claim script from this to prove the wallet about to
+   * sign is the wallet that can spend.
+   */
+  depositorBtcPubkey: string;
+  feeRate: number;
+  signPsbt: (psbtHex: string, opts: SignPsbtOptions) => Promise<string>;
+  signal?: AbortSignal;
+}
+
+/**
+ * Build, sign, and broadcast a reclaim sweeping one vault's reserve.
+ *
+ * @returns the broadcast transaction id
+ * @throws {@link ReclaimAlreadySettledError} if the reserve is already spent
+ */
+export async function buildAndBroadcastReclaimTransaction(
+  params: BroadcastReclaimParams,
+): Promise<string> {
+  const { vaultId, depositorBtcPubkey, feeRate, signPsbt, signal } = params;
+
+  // Re-probe immediately before signing: the modal may have been open a while,
+  // and sweeping an already-spent reserve is a guaranteed broadcast failure
+  // after a pointless wallet prompt.
+  const chainState = await readReclaimChainState(vaultId);
+  if (chainState.reserveSpend.spent) {
+    throw new ReclaimAlreadySettledError(undefined);
+  }
+
+  const expectedClaimValue = await readExpectedClaimValue(vaultId);
+  const onChainVault = await getVaultFromChain(vaultId);
+  const apiUrl = getMempoolApiUrl();
+  const reserveUtxo = await getUtxoInfo(
+    chainState.peginTxid,
+    PEGIN_DEPOSITOR_CLAIM_VOUT,
+    apiUrl,
+  );
+
+  const readVaults = async (): Promise<ReclaimVaultData[]> => [
+    {
+      depositorSignedPeginTxHex: onChainVault.depositorSignedPeginTx,
+      observed: {
+        scriptPubKey: reserveUtxo.scriptPubKey,
+        value: BigInt(reserveUtxo.value),
+      },
+      expectedClaimValue,
+    },
+  ];
+
+  try {
+    const { txId } = await buildAndBroadcastReclaim({
+      vaultIds: [vaultId],
+      depositorBtcPubkey,
+      readVaults,
+      feeRate,
+      signPsbt,
+      broadcastTx: async (signedTxHex: string) => ({
+        txId: await pushTx(signedTxHex, apiUrl),
+      }),
+      signal,
+    });
+    return txId;
+  } catch (error) {
+    // A concurrent sweep from another device lands here rather than at the
+    // pre-probe above. Both rejection codes mean the same thing for us: the
+    // reserve is gone, and the depositor's money is where they wanted it.
+    if (error instanceof Error) {
+      if (
+        ALREADY_IN_CHAIN_CODE_RE.test(error.message) ||
+        MISSING_OR_SPENT_INPUTS_CODE_RE.test(error.message)
+      ) {
+        throw new ReclaimAlreadySettledError(undefined);
+      }
+    }
+    throw error;
+  }
+}

--- a/services/vault/src/utils/formatting.ts
+++ b/services/vault/src/utils/formatting.ts
@@ -68,6 +68,21 @@ const BTC_FRACTIONAL_DIGITS = SATS_PER_BTC.toString().length - 1;
  *
  * @param sats - Total in satoshis. Zero or negative returns "0 BTC/sBTC".
  */
+/**
+ * Format a satoshi-denominated bigint as a grouped integer, e.g. `33,000`.
+ *
+ * Sub-BTC amounts like the depositor-claim reserve read better in whole sats
+ * than as `0.00033 BTC`. The unit itself lives in `copy.ts`, not here.
+ * Grouping is done on the bigint's own digits so totals beyond the JS
+ * safe-integer range stay exact.
+ */
+export function formatSats(sats: bigint): string {
+  const negative = sats < 0n;
+  const digits = (negative ? -sats : sats).toString();
+  const grouped = digits.replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+  return negative ? `-${grouped}` : grouped;
+}
+
 export function formatBtcFromSats(sats: bigint): string {
   if (sats <= 0n) return `0 ${btcConfig.coinSymbol}`;
   const whole = sats / SATS_PER_BTC;


### PR DESCRIPTION
Closes https://github.com/babylonlabs-io/babylon-toolkit/issues/2276

https://github.com/user-attachments/assets/a92adc6a-d7bf-4fe0-b2d6-eec19a43120e

## What this fixes

Every peg-in quietly sets aside a small amount of the depositor's BTC — around 26,000–33,000 sats depending on the signer set and fee rate. That money funds the depositor's own `claim_tx`, which is their fallback if the vault provider fails during peg-out.

On the happy path the vault provider claims using its own wallet, the depositor withdraws normally, and that set-aside amount is never touched by anyone. Nothing in this repository could spend it, so it was stranded on Bitcoin permanently. Roughly $25 disappeared on every successful deposit.

The deposit screen has been promising the opposite the whole time. `COPY.deposit.form.transactionReserveTooltip` told depositors the reserve "is returned to you if unused" — a promise only the refund path could keep.

This PR adds a **Reclaim** action that sweeps that reserve back to the depositor once their vault has settled, and rewrites the deposit-time tooltip to describe what actually happens.

## Where the money actually is

This was the first thing worth getting right, because it is easy to assume the reserve sits somewhere it does not.

The reserve is **not** a separate output of the Pre-PegIn transaction. It is carried *inside* the Pre-PegIn HTLC output's value, and only becomes a standalone UTXO once the PegIn transaction is broadcast — landing at **PegIn output index 1**.

That output is a Taproot output with an unspendable internal key and exactly one script leaf: `<depositorPubkey> OP_CHECKSIG`. No timelock, no covenant, no counterparty. The depositor can spend it alone, at any time, with a single signature.

That also explains why the refund path already returns this money and why none of it could be reused: the refund spends the whole HTLC output *before the PegIn ever exists*, so the reserve comes back as part of the refunded amount. Once the PegIn is broadcast the HTLC is gone and the refund code has nothing left to spend. The reclaim transaction is genuinely new code.

## The important safety decision

Since the depositor can spend this output at any moment, the real question is not *can we* but *when should we offer it*.

Spending it early is worse than it sounds. The depositor's pre-signed `claim_tx` hard-codes this exact outpoint as its only input, and every downstream pre-signed transaction (Assert, Payout, NoPayout, the challenge transactions) commits to that transaction's id. There is no way to re-fund it. **Sweeping the reserve while the vault is still live permanently destroys the depositor's entire pre-signed recovery set.**

So the gate has to be certain the recovery set is already useless.

### Approach A — gate on the Ethereum vault status (what the issue proposed)

Offer the action once the contract reports `Redeemed` and the indexer reports `DEPOSITOR_WITHDRAWN`.

**Rejected, because it is not safe.** Reading the contracts showed that `RedeemLogic.redeemForDepositor` sets `Redeemed` *before* any Bitcoin claim has happened, and then emits `VaultClaimableBy` for **both** the vault provider's key and the depositor's key. That is permission granted to two parties, not a record of who acted. There is no `markClaimed`, no payout proof, and no claim-completion event anywhere in `BTCVaultRegistry.sol` — nothing on Ethereum distinguishes "the vault provider claimed" from "the depositor claimed".

A depositor could therefore withdraw, see the button appear immediately, sweep the reserve, and destroy their fallback during exactly the window where the vault provider might still fail them.

### Approach B — gate on Bitcoin (chosen)

Offer the action only once **PegIn output 0 (the vault UTXO) has been spent and is at least 6 confirmations deep**.

That spend *is* the Payout. Once the vault UTXO is consumed, the depositor's claim graph can no longer serve any purpose, so the reserve is provably dead weight. This is the only signal that is both trustworthy and verifiable, and it is checked directly against Bitcoin rather than taken from any indexer.

The full gate is: contract status `Redeemed`, **and** PegIn output 0 spent with ≥6 confirmations, **and** PegIn output 1 still unspent, **and** the vault belongs to the connected wallet. Any read that fails or has not loaded hides the action rather than showing it — it fails closed.

The indexer's `DEPOSITOR_WITHDRAWN` status is still used, but only as a cheap filter to decide *which* vaults are worth checking on Bitcoin. It never decides eligibility.

There is a comment at the gate explaining why, and a test named for the exact case Approach A would have wrongly allowed, so nobody "simplifies" this back into a status read later.

## What the depositor sees

A **Reclaim** button on the settled vault's row in the Inactive Vaults section, with the reclaimable amount beside it, then a review modal and a success screen.

The row keeps three states, mirroring how the refund path already shows Refunding → Refunded:

| Reserve state | Status | Amount shown | Button |
|---|---|---|---|
| Unspent, eligible | `Redeemed` | `26,228 sats / reclaimable` | Reclaim, enabled |
| Sweep sent, not yet confirmed | `Reclaiming` | `26,228 sats / reclaimable` | Reclaim, disabled |
| Sweep confirmed | `Redeemed` | — | — |

The row stays in the list permanently once reclaimed, which matches what an already-refunded expired vault does today.

## Deliberate differences from the design file

Three, all agreed with design beforehand and worth a look during review.

**The review modal gained fee rows.** As drawn it showed only the gross amount and a Confirm button. At ~26,000 sats the network fee is 2% of the reserve at 5 sat/vB and 39% at 100 sat/vB, so the number on screen was not what the depositor would receive — and the "fee is too high" states had nowhere to appear. The modal now shows the fee rate, the network fee, and the net amount received, reusing the refund modal's existing components. The design component already had these rows built and hidden, so this turns them on rather than inventing anything.

**The section keeps its name and the row says "Redeemed".** The design titled the section "Expired Deposits" and gave the reclaim row an "Expired" status. Both are wrong for a vault whose peg-out completed successfully — it did not expire. The section stays "Inactive Vaults" and the row uses the existing "Redeemed" label.

**Typo fix.** The design reads "Reclain Amount"; the copy says "Reclaim Amount".

Separately, and *not* changed here: the design shows the inactive row's Withdraw button in red, but the app currently renders it orange — only the Activity page uses red today. That is a pre-existing inconsistency on a surface this PR does not otherwise touch, so it is flagged rather than fixed.

## Fee handling

The transaction shape is completely fixed, so its size is exact rather than estimated: **129 vbytes** for a single-input sweep, plus 75 vbytes per additional input. This is shipped as a function with both terms named, not a magic number, and there is a test that builds a real transaction and measures it rather than trusting the arithmetic.

The existing peg-in fee helper is deliberately **not** reused — its P2TR input size assumes a key-path spend, and would under-fee this shape by about 25%.

Two safety caps mirror the refund path's, and reject rather than silently clamp: a maximum fee rate, and a maximum fee as a fraction of the amount being swept. One thing reviewers should not "tidy":

> The fee-fraction cap here is measured against the **swept reserve itself** (block above 25%, warn above 10%). The refund measures its cap against the much larger deposit, which is why its 10% is generous there and would be far too strict here — it would block every reclaim above roughly 25 sat/vB. There is a comment saying so at both the SDK and UI cap sites. Do not align the two.

Blocking is also safe here in a way it is not for the refund: nothing is at risk and nothing expires, the reserve simply stays where it is until fees drop. The copy says exactly that.

## Safety checks before signing

This path builds and signs a Bitcoin transaction that moves real money, so it falls under the critical-path rules in `CLAUDE.md` and needs two reviewers.

- **Three-way check on the output being spent.** The script and value must match across the contract's own copy of the signed PegIn transaction, an independent lookup of the UTXO on Bitcoin, and a fresh derivation in JavaScript. Any disagreement aborts before the wallet is asked to sign.
- **The derivation uses the connected wallet's live public key**, never the indexer's copy. That is what makes the check meaningful: it proves the wallet about to sign is the wallet that can actually spend, and turns a wrong-wallet situation into a clear error instead of an unspendable broadcast.
- **Value is pinned**: the input must equal the independently recomputed reserve value, and the output must equal inputs minus fee exactly.
- **Every signature is verified** against a recomputed sighash before the transaction is finalised — not just the first input. The wallet reporting success is not treated as evidence, because the signing flags used here are known to fail silently on some wallets.

## Two bugs found along the way

**A real validation gap in existing code.** `deriveDepositorClaimScriptPubKey` accepted a malformed public key — the script compiler emits a shorter push for a truncated key, producing a well-formed script that is not the claim leaf. That function was already live on the peg-in validation path. It now rejects anything that is not a 32-byte key.

**A duplicate-input case.** The builder now rejects a batch naming the same reserve twice with a clear message, instead of failing deep inside the PSBT library.

## Ledger is out of scope

cc @jrwbabylonlab 

The Ledger BTC Vault app **cannot sign this transaction**, and this is a firmware limitation rather than something fixable here. Its PSBT validator routes any 34-byte `<D> OP_CHECKSIG` leaf to the claim-transaction validator, which requires exactly 1 input and 2 outputs; a 1-in/1-out sweep is rejected on the output count before any device interaction.

A workaround exists and was **deliberately rejected**: output 0's script is not validated, so a 1-in/2-out transaction would pass — but the device would then display a "Claim transaction" approval for something that is not a claim, with no destination shown. That defeats the purpose of a hardware wallet.

So the action is gated off for Ledger wallets, showing a disabled button with an explanation rather than hiding it, so those users still learn the reserve exists and can sweep it from another wallet. The gate is deliberately specific to reclaim — refund *is* supported on the device and must keep working. Supporting this properly needs a new firmware validator with its own approval screen plus matching host-side work.

## Verified against real chain state

Tested end to end against a genuinely settled vault on testnet (signet), not just mocks:

- The PegIn transaction id derived from the contract's stored transaction matched the indexer's independently — confirming the id source is correct.
- The claim script derived in JavaScript came out **byte-identical** to the output actually sitting on signet, which validates the derivation against real Rust-produced output rather than only against our own test expectations.
- The gate correctly recognised the vault as eligible: status `Redeemed`, vault output spent 12,750 confirmations deep, reserve output unspent at 26,228 sats.
- The row rendered, the reclaim was performed, and the money arrived.

## Tests

- **SDK, 41 new.** The script derivation is checked against a second, independent BIP-341 implementation over a pinned vector **plus 64 randomised keys** — a single hardcoded vector pins one input, not the function. Plus one rejection test per safety check, value conservation, a two-input batch, and the measured transaction-size test.
- **App, 26 new.** Every eligibility state including the unsafe one Approach A would have allowed; the reclaiming and settled row states; and the modal's four screens.
- Full suites green: 1,735 SDK tests, 3,589 vault tests, lint clean, production build passes.

## Follow-ups, not in this PR

- Batching several reserves into one transaction. The transaction builder already takes a list of inputs, so this is a later change rather than a rewrite. Three vaults swept together cost about 14% of the total in fees versus 19.5% done one at a time. cc @jrwbabylonlab 
- Surfacing the action on the Activity page. That feed is an event log, so adding a call-to-action to a row that reads as finished is a product decision rather than a mechanical port.
- Mapping the design components to code via Code Connect.
- `LIQUIDATED` and `INVALID` vaults are excluded pending an answer on whether the depositor's claim graph still has a role after liquidation.
- `VaultProtocolInfo.claimExpiredUntil` is read on chain but never used, and may be a second independent reason the reserve is reclaimable. Its wording points at the HTLC grace window instead, so it needs input from the contracts side before anything relies on it.
- The refund path calls `signPsbt` without the device terms approval, so it would already fail on a Ledger vault wallet today. Unrelated to this change and worth its own issue.