### PR TITLE
fix(vault): apply the updated product copy from the v3 design review

### DIFF
--- a/packages/babylon-core-ui/src/components/LiquidationChart/BandLayer.tsx
+++ b/packages/babylon-core-ui/src/components/LiquidationChart/BandLayer.tsx
@@ -161,7 +161,9 @@ export function BandLayer({
               // the rect names itself.
               tabIndex={hoverable ? 0 : undefined}
               aria-label={
-                hoverable ? [band.label, band.sublabel, band.amountLabel].filter(Boolean).join(" ") : undefined
+                hoverable
+                  ? [band.label, band.sublabel ?? band.accessibleDetail, band.amountLabel].filter(Boolean).join(" ")
+                  : undefined
               }
               onMouseEnter={(e) => {
                 cancelClose();

--- a/packages/babylon-core-ui/src/components/LiquidationChart/types.ts
+++ b/packages/babylon-core-ui/src/components/LiquidationChart/types.ts
@@ -38,6 +38,12 @@ export interface LiquidationBand {
   /** Secondary label, e.g. "(contain vault 1)". Hidden in compact / tight bands. */
   sublabel?: string;
   /**
+   * Extra detail folded into the focusable rect's accessible name, for callers
+   * that render no `sublabel` but still need its content read out — e.g. the
+   * vault names behind an event.
+   */
+  accessibleDetail?: string;
+  /**
    * Collateral seized in this event, pre-formatted, e.g. "0.6 BTC". Rendered
    * as its own line when the band is tall enough. Omit when the caller has
    * already folded the amount into `label`.

--- a/packages/babylon-core-ui/src/components/Notification/Notification.stories.tsx
+++ b/packages/babylon-core-ui/src/components/Notification/Notification.stories.tsx
@@ -109,13 +109,13 @@ export const WarningNoIconWithLabel: Story = {
     icon: null,
     title: "First liquidation takes everything",
     children:
-      "With your current vaults, a single liquidation event seizes all your BTC — nothing remains protected behind it.",
+      "With your current BTCvaults, a single liquidation event liquidates all your BTC in collateral.",
     suggestion: (
       <>
         <SuggestionLabel>Suggestion</SuggestionLabel>
         <Text variant="body2" as="div" className="text-accent-secondary">
           To enable partial liquidation, withdraw your 0.70 BTC and re-deposit as
-          two smaller vaults: 0.40 BTC sacrificial + 0.30 BTC protected.
+          two smaller vaults: 0.40 BTC + 0.30 BTC.
         </Text>
       </>
     ),

--- a/packages/babylon-core-ui/src/components/Notification/Notification.stories.tsx
+++ b/packages/babylon-core-ui/src/components/Notification/Notification.stories.tsx
@@ -109,13 +109,13 @@ export const WarningNoIconWithLabel: Story = {
     icon: null,
     title: "First liquidation takes everything",
     children:
-      "With your current BTCvaults, a single liquidation event liquidates all your BTC in collateral.",
+      "With your current BTCVaults, a single liquidation event liquidates all your BTC in collateral.",
     suggestion: (
       <>
         <SuggestionLabel>Suggestion</SuggestionLabel>
         <Text variant="body2" as="div" className="text-accent-secondary">
-          To enable partial liquidation, withdraw your 0.70 BTC and re-deposit as
-          two smaller vaults: 0.40 BTC + 0.30 BTC.
+          To enable partial liquidation, withdraw your 0.70 BTC and re-deposit
+          as two smaller vaults: 0.40 BTC + 0.30 BTC.
         </Text>
       </>
     ),

--- a/packages/babylon-core-ui/src/components/Notification/Notification.stories.tsx
+++ b/packages/babylon-core-ui/src/components/Notification/Notification.stories.tsx
@@ -108,14 +108,13 @@ export const WarningNoIconWithLabel: Story = {
     variant: "warning",
     icon: null,
     title: "First liquidation takes everything",
-    children:
-      "With your current BTCVaults, a single liquidation event liquidates all your BTC in collateral.",
+    children: "With your current BTCVaults, a single liquidation event liquidates all your BTC in collateral.",
     suggestion: (
       <>
         <SuggestionLabel>Suggestion</SuggestionLabel>
         <Text variant="body2" as="div" className="text-accent-secondary">
-          To enable partial liquidation, withdraw your 0.70 BTC and re-deposit
-          as two smaller vaults: 0.40 BTC + 0.30 BTC.
+          To enable partial liquidation, withdraw your 0.70 BTC and re-deposit as two smaller BTCVaults: 0.40 BTC + 0.30
+          BTC.
         </Text>
       </>
     ),

--- a/services/vault/src/applications/aave/components/AssetSelectionPanel/__tests__/AssetSelectionPanel.test.tsx
+++ b/services/vault/src/applications/aave/components/AssetSelectionPanel/__tests__/AssetSelectionPanel.test.tsx
@@ -100,7 +100,7 @@ describe("AssetSelectionPanel", () => {
     expect(screen.getByText("Select asset")).toBeInTheDocument();
     // Borrow-only columns are present.
     expect(screen.getByText("Borrow APR")).toBeInTheDocument();
-    expect(screen.getByText("Available")).toBeInTheDocument();
+    expect(screen.getByText("Available Liquidity")).toBeInTheDocument();
     // Live data: a reserve row with its real (formatted) borrow APR.
     expect(screen.getByText("USD Coin")).toBeInTheDocument();
     expect(screen.getByText("3.5%")).toBeInTheDocument();
@@ -111,7 +111,7 @@ describe("AssetSelectionPanel", () => {
     expect(screen.getByText("1.23M WBTC")).toBeInTheDocument();
   });
 
-  it("hides the Available and Borrow APR columns in repay mode", () => {
+  it("hides the Available Liquidity and Borrow APR columns in repay mode", () => {
     renderPanel(
       <AssetSelectionPanel
         onSelectAsset={vi.fn()}
@@ -131,7 +131,7 @@ describe("AssetSelectionPanel", () => {
     expect(screen.getByText("Select asset")).toBeInTheDocument();
     expect(screen.getByText("USD Coin")).toBeInTheDocument();
     expect(screen.queryByText("Borrow APR")).not.toBeInTheDocument();
-    expect(screen.queryByText("Available")).not.toBeInTheDocument();
+    expect(screen.queryByText("Available Liquidity")).not.toBeInTheDocument();
   });
 
   it("omits the Market Info button in repay mode, which has no market data", () => {

--- a/services/vault/src/applications/aave/components/LoanCard/Repay/RepayDetailsCard/RepayDetailsCard.tsx
+++ b/services/vault/src/applications/aave/components/LoanCard/Repay/RepayDetailsCard/RepayDetailsCard.tsx
@@ -1,4 +1,4 @@
-import { Hint, SubSection } from "@babylonlabs-io/core-ui";
+import { SubSection } from "@babylonlabs-io/core-ui";
 
 import {
   getHealthFactorColor,
@@ -48,7 +48,6 @@ export function RepayDetailsCard({
       <div className={ROW_CLASS}>
         <div className="flex items-center gap-1 text-accent-secondary">
           {COPY.loans.debtLabel}
-          <Hint tooltip={COPY.loans.debtTooltip} />
         </div>
         <span className="text-accent-primary">
           {debtOriginal ? (
@@ -68,7 +67,6 @@ export function RepayDetailsCard({
       <div className={ROW_CLASS}>
         <div className="flex items-center gap-1 text-accent-secondary">
           {COPY.loans.healthFactorLabel}
-          <Hint tooltip={COPY.tooltips.healthFactor} />
         </div>
         <span className="flex items-center gap-2 text-accent-primary">
           {healthFactorOriginal && originalColor ? (

--- a/services/vault/src/applications/aave/components/LoanCard/Repay/RepayDetailsCard/RepayDetailsCard.tsx
+++ b/services/vault/src/applications/aave/components/LoanCard/Repay/RepayDetailsCard/RepayDetailsCard.tsx
@@ -1,4 +1,4 @@
-import { SubSection } from "@babylonlabs-io/core-ui";
+import { Hint, SubSection } from "@babylonlabs-io/core-ui";
 
 import {
   getHealthFactorColor,
@@ -46,9 +46,7 @@ export function RepayDetailsCard({
   return (
     <SubSection className="w-full flex-col gap-4 !bg-secondary-highlight">
       <div className={ROW_CLASS}>
-        <div className="flex items-center gap-1 text-accent-secondary">
-          {COPY.loans.debtLabel}
-        </div>
+        <span className="text-accent-secondary">{COPY.loans.debtLabel}</span>
         <span className="text-accent-primary">
           {debtOriginal ? (
             <span className="flex items-center gap-2">
@@ -67,6 +65,7 @@ export function RepayDetailsCard({
       <div className={ROW_CLASS}>
         <div className="flex items-center gap-1 text-accent-secondary">
           {COPY.loans.healthFactorLabel}
+          <Hint tooltip={COPY.tooltips.healthFactor} />
         </div>
         <span className="flex items-center gap-2 text-accent-primary">
           {healthFactorOriginal && originalColor ? (

--- a/services/vault/src/applications/aave/positionNotifications/__tests__/calculate.test.ts
+++ b/services/vault/src/applications/aave/positionNotifications/__tests__/calculate.test.ts
@@ -290,7 +290,7 @@ describe("golden vectors (reference scenario suite)", () => {
     // existing vault becomes protected.
     expect(result.suggestedNewVaultBtc).toBe(0.72);
     expect(getWarning(result.warnings, "cliff")?.suggestion).toContain(
-      "Adding a 0.72 BTCVault enables partial liquidation",
+      "Adding a new BTCVault of 0.72 BTC enables partial liquidation.",
     );
   });
 

--- a/services/vault/src/applications/aave/positionNotifications/__tests__/calculate.test.ts
+++ b/services/vault/src/applications/aave/positionNotifications/__tests__/calculate.test.ts
@@ -290,7 +290,7 @@ describe("golden vectors (reference scenario suite)", () => {
     // existing vault becomes protected.
     expect(result.suggestedNewVaultBtc).toBe(0.72);
     expect(getWarning(result.warnings, "cliff")?.suggestion).toContain(
-      "sacrificial 0.72 BTC Vault creates a buffer",
+      "Adding a 0.72 BTCVault enables partial liquidation",
     );
   });
 
@@ -299,11 +299,10 @@ describe("golden vectors (reference scenario suite)", () => {
     const cliff = getWarning(result.warnings, "cliff");
     expect(cliff?.title).toBe("First liquidation takes everything");
     // The needed add exceeds the position, so there is no actionable CTA; the
-    // fix is to withdraw and re-split. sacrificial + protected === withdraw.
+    // fix is to withdraw and re-split. The two parts sum to the withdraw.
     expect(result.suggestedNewVaultBtc).toBeNull();
     expect(cliff?.suggestion).toContain("withdraw your 2.00 BTC");
-    expect(cliff?.suggestion).toContain("1.28 BTC sacrificial");
-    expect(cliff?.suggestion).toContain("0.72 BTC protected");
+    expect(cliff?.suggestion).toContain("1.28 BTC + 0.72 BTC");
   });
 
   it("A9 — non-cent-aligned vault: the three re-deposit amounts reconcile", () => {
@@ -312,7 +311,7 @@ describe("golden vectors (reference scenario suite)", () => {
     const result = calculate(makeParams([v(1.045)], { THF: 1.4 }));
     const suggestion = getWarning(result.warnings, "cliff")?.suggestion ?? "";
     const match = suggestion.match(
-      /withdraw your ([\d.]+) BTC.*?([\d.]+) BTC sacrificial \+ ([\d.]+) BTC protected/,
+      /withdraw your ([\d.]+) BTC.*?([\d.]+) BTC \+ ([\d.]+) BTC/,
     );
     expect(match).not.toBeNull();
     const [, withdraw, sacrificial, protectedAmt] = match!;

--- a/services/vault/src/applications/aave/positionNotifications/calculate.ts
+++ b/services/vault/src/applications/aave/positionNotifications/calculate.ts
@@ -398,7 +398,7 @@ export function calculate(params: CalculatorParams): CalculatorResult {
       warnings.push({
         type: "urgent",
         title: urgent.approachingTitle(distAbs.toFixed(1)),
-        detail: urgent.approachingDetail(liqPriceStr, distAbs.toFixed(2)),
+        detail: urgent.approachingDetail(liqPriceStr),
         suggestion: urgent.approachingSuggestion,
       });
     }

--- a/services/vault/src/components/pages/BorrowingMarketsData/BorrowMarketsTable.tsx
+++ b/services/vault/src/components/pages/BorrowingMarketsData/BorrowMarketsTable.tsx
@@ -1,4 +1,4 @@
-import { Avatar, Hint } from "@babylonlabs-io/core-ui";
+import { Avatar } from "@babylonlabs-io/core-ui";
 
 import { COPY } from "@/copy";
 
@@ -57,11 +57,8 @@ export function BorrowMarketsTable({ rows }: { rows: BorrowMarketRow[] }) {
             <div className={`${DATA_COLUMN_CLASS} ${HEADER_TEXT_CLASS}`}>
               {columns.borrowApr}
             </div>
-            <div
-              className={`${DATA_COLUMN_CLASS} flex items-center gap-1 ${HEADER_TEXT_CLASS}`}
-            >
+            <div className={`${DATA_COLUMN_CLASS} ${HEADER_TEXT_CLASS}`}>
               {columns.available}
-              <Hint tooltip={columns.availableTooltip} />
             </div>
             <div className={`${DATA_COLUMN_CLASS} ${HEADER_TEXT_CLASS}`}>
               {columns.utilization}

--- a/services/vault/src/components/pages/BorrowingMarketsData/__tests__/BorrowMarketsTable.test.tsx
+++ b/services/vault/src/components/pages/BorrowingMarketsData/__tests__/BorrowMarketsTable.test.tsx
@@ -52,7 +52,7 @@ describe("BorrowMarketsTable", () => {
 
     expect(screen.getByText("Market")).toBeInTheDocument();
     expect(screen.getByText("Borrow APR")).toBeInTheDocument();
-    expect(screen.getByText("Available")).toBeInTheDocument();
+    expect(screen.getByText("Available Liquidity")).toBeInTheDocument();
     expect(screen.getByText("Utilization")).toBeInTheDocument();
     expect(screen.getByText("Borrowed")).toBeInTheDocument();
     expect(screen.getByText("Supplied")).toBeInTheDocument();

--- a/services/vault/src/components/pages/Liquidations/LiquidationEventCard.tsx
+++ b/services/vault/src/components/pages/Liquidations/LiquidationEventCard.tsx
@@ -10,8 +10,8 @@ import type { LiquidationEventCard as EventCardData } from "./liquidationChartDa
  * Per-event breakdown card (Figma node 10251:64809). Purely presentational —
  * every value arrives pre-formatted from `buildLiquidationChartData`.
  *
- * The top rule and the badge both carry the event's identity: the rule matches
- * the band's colour lane in the chart, the badge its role in the cascade.
+ * The top rule carries the event's identity, matching the band's colour lane
+ * in the chart.
  */
 
 const TONE_BORDER: Record<EventCardData["tone"], string> = {
@@ -117,12 +117,6 @@ function SeizureRow({
 }
 
 export function LiquidationEventCard({ card }: { card: EventCardData }) {
-  const sacrificial = card.badge === "sacrificial";
-  // Colour tracks whether the event has FIRED, not its position in the
-  // cascade. Keying off `sacrificial` left every protected event green even
-  // once the price had fallen through its trigger — with `formatSignedPct`
-  // unsigned at the time, the minus sign was the only cue left that anything
-  // had happened.
   const { triggered } = card;
 
   return (
@@ -136,16 +130,6 @@ export function LiquidationEventCard({ card }: { card: EventCardData }) {
         <h3 className="text-xl leading-[1.6] tracking-[0.15px] text-accent-primary">
           {card.title}
         </h3>
-        <span
-          className={twJoin(
-            "rounded-full px-2.5 py-1 text-xs leading-[1.4] tracking-[0.4px] text-primary-main",
-            sacrificial ? "bg-risk-amber" : "bg-risk-green",
-          )}
-        >
-          {sacrificial
-            ? COPY.liquidations.events.badgeSacrificial
-            : COPY.liquidations.events.badgeProtected}
-        </span>
       </div>
 
       <div className="flex gap-16">

--- a/services/vault/src/components/pages/Liquidations/LiquidationEventCard.tsx
+++ b/services/vault/src/components/pages/Liquidations/LiquidationEventCard.tsx
@@ -126,11 +126,9 @@ export function LiquidationEventCard({ card }: { card: EventCardData }) {
         TONE_BORDER[card.tone],
       )}
     >
-      <div className="flex items-center justify-between">
-        <h3 className="text-xl leading-[1.6] tracking-[0.15px] text-accent-primary">
-          {card.title}
-        </h3>
-      </div>
+      <h3 className="text-xl leading-[1.6] tracking-[0.15px] text-accent-primary">
+        {card.title}
+      </h3>
 
       <div className="flex gap-16">
         <Stat

--- a/services/vault/src/components/pages/Liquidations/PositionOverview.tsx
+++ b/services/vault/src/components/pages/Liquidations/PositionOverview.tsx
@@ -50,7 +50,6 @@ export function PositionOverview({
     () => [
       {
         label: COPY.liquidations.position.totalCollateralValue,
-        tooltip: COPY.overview.totalCollateralValueTooltip,
         value: formatBtcAmount(collateralBtc),
         caption:
           collateralValueUsd !== null

--- a/services/vault/src/components/pages/Liquidations/__tests__/LiquidationEventCard.test.tsx
+++ b/services/vault/src/components/pages/Liquidations/__tests__/LiquidationEventCard.test.tsx
@@ -57,7 +57,7 @@ describe("LiquidationEventCard", () => {
     ).toBeInTheDocument();
   });
 
-  it("shows no fairness tooltip when the card supplies none", () => {
+  it("shows the debt-repaid fairness tooltip on a non-full liquidation", () => {
     render(
       <LiquidationEventCard
         card={{
@@ -65,13 +65,14 @@ describe("LiquidationEventCard", () => {
           fairness: {
             label: COPY.liquidations.events.fairnessDebtRepaid,
             value: "$50",
+            tooltip: COPY.liquidations.events.fairnessDebtRepaidTooltip,
           },
         }}
       />,
     );
 
     expect(
-      screen.queryByText(COPY.liquidations.events.fairnessPaymentTooltip),
-    ).not.toBeInTheDocument();
+      screen.getByText(COPY.liquidations.events.fairnessDebtRepaidTooltip),
+    ).toBeInTheDocument();
   });
 });

--- a/services/vault/src/components/pages/Liquidations/__tests__/LiquidationEventCard.test.tsx
+++ b/services/vault/src/components/pages/Liquidations/__tests__/LiquidationEventCard.test.tsx
@@ -15,7 +15,6 @@ import type { LiquidationEventCard as EventCardData } from "../liquidationChartD
 const CARD: EventCardData = {
   key: "0",
   title: "Liq Event 1",
-  badge: "sacrificial",
   tone: "1",
   triggered: false,
   collateralLabel: "0.42 BTC",

--- a/services/vault/src/components/pages/Liquidations/__tests__/liquidationChartData.test.ts
+++ b/services/vault/src/components/pages/Liquidations/__tests__/liquidationChartData.test.ts
@@ -185,7 +185,7 @@ describe("buildLiquidationChartData", () => {
     expect(bands[1].cumulativeLabel).toBe("100% seized");
   });
 
-  it("keys titles and badges off array position, not the calculator's 1-based index", () => {
+  it("keys titles off array position, not the calculator's 1-based index", () => {
     // calculate() emits group.index starting at 1.
     const result = makeResult([
       makeGroup(1, { liquidationPrice: 77_682 }),
@@ -199,8 +199,7 @@ describe("buildLiquidationChartData", () => {
 
     expect(bands[0].label).toBe("Liq Event 1");
     expect(cards[0].title).toBe("Liq Event 1");
-    expect(cards[0].badge).toBe("sacrificial");
-    expect(cards[1].badge).toBe("protected");
+    expect(cards[1].title).toBe("Liq Event 2");
   });
 
   it("prices each event's aftermath at its own trigger, not the simulated price", () => {
@@ -382,9 +381,9 @@ describe("buildLiquidationChartData", () => {
   });
 
   // Group `index` fields are 1-based and unrelated to array position (a real
-  // cascade never emits index 0 — see calculate.ts). Badge, title, and tone
-  // must all key off the group's POSITION in the array, not `group.index`.
-  it("badges only the first-seized group (by array position, not group.index) as sacrificial", () => {
+  // cascade never emits index 0 — see calculate.ts). Title and tone must both
+  // key off the group's POSITION in the array, not `group.index`.
+  it("titles and tones groups by array position, not group.index", () => {
     const result = makeResult([makeGroup(1), makeGroup(2), makeGroup(3)]);
     const { cards } = buildLiquidationChartData(result, {
       vaultsTotal: vaultCount(result),
@@ -392,11 +391,12 @@ describe("buildLiquidationChartData", () => {
       collateralFactor: CF,
     });
 
-    expect(cards.map((c) => c.badge)).toEqual([
-      "sacrificial",
-      "protected",
-      "protected",
+    expect(cards.map((c) => c.title)).toEqual([
+      "Liq Event 1",
+      "Liq Event 2",
+      "Liq Event 3",
     ]);
+    expect(cards.map((c) => c.tone)).toEqual(["1", "2", "3"]);
   });
 
   it("titles the first event 'Liq Event 1' regardless of the group's index field", () => {
@@ -430,7 +430,7 @@ describe("buildLiquidationChartData", () => {
   // Drives the assertions from a REAL calculate() cascade (not hand-built
   // groups), so these fixtures can't drift from the calculator's actual index
   // base the way the hand-built ones once did.
-  it("badges, titles, and tones the first real-cascade group as sacrificial from a real calculate() result", () => {
+  it("titles and tones groups by array position from a real calculate() result", () => {
     const result = realCascadeResult();
     expect(result.groups).toHaveLength(3);
     // Confirms the fixture still exercises the bug: calculate() emits 1-based
@@ -443,11 +443,6 @@ describe("buildLiquidationChartData", () => {
       collateralFactor: REAL_CF,
     });
 
-    expect(cards.map((c) => c.badge)).toEqual([
-      "sacrificial",
-      "protected",
-      "protected",
-    ]);
     expect(cards[0].title).toBe("Liq Event 1");
     expect(cards.map((c) => c.tone)).toEqual(bands.map((b) => b.tone));
     expect(cards.map((c) => c.key)).toEqual(bands.map((b) => b.key));
@@ -502,10 +497,9 @@ describe("buildLiquidationChartData", () => {
     ).toBe(COPY.liquidations.events.fairnessDebtRepaidTooltip);
   });
 
-  // The card colour used to key off `badge` (array position), so a protected
-  // event stayed green under a "Protected" pill even after the price had
-  // fallen through its trigger.
-  it("marks a card triggered on the same rule that flips its band, regardless of badge", () => {
+  // The card colour used to key off array position, so a later event stayed
+  // green even after the price had fallen through its trigger.
+  it("marks a card triggered on the same rule that flips its band", () => {
     const result = makeResult([
       makeGroup(1, { liquidationPrice: 77_682 }),
       makeGroup(2, { liquidationPrice: 40_283 }),
@@ -522,8 +516,7 @@ describe("buildLiquidationChartData", () => {
     expect(cards.map((c) => c.triggered)).toEqual(
       bands.map((b) => b.state === "liquidated"),
     );
-    // Position 1 onwards is "protected", yet it has demonstrably triggered.
-    expect(cards[1].badge).toBe("protected");
+    // A later-position event has demonstrably triggered.
     expect(cards[1].triggered).toBe(true);
   });
 

--- a/services/vault/src/components/pages/Liquidations/__tests__/liquidationChartData.test.ts
+++ b/services/vault/src/components/pages/Liquidations/__tests__/liquidationChartData.test.ts
@@ -476,9 +476,10 @@ describe("buildLiquidationChartData", () => {
     expect(cards[0].fairness.value).toContain("0.002");
   });
 
-  // The tooltip describes a payment to the user's wallet, which only the
-  // full-liquidation variant makes — the debt-repaid row must not claim it.
-  it("carries the fairness tooltip on the payment variant only", () => {
+  // Each fairness variant carries its own tooltip: the payment variant
+  // describes a payment to the user's wallet, the debt-repaid variant
+  // describes the liquidator's additional debt repayment.
+  it("carries the matching fairness tooltip per variant", () => {
     const paymentResult = makeResult([
       makeGroup(1, { isFullLiquidation: true, fairnessPaymentUsd: 81 }),
     ]);
@@ -498,7 +499,7 @@ describe("buildLiquidationChartData", () => {
     expect(
       buildLiquidationChartData(debtRepaidResult, options).cards[0].fairness
         .tooltip,
-    ).toBeUndefined();
+    ).toBe(COPY.liquidations.events.fairnessDebtRepaidTooltip);
   });
 
   // The card colour used to key off `badge` (array position), so a protected

--- a/services/vault/src/components/pages/Liquidations/liquidationChartData.ts
+++ b/services/vault/src/components/pages/Liquidations/liquidationChartData.ts
@@ -376,6 +376,7 @@ function toCard(
     : {
         label: COPY.liquidations.events.fairnessDebtRepaid,
         value: formatUsd(group.fairnessDebtRepay),
+        tooltip: COPY.liquidations.events.fairnessDebtRepaidTooltip,
       };
 
   return {
@@ -438,9 +439,6 @@ export function buildLiquidationChartData(
     return {
       key: String(i),
       label: COPY.liquidations.eventTitle(i + 1),
-      sublabel: COPY.liquidations.containVaults(
-        group.vaults.map((v) => v.name.toLowerCase()).join(", "),
-      ),
       amountLabel: formatBtcAmount(group.combinedBtc),
       priceTop: group.liquidationPrice,
       priceBottom,

--- a/services/vault/src/components/pages/Liquidations/liquidationChartData.ts
+++ b/services/vault/src/components/pages/Liquidations/liquidationChartData.ts
@@ -62,7 +62,7 @@ export interface LiquidationEventCard {
   debtRepaidLabel: string;
   liquidatorProfitLabel: string;
   /** Full group shows a wBTC fairness payment; safe groups show fairness debt repaid. */
-  fairness: { label: string; value: string; tooltip?: string };
+  fairness: { label: string; value: string; tooltip: string };
   btcRemainingLabel: string;
   debtRemainingLabel: string;
   hfAfterLabel: string;
@@ -426,6 +426,9 @@ export function buildLiquidationChartData(
     return {
       key: String(i),
       label: COPY.liquidations.eventTitle(i + 1),
+      accessibleDetail: COPY.liquidations.containVaults(
+        group.vaults.map((v) => v.name.toLowerCase()).join(", "),
+      ),
       amountLabel: formatBtcAmount(group.combinedBtc),
       priceTop: group.liquidationPrice,
       priceBottom,

--- a/services/vault/src/components/pages/Liquidations/liquidationChartData.ts
+++ b/services/vault/src/components/pages/Liquidations/liquidationChartData.ts
@@ -31,11 +31,6 @@ import {
  *    — the event's own trigger price, not the simulated price, since the
  *    fairness payment is a property of that liquidation, not of wherever the
  *    simulator currently sits.
- *  - Sacrificial vs Protected badge: no backing field exists. `calculate.ts`
- *    emits groups in seizure order but with a 1-based `index` field, so
- *    "first group" is the group's POSITION in the `groups` array (position 0),
- *    never `group.index` itself. The first-position group is the sacrificial
- *    one; the rest are protected.
  */
 
 const TONES: LiquidationBandTone[] = ["1", "2", "3"];
@@ -50,21 +45,15 @@ export interface AmountParts {
 export interface LiquidationEventCard {
   key: string;
   title: string;
-  badge: "sacrificial" | "protected";
   /** Matches the band's colour lane — drives the card's top rule. */
   tone: LiquidationBandTone;
-  /**
-   * The price has fallen to or through this event's trigger. Distinct from
-   * `badge`, which is the event's fixed role in the cascade (position 0 is
-   * sacrificial) and does not move with the simulator.
-   */
+  /** The price has fallen to or through this event's trigger. */
   triggered: boolean;
   collateralLabel: string;
   liqPriceLabel: string;
   distanceLabel: string;
   /** Sign of the distance, so a consumer can tint it without re-parsing
-   *  `distanceLabel`. The overview cards tint negative distances; the
-   *  dashboard-page cards tint by `badge` instead. */
+   *  `distanceLabel`. The overview cards tint negative distances. */
   distanceNegative: boolean;
   seizedVaults: ({ name: string } & AmountParts)[];
   targetSeizure: AmountParts;
@@ -356,8 +345,8 @@ function hfAfter(group: LiquidationGroup, cf: number): string {
 }
 
 // `position` is the group's array index: `calculate()` emits 1-based
-// `group.index`, so array position is the only safe identity for titles,
-// badges, and keys. Aftermath figures are priced at the event's own trigger —
+// `group.index`, so array position is the only safe identity for titles
+// and keys. Aftermath figures are priced at the event's own trigger —
 // the price at which the liquidation actually executes — never the ambient
 // (possibly simulated) price.
 function toCard(
@@ -366,7 +355,6 @@ function toCard(
   cf: number,
   btcPrice: number,
 ): LiquidationEventCard {
-  const sacrificial = position === 0;
   const fairness = group.isFullLiquidation
     ? {
         label: COPY.liquidations.events.fairnessPaymentWbtc,
@@ -382,7 +370,6 @@ function toCard(
   return {
     key: String(position),
     title: COPY.liquidations.eventTitle(position + 1),
-    badge: sacrificial ? "sacrificial" : "protected",
     // Same rule as a band's `state`, so a card and its band can never
     // disagree about whether the event has fired.
     triggered: btcPrice <= group.liquidationPrice,

--- a/services/vault/src/components/shared/NotificationCard.tsx
+++ b/services/vault/src/components/shared/NotificationCard.tsx
@@ -60,7 +60,7 @@ const SURFACE_CONTRAST = "bg-background-contrast";
 // deviate per card.
 const ACTION_RADIUS = "rounded-lg";
 const ACTION_SIZE_DEFAULT = "";
-const ACTION_SIZE_TALL = "h-10 text-base"; // "Add sacrificial vault" (§3)
+const ACTION_SIZE_TALL = "h-10 text-base"; // Cliff's "Add Collateral" (§3)
 const ACTION_SIZE_WIDE = "h-9 px-6"; // "Apply Optimal Order" (§5)
 
 // Outlined actions take Figma's `stroke/primary` (#5A5A5A in dark), not the

--- a/services/vault/src/components/shared/__tests__/NotificationCard.test.tsx
+++ b/services/vault/src/components/shared/__tests__/NotificationCard.test.tsx
@@ -84,7 +84,7 @@ describe("NotificationCard", () => {
   it("sizes the action button per tone", () => {
     const actions = [{ label: "Go", onClick: vi.fn() }];
 
-    // Cliff's "Add sacrificial vault" is 40px tall with 16px text.
+    // Cliff's "Add Collateral" is 40px tall with 16px text.
     const cliff = render(
       <NotificationCard
         tone="cliff"

--- a/services/vault/src/components/simple/CollateralFactorRow.tsx
+++ b/services/vault/src/components/simple/CollateralFactorRow.tsx
@@ -32,18 +32,15 @@ export function CollateralFactorRow({
   return (
     <div className="flex items-center justify-between text-sm">
       <span className="text-accent-primary">{FORM_COPY.maxToBorrowLabel}</span>
-      <span>
+      <span className="inline-flex items-center gap-1">
         <span className="text-accent-primary">
           {maxBorrowUsd !== null
             ? `${formatCompactUsd(maxBorrowUsd)} USD`
             : "--"}
         </span>
         <span className="text-accent-secondary">
-          {" "}
           {FORM_COPY.cfParenthetical(percent)}
         </span>
-        {/* attach-to-children keeps the markup inline-valid inside this
-            span (a bare Hint would nest a div inside it). */}
         <Hint tooltip={COPY.tooltips.collateralFactor} attachToChildren>
           <InfoIcon size={16} className="text-accent-secondary" />
         </Hint>

--- a/services/vault/src/components/simple/CollateralFactorRow.tsx
+++ b/services/vault/src/components/simple/CollateralFactorRow.tsx
@@ -1,4 +1,4 @@
-import { Hint } from "@babylonlabs-io/core-ui";
+import { Hint, InfoIcon } from "@babylonlabs-io/core-ui";
 
 import { COPY } from "@/copy";
 import { computeMaxBorrowUsd } from "@/utils/collateral";
@@ -42,7 +42,11 @@ export function CollateralFactorRow({
           {" "}
           {FORM_COPY.cfParenthetical(percent)}
         </span>
-        <Hint tooltip={COPY.tooltips.collateralFactor} />
+        {/* attach-to-children keeps the markup inline-valid inside this
+            span (a bare Hint would nest a div inside it). */}
+        <Hint tooltip={COPY.tooltips.collateralFactor} attachToChildren>
+          <InfoIcon size={16} className="text-accent-secondary" />
+        </Hint>
       </span>
     </div>
   );

--- a/services/vault/src/components/simple/CollateralFactorRow.tsx
+++ b/services/vault/src/components/simple/CollateralFactorRow.tsx
@@ -1,3 +1,5 @@
+import { Hint } from "@babylonlabs-io/core-ui";
+
 import { COPY } from "@/copy";
 import { computeMaxBorrowUsd } from "@/utils/collateral";
 import { formatCompactUsd } from "@/utils/formatting";
@@ -40,6 +42,7 @@ export function CollateralFactorRow({
           {" "}
           {FORM_COPY.cfParenthetical(percent)}
         </span>
+        <Hint tooltip={COPY.tooltips.collateralFactor} />
       </span>
     </div>
   );

--- a/services/vault/src/components/simple/DepositProgressView/__tests__/DepositProgressView.test.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/__tests__/DepositProgressView.test.tsx
@@ -506,9 +506,7 @@ describe("DepositProgressView", () => {
       );
 
       expect(
-        screen.getByRole("button", {
-          name: "You can close and come back later",
-        }),
+        screen.getByRole("button", { name: "Close & continue later" }),
       ).toBeInTheDocument();
     });
 

--- a/services/vault/src/components/simple/DepositProgressView/__tests__/DepositProgressView.test.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/__tests__/DepositProgressView.test.tsx
@@ -507,7 +507,7 @@ describe("DepositProgressView", () => {
 
       expect(
         screen.getByRole("button", {
-          name: "Close & continue later",
+          name: "You can close and come back later",
         }),
       ).toBeInTheDocument();
     });

--- a/services/vault/src/components/simple/OverviewSection.tsx
+++ b/services/vault/src/components/simple/OverviewSection.tsx
@@ -60,7 +60,6 @@ export function OverviewSection({
     () => [
       {
         label: COPY.overview.totalCollateralValueLabel,
-        tooltip: COPY.overview.totalCollateralValueTooltip,
         value: totalCollateralValue,
         caption: collateralBtc,
         actionLabel: COPY.overview.depositAction,

--- a/services/vault/src/components/simple/PositionNotificationBanner/BannerActions.tsx
+++ b/services/vault/src/components/simple/PositionNotificationBanner/BannerActions.tsx
@@ -32,9 +32,9 @@ interface BuildBannerActionsArgs {
  * `Notification` `actions` slot:
  * - urgent: "Add Collateral" (primary, filled) + "Repay Debt" (secondary,
  *   outlined) — the core safety actions, matching the Figma callout.
- * - cliff with an affordable sacrificial size: "Add sacrificial vault" (generic
- *   label per Figma; the amount lives in the suggestion text) — opens the
- *   deposit flow with that amount pre-filled.
+ * - cliff with an affordable actionable size: "Add Collateral" (same label as
+ *   the urgent CTA per Figma; the amount lives in the suggestion text) —
+ *   opens the deposit flow with that amount pre-filled.
  * - optimal reorder available: "Apply Optimal Order" — filled (primary) on the
  *   standalone reorder card, secondary when it accompanies the urgent callout.
  *
@@ -79,17 +79,18 @@ export function buildBannerActions({
     );
   }
 
-  // Add-sacrificial-vault CTA on a cliff when the calculator produced an
-  // actionable size — "add a sacrificial vault of this exact size". When an
-  // urgent warning is primary it rides along as a secondary action so the
-  // safety actions lead. The calculator guarantees the amount is positive and
-  // no larger than the position. Generic "Add sacrificial vault" label (the
-  // amount lives in the suggestion text per Figma).
+  // Add-vault CTA on a cliff when the calculator produced an actionable size
+  // — "add a vault of this exact size". When an urgent warning is primary it
+  // rides along as a secondary action so the safety actions lead. The
+  // calculator guarantees the amount is positive and no larger than the
+  // position. Shares the "Add Collateral" label with the urgent CTA per
+  // Figma (the amount lives in the suggestion text); the two can render
+  // together as duplicate-labeled buttons when both warnings are active.
   const hasCliffWarning = result.warnings.some((w) => w.type === "cliff");
   if (hasCliffWarning && result.suggestedNewVaultBtc !== null) {
     const amountBtc = result.suggestedNewVaultBtc.toFixed(2);
     actions.push({
-      label: COPY.banner.addSacrificialVault,
+      label: COPY.banner.addCollateral,
       onClick: () => onDeposit(amountBtc),
       emphasis: isUrgent ? "secondary" : "primary",
       // Adding a vault is a deposit — blocked under a protocol Freeze/Pause.

--- a/services/vault/src/components/simple/PositionNotificationBanner/BannerActions.tsx
+++ b/services/vault/src/components/simple/PositionNotificationBanner/BannerActions.tsx
@@ -32,9 +32,9 @@ interface BuildBannerActionsArgs {
  * `Notification` `actions` slot:
  * - urgent: "Add Collateral" (primary, filled) + "Repay Debt" (secondary,
  *   outlined) — the core safety actions, matching the Figma callout.
- * - cliff with an affordable actionable size: "Add Collateral" (same label as
- *   the urgent CTA per Figma; the amount lives in the suggestion text) —
- *   opens the deposit flow with that amount pre-filled.
+ * - cliff with an affordable actionable size: "Add <amount> BTC" — opens the
+ *   deposit flow with that amount pre-filled. The amount sits in the label so
+ *   the button stays distinguishable from the urgent "Add Collateral" CTA.
  * - optimal reorder available: "Apply Optimal Order" — filled (primary) on the
  *   standalone reorder card, secondary when it accompanies the urgent callout.
  *
@@ -83,14 +83,13 @@ export function buildBannerActions({
   // — "add a vault of this exact size". When an urgent warning is primary it
   // rides along as a secondary action so the safety actions lead. The
   // calculator guarantees the amount is positive and no larger than the
-  // position. Shares the "Add Collateral" label with the urgent CTA per
-  // Figma (the amount lives in the suggestion text); the two can render
-  // together as duplicate-labeled buttons when both warnings are active.
+  // position. The amount sits in the label so this button never collides
+  // with the urgent "Add Collateral" CTA when both warnings are active.
   const hasCliffWarning = result.warnings.some((w) => w.type === "cliff");
   if (hasCliffWarning && result.suggestedNewVaultBtc !== null) {
     const amountBtc = result.suggestedNewVaultBtc.toFixed(2);
     actions.push({
-      label: COPY.banner.addCollateral,
+      label: COPY.banner.addVaultOfSize(amountBtc),
       onClick: () => onDeposit(amountBtc),
       emphasis: isUrgent ? "secondary" : "primary",
       // Adding a vault is a deposit — blocked under a protocol Freeze/Pause.

--- a/services/vault/src/components/simple/PositionNotificationBanner/__tests__/BannerActions.test.ts
+++ b/services/vault/src/components/simple/PositionNotificationBanner/__tests__/BannerActions.test.ts
@@ -139,7 +139,7 @@ describe("buildBannerActions — urgent CTA gating", () => {
     ).toBe(false);
   });
 
-  it("disables the cliff Add-sacrificial-vault CTA when deposits are blocked", () => {
+  it("disables the cliff Add Collateral CTA when deposits are blocked", () => {
     const cliffState: BannerState = {
       severity: "yellow",
       primaryWarning: {
@@ -163,13 +163,13 @@ describe("buildBannerActions — urgent CTA gating", () => {
 
     expect(
       build(cliffState, cliffResult).find(
-        (a) => a.label === COPY.banner.addSacrificialVault,
+        (a) => a.label === COPY.banner.addCollateral,
       )?.disabled,
     ).toBe(false);
 
     expect(
       build(cliffState, cliffResult, { depositBlocked: true }).find(
-        (a) => a.label === COPY.banner.addSacrificialVault,
+        (a) => a.label === COPY.banner.addCollateral,
       )?.disabled,
     ).toBe(true);
   });

--- a/services/vault/src/components/simple/PositionNotificationBanner/__tests__/BannerActions.test.ts
+++ b/services/vault/src/components/simple/PositionNotificationBanner/__tests__/BannerActions.test.ts
@@ -27,6 +27,7 @@ function makeResult(
 }
 
 interface GateOpts {
+  onDeposit?: (initialAmountBtc?: string) => void;
   reorderBlocked?: boolean;
   orderVerifiable?: boolean;
   depositBlocked?: boolean;
@@ -41,7 +42,7 @@ function build(
   return buildBannerActions({
     result,
     bannerState,
-    onDeposit: vi.fn(),
+    onDeposit: gate.onDeposit ?? vi.fn(),
     onRepay: vi.fn(),
     onApplyOrder: vi.fn(),
     isReordering: false,
@@ -139,7 +140,7 @@ describe("buildBannerActions — urgent CTA gating", () => {
     ).toBe(false);
   });
 
-  it("disables the cliff Add Collateral CTA when deposits are blocked", () => {
+  it("disables the cliff add-vault CTA when deposits are blocked", () => {
     const cliffState: BannerState = {
       severity: "yellow",
       primaryWarning: {
@@ -163,14 +164,51 @@ describe("buildBannerActions — urgent CTA gating", () => {
 
     expect(
       build(cliffState, cliffResult).find(
-        (a) => a.label === COPY.banner.addCollateral,
+        (a) => a.label === COPY.banner.addVaultOfSize("0.14"),
       )?.disabled,
     ).toBe(false);
 
     expect(
       build(cliffState, cliffResult, { depositBlocked: true }).find(
-        (a) => a.label === COPY.banner.addCollateral,
+        (a) => a.label === COPY.banner.addVaultOfSize("0.14"),
       )?.disabled,
     ).toBe(true);
+  });
+
+  it("gives the urgent and cliff CTAs distinct labels and payloads", () => {
+    const onDeposit = vi.fn();
+    const urgentCliffState: BannerState = {
+      severity: "red",
+      primaryWarning: {
+        type: "urgent",
+        title: "Liquidation risk",
+        detail: "…",
+      },
+      secondaryWarnings: [],
+      suggestReorder: false,
+    };
+    const urgentCliffResult = makeResult({
+      warnings: [
+        { type: "urgent", title: "Liquidation risk", detail: "…" },
+        {
+          type: "cliff",
+          title: "First liquidation takes everything",
+          detail: "…",
+        },
+      ],
+      suggestedNewVaultBtc: 0.72,
+    });
+
+    const actions = build(urgentCliffState, urgentCliffResult, { onDeposit });
+    const labels = actions.map((a) => a.label);
+    expect(new Set(labels).size).toBe(labels.length);
+
+    actions.find((a) => a.label === COPY.banner.addCollateral)?.onClick();
+    expect(onDeposit).toHaveBeenLastCalledWith();
+
+    actions
+      .find((a) => a.label === COPY.banner.addVaultOfSize("0.72"))
+      ?.onClick();
+    expect(onDeposit).toHaveBeenLastCalledWith("0.72");
   });
 });

--- a/services/vault/src/components/simple/PositionNotificationBanner/__tests__/PositionNotificationBanner.test.tsx
+++ b/services/vault/src/components/simple/PositionNotificationBanner/__tests__/PositionNotificationBanner.test.tsx
@@ -566,7 +566,7 @@ describe("PositionNotificationBanner", () => {
     expect(screen.queryByTestId("position-notification-banner")).toBeNull();
   });
 
-  it("keeps the cliff Add Collateral CTA (secondary) when a single-vault cliff is also urgent", () => {
+  it("keeps the cliff add-vault CTA (secondary) when a single-vault cliff is also urgent", () => {
     const result = makeBaseResult({
       warnings: [
         {
@@ -588,13 +588,11 @@ describe("PositionNotificationBanner", () => {
 
     const banner = screen.getByTestId("position-notification-banner");
     expect(banner.dataset.severity).toBe("red");
-    // Safety actions still lead, and the pre-filled cliff CTA is still offered
-    // — it shares the "Add Collateral" label with the urgent CTA per Figma,
-    // so both buttons render with identical text.
-    const addCollateralButtons = screen.getAllByText("Add Collateral");
-    expect(addCollateralButtons).toHaveLength(2);
+    // Safety actions still lead, and the pre-filled cliff CTA rides along with
+    // its amount in the label so the two buttons stay distinguishable.
+    expect(screen.getByText("Add Collateral")).toBeTruthy();
     expect(screen.getByText("Repay Debt")).toBeTruthy();
-    fireEvent.click(addCollateralButtons[1]);
+    fireEvent.click(screen.getByText("Add 0.72 BTC"));
     expect(onDeposit).toHaveBeenCalledWith("0.72");
   });
 });
@@ -640,7 +638,8 @@ describe("PositionNotificationBanner v3", () => {
           type: "cliff",
           title: "First liquidation takes everything",
           detail: "A single liquidation event seizes all your BTC.",
-          suggestion: "Adding a 0.14 BTCVault enables partial liquidation",
+          suggestion:
+            "Adding a new BTCVault of 0.14 BTC enables partial liquidation.",
         },
       ],
       suggestedNewVaultBtc: 0.12,
@@ -649,10 +648,8 @@ describe("PositionNotificationBanner v3", () => {
 
     const banner = screen.getByTestId("position-notification-banner");
     expect(banner.dataset.tone).toBe("cliff");
-    expect(
-      screen.getByText(/Adding a 0.14 BTCVault enables partial liquidation/),
-    ).toBeTruthy();
-    expect(screen.getByText("Add Collateral")).toBeTruthy();
+    expect(screen.getByText(/Adding a new BTCVault of 0.14 BTC/)).toBeTruthy();
+    expect(screen.getByText("Add 0.12 BTC")).toBeTruthy();
     expect(screen.queryByText("Suggestion")).toBeNull();
   });
 

--- a/services/vault/src/components/simple/PositionNotificationBanner/__tests__/PositionNotificationBanner.test.tsx
+++ b/services/vault/src/components/simple/PositionNotificationBanner/__tests__/PositionNotificationBanner.test.tsx
@@ -566,7 +566,7 @@ describe("PositionNotificationBanner", () => {
     expect(screen.queryByTestId("position-notification-banner")).toBeNull();
   });
 
-  it("keeps the sacrificial CTA (secondary) when a single-vault cliff is also urgent", () => {
+  it("keeps the cliff Add Collateral CTA (secondary) when a single-vault cliff is also urgent", () => {
     const result = makeBaseResult({
       warnings: [
         {
@@ -578,9 +578,8 @@ describe("PositionNotificationBanner", () => {
           type: "cliff",
           title: "First liquidation takes everything",
           detail:
-            "With your current BTC Vaults, a single liquidation event seizes all your BTC — nothing remains protected behind it.",
-          suggestion:
-            "Adding a sacrificial 0.72 BTC Vault creates a buffer — it gets liquidated first, your existing BTC survives.",
+            "With your current BTCvaults, a single liquidation event liquidates all your BTC in collateral.",
+          suggestion: "Adding a 0.72 BTCVault enables partial liquidation",
         },
       ],
       suggestedNewVaultBtc: 0.72,
@@ -589,10 +588,13 @@ describe("PositionNotificationBanner", () => {
 
     const banner = screen.getByTestId("position-notification-banner");
     expect(banner.dataset.severity).toBe("red");
-    // Safety actions still lead, and the pre-filled cliff CTA is still offered.
-    expect(screen.getByText("Add Collateral")).toBeTruthy();
+    // Safety actions still lead, and the pre-filled cliff CTA is still offered
+    // — it shares the "Add Collateral" label with the urgent CTA per Figma,
+    // so both buttons render with identical text.
+    const addCollateralButtons = screen.getAllByText("Add Collateral");
+    expect(addCollateralButtons).toHaveLength(2);
     expect(screen.getByText("Repay Debt")).toBeTruthy();
-    fireEvent.click(screen.getByText("Add sacrificial BTCVault"));
+    fireEvent.click(addCollateralButtons[1]);
     expect(onDeposit).toHaveBeenCalledWith("0.72");
   });
 });
@@ -638,7 +640,7 @@ describe("PositionNotificationBanner v3", () => {
           type: "cliff",
           title: "First liquidation takes everything",
           detail: "A single liquidation event seizes all your BTC.",
-          suggestion: "Adding a 0.14 BTC sacrificial vault creates a buffer.",
+          suggestion: "Adding a 0.14 BTCVault enables partial liquidation",
         },
       ],
       suggestedNewVaultBtc: 0.12,
@@ -648,9 +650,9 @@ describe("PositionNotificationBanner v3", () => {
     const banner = screen.getByTestId("position-notification-banner");
     expect(banner.dataset.tone).toBe("cliff");
     expect(
-      screen.getByText(/Adding a 0.14 BTC sacrificial vault/),
+      screen.getByText(/Adding a 0.14 BTCVault enables partial liquidation/),
     ).toBeTruthy();
-    expect(screen.getByText("Add sacrificial BTCVault")).toBeTruthy();
+    expect(screen.getByText("Add Collateral")).toBeTruthy();
     expect(screen.queryByText("Suggestion")).toBeNull();
   });
 
@@ -673,7 +675,7 @@ describe("PositionNotificationBanner v3", () => {
     expect(banner.dataset.tone).toBe("cliff");
     expect(screen.getByText("Suggestion")).toBeTruthy();
     expect(screen.getByText(/withdraw your 1 BTC/)).toBeTruthy();
-    expect(screen.queryByText("Add sacrificial BTCVault")).toBeNull();
+    expect(screen.queryByText("Add Collateral")).toBeNull();
   });
 
   it("renders the dust advisory as a dismissible v3 card that stays dismissed", () => {

--- a/services/vault/src/components/simple/PositionNotificationBanner/__tests__/PositionNotificationBanner.test.tsx
+++ b/services/vault/src/components/simple/PositionNotificationBanner/__tests__/PositionNotificationBanner.test.tsx
@@ -578,7 +578,7 @@ describe("PositionNotificationBanner", () => {
           type: "cliff",
           title: "First liquidation takes everything",
           detail:
-            "With your current BTCvaults, a single liquidation event liquidates all your BTC in collateral.",
+            "With your current BTCVaults, a single liquidation event liquidates all your BTC in collateral.",
           suggestion: "Adding a 0.72 BTCVault enables partial liquidation",
         },
       ],

--- a/services/vault/src/components/simple/ReorderVaults/ReorderVaultsModal.tsx
+++ b/services/vault/src/components/simple/ReorderVaults/ReorderVaultsModal.tsx
@@ -23,12 +23,6 @@ import { V3ModalShell } from "@/components/shared/V3ModalShell";
 import { COPY } from "@/copy";
 import type { CollateralVaultEntry } from "@/types/collateral";
 
-import {
-  NETWORK_FEE_LABEL,
-  REORDER_INFO_TEXT,
-  REORDER_MODAL_SUBTITLE,
-  REORDER_MODAL_TITLE,
-} from "./constants";
 import { ReorderVaultItem } from "./ReorderVaultItem";
 import { useReorderGasEstimate } from "./useReorderGasEstimate";
 import { useReorderModal } from "./useReorderModal";
@@ -96,10 +90,10 @@ export function ReorderVaultsModal({
             as="h2"
             className="font-normal text-accent-primary"
           >
-            {REORDER_MODAL_TITLE}
+            {COPY.reorder.modalTitle}
           </Heading>
           <Text variant="subtitle1" className="text-accent-secondary">
-            {REORDER_MODAL_SUBTITLE}
+            {COPY.reorder.modalSubtitle}
           </Text>
         </div>
 
@@ -129,7 +123,7 @@ export function ReorderVaultsModal({
 
           {hasOrderChanged && (
             <p className="rounded-lg bg-secondary-contrast/5 p-3 text-sm text-accent-secondary">
-              {REORDER_INFO_TEXT}
+              {COPY.reorder.infoText}
             </p>
           )}
 
@@ -157,7 +151,7 @@ export function ReorderVaultsModal({
             )}
             {hasOrderChanged && (
               <div className="flex items-center justify-between pt-3 text-sm text-accent-secondary">
-                <span>{NETWORK_FEE_LABEL}</span>
+                <span>{COPY.reorder.networkFeeLabel}</span>
                 <span>
                   {feeEth} {feeUsd}
                 </span>

--- a/services/vault/src/components/simple/ReorderVaults/constants.ts
+++ b/services/vault/src/components/simple/ReorderVaults/constants.ts
@@ -1,9 +1,9 @@
-export const REORDER_MODAL_TITLE = "Reorder BTC Vaults";
+export const REORDER_MODAL_TITLE = "Reorder Vaults";
 
 export const REORDER_MODAL_SUBTITLE =
-  "BTC Vault order determines which collateral is liquidated first. Drag to change the liquidation priority.";
+  "This is the liquidation order of your BTCvaults. Drag to change the order.";
 
 export const REORDER_INFO_TEXT =
-  "BTC Vaults are liquidated in order from first to last. Place your smallest BTC Vault first so it acts as a sacrificial buffer. If your largest BTC Vault is first, it will be seized before smaller ones, resulting in a greater loss.";
+  "BTC Vaults are liquidated in order from first to last. Place your smallest BTC Vault first so it acts as a buffer. If your largest BTC Vault is first, it will be seized before smaller ones, resulting in a greater loss.";
 
 export const NETWORK_FEE_LABEL = "Ethereum network fee";

--- a/services/vault/src/components/simple/ReorderVaults/constants.ts
+++ b/services/vault/src/components/simple/ReorderVaults/constants.ts
@@ -1,9 +1,0 @@
-export const REORDER_MODAL_TITLE = "Reorder Vaults";
-
-export const REORDER_MODAL_SUBTITLE =
-  "This is the liquidation order of your BTCvaults. Drag to change the order.";
-
-export const REORDER_INFO_TEXT =
-  "BTC Vaults are liquidated in order from first to last. Place your smallest BTC Vault first so it acts as a buffer. If your largest BTC Vault is first, it will be seized before smaller ones, resulting in a greater loss.";
-
-export const NETWORK_FEE_LABEL = "Ethereum network fee";

--- a/services/vault/src/components/simple/ResumeDepositContent.tsx
+++ b/services/vault/src/components/simple/ResumeDepositContent.tsx
@@ -526,7 +526,7 @@ export function ResumeWotsContent({
       if (mountedRef.current) {
         setLoading(false);
         // Refetch dashboard activities so the next action surfaces while
-        // the modal stays parked on "Close & continue later".
+        // the modal stays parked on "You can close and come back later".
         onSuccess();
       }
     } catch (err) {
@@ -602,8 +602,8 @@ export function ResumeWotsContent({
 
   // Advance off the WOTS step once the local submit resolves OR the polled VP
   // status confirms acceptance. Then the modal sits on the next step as a
-  // closeable background wait ("Close & continue later"), matching the other
-  // resume waits — no separate success banner needed.
+  // closeable background wait ("You can close and come back later"),
+  // matching the other resume waits — no separate success banner needed.
   //
   // `started` gates the local half: a re-offer sits idle (not loading, no
   // error) until the user clicks, and without this that idle state would read

--- a/services/vault/src/components/simple/__tests__/CollateralFactorRow.test.tsx
+++ b/services/vault/src/components/simple/__tests__/CollateralFactorRow.test.tsx
@@ -1,5 +1,10 @@
 import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+// Component tests mock core-ui (its dist isn't built in the test run).
+vi.mock("@babylonlabs-io/core-ui", () => ({
+  Hint: () => null,
+}));
 
 import { CollateralFactorRow } from "../CollateralFactorRow";
 

--- a/services/vault/src/components/simple/__tests__/CollateralFactorRow.test.tsx
+++ b/services/vault/src/components/simple/__tests__/CollateralFactorRow.test.tsx
@@ -1,9 +1,11 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
-// Component tests mock core-ui (its dist isn't built in the test run).
+import { COPY } from "@/copy";
+
+// The mock surfaces the tooltip text so it can be asserted against its row.
 vi.mock("@babylonlabs-io/core-ui", () => ({
-  Hint: () => null,
+  Hint: ({ tooltip }: { tooltip?: string }) => <span>{tooltip}</span>,
   InfoIcon: () => null,
 }));
 
@@ -61,6 +63,20 @@ describe("CollateralFactorRow", () => {
     );
     expect(screen.getByText("(CF=72%)")).toBeInTheDocument();
     expect(screen.getByText(/\$63\.6k USD/)).toBeInTheDocument();
+  });
+
+  it("explains the collateral factor in a tooltip on the row", () => {
+    render(
+      <CollateralFactorRow
+        collateralFactor={0.72}
+        amountBtc="1"
+        btcPrice={88_400}
+        hasPriceFetchError={false}
+      />,
+    );
+    expect(
+      screen.getByText(COPY.tooltips.collateralFactor),
+    ).toBeInTheDocument();
   });
 
   it("shows -- for max-to-borrow when hasPriceFetchError is true", () => {

--- a/services/vault/src/components/simple/__tests__/CollateralFactorRow.test.tsx
+++ b/services/vault/src/components/simple/__tests__/CollateralFactorRow.test.tsx
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from "vitest";
 // Component tests mock core-ui (its dist isn't built in the test run).
 vi.mock("@babylonlabs-io/core-ui", () => ({
   Hint: () => null,
+  InfoIcon: () => null,
 }));
 
 import { CollateralFactorRow } from "../CollateralFactorRow";

--- a/services/vault/src/components/simple/__tests__/ResumeDepositContent.test.tsx
+++ b/services/vault/src/components/simple/__tests__/ResumeDepositContent.test.tsx
@@ -555,7 +555,7 @@ describe("ResumeWotsContent — polled-status terminal", () => {
 
   it("advances to a closeable background wait once the VP is past WOTS", async () => {
     // VP has accepted the WOTS key and advanced; the modal moves off the WOTS
-    // step to the next step as a "Close & continue later" background wait —
+    // step to the next step as a "You can close and come back later" background wait —
     // no separate success banner.
     mockUseDepositPollingResult.mockReturnValue({
       peginState: { contractStatus: 0 },
@@ -584,7 +584,7 @@ describe("ResumeWotsContent — polled-status terminal", () => {
     const { getByTestId } = renderWots();
 
     // The submit auto-fires; once it resolves the modal advances to the next
-    // step as a "Close & continue later" background wait with no terminal
+    // step as a "You can close and come back later" background wait with no terminal
     // banner — even though the polled state has not yet confirmed acceptance.
     await waitFor(() =>
       expect(mockSubmitWotsPublicKey).toHaveBeenCalledTimes(1),

--- a/services/vault/src/components/vaults/VaultsSummaryCard.tsx
+++ b/services/vault/src/components/vaults/VaultsSummaryCard.tsx
@@ -52,7 +52,6 @@ export function VaultsSummaryCard({
   const cards: PositionStatCard[] = [
     {
       label: COPY.vaults.summary.totalCollateralLabel,
-      tooltip: COPY.overview.totalCollateralValueTooltip,
       value: totalCollateralBtc,
       caption: totalCollateralUsd,
       actionLabel: COPY.vaults.empty.depositAction,

--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -93,8 +93,7 @@ const SIGN_TRANSACTION_LABEL = "Sign Transaction";
 // standalone download dialog and the activate-confirmation dialog so the
 // two can't drift.
 const ARTIFACTS_DOWNLOADED_TITLE = "Artifacts downloaded";
-const ARTIFACTS_DOWNLOADED_BODY =
-  "Your files are stored locally and never uploaded.";
+const ARTIFACTS_DOWNLOADED_BODY = "Keep your artifact files in the safe place!";
 
 /**
  * A run of modal body text. `emphasis` segments render in the primary text
@@ -115,7 +114,7 @@ export const COPY = {
       "The maximum percentage of borrowing power from the total collateral value.",
     // Overview position cards, risk card body, borrow / repay detail cards.
     healthFactor:
-      "Indicates the health of your position. If it falls below 1.0, your position may be liquidated.",
+      "Indicates the health of your position. If the margin ratio falls below 1.0, your position may be liquidated.",
   },
   pegin: {
     labels: {
@@ -395,7 +394,7 @@ export const COPY = {
       summary: {
         estimate: (duration: string) => `~${duration}`,
         description:
-          "Each step is divided into several wallet signature confirmations. The progress counter shows how many are completed. Your Bitcoin will only be locked once the BTC Vault is activated.",
+          "Each step is divided into several wallet signature confirmations. The progress counter shows how many are completed. You will be able to borrow assets once BTCVault is activated.",
       },
       stepsCompleted: (completed: number, total: number) =>
         `${completed} of ${total} steps completed`,
@@ -405,11 +404,10 @@ export const COPY = {
         `Step ${current} of ${total}`,
       defaultSuccessMessage: PRE_PEGIN_BROADCAST_CONFIRMATION_MESSAGE,
       doNotSpendWarning:
-        "To ensure a seamless deposit, do not spend the BTC allocated for this process until the transaction is confirmed.",
-      splitVaultColumnLabel: (vaultNumber: number) =>
-        `BTC Vault ${vaultNumber}`,
+        "Do not spend the BTC used for this deposit until the transactions are confirmed.",
+      splitVaultColumnLabel: (vaultNumber: number) => `BTCVault ${vaultNumber}`,
       buttons: {
-        closeContinueLater: "Close & continue later",
+        closeContinueLater: "You can close and come back later",
         retry: "Retry",
         close: "Close",
         done: "Done",
@@ -516,7 +514,7 @@ export const COPY = {
         { text: "Before activating, ", emphasis: false },
         { text: "download the recovery artifacts", emphasis: true },
         {
-          text: " of your BTC Vault. These files will make sure your BTC Vault is fully functional even if your vault provider becomes unavailable.",
+          text: " of your vault. These files will make sure your BTCVault is fully functional even if your vault provider becomes unavailable.",
           emphasis: false,
         },
       ] satisfies EmphasisBodySegment[],
@@ -595,8 +593,8 @@ export const COPY = {
       doneButton: "Done",
     },
     vaultActivatedSuccess: {
-      heading: "Vault activated",
-      body: "Your vault is now active and ready for borrowing.",
+      heading: "BTCVault activated",
+      body: "Your BTCvault is now active and ready for borrowing.",
       goToDashboard: "Go to Dashboard",
     },
     recoveryArtifacts: {
@@ -1432,7 +1430,7 @@ export const COPY = {
     // token units (before → after the repayment).
     debtLabel: "Debt",
     healthFactorLabel: "Health factor",
-    availableLiquidityLabel: "Available liquidity",
+    availableLiquidityLabel: "Available Liquidity",
     utilizationLabel: "Utilization",
     availableLabel: "Available",
     // Repay amount slider: prefixes the user's wallet balance shown beside Max.
@@ -1441,8 +1439,6 @@ export const COPY = {
     borrowAprTooltip: "Borrow APR currently offered on this market",
     utilizationTooltip:
       "Percentage of deposited assets currently being borrowed on this market.",
-    debtTooltip:
-      "The total amount you currently owe for this asset, including accrued interest.",
     borrowingUnavailable:
       "Borrowing is temporarily unavailable. Please check back later.",
     priceUnavailable:
@@ -1485,7 +1481,7 @@ export const COPY = {
       title: "Select asset",
       columnAsset: "Asset",
       columnPrice: "Price",
-      columnAvailable: "Available",
+      columnAvailable: "Available Liquidity",
       columnBorrowApr: "Borrow APR",
       loading: "Loading assets...",
       emptyBorrow: "No borrowable assets available",
@@ -1630,7 +1626,7 @@ export const COPY = {
     interestRateModel: {
       title: "Interest rate model",
       description:
-        "The more liquidity is borrowed, the higher the rate — this keeps the market balanced.",
+        "The more liquidity is borrowed, the higher borrowing rate according to the AAVE's Interest rate model on this market.",
     },
     borrowMarkets: {
       title: "Borrow markets",
@@ -1639,9 +1635,7 @@ export const COPY = {
       columns: {
         market: "Market",
         borrowApr: "Borrow APR",
-        available: "Available",
-        availableTooltip:
-          "Liquidity still borrowable from this market right now.",
+        available: "Available Liquidity",
         utilization: "Utilization",
         borrowed: "Borrowed",
         supplied: "Supplied",
@@ -1739,7 +1733,6 @@ export const COPY = {
     },
     reset: "Reset",
     eventTitle: (eventNumber: number) => `Liq Event ${eventNumber}`,
-    containVaults: (names: string) => `(contain ${names})`,
     cumulativeSeized: (percent: number) => `${percent}% seized`,
     popover: {
       atPrice: "At price",
@@ -1752,12 +1745,10 @@ export const COPY = {
     events: {
       heading: "Liquidation Events",
       subheading:
-        "Vaults are seized in order — each vault group is one liquidation event.",
-      badgeSacrificial: "Sacrificial",
-      badgeProtected: "Protected",
+        "BTCVaults are seized in order each BTCVault group is one liquidation event. To change the order please open Vaults page.",
       collateral: "Collateral",
       liqPrice: "Liq Price",
-      distance: "Distance",
+      distance: "% to Liquidation",
       seizedVaultsSection: "Seized Vaults",
       targetSeizure: "Target seizure",
       targetSeizureTooltip:
@@ -1766,13 +1757,15 @@ export const COPY = {
       overSeizureTooltip:
         "An additional portion of the collateral value that the liquidator may seize due to the nature of indivisible BTC Vaults.",
       estimatedLiquidationSection: "Estimated Liquidation",
-      collateralLiquidated: "Collateral liquidated",
+      collateralLiquidated: "BTCVault",
       debtRepaid: "Debt Repaid",
       liquidatorProfit: "Liquidator profit",
       fairnessDebtRepaid: "Fairness Debt Repaid",
+      // Additional debt the liquidator repays because indivisible BTC Vaults
+      // forced an over-seizure; pairs with fairnessPaymentTooltip below.
+      fairnessDebtRepaidTooltip:
+        "Additional repayment of debt by the liquidator due to over seizure of collateral.",
       fairnessPaymentWbtc: "Fairness Payment (wBTC)",
-      // Describes the payment variant only; the debt-repaid variant of the
-      // row carries no tooltip.
       fairnessPaymentTooltip:
         "Payment by the liquidator to the user's wallet due to over seizure of collateral.",
       positionAfterSection: "Position After Liquidation",
@@ -1797,8 +1790,6 @@ export const COPY = {
     positionTitle: "Position",
     healthFactorLabel: "Health factor",
     totalCollateralValueLabel: "Total collateral value",
-    totalCollateralValueTooltip:
-      "The total value of assets used as collateral.",
     totalBorrowedLabel: "Total borrowed",
     availableToBorrowLabel: "Available to borrow",
     depositAction: "Deposit",
@@ -1904,8 +1895,8 @@ export const COPY = {
       // Heading over the vaults list before any vault is active — the count
       // is dropped while the section only holds the empty state.
       vaultsTitle: "Vaults",
-      activeVaultsTitle: "Active Vaults",
-      inactiveVaultsTitle: "Inactive Vaults",
+      activeVaultsTitle: "Total Collateral",
+      inactiveVaultsTitle: "Expired Deposits",
       count: (count: number) => `(${count})`,
     },
     progressPercent: (percent: number) => `${percent}%`,
@@ -1985,7 +1976,7 @@ export const COPY = {
     // gets the Refund chip and a dimmed row.
     emptyV3Title: "No activity yet",
     emptyV3Body:
-      "Your account activity will appear here once you start using Babylon",
+      "Your account activity will appear here after your first transaction",
     pendingLabel: "Pending",
     refundChip: "Refund",
     dateToday: "Today",
@@ -1996,7 +1987,6 @@ export const COPY = {
     addCollateral: "Add Collateral",
     repayDebt: "Repay Debt",
     applyOptimalOrder: "Apply Optimal Order",
-    addSacrificialVault: "Add sacrificial BTCVault",
   },
   geoBlock: {
     title: "Service unavailable in your region",
@@ -2011,24 +2001,24 @@ export const COPY = {
   protocolFees: {
     sectionTitle: "Protocol Parameters",
     minDeposit: {
-      label: "Min deposit",
+      label: "Min Deposit",
       tooltip: "The minimum amount of BTC required to make a deposit.",
     },
     minForSplit: {
-      label: "Effective minimum for split",
+      label: "Effective Minimum for Split",
       tooltip:
-        "The minimum amount of BTC required to enable partial liquidation by splitting a deposit into two BTC Vaults.",
+        "The minimum amount of BTC required to enable partial liquidation via splitting deposit into two BTCVaults.",
     },
     ltv: {
-      label: "LTV / Collateral Factor",
+      label: "Collateral Factor",
     },
     liquidationThreshold: {
-      label: "Liquidation threshold (THF)",
+      label: "Target Health Factor",
       tooltip: "The ideal health factor to restore during liquidation",
     },
     liquidationBonus: {
-      label: "Liquidation Bonus (LB)",
-      tooltip: "Bonus percentage awarded to liquidators on seized collateral.",
+      label: "Liquidation Fee",
+      tooltip: "The penalty range applied during the liquidation.",
     },
   },
   // Operator-controlled protocol governance-status banners (Freeze / Pause). The
@@ -2074,8 +2064,8 @@ export const COPY = {
         "Add more BTC or repay debt immediately to bring your health factor back above 1.0.",
       approachingTitle: (distancePct: string) =>
         `Liquidation is ${distancePct}% away`,
-      approachingDetail: (liqPriceUsd: string, distancePct: string) =>
-        `A drop to $${liqPriceUsd} (just ${distancePct}% lower than now) triggers your first liquidation event.`,
+      approachingDetail: (liqPriceUsd: string) =>
+        `BTC price drop to $${liqPriceUsd} triggers liquidation.`,
       approachingSuggestion:
         "Add collateral or repay part of the debt to reduce your liquidation risk.",
     },
@@ -2097,14 +2087,14 @@ export const COPY = {
     // what action is feasible.
     cliff: {
       title: "First liquidation takes everything",
-      body: "With your current BTC Vaults, a single liquidation event seizes all your BTC — nothing remains protected behind it.",
+      body: "With your current BTCvaults, a single liquidation event liquidates all your BTC in collateral.",
       // Header shown above the suggestion text when there is no actionable CTA
       // (the withdraw/re-deposit and multi-vault cases). Rendered uppercase.
       suggestionLabel: "Suggestion",
       // Variant A (#1948): an affordable sacrificial vault buffers the existing
       // position. The amount lives here; the CTA label stays generic.
       addSacrificialSuggestion: (sacrificialBtc: string) =>
-        `Adding a sacrificial ${sacrificialBtc} BTC Vault creates a buffer — it gets liquidated first, your existing BTC survives.`,
+        `Adding a ${sacrificialBtc} BTCVault enables partial liquidation`,
       // Variant B (#1949): the single vault is too large to buffer cheaply —
       // withdraw it and re-deposit as two smaller vaults instead.
       withdrawResplitSuggestion: (
@@ -2112,7 +2102,7 @@ export const COPY = {
         sacrificialBtc: string,
         protectedBtc: string,
       ) =>
-        `To enable partial liquidation, withdraw your ${withdrawBtc} BTC and re-deposit as two smaller BTC Vaults: ${sacrificialBtc} BTC sacrificial + ${protectedBtc} BTC protected. Alternatively: add collateral or repay debt to manage the liquidation.`,
+        `To enable partial liquidation, withdraw your ${withdrawBtc} BTC and re-deposit as two smaller vaults: ${sacrificialBtc} BTC + ${protectedBtc} BTC. Alternatively: add collateral or repay debt to manage the liquidation.`,
       // Protocol params disallow splitting entirely — no re-split is possible.
       noSplitSuggestion:
         "Current protocol parameters do not allow BTC Vault splitting as a protection strategy. Add collateral or repay part of the debt to keep this position safe.",
@@ -2123,7 +2113,7 @@ export const COPY = {
         enablePartial: (deficitBtc: string, largestName: string) =>
           `To enable partial liquidation, add ≥ ${deficitBtc} BTC alongside ${largestName}. `,
         suggestion: (targetSeizureBtc: string, enablePartialStr: string) =>
-          `Neither BTC Vault alone covers the target seizure (${targetSeizureBtc} BTC). ${enablePartialStr}You can also add collateral or repay part of the debt to keep this position safe. Alternatively: repay the loan, split BTC into optimal UTXOs, and re-open with a sacrificial BTC Vault.`,
+          `Neither BTC Vault alone covers the target seizure (${targetSeizureBtc} BTC). ${enablePartialStr}You can also add collateral or repay part of the debt to keep this position safe. Alternatively: repay the loan, split BTC into optimal UTXOs, and re-open with a new BTC Vault.`,
       },
       multiVault: {
         suggestion: (
@@ -2153,7 +2143,7 @@ export const COPY = {
         `This position already has the maximum number of BTC Vaults (${cap}).`,
     },
     dust: {
-      title: "Position too small for BTC Vault analysis",
+      title: "Position too small to enable partial liquidation",
       detail:
         "Below $1,000 the cascade simplifies — all BTC Vaults are shown as one liquidation event. Small positions don't have meaningful multi-event behavior.",
     },

--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -93,7 +93,8 @@ const SIGN_TRANSACTION_LABEL = "Sign Transaction";
 // standalone download dialog and the activate-confirmation dialog so the
 // two can't drift.
 const ARTIFACTS_DOWNLOADED_TITLE = "Artifacts downloaded";
-const ARTIFACTS_DOWNLOADED_BODY = "Keep your artifact files in a safe place!";
+const ARTIFACTS_DOWNLOADED_BODY =
+  "Your files are stored locally and never uploaded. Keep them somewhere safe.";
 
 /**
  * A run of modal body text. `emphasis` segments render in the primary text
@@ -111,7 +112,7 @@ export const COPY = {
   tooltips: {
     // Risk card, markets collateral card, protocol parameters (LTV).
     collateralFactor:
-      "The maximum percentage of borrowing power from the total collateral value.",
+      "The maximum percentage of your total collateral value that can be borrowed.",
     // Overview position cards, risk card body, borrow / repay detail cards.
     healthFactor:
       "Indicates the health of your position. If it falls below 1.0, your position may be liquidated.",
@@ -394,7 +395,7 @@ export const COPY = {
       summary: {
         estimate: (duration: string) => `~${duration}`,
         description:
-          "Each step is divided into several wallet signature confirmations. The progress counter shows how many are completed. You will be able to borrow assets once BTCVault is activated.",
+          "Each step is divided into several wallet signature confirmations. The progress counter shows how many are completed. Your Bitcoin will only be locked once your BTCVault is activated, and you will be able to borrow assets from that point.",
       },
       stepsCompleted: (completed: number, total: number) =>
         `${completed} of ${total} steps completed`,
@@ -407,7 +408,7 @@ export const COPY = {
         "Do not spend the BTC used for this deposit until the transactions are confirmed.",
       splitVaultColumnLabel: (vaultNumber: number) => `BTCVault ${vaultNumber}`,
       buttons: {
-        closeContinueLater: "You can close and come back later",
+        closeContinueLater: "Close & continue later",
         retry: "Retry",
         close: "Close",
         done: "Done",
@@ -514,7 +515,7 @@ export const COPY = {
         { text: "Before activating, ", emphasis: false },
         { text: "download the recovery artifacts", emphasis: true },
         {
-          text: " of your vault. These files will make sure your BTCVault is fully functional even if your vault provider becomes unavailable.",
+          text: " of your BTCVault. These files will make sure your BTCVault is fully functional even if your vault provider becomes unavailable.",
           emphasis: false,
         },
       ] satisfies EmphasisBodySegment[],
@@ -795,9 +796,9 @@ export const COPY = {
       wotsReadinessTimeout: (vaultNumber: number) =>
         `Vault ${vaultNumber}: WOTS key submission skipped - vault provider was not ready before the readiness timeout`,
       wotsReadinessTerminal: (vaultNumber: number) =>
-        `Vault ${vaultNumber}: WOTS key submission skipped - vault provider reported this BTC Vault cannot continue`,
+        `Vault ${vaultNumber}: WOTS key submission skipped - vault provider reported this BTCVault cannot continue`,
       payoutReadinessTerminal: (vaultNumber: number) =>
-        `Vault ${vaultNumber}: Payout signing skipped - vault provider reported this BTC Vault cannot continue`,
+        `Vault ${vaultNumber}: Payout signing skipped - vault provider reported this BTCVault cannot continue`,
       wotsSubmissionFailed: (vaultNumber: number, error: string) =>
         `Vault ${vaultNumber}: WOTS key submission failed - ${error}`,
       payoutSigningFailed: (vaultNumber: number, error: string) =>
@@ -1430,7 +1431,7 @@ export const COPY = {
     // token units (before → after the repayment).
     debtLabel: "Debt",
     healthFactorLabel: "Health factor",
-    availableLiquidityLabel: "Available Liquidity",
+    availableLiquidityLabel: "Available liquidity",
     utilizationLabel: "Utilization",
     availableLabel: "Available",
     // Repay amount slider: prefixes the user's wallet balance shown beside Max.
@@ -1733,6 +1734,9 @@ export const COPY = {
     },
     reset: "Reset",
     eventTitle: (eventNumber: number) => `Liq Event ${eventNumber}`,
+    // Screen-reader-only. The band no longer draws this line, but the vault
+    // names still belong in the focusable rect's accessible name.
+    containVaults: (names: string) => `(contain ${names})`,
     cumulativeSeized: (percent: number) => `${percent}% seized`,
     popover: {
       atPrice: "At price",
@@ -1748,14 +1752,14 @@ export const COPY = {
         "BTCVaults are seized in order. Each BTCVault group is one liquidation event. To change the order, open the Vaults page.",
       collateral: "Collateral",
       liqPrice: "Liq Price",
-      distance: "% to Liquidation",
+      distance: "Distance",
       seizedVaultsSection: "Seized Vaults",
       targetSeizure: "Target seizure",
       targetSeizureTooltip:
         "The collateral value that the liquidator may receive during the liquidation process.",
-      overSeizure: "Over seizure",
+      overSeizure: "Over-seizure",
       overSeizureTooltip:
-        "An additional portion of the collateral value that the liquidator may seize due to the nature of indivisible BTC Vaults.",
+        "An additional portion of the collateral value that the liquidator may seize due to the nature of indivisible BTCVaults.",
       estimatedLiquidationSection: "Estimated Liquidation",
       collateralLiquidated: "Collateral liquidated",
       debtRepaid: "Debt Repaid",
@@ -1764,10 +1768,10 @@ export const COPY = {
       // Additional debt the liquidator repays because indivisible BTC Vaults
       // forced an over-seizure; pairs with fairnessPaymentTooltip below.
       fairnessDebtRepaidTooltip:
-        "Additional repayment of debt by the liquidator due to over seizure of collateral.",
+        "Additional repayment of debt by the liquidator due to over-seizure of collateral.",
       fairnessPaymentWbtc: "Fairness Payment (wBTC)",
       fairnessPaymentTooltip:
-        "Payment by the liquidator to the user's wallet due to over seizure of collateral.",
+        "Payment by the liquidator to the user's wallet due to over-seizure of collateral.",
       positionAfterSection: "Position After Liquidation",
       btcRemaining: "BTC remaining",
       debtRemaining: "Debt remaining",
@@ -1895,8 +1899,8 @@ export const COPY = {
       // Heading over the vaults list before any vault is active — the count
       // is dropped while the section only holds the empty state.
       vaultsTitle: "Vaults",
-      activeVaultsTitle: "Total Collateral",
-      inactiveVaultsTitle: "Expired Deposits",
+      activeVaultsTitle: "Active Vaults",
+      inactiveVaultsTitle: "Inactive Vaults",
       count: (count: number) => `(${count})`,
     },
     progressPercent: (percent: number) => `${percent}%`,
@@ -1985,6 +1989,9 @@ export const COPY = {
   },
   banner: {
     addCollateral: "Add Collateral",
+    // Cliff CTA. Carries the amount so it cannot collide with the urgent
+    // "Add Collateral" button when both warnings render together.
+    addVaultOfSize: (btc: string) => `Add ${btc} BTC`,
     repayDebt: "Repay Debt",
     applyOptimalOrder: "Apply Optimal Order",
   },
@@ -1997,12 +2004,12 @@ export const COPY = {
     modalSubtitle:
       "This is the liquidation order of your BTCVaults. Drag to change the order.",
     infoText:
-      "BTCVaults are liquidated in order from first to last. A liquidation event seizes BTCVaults from the front until it covers the amount owed, so the order decides how much of your BTC survives.",
+      "BTCVaults are liquidated in order from first to last. A liquidation event seizes BTCVaults from the front until it covers that event's target seizure amount, so the order decides how much of your BTC survives.",
     networkFeeLabel: "Ethereum network fee",
     confirmButton: "Confirm",
     doneButton: "Done",
-    successTitle: "BTC Vault order updated",
-    successText: "The liquidation order of your BTC Vaults has been updated.",
+    successTitle: "BTCVault order updated",
+    successText: "The liquidation order of your BTCVaults has been updated.",
   },
   protocolFees: {
     sectionTitle: "Protocol Parameters",
@@ -2022,9 +2029,10 @@ export const COPY = {
       label: "Target Health Factor",
       tooltip: "The ideal health factor to restore during liquidation",
     },
-    liquidationBonus: {
-      label: "Liquidation Fee",
-      tooltip: "The penalty range applied during the liquidation.",
+    maxLiquidationPenalty: {
+      label: "Max Liquidation Penalty",
+      tooltip:
+        "The maximum penalty applied to seized collateral during liquidation. The actual penalty scales with how far the health factor has fallen.",
     },
   },
   // Operator-controlled protocol governance-status banners (Freeze / Pause). The
@@ -2100,7 +2108,7 @@ export const COPY = {
       // Variant A (#1948): an affordable sacrificial vault buffers the existing
       // position. The amount lives here; the CTA label stays generic.
       addSacrificialSuggestion: (sacrificialBtc: string) =>
-        `Adding a ${sacrificialBtc} BTCVault enables partial liquidation`,
+        `Adding a new BTCVault of ${sacrificialBtc} BTC enables partial liquidation.`,
       // Variant B (#1949): the single vault is too large to buffer cheaply —
       // withdraw it and re-deposit as two smaller vaults instead.
       withdrawResplitSuggestion: (
@@ -2108,10 +2116,10 @@ export const COPY = {
         sacrificialBtc: string,
         protectedBtc: string,
       ) =>
-        `To enable partial liquidation, withdraw your ${withdrawBtc} BTC and re-deposit as two smaller vaults: ${sacrificialBtc} BTC + ${protectedBtc} BTC. Alternatively: add collateral or repay debt to manage the liquidation.`,
+        `To enable partial liquidation, withdraw your ${withdrawBtc} BTC and re-deposit as two smaller BTCVaults: ${sacrificialBtc} BTC + ${protectedBtc} BTC. Alternatively: add collateral or repay debt to manage the liquidation.`,
       // Protocol params disallow splitting entirely — no re-split is possible.
       noSplitSuggestion:
-        "Current protocol parameters do not allow BTC Vault splitting as a protection strategy. Add collateral or repay part of the debt to keep this position safe.",
+        "Current protocol parameters do not allow BTCVault splitting as a protection strategy. Add collateral or repay part of the debt to keep this position safe.",
       // 2-vault / 3+ cliffs share the title/body/severity but keep their
       // structural suggestion, since "re-deposit as two smaller vaults" doesn't
       // apply when you already hold multiple vaults.
@@ -2149,9 +2157,9 @@ export const COPY = {
         `This position already has the maximum number of BTC Vaults (${cap}).`,
     },
     dust: {
-      title: "Position too small to enable partial liquidation",
+      title: "Small position - simplified view",
       detail:
-        "Below $1,000 the cascade simplifies — all BTC Vaults are shown as one liquidation event. Small positions don't have meaningful multi-event behavior.",
+        "Below $1,000 the cascade simplifies — all BTCVaults are shown as one liquidation event. Small positions don't have meaningful multi-event behavior.",
     },
     weirdParams: {
       title: "Protocol parameters don't compute",

--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -93,7 +93,7 @@ const SIGN_TRANSACTION_LABEL = "Sign Transaction";
 // standalone download dialog and the activate-confirmation dialog so the
 // two can't drift.
 const ARTIFACTS_DOWNLOADED_TITLE = "Artifacts downloaded";
-const ARTIFACTS_DOWNLOADED_BODY = "Keep your artifact files in the safe place!";
+const ARTIFACTS_DOWNLOADED_BODY = "Keep your artifact files in a safe place!";
 
 /**
  * A run of modal body text. `emphasis` segments render in the primary text
@@ -114,7 +114,7 @@ export const COPY = {
       "The maximum percentage of borrowing power from the total collateral value.",
     // Overview position cards, risk card body, borrow / repay detail cards.
     healthFactor:
-      "Indicates the health of your position. If the margin ratio falls below 1.0, your position may be liquidated.",
+      "Indicates the health of your position. If it falls below 1.0, your position may be liquidated.",
   },
   pegin: {
     labels: {
@@ -594,7 +594,7 @@ export const COPY = {
     },
     vaultActivatedSuccess: {
       heading: "BTCVault activated",
-      body: "Your BTCvault is now active and ready for borrowing.",
+      body: "Your BTCVault is now active and ready for borrowing.",
       goToDashboard: "Go to Dashboard",
     },
     recoveryArtifacts: {
@@ -1626,7 +1626,7 @@ export const COPY = {
     interestRateModel: {
       title: "Interest rate model",
       description:
-        "The more liquidity is borrowed, the higher borrowing rate according to the AAVE's Interest rate model on this market.",
+        "The more liquidity is borrowed, the higher the borrowing rate according to Aave's interest rate model on this market.",
     },
     borrowMarkets: {
       title: "Borrow markets",
@@ -1745,7 +1745,7 @@ export const COPY = {
     events: {
       heading: "Liquidation Events",
       subheading:
-        "BTCVaults are seized in order each BTCVault group is one liquidation event. To change the order please open Vaults page.",
+        "BTCVaults are seized in order. Each BTCVault group is one liquidation event. To change the order, open the Vaults page.",
       collateral: "Collateral",
       liqPrice: "Liq Price",
       distance: "% to Liquidation",
@@ -1757,7 +1757,7 @@ export const COPY = {
       overSeizureTooltip:
         "An additional portion of the collateral value that the liquidator may seize due to the nature of indivisible BTC Vaults.",
       estimatedLiquidationSection: "Estimated Liquidation",
-      collateralLiquidated: "BTCVault",
+      collateralLiquidated: "Collateral liquidated",
       debtRepaid: "Debt Repaid",
       liquidatorProfit: "Liquidator profit",
       fairnessDebtRepaid: "Fairness Debt Repaid",
@@ -1993,6 +1993,12 @@ export const COPY = {
     body: "We're unable to provide access from your current region due to regulatory restrictions.",
   },
   reorder: {
+    modalTitle: "Reorder Vaults",
+    modalSubtitle:
+      "This is the liquidation order of your BTCVaults. Drag to change the order.",
+    infoText:
+      "BTCVaults are liquidated in order from first to last. A liquidation event seizes BTCVaults from the front until it covers the amount owed, so the order decides how much of your BTC survives.",
+    networkFeeLabel: "Ethereum network fee",
     confirmButton: "Confirm",
     doneButton: "Done",
     successTitle: "BTC Vault order updated",
@@ -2007,7 +2013,7 @@ export const COPY = {
     minForSplit: {
       label: "Effective Minimum for Split",
       tooltip:
-        "The minimum amount of BTC required to enable partial liquidation via splitting deposit into two BTCVaults.",
+        "The minimum amount of BTC required to enable partial liquidation via splitting a deposit into two BTCVaults.",
     },
     ltv: {
       label: "Collateral Factor",
@@ -2087,7 +2093,7 @@ export const COPY = {
     // what action is feasible.
     cliff: {
       title: "First liquidation takes everything",
-      body: "With your current BTCvaults, a single liquidation event liquidates all your BTC in collateral.",
+      body: "With your current BTCVaults, a single liquidation event liquidates all your BTC in collateral.",
       // Header shown above the suggestion text when there is no actionable CTA
       // (the withdraw/re-deposit and multi-vault cases). Rendered uppercase.
       suggestionLabel: "Suggestion",

--- a/services/vault/src/hooks/deposit/__tests__/useDepositFlow.test.tsx
+++ b/services/vault/src/hooks/deposit/__tests__/useDepositFlow.test.tsx
@@ -1175,7 +1175,7 @@ describe("useDepositFlow", () => {
         expect.arrayContaining([
           expect.objectContaining({
             message: expect.stringContaining(
-              "Vault 1: WOTS key submission skipped - vault provider reported this BTC Vault cannot continue",
+              "Vault 1: WOTS key submission skipped - vault provider reported this BTCVault cannot continue",
             ),
           }),
         ]),

--- a/services/vault/src/hooks/deposit/useDepositFlow.ts
+++ b/services/vault/src/hooks/deposit/useDepositFlow.ts
@@ -1094,7 +1094,7 @@ export function useDepositFlow(
           ...confirmedBtcWallet,
           // `isWaiting` flips to `false` while a popup is open and back
           // to `true` after it closes, so the SDK polling that follows
-          // remains "Close & continue later"-able.
+          // remains "You can close and come back later"-able.
           deriveContextHash: async (appName, context) => {
             const returnStep = baseStep;
             if (baseStep === DepositFlowStep.AWAIT_PAYOUT_TRANSACTIONS) {

--- a/services/vault/src/hooks/useProtocolFeeRows.ts
+++ b/services/vault/src/hooks/useProtocolFeeRows.ts
@@ -73,9 +73,9 @@ function buildFeeRows(
 
     const bonusPercent = (LB - 1) * PERCENT_SCALE;
     rows.push({
-      label: COPY.protocolFees.liquidationBonus.label,
+      label: COPY.protocolFees.maxLiquidationPenalty.label,
       value: `${bonusPercent.toFixed(0)}%`,
-      tooltip: COPY.protocolFees.liquidationBonus.tooltip,
+      tooltip: COPY.protocolFees.maxLiquidationPenalty.tooltip,
     });
   }
 


### PR DESCRIPTION
Applies the product-copy updates from the v3 design review. Every change was verified against the current Figma frame, not just the comment. Strings live in `copy.ts`. Two changes are not copy-only and are called out under **Beyond copy** below.

## Applied

| Surface | Change |
|---|---|
| Terminology | "BTC Vault" → "BTCVault" on the flagged labels (activation modal, split column headers, liquidation event rows, reorder modal); removed "sacrificial"/"protected" wording everywhere (badges deleted from `LiquidationEventCard`, banner copy reworded, reorder info text) |
| Overview | Health-factor tooltip now names the 1.0 liquidation threshold, "If it falls below 1.0…" (shared key, propagates to Liquidations and Borrow); removed the Total Collateral Value tooltips (`OverviewSection`, `VaultsSummaryCard`, Liquidations `PositionOverview`); activity empty state → "…after your first transaction"; section titles unchanged (see **Second review pass**) |
| Liquidations | new debt-repayment fairness tooltip; seizure-order subheading updated to the frame text; chart bands are single-line ("contain vaults" sublabel removed) |
| Borrow / markets | "Available Liquidity" label casing (loan cards, asset-selection column, markets table column); removed the markets-table Available Liquidity header tooltip; interest-rate model description updated |
| Repay | Removed the Debt and Health Factor tooltips per the frame |
| Deposit flow | Fee/terms rows relabeled: "LTV / Collateral Factor" → "Collateral Factor", "Liquidation threshold (THF)" → "Target Health Factor" (its tooltip always described THF), "Liquidation Bonus (LB)" → "Max Liquidation Penalty"; split-minimum tooltip reworded; collateral-factor Hint added to the Max-to-Borrow row; signing-progress explainer extended with the borrowing note; do-not-spend warning shortened |
| Position banners | Urgent detail → "BTC price drop to $X triggers liquidation."; cliff body → "With your current BTCVaults, a single liquidation event liquidates all your BTC in collateral."; suggestion → "Adding a new BTCVault of X BTC enables partial liquidation."; cliff CTA → "Add X BTC"; dust title → "Small position - simplified view" |

## Needs a product call (applied as noted, flag before merge)

- **Transaction-reserve tooltip:** the design frame still carries pre-reclaim wording ("returned to you if unused"), but #2317 deliberately changed this string to describe the shipped reclaim flow. Kept the #2317 wording; the frame needs updating instead.
- **Cliff CTA label deviates from the frame.** The frame gives both the urgent and the cliff CTA the label "Add Collateral", but they do different things (the cliff one pre-fills an amount) and `NotificationAction` has no accessible-name field separate from `label` — so the two were indistinguishable to keyboard and screen-reader users, and the test had to select by DOM position. The cliff CTA now reads "Add 0.72 BTC", which also restores the link to the suggestion text above it. Same precedent as the transaction-reserve tooltip: the frame needs updating.
- **Reorder guidance:** `REORDER_INFO_TEXT` told users to place their smallest BTC Vault first. That is not what the calculator does, and neither is "largest first": a vault only isolates the first liquidation event if it alone covers the target seizure, so the best order depends on the vault sizes (which is what `computeOptimalOrder`'s DP is for). The text now explains the front-to-back seizure mechanism and prescribes no ordering rule. This string does not come from the design review, so product should confirm the new wording.

## Not applied (no code counterpart or out of copy scope)

- Simulator explainer tooltips (13251:41849): no tooltip slot exists on the shipped chart header; adding one is a UI change.
- Landing-page copy (10206:56371): the landing page is not in this repo.
- Wallet-connect items (12450:7033 unsupported-address error state, 2195:59090 wrong-wallet notice): unbuilt UI.
- Design/UX comments (chart size/colors, info button, Aave in the wallet list, support-link placement) — tracked separately.
- Nodes deleted from Figma since the comment (8082:92162, 10051:26752, 10233:51372).

## Beyond copy

Two items in this PR are not string-only and deserve a design/QA look:

- **Fairness tooltip on the debt-repaid branch.** `liquidationChartData` now sets a tooltip on both fairness branches, so a new info icon renders in the "Fairness Debt Repaid" row of every non-full-liquidation event card. The field is now required on the type rather than optional.
- **Chart band sublabel removed.** The "(contain vault 1, vault 2)" line is gone from every band, which re-centres each band's text block. The vault names were also part of the focusable rect's accessible name, so a new optional `accessibleDetail` field on `LiquidationBand` keeps them there for screen readers while the visual line stays removed. Whether `sublabel` should remain public core-ui API now that the vault app passes none is an open question.

## Verification

- `tsc --noEmit` clean on `services/vault` and `packages/babylon-core-ui`; eslint 0 errors; prettier clean on every touched file under each package's own config.
- `services/vault` vitest: 3604/3610 passing (6 pre-existing skips). `packages/babylon-core-ui` vitest: 113/113. All copy-asserting tests updated.
- Rebased on `main`; merges clean.
- Unrelated flake seen under parallel load in `lazyWithRetry.test.ts` and `VaultWalletConnectionProvider.disabledWallets.test.tsx` — both pass in isolation, neither is in this diff, and both mutate global state. Worth a separate look.

## Review pass

Applied after review:

- Reorder-modal strings moved out of `ReorderVaults/constants.ts` (now deleted) into `COPY.reorder`, per the centralized-copy rule.
- `CollateralFactorRow`'s new Hint uses the `attachToChildren` + `InfoIcon` pattern, so it no longer nests a `div` inside the row's `span`.
- Terminology: the three stray `BTCvault`/`BTCvaults` spellings normalised to `BTCVault`/`BTCVaults`, matching the glossary landed in #2309.
- Grammar: "a safe place", "Aave's interest rate model", "splitting a deposit", and the liquidation-events subheading split into separate sentences.
- Dead code: the `badge` field on `LiquidationEventCard` lost its only reader when the sacrificial/protected pill was removed — field, computation, stale doc comments and the tests that asserted it are gone.
- `collateralLiquidated` reverted from `"BTCVault"` to `"Collateral liquidated"`: the row labels a BTC amount, so the bare product noun misdescribed the value.

## Second review pass

Reverts, where the new copy was demonstrably wrong against the code:

- **`"% to Liquidation"` → `"Distance"`.** `distancePct = ((liqPrice - btcPrice) / btcPrice) * 100`, so an event that has *not* fired renders `-18.1%`. Under the new heading that reads backwards. The band popover also still called the same value "Distance".
- **`"Liquidation Fee"` → `"Max Liquidation Penalty"`** (key renamed too). `DynamicReserveConfig` has a distinct `liquidationFee` field this app never reads; the row renders `(maxLiquidationBonus - 1) * 100`, which is a ceiling that scales with health factor, not a fee. The old tooltip promised a "range" where a single scalar renders.
- **`"Expired Deposits"` → `"Inactive Vaults"`.** The section is fed `[...expiredActivities, ...reclaimableCandidates]`, and the latter are settled `DEPOSITOR_WITHDRAWN` rows carrying a Reclaim action.
- **`"Total Collateral"` → `"Active Vaults"`.** The heading takes a `(count)` suffix of `vaults.length`, and the same page already shows a "Total Collateral Value" stat.
- **Dust title → "Small position - simplified view".** The gate is `totalDebtUsd < $1,000 || collateralValue < $1,000` and only forces a single display group; it is not a protocol rule, partial liquidation is not disabled, and the unchanged body directly below already said "shown as one liquidation event".
- **Button label → "Close & continue later".** The declarative sentence rendered as a primary button's accessible name.
- **Artifact body keeps the privacy claim:** "Your files are stored locally and never uploaded. Keep them somewhere safe."
- **Signing-progress explainer keeps the not-yet-locked reassurance** alongside the borrowing note.
- **Repay health-factor tooltip restored** — it was removed on Repay but kept on Borrow and four other surfaces, and it is the only place in the app stating the 1.0 threshold.

Fixes:

- Cliff suggestion regained its BTC unit and terminal period: "Adding a new BTCVault of 0.72 BTC enables partial liquidation."
- Reorder `infoText` corrected — an event seizes until it covers *that event's target seizure amount* (a fraction of remaining collateral), not "the amount owed".
- `CollateralFactorRow`'s hinted row now carries `inline-flex items-center gap-1` on the parent, matching the `DepositForm` precedent; without it the icon butted flush against `(CF=72%)` and sat off-baseline.
- Its test mock now surfaces the tooltip text and asserts it, instead of stubbing `Hint` to `null` and covering the new feature with nothing.
- Dead structure removed: the `justify-between` wrapper the badge left behind, and the two `flex gap-1` label wrappers in `RepayDetailsCard`.
- `LiquidationEventCard`'s "no fairness tooltip" test replaced — it constructed a shape production can no longer emit.
- Same-surface terminology made consistent (cliff siblings, reorder success strings, deposit-flow readiness messages, dust body). Repo-wide convergence on `BTCVault` is deliberately left to the glossary bot that produced #2309; ~143 occurrences remain, including `utils/errors/errorMessages.ts`, which is outside this diff.
- Sentence-case `loans.availableLiquidityLabel`; Title Case kept on the stats bar and table column headers, which the style header exempts.
- "over seizure" hyphenated to "over-seizure" throughout.
- The core-ui story is now formatted at the package's own `printWidth: 120`. The earlier "prettier clean" claim was checked with the wrong config.