### PR TITLE
fix(ledger-vault): stop expecting a signature on payout input 1

### DIFF
--- a/packages/babylon-ledger-vault-signer/src/__tests__/expectedSignatures.test.ts
+++ b/packages/babylon-ledger-vault-signer/src/__tests__/expectedSignatures.test.ts
@@ -98,6 +98,8 @@ function fixtureLeafScript(vector: SignPsbtVector, inputIndex: number): Buffer {
 }
 
 describe("expected-signature table classification (G2, 22 fixtures)", () => {
+  // Pin-dependent: at fixtures commit 8f99b8b these PSBTs' input 1 carries no
+  // leaf, so no requested set is needed. A post-#2281 Payout must pass one.
   it.each(TAPSCRIPT_VECTOR_NAMES.map((name) => [name]))("%s: input 0 tapscript, other inputs absent", (name) => {
     const vector = loadVector(name);
     const { table } = prepareSignPsbt({ psbtHex: vector.psbt_hex, depositorXOnlyHex: TEST_DEPOSITOR_KEY_HEX });
@@ -443,6 +445,161 @@ describe("tapscript control block must commit to its leaf, driven by PegIn fixtu
     );
 
     expectPrepareRejects(psbtHex, /is tapscript but its witnessUtxo script is not P2TR/);
+  });
+});
+
+describe("caller-requested input set narrows the expectation, never the structural gates", () => {
+  // Post-#2281 Payout shape: input 1 (Assert:0) carries a tapLeafScript so the
+  // device can read the payout leaf to display terms, but it is never signed.
+  const PAYOUT_OUTPUT_SCRIPT = Buffer.concat([Buffer.from([0x51, 0x20]), Buffer.alloc(32, 0x2b)]);
+  const INPUT_0_LEAF = Buffer.from([0x51]);
+  const INPUT_1_LEAF = Buffer.from([0x52]);
+
+  /** Single-leaf taptree, so the control block genuinely commits to its witnessUtxo. */
+  function leafInput(script: Buffer): { scriptPubKey: Buffer; controlBlock: Buffer } {
+    const leaf = { output: script, version: 0xc0 };
+    const p2tr = payments.p2tr({ internalPubkey: Buffer.from(OTHER_KEY_HEX, "hex"), scriptTree: leaf, redeem: leaf });
+    if (!p2tr.output || !p2tr.witness) throw new Error("p2tr produced no script-path spend");
+    return { scriptPubKey: p2tr.output, controlBlock: p2tr.witness[p2tr.witness.length - 1] };
+  }
+
+  /** Two tapscript inputs, exactly the shape `buildPayoutPsbt` emits since #2281. */
+  function payoutShapedPsbtHex(mutateInput1ControlBlock = false): string {
+    const psbt = new Psbt();
+    [INPUT_0_LEAF, INPUT_1_LEAF].forEach((script, index) => {
+      psbt.addInput({ hash: Buffer.alloc(32, index + 1), index });
+    });
+    psbt.addOutput({ script: PAYOUT_OUTPUT_SCRIPT, value: 9000 });
+    [INPUT_0_LEAF, INPUT_1_LEAF].forEach((script, index) => {
+      const { scriptPubKey, controlBlock } = leafInput(script);
+      const usedControlBlock =
+        mutateInput1ControlBlock && index === 1
+          ? // Swap in a different (valid) internal key: the path still folds, to
+            // an output key the witnessUtxo never paid to.
+            Buffer.concat([
+              controlBlock.subarray(0, 1),
+              Buffer.from(TEST_DEPOSITOR_KEY_HEX, "hex"),
+              controlBlock.subarray(33),
+            ])
+          : controlBlock;
+      psbt.updateInput(index, {
+        witnessUtxo: { script: scriptPubKey, value: 10000 },
+        tapLeafScript: [{ leafVersion: 0xc0, script, controlBlock: usedControlBlock }],
+      });
+    });
+    return psbt.toHex();
+  }
+
+  it("expects only input 0 when the caller requests input 0", () => {
+    const { table } = prepareSignPsbt({
+      psbtHex: payoutShapedPsbtHex(),
+      depositorXOnlyHex: TEST_DEPOSITOR_KEY_HEX,
+      signInputIndexes: [0],
+    });
+
+    expect([...table.byInput.keys()]).toEqual([0]);
+  });
+
+  it("counts one expected yield for a requested set of one input", () => {
+    const { table } = prepareSignPsbt({
+      psbtHex: payoutShapedPsbtHex(),
+      depositorXOnlyHex: TEST_DEPOSITOR_KEY_HEX,
+      signInputIndexes: [0],
+    });
+
+    expect(table.expectedYieldCount).toBe(1);
+  });
+
+  it("expects every leaf input when the caller requests nothing", () => {
+    const { table } = prepareSignPsbt({
+      psbtHex: payoutShapedPsbtHex(),
+      depositorXOnlyHex: TEST_DEPOSITOR_KEY_HEX,
+    });
+
+    expect([...table.byInput.keys()]).toEqual([0, 1]);
+    expect(table.expectedYieldCount).toBe(2);
+  });
+
+  it("still rejects a control block that does not commit to its leaf on a NON-requested input", () => {
+    expectRejects(
+      () =>
+        prepareSignPsbt({
+          psbtHex: payoutShapedPsbtHex(true),
+          depositorXOnlyHex: TEST_DEPOSITOR_KEY_HEX,
+          signInputIndexes: [0],
+        }),
+      /input 1 control block does not commit to its TAP_LEAF_SCRIPT/,
+    );
+  });
+
+  it("completes the ceremony when the device yields input 0 alone", () => {
+    // The live regression: the device signs input 0, then assertComplete threw
+    // "missing 1: 1:<leafhash>" — after the one-shot payout slot was spent.
+    const prepared = prepareSignPsbt({
+      psbtHex: payoutShapedPsbtHex(),
+      depositorXOnlyHex: TEST_DEPOSITOR_KEY_HEX,
+      signInputIndexes: [0],
+    });
+    const { collector } = getPreparedSignPsbtState(prepared);
+    const expectation = prepared.table.byInput.get(0);
+    if (expectation?.kind !== "tapscript") throw new Error("input 0 must classify tapscript");
+    // varint(input 0) ‖ augmLen(0x40) ‖ signer key(32) ‖ leaf hash(32) ‖ sig(64).
+    collector.assertAndRecord(
+      Buffer.from("0040" + TEST_DEPOSITOR_KEY_HEX + [...expectation.expectedLeafHashHexes][0] + "ab".repeat(64), "hex"),
+    );
+
+    expect(() => collector.assertComplete()).not.toThrow();
+  });
+
+  it("rejects a requested input that carries no signing metadata", () => {
+    expectRejects(
+      () =>
+        prepareSignPsbt({
+          psbtHex: payoutShapedPsbtHex(),
+          depositorXOnlyHex: TEST_DEPOSITOR_KEY_HEX,
+          signInputIndexes: [0, 2],
+        }),
+      /input 2 was requested for signing but carries no signing metadata/,
+    );
+  });
+});
+
+describe("the requested input set is inert for key-path signing", () => {
+  // Under a wallet policy the base app signs EVERY internal input
+  // (`base:sign_psbt.c:142-148`), so narrowing would under-expect and the extra
+  // yields would fail AFTER the user already approved on-device.
+  const FIXTURE = "deposit-flow__pre_pegin__0";
+
+  it("expects every key-path input even when the caller requests a subset", () => {
+    const vector = loadVector(FIXTURE);
+    const depositorXOnlyHex = fixtureInternalKeyHex(vector);
+
+    const { table } = prepareSignPsbt({ psbtHex: vector.psbt_hex, depositorXOnlyHex, signInputIndexes: [0] });
+
+    expect([...table.byInput.keys()]).toEqual([0, 1]);
+    expect(table.expectedYieldCount).toBe(2);
+  });
+
+  it("accepts the device yielding every key-path input, and completes", () => {
+    const vector = loadVector(FIXTURE);
+    const depositorXOnlyHex = fixtureInternalKeyHex(vector);
+    const prepared = prepareSignPsbt({ psbtHex: vector.psbt_hex, depositorXOnlyHex, signInputIndexes: [0] });
+    const { collector } = getPreparedSignPsbtState(prepared);
+
+    for (let inputIndex = 0; inputIndex < vector.n_inputs; inputIndex++) {
+      // varint(index) ‖ augmLen(0x20) ‖ tweaked output key(32) ‖ sig(64).
+      collector.assertAndRecord(
+        Buffer.from(
+          inputIndex.toString(16).padStart(2, "0") +
+            "20" +
+            fixtureWitnessProgramHex(vector, inputIndex) +
+            "cd".repeat(64),
+          "hex",
+        ),
+      );
+    }
+
+    expect(() => collector.assertComplete()).not.toThrow();
   });
 });
 

--- a/packages/babylon-ledger-vault-signer/src/expectedSignatures.ts
+++ b/packages/babylon-ledger-vault-signer/src/expectedSignatures.ts
@@ -126,6 +126,13 @@ export interface BuildExpectedSignatureTableParams {
   readonly psbt: ExpectedSignaturePsbt;
   /** Connected depositor x-only key (64 lowercase hex) — pins the table. */
   readonly depositorXOnlyHex: string;
+  /**
+   * Input indices the caller asked to sign. Narrows TAPSCRIPT expectations
+   * only, and is inert for key-path/policy signing — there the base app picks
+   * the set. Structural gates still run on EVERY input. Omit to expect every
+   * device-signable input (the pre-#2281 behaviour).
+   */
+  readonly signInputIndexes?: readonly number[];
 }
 
 /**
@@ -222,11 +229,19 @@ function assertControlBlockCommitsToLeaf(
  * spec §3.1; BIP-371 key types verified against `base:psbt.h:37-42`).
  * Throws `LedgerSignPsbtProtocolError` on any rule violation — all before any
  * device I/O.
+ *
+ * Carrying signing metadata is NOT the same as being signed: since #2281 Payout
+ * input 1 carries the Assert payout leaf purely so the device can display the
+ * terms, while the firmware signs input 0 alone — the index is the literal 0 at
+ * `fw:sign_custom_inputs.c:276,334`, with no loop over inputs.
+ * `signInputIndexes` is what separates the two.
  */
 export function buildExpectedSignatureTable(params: BuildExpectedSignatureTableParams): ExpectedSignatureTable {
-  const { psbt, depositorXOnlyHex } = params;
+  const { psbt, depositorXOnlyHex, signInputIndexes } = params;
   const byInput = new Map<number, InputSigExpectation>();
   const inputCount = psbt.getGlobalInputCount();
+  const requestedInputs = signInputIndexes === undefined ? undefined : new Set(signInputIndexes);
+  const isRequested = (inputIndex: number): boolean => requestedInputs === undefined || requestedInputs.has(inputIndex);
 
   // Precompute the depositor-owned scriptPubKeys once for the ownership scan.
   const depositorP2trScript = bip86OutputScript(depositorXOnlyHex);
@@ -271,11 +286,15 @@ export function buildExpectedSignatureTable(params: BuildExpectedSignatureTableP
       const leafHash = tapLeafHash(TAPSCRIPT_LEAF_VERSION, script);
       // BIP-371 keyData of a TAP_LEAF_SCRIPT entry IS the control block.
       assertControlBlockCommitsToLeaf(inputIndex, leafEntries[0].keyData, leafHash, leafWitnessUtxo.scriptPubKey);
-      byInput.set(inputIndex, {
-        kind: "tapscript",
-        expectedLeafHashHexes: new Set([leafHash.toString("hex")]),
-        expectedSignerXOnlyHex: depositorXOnlyHex,
-      });
+      // Gated AFTER every structural gate above: a leaf we never sign is still
+      // a leaf the spent output must have committed to.
+      if (isRequested(inputIndex)) {
+        byInput.set(inputIndex, {
+          kind: "tapscript",
+          expectedLeafHashHexes: new Set([leafHash.toString("hex")]),
+          expectedSignerXOnlyHex: depositorXOnlyHex,
+        });
+      }
       continue;
     }
 
@@ -303,6 +322,8 @@ export function buildExpectedSignatureTable(params: BuildExpectedSignatureTableP
           `input ${inputIndex} witnessUtxo is not the BIP-86 P2TR of the depositor key`,
         );
       }
+      // NEVER narrowed: under a policy the base app signs every internal input
+      // (`base:sign_psbt.c:142-148`), so the device picks the set, not the caller.
       byInput.set(inputIndex, {
         kind: "taproot-keypath",
         expectedOutputKeyHex: script.subarray(P2TR_SCRIPT_PREFIX.length).toString("hex"),
@@ -310,7 +331,7 @@ export function buildExpectedSignatureTable(params: BuildExpectedSignatureTableP
       continue;
     }
 
-    // Not signed by the device (Payout input 1, NoPayout inputs 1-2 today).
+    // No taproot signing metadata at all (NoPayout inputs 1-2 today).
     // Ownership scan: a depositor-owned UTXO here means our builder dropped
     // the device-required metadata — fail before burning a ceremony. Deliberately
     // limited to these inputs: a Pre-PegIn keypath input legitimately IS the
@@ -326,6 +347,16 @@ export function buildExpectedSignatureTable(params: BuildExpectedSignatureTableP
     ) {
       throw new LedgerSignPsbtProtocolError(
         `input ${inputIndex} spends a depositor-owned UTXO but carries no signing metadata`,
+      );
+    }
+  }
+
+  // A requested index with no expectation means the caller and the builder
+  // disagree about the PSBT — a host bug, caught at zero device I/O.
+  for (const inputIndex of requestedInputs ?? []) {
+    if (!byInput.has(inputIndex)) {
+      throw new LedgerSignPsbtProtocolError(
+        `input ${inputIndex} was requested for signing but carries no signing metadata`,
       );
     }
   }

--- a/packages/babylon-ledger-vault-signer/src/signPsbt.ts
+++ b/packages/babylon-ledger-vault-signer/src/signPsbt.ts
@@ -27,6 +27,13 @@ export interface SignVaultPsbtParams {
   /** Cached GET_EXTENDED_PUBKEY read (64 lowercase hex) — pins the table. */
   readonly depositorXOnlyHex: string;
   /**
+   * Input indices to sign, narrowing TAPSCRIPT expectations without relaxing any
+   * structural gate — a Payout must pass `[0]`, since its input 1 carries a leaf
+   * the device displays but never signs. Inert for key-path/policy signing, where
+   * the base app signs every internal input. See {@link prepareSignPsbt}.
+   */
+  readonly signInputIndexes?: readonly number[];
+  /**
    * Fires after each accepted YIELD. Invocation is isolated: a throw inside
    * the callback is swallowed — progress is display-only, and a caller bug
    * must not abort a non-idempotent ceremony mid-loop.
@@ -58,7 +65,10 @@ export interface SignVaultPsbtResult {
 }
 
 /** The device-facing half of {@link SignVaultPsbtParams} — everything but the PSBT itself. */
-export type SignPreparedVaultPsbtOptions = Omit<SignVaultPsbtParams, "psbtHex" | "depositorXOnlyHex">;
+export type SignPreparedVaultPsbtOptions = Omit<
+  SignVaultPsbtParams,
+  "psbtHex" | "depositorXOnlyHex" | "signInputIndexes"
+>;
 
 // Single-use: a prepared object's mutable collector/interpreter would replay a
 // non-idempotent device ceremony with stale yields on a second run.
@@ -126,7 +136,7 @@ export async function signPreparedVaultPsbt(
  * call that itself hangs is not cancelled.
  */
 export async function signVaultPsbt(send: RawApduSender, params: SignVaultPsbtParams): Promise<SignVaultPsbtResult> {
-  const { psbtHex, depositorXOnlyHex, ...options } = params;
-  const prepared = prepareSignPsbt({ psbtHex, depositorXOnlyHex });
+  const { psbtHex, depositorXOnlyHex, signInputIndexes, ...options } = params;
+  const prepared = prepareSignPsbt({ psbtHex, depositorXOnlyHex, signInputIndexes });
   return signPreparedVaultPsbt(send, prepared, options);
 }

--- a/packages/babylon-ledger-vault-signer/src/signPsbtPrepare.ts
+++ b/packages/babylon-ledger-vault-signer/src/signPsbtPrepare.ts
@@ -191,6 +191,13 @@ export interface PrepareSignPsbtParams {
   /** Cached GET_EXTENDED_PUBKEY read (64 lowercase hex) — pins the table. */
   readonly depositorXOnlyHex: string;
   /**
+   * Input indices the caller asked to sign, narrowing TAPSCRIPT expectations
+   * without relaxing any structural gate. Inert under `walletPolicy`: key-path
+   * expectations are never narrowed, because the base app signs every internal
+   * input. See {@link buildExpectedSignatureTable}; omit for pre-#2281 behaviour.
+   */
+  readonly signInputIndexes?: readonly number[];
+  /**
    * Wallet-policy mode: the SIGN_PSBT wallet_id becomes the policy id and the
    * interpreter serves the policy preimages. Required for key-path signing
    * (PoP, Pre-PegIn): without a policy the base app skips `sign_internal_inputs`
@@ -257,7 +264,7 @@ export function getPreparedSignPsbtState(prepared: PreparedSignPsbt): PreparedSi
  * device I/O.
  */
 export function prepareSignPsbt(params: PrepareSignPsbtParams): PreparedSignPsbt {
-  const { psbtHex, depositorXOnlyHex, walletPolicy } = params;
+  const { psbtHex, depositorXOnlyHex, signInputIndexes, walletPolicy } = params;
   if (!DEPOSITOR_X_ONLY_HEX_RE.test(depositorXOnlyHex)) {
     throw new LedgerSignPsbtProtocolError("depositorXOnlyHex must be 64 lowercase hex characters");
   }
@@ -307,7 +314,7 @@ export function prepareSignPsbt(params: PrepareSignPsbtParams): PreparedSignPsbt
   try {
     merkelized = new MerkelizedPsbt(psbt);
     // Table from the SAME instance that was committed — no re-parse gap.
-    table = buildExpectedSignatureTable({ psbt: merkelized, depositorXOnlyHex });
+    table = buildExpectedSignatureTable({ psbt: merkelized, depositorXOnlyHex, signInputIndexes });
   } catch (error) {
     // Totalize the typed contract: already-typed rejections pass through;
     // anything else (vendored reader throws, bitcoinjs point math) is wrapped.

--- a/packages/babylon-wallet-connector/src/core/wallets/btc/ledger-vault/__tests__/provider.test.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/ledger-vault/__tests__/provider.test.ts
@@ -495,6 +495,27 @@ describe("LedgerVaultProvider", () => {
       expect(signMock.signPreparedVaultPsbt).not.toHaveBeenCalled();
     });
 
+    it("forwards the caller's requested input indices to prepare", async () => {
+      const provider = await approved();
+
+      // The Payout shape: the SDK asks for input 0 only, even though input 1
+      // carries a leaf for the device to display (#2281).
+      await provider.signPsbt(PSBT_A, {
+        autoFinalized: false,
+        signInputs: [{ index: 0, publicKey: "02".repeat(33), useTweakedSigner: false }],
+      });
+
+      expect(signMock.prepareSignPsbt.mock.calls[0][0].signInputIndexes).toEqual([0]);
+    });
+
+    it("leaves the requested set undefined when the caller does not restrict inputs", async () => {
+      const provider = await approved();
+
+      await provider.signPsbt(PSBT_A, { autoFinalized: false });
+
+      expect(signMock.prepareSignPsbt.mock.calls[0][0].signInputIndexes).toBeUndefined();
+    });
+
     it("throws on autoFinalized: true instead of silently not finalizing", async () => {
       const provider = await approved();
 

--- a/packages/babylon-wallet-connector/src/core/wallets/btc/ledger-vault/provider.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/ledger-vault/provider.ts
@@ -818,9 +818,12 @@ export class LedgerVaultProvider implements IBTCProvider {
         wallet: WALLET_PROVIDER_NAME,
       });
     }
+    // Carrying a leaf is not the same as being signed: since #2281 Payout input 1
+    // carries the Assert payout leaf only so the device can display the terms.
+    const signInputIndexes = options?.signInputs?.map((input) => input.index);
     let prepared: PreparedSignPsbt;
     try {
-      prepared = prepareSignPsbt({ psbtHex, depositorXOnlyHex });
+      prepared = prepareSignPsbt({ psbtHex, depositorXOnlyHex, signInputIndexes });
     } catch (error) {
       throw toStagingWalletError(error, `${label} rejected before device I/O`);
     }
@@ -857,6 +860,7 @@ export class LedgerVaultProvider implements IBTCProvider {
       try {
         // Pass the AUGMENTED hex: the signer's merge target is whatever hex it
         // prepared, so the SDK gets the derivation fields back with the tapKeySig.
+        // No signInputIndexes: it narrows tapscript only, and this path is key-path.
         prepared = prepareSignPsbt({ psbtHex: augmented, depositorXOnlyHex, walletPolicy: policy });
       } catch (error) {
         throw toStagingWalletError(error, `${label} rejected at policy-mode prepare`);


### PR DESCRIPTION
The payout presign failed with "missing 1: 1:<leafhash>", after the device had
already signed input 0 and burnt its one-shot slot.

The expectation table arms on tap-leaf presence alone, and #2281 added a leaf to
input 1 so the device can display the terms. Nothing signs it: firmware,
btc-vault and the VP all want input 0 only.

Threads the caller's existing signInputs through; structural gates still run on
every input. Verified on a real Flex.