### PR TITLE
feat(vault, wallet-connector): tick the signing counters per Ledger c…

### DIFF
--- a/packages/babylon-wallet-connector/docs/vault-integration-guide.md
+++ b/packages/babylon-wallet-connector/docs/vault-integration-guide.md
@@ -99,7 +99,7 @@ are in [`src/core/types.ts`](../src/core/types.ts).
 | `on` / `off` | `(eventName: string, cb: () => void) => void` | Register/unregister event listener |
 | `getInscriptions` | `() => Promise<InscriptionIdentifier[]>` | Optional. UTXO filtering. |
 | `cancelSigning` | `() => void` | Optional. Requests cancellation of the in-flight ceremony; settles at the next device exchange. Feature-detect. |
-| `subscribeSigningProgress` | `(listener: (p: { completed: number; total: number }) => void) => () => void` | Optional. Per-PSBT ticks inside `signPsbts` for providers that run one device ceremony per PSBT. Fires after each commit, never on rejection. Feature-detect; returns the unsubscribe. |
+| `subscribeSigningProgress` | `(listener: (p: { completed: number; total: number }) => void) => () => void` | Optional. Per-PSBT ticks inside `signPsbts` for providers that run one device ceremony per PSBT. Fires after each committed ceremony; a failed ceremony emits no tick and earlier ticks stand. Feature-detect; returns the unsubscribe. |
 
 Reference implementations:
 [Unisat](../src/core/wallets/btc/unisat/provider.ts),

--- a/packages/babylon-wallet-connector/docs/vault-integration-guide.md
+++ b/packages/babylon-wallet-connector/docs/vault-integration-guide.md
@@ -99,7 +99,7 @@ are in [`src/core/types.ts`](../src/core/types.ts).
 | `on` / `off` | `(eventName: string, cb: () => void) => void` | Register/unregister event listener |
 | `getInscriptions` | `() => Promise<InscriptionIdentifier[]>` | Optional. UTXO filtering. |
 | `cancelSigning` | `() => void` | Optional. Requests cancellation of the in-flight ceremony; settles at the next device exchange. Feature-detect. |
-| `subscribeSigningProgress` | `(listener: (p: { completed: number; total: number }) => void) => () => void` | Optional. Per-PSBT ticks inside `signPsbts` for providers that run one device ceremony per PSBT. Fires after each committed ceremony; a failed ceremony emits no tick and earlier ticks stand. Feature-detect; returns the unsubscribe. |
+| `subscribeSigningProgress` | `(listener: (p: SigningProgress) => void) => () => void` | Optional. Per-PSBT ticks inside `signPsbts` for providers that run one device ceremony per PSBT. Fires after each committed ceremony; a failed ceremony emits no tick and earlier ticks stand. Feature-detect; returns the unsubscribe. Outlives the batch; dropped on session teardown. Listener is sync; an overlapping `signPsbts` is rejected, never queued; never fires for `signPsbt`. |
 
 Reference implementations:
 [Unisat](../src/core/wallets/btc/unisat/provider.ts),

--- a/packages/babylon-wallet-connector/docs/vault-integration-guide.md
+++ b/packages/babylon-wallet-connector/docs/vault-integration-guide.md
@@ -98,6 +98,8 @@ are in [`src/core/types.ts`](../src/core/types.ts).
 | `getNetwork` | `() => Promise<Network>` | Get BTC network. Wallet must operate on the network the dApp is configured for (signet vs mainnet); mismatch must error. |
 | `on` / `off` | `(eventName: string, cb: () => void) => void` | Register/unregister event listener |
 | `getInscriptions` | `() => Promise<InscriptionIdentifier[]>` | Optional. UTXO filtering. |
+| `cancelSigning` | `() => void` | Optional. Requests cancellation of the in-flight ceremony; settles at the next device exchange. Feature-detect. |
+| `subscribeSigningProgress` | `(listener: (p: { completed: number; total: number }) => void) => () => void` | Optional. Per-PSBT ticks inside `signPsbts` for providers that run one device ceremony per PSBT. Fires after each commit, never on rejection. Feature-detect; returns the unsubscribe. |
 
 Reference implementations:
 [Unisat](../src/core/wallets/btc/unisat/provider.ts),

--- a/packages/babylon-wallet-connector/src/core/types.ts
+++ b/packages/babylon-wallet-connector/src/core/types.ts
@@ -423,10 +423,11 @@ export interface IBTCProvider extends IProvider {
   /**
    * Subscribes to per-PSBT progress inside `signPsbts`: fires after each
    * device ceremony commits, with `completed` = signatures the call will
-   * return so far and `total` = the batch length. Never fires for `signPsbt`,
-   * never before the first ceremony, never on rejection — the promise settle
-   * is the terminal signal. Listener throws are swallowed. Returns the
-   * unsubscribe.
+   * return so far and `total` = the batch length. Never fires for `signPsbt`
+   * or before the first ceremony. A ceremony that fails emits no tick, while
+   * ticks for ceremonies that committed before a later rejection stand — the
+   * promise settle is the terminal signal. Listener throws are swallowed.
+   * Returns the unsubscribe.
    *
    * Implemented only by hardware providers that run one device ceremony per
    * PSBT (currently the Ledger vault provider). Optional — callers MUST

--- a/packages/babylon-wallet-connector/src/core/types.ts
+++ b/packages/babylon-wallet-connector/src/core/types.ts
@@ -422,8 +422,8 @@ export interface IBTCProvider extends IProvider {
 
   /**
    * Subscribes to per-PSBT progress inside `signPsbts`: fires after each
-   * device ceremony commits, with `completed` = signatures the call will
-   * return so far and `total` = the batch length. Never fires for `signPsbt`
+   * device ceremony commits, with `completed` = PSBT ceremonies committed
+   * so far and `total` = the batch length. Never fires for `signPsbt`
    * or before the first ceremony. A ceremony that fails emits no tick, while
    * ticks for ceremonies that committed before a later rejection stand — the
    * promise settle is the terminal signal. Listener throws are swallowed.

--- a/packages/babylon-wallet-connector/src/core/types.ts
+++ b/packages/babylon-wallet-connector/src/core/types.ts
@@ -361,6 +361,12 @@ export interface SignPsbtOptions {
   displayMessage?: string;
 }
 
+/** One committed device ceremony inside a `signPsbts` batch. Counts only — never payload. */
+export interface SigningProgress {
+  readonly completed: number;
+  readonly total: number;
+}
+
 export interface IBTCProvider extends IProvider {
   /**
    * Signs the given PSBT in hex format.
@@ -413,6 +419,21 @@ export interface IBTCProvider extends IProvider {
    * hide the cancel affordance when the method is missing.
    */
   cancelSigning?(): void;
+
+  /**
+   * Subscribes to per-PSBT progress inside `signPsbts`: fires after each
+   * device ceremony commits, with `completed` = signatures the call will
+   * return so far and `total` = the batch length. Never fires for `signPsbt`,
+   * never before the first ceremony, never on rejection — the promise settle
+   * is the terminal signal. Listener throws are swallowed. Returns the
+   * unsubscribe.
+   *
+   * Implemented only by hardware providers that run one device ceremony per
+   * PSBT (currently the Ledger vault provider). Optional — callers MUST
+   * feature-detect (`typeof provider.subscribeSigningProgress === "function"`)
+   * and fall back to the batch settle when the method is missing.
+   */
+  subscribeSigningProgress?(listener: (progress: SigningProgress) => void): () => void;
 
   /**
    * Signs a message using either BIP322-Simple or ECDSA signing method.

--- a/packages/babylon-wallet-connector/src/core/types.ts
+++ b/packages/babylon-wallet-connector/src/core/types.ts
@@ -426,8 +426,13 @@ export interface IBTCProvider extends IProvider {
    * so far and `total` = the batch length. Never fires for `signPsbt`
    * or before the first ceremony. A ceremony that fails emits no tick, while
    * ticks for ceremonies that committed before a later rejection stand — the
-   * promise settle is the terminal signal. Listener throws are swallowed.
-   * Returns the unsubscribe.
+   * promise settle is the terminal signal. Listeners run synchronously inside
+   * the signing loop: a throw is swallowed, a returned promise is neither
+   * awaited nor observed. Ticks carry no batch identity, so implementers MUST
+   * reject an overlapping `signPsbts` rather than queue it. Returns the
+   * unsubscribe. The subscription outlives a batch but not the session —
+   * teardown (disconnect or dead-session cleanup) drops every listener, so
+   * subscribe per sign call.
    *
    * Implemented only by hardware providers that run one device ceremony per
    * PSBT (currently the Ledger vault provider). Optional — callers MUST

--- a/packages/babylon-wallet-connector/src/core/wallets/btc/ledger-vault/__tests__/provider.test.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/ledger-vault/__tests__/provider.test.ts
@@ -1069,6 +1069,20 @@ describe("LedgerVaultProvider", () => {
         expect(ticks).toEqual([]);
       });
 
+      it("a subscriber from before disconnect receives nothing from the next connection's batch", async () => {
+        const provider = await approved();
+        const ticks: SigningProgress[] = [];
+        provider.subscribeSigningProgress((progress) => ticks.push(progress));
+
+        await provider.disconnect();
+        await provider.connectWallet();
+        await provider.deriveContextHash("app", "aa".repeat(32));
+        await provider.approveDepositTerms(TERMS);
+        await provider.signPsbts([PSBT_B]);
+
+        expect(ticks).toEqual([]);
+      });
+
       it("signPsbt never emits signing progress", async () => {
         const provider = await approved();
         const ticks: SigningProgress[] = [];
@@ -1089,6 +1103,28 @@ describe("LedgerVaultProvider", () => {
         expect(signMock.signPreparedVaultPsbt).toHaveBeenCalledTimes(2);
       });
 
+      it("every registered listener receives every tick, even when one between them throws", async () => {
+        const provider = await approved();
+        const before: SigningProgress[] = [];
+        const after: SigningProgress[] = [];
+        provider.subscribeSigningProgress((progress) => before.push(progress));
+        provider.subscribeSigningProgress(() => {
+          throw new Error("display bug");
+        });
+        provider.subscribeSigningProgress((progress) => after.push(progress));
+
+        await provider.signPsbts([PSBT_A, PSBT_B]);
+
+        expect(before).toEqual([
+          { completed: 1, total: 2 },
+          { completed: 2, total: 2 },
+        ]);
+        expect(after).toEqual([
+          { completed: 1, total: 2 },
+          { completed: 2, total: 2 },
+        ]);
+      });
+
       it("the returned unsubscribe stops further ticks and is idempotent", async () => {
         const provider = await approved();
         const ticks: SigningProgress[] = [];
@@ -1100,6 +1136,18 @@ describe("LedgerVaultProvider", () => {
         await provider.signPsbts([PSBT_B]);
 
         expect(ticks).toEqual([{ completed: 1, total: 1 }]);
+      });
+
+      it("a listener subscribed inside a tick first hears the next tick", async () => {
+        const provider = await approved();
+        const lateTicks: SigningProgress[] = [];
+        provider.subscribeSigningProgress(({ completed }) => {
+          if (completed === 1) provider.subscribeSigningProgress((progress) => lateTicks.push(progress));
+        });
+
+        await provider.signPsbts([PSBT_A, PSBT_B]);
+
+        expect(lateTicks).toEqual([{ completed: 2, total: 2 }]);
       });
 
       it("is an own property that survives the dApp's object spread into a wrapper", async () => {

--- a/packages/babylon-wallet-connector/src/core/wallets/btc/ledger-vault/__tests__/provider.test.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/ledger-vault/__tests__/provider.test.ts
@@ -23,6 +23,7 @@ import * as ecc from "@bitcoin-js/tiny-secp256k1-asmjs";
 import { initEccLib, payments, Psbt } from "bitcoinjs-lib";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import type { SigningProgress } from "@/core/types";
 import { Network } from "@/core/types";
 import { getTaprootAddress, toNetwork } from "@/core/utils/wallet";
 import { ERROR_CODES, WalletError } from "@/error";
@@ -956,6 +957,162 @@ describe("LedgerVaultProvider", () => {
 
       await expect(provider.signPsbts([PSBT_A, PSBT_A])).rejects.toThrow(/signPsbts\[1\].*duplicated within the batch/);
       expect(signMock.signPreparedVaultPsbt).not.toHaveBeenCalled();
+    });
+
+    describe("subscribeSigningProgress", () => {
+      it("emits {completed,total} once per committed PSBT, in batch order, with total equal to the batch length", async () => {
+        const provider = await approved();
+        const ticks: SigningProgress[] = [];
+        provider.subscribeSigningProgress((progress) => ticks.push(progress));
+
+        await provider.signPsbts([PSBT_A, PSBT_B, PSBT_C]);
+
+        expect(ticks).toEqual([
+          { completed: 1, total: 3 },
+          { completed: 2, total: 3 },
+          { completed: 3, total: 3 },
+        ]);
+      });
+
+      it("a tick is observed before the next ceremony starts", async () => {
+        // The counter must not run ahead of the device: at tick k exactly k
+        // ceremonies have been started.
+        const provider = await approved();
+        const ceremoniesAtTick: number[] = [];
+        provider.subscribeSigningProgress(({ completed }) => {
+          ceremoniesAtTick.push(signMock.signPreparedVaultPsbt.mock.calls.length - completed);
+        });
+
+        await provider.signPsbts([PSBT_A, PSBT_B]);
+
+        expect(ceremoniesAtTick).toEqual([0, 0]);
+      });
+
+      it("emits nothing before the first ceremony and nothing after the last commit", async () => {
+        const provider = await approved();
+        const ticks: SigningProgress[] = [];
+        provider.subscribeSigningProgress((progress) => ticks.push(progress));
+
+        await provider.signPsbts([PSBT_A]);
+
+        expect(ticks).toEqual([{ completed: 1, total: 1 }]);
+      });
+
+      it("a failing element emits no tick; the ticks already committed stand", async () => {
+        const provider = await approved();
+        signMock.signPreparedVaultPsbt
+          .mockImplementationOnce(async (_send, prepared: { originalPsbtHex: string }) => ({
+            signedPsbtHex: `signed:${prepared.originalPsbtHex}`,
+            yields: [],
+          }))
+          .mockRejectedValueOnce(new LedgerDeviceError(0xb00a, "SW_CAP_EXCEEDED"));
+        const ticks: SigningProgress[] = [];
+        provider.subscribeSigningProgress((progress) => ticks.push(progress));
+
+        await expect(provider.signPsbts([PSBT_A, PSBT_B, PSBT_C])).rejects.toMatchObject({
+          code: ERROR_CODES.DEVICE_CEREMONY_INVALID,
+        });
+
+        expect(ticks).toEqual([{ completed: 1, total: 3 }]);
+      });
+
+      it("cancelSigning mid-element still emits the committed element before the batch rejects", async () => {
+        const provider = await approved();
+        signMock.signPreparedVaultPsbt.mockImplementationOnce(async (_send, prepared: { originalPsbtHex: string }) => {
+          provider.cancelSigning();
+          return { signedPsbtHex: `signed:${prepared.originalPsbtHex}`, yields: [] };
+        });
+        const ticks: SigningProgress[] = [];
+        provider.subscribeSigningProgress((progress) => ticks.push(progress));
+
+        await expect(provider.signPsbts([PSBT_A, PSBT_B])).rejects.toMatchObject({
+          code: ERROR_CODES.CONNECTION_REJECTED,
+          message: expect.stringMatching(/after 1 of 2/),
+        });
+
+        expect(ticks).toEqual([{ completed: 1, total: 2 }]);
+      });
+
+      it("a batch rejected before the first ceremony emits nothing", async () => {
+        const provider = await approved();
+        const ticks: SigningProgress[] = [];
+        provider.subscribeSigningProgress((progress) => ticks.push(progress));
+
+        await expect(provider.signPsbts([PSBT_A, PSBT_A])).rejects.toThrow(/duplicated within the batch/);
+        await expect(provider.signPsbts([PSBT_A, PSBT_B], [{}, { autoFinalized: true }])).rejects.toThrow(
+          /signPsbts\[1\]/,
+        );
+
+        expect(ticks).toEqual([]);
+      });
+
+      it("a stale batch settling after reconnect emits nothing", async () => {
+        const provider = await approved();
+        let resolveStale: (value: { signedPsbtHex: string; yields: never[] }) => void = () => {};
+        signMock.signPreparedVaultPsbt.mockImplementationOnce(
+          () =>
+            new Promise<{ signedPsbtHex: string; yields: never[] }>((resolve) => {
+              resolveStale = resolve;
+            }),
+        );
+        const ticks: SigningProgress[] = [];
+        provider.subscribeSigningProgress((progress) => ticks.push(progress));
+        const stale = provider.signPsbts([PSBT_A]);
+        stale.catch(() => {});
+        await vi.waitFor(() => expect(signMock.signPreparedVaultPsbt).toHaveBeenCalledTimes(1));
+
+        await provider.disconnect();
+        await provider.connectWallet();
+        resolveStale({ signedPsbtHex: `signed:${PSBT_A}`, yields: [] });
+        await expect(stale).rejects.toThrow(/connection changed/);
+
+        expect(ticks).toEqual([]);
+      });
+
+      it("signPsbt never emits signing progress", async () => {
+        const provider = await approved();
+        const ticks: SigningProgress[] = [];
+        provider.subscribeSigningProgress((progress) => ticks.push(progress));
+
+        await provider.signPsbt(PSBT_A);
+
+        expect(ticks).toEqual([]);
+      });
+
+      it("a listener that throws neither aborts the batch nor changes what it returns", async () => {
+        const provider = await approved();
+        provider.subscribeSigningProgress(() => {
+          throw new Error("display bug");
+        });
+
+        await expect(provider.signPsbts([PSBT_A, PSBT_B])).resolves.toEqual([`signed:${PSBT_A}`, `signed:${PSBT_B}`]);
+        expect(signMock.signPreparedVaultPsbt).toHaveBeenCalledTimes(2);
+      });
+
+      it("the returned unsubscribe stops further ticks and is idempotent", async () => {
+        const provider = await approved();
+        const ticks: SigningProgress[] = [];
+        const stop = provider.subscribeSigningProgress((progress) => ticks.push(progress));
+        await provider.signPsbts([PSBT_A]);
+        stop();
+        stop();
+
+        await provider.signPsbts([PSBT_B]);
+
+        expect(ticks).toEqual([{ completed: 1, total: 1 }]);
+      });
+
+      it("is an own property that survives the dApp's object spread into a wrapper", async () => {
+        // The dApp wrappers spread the provider; a prototype method would be dropped.
+        const provider = await approved();
+        const copy = { ...provider };
+        const ticks: SigningProgress[] = [];
+        copy.subscribeSigningProgress((progress) => ticks.push(progress));
+
+        await provider.signPsbts([PSBT_A]);
+
+        expect(ticks).toEqual([{ completed: 1, total: 1 }]);
+      });
     });
 
     it("a byte-variant serialization of a signed request is still blocked", async () => {

--- a/packages/babylon-wallet-connector/src/core/wallets/btc/ledger-vault/provider.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/ledger-vault/provider.ts
@@ -192,6 +192,7 @@ export class LedgerVaultProvider implements IBTCProvider {
   private activeOperation: symbol | undefined;
   /** Abort handle into the in-flight signing loop; fired by teardown (B3's only abort source). */
   private signAbortController: AbortController | undefined;
+  /** Connection-scoped like the fields above: cleared in teardownSession. */
   private readonly signingProgressListeners = new Set<(progress: SigningProgress) => void>();
 
   constructor(private readonly network: Network = Network.MAINNET) {}
@@ -346,6 +347,8 @@ export class LedgerVaultProvider implements IBTCProvider {
     this.pubkeyHexPromise = undefined;
     this.policyContextPromise = undefined;
     this.signedFingerprints = new Set();
+    // A subscriber abandoned by a stale batch must not see the next connection's ticks.
+    this.signingProgressListeners.clear();
     // Release the ceremony lock and stop an in-flight signing loop NOW — the
     // stale call's finally only releases its own token, and its rejection
     // commits nothing (the generation just changed).
@@ -736,8 +739,8 @@ export class LedgerVaultProvider implements IBTCProvider {
           }
           this.assertSameConnection(ctx.generation);
           signed.push(await this.signStaged(one, ctx, controller));
-          // After the commit (generation checked, fingerprint recorded), so a
-          // tick never counts a signature the call will not return.
+          // After signStaged's commit (generation checked, fingerprint
+          // recorded), so a stale or failed ceremony never ticks.
           this.emitSigningProgress({ completed: signed.length, total: psbtsHexes.length });
         }
         return signed;
@@ -765,7 +768,8 @@ export class LedgerVaultProvider implements IBTCProvider {
   // Display-only: a listener bug must not abort a non-idempotent ceremony
   // (same contract as the signer's per-YIELD onProgress).
   private emitSigningProgress(progress: SigningProgress): void {
-    for (const listener of this.signingProgressListeners) {
+    // Snapshot: a listener that (un)subscribes inside a tick must not extend this loop.
+    for (const listener of [...this.signingProgressListeners]) {
       try {
         listener(progress);
       } catch {

--- a/packages/babylon-wallet-connector/src/core/wallets/btc/ledger-vault/provider.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/ledger-vault/provider.ts
@@ -53,7 +53,7 @@ import {
   type SignVaultPsbtResult,
 } from "@babylonlabs-io/ledger-vault-signer";
 
-import type { IBTCProvider, InscriptionIdentifier, SignPsbtOptions } from "@/core/types";
+import type { IBTCProvider, InscriptionIdentifier, SigningProgress, SignPsbtOptions } from "@/core/types";
 import { Network } from "@/core/types";
 import { getTaprootAddress, toNetwork } from "@/core/utils/wallet";
 import { ERROR_CODES, WalletError } from "@/error";
@@ -192,6 +192,7 @@ export class LedgerVaultProvider implements IBTCProvider {
   private activeOperation: symbol | undefined;
   /** Abort handle into the in-flight signing loop; fired by teardown (B3's only abort source). */
   private signAbortController: AbortController | undefined;
+  private readonly signingProgressListeners = new Set<(progress: SigningProgress) => void>();
 
   constructor(private readonly network: Network = Network.MAINNET) {}
 
@@ -735,6 +736,9 @@ export class LedgerVaultProvider implements IBTCProvider {
           }
           this.assertSameConnection(ctx.generation);
           signed.push(await this.signStaged(one, ctx, controller));
+          // After the commit (generation checked, fingerprint recorded), so a
+          // tick never counts a signature the call will not return.
+          this.emitSigningProgress({ completed: signed.length, total: psbtsHexes.length });
         }
         return signed;
       }),
@@ -749,6 +753,26 @@ export class LedgerVaultProvider implements IBTCProvider {
   cancelSigning = (): void => {
     this.signAbortController?.abort();
   };
+
+  /** Optional affordance (see `IBTCProvider`): per-ceremony ticks out of a `signPsbts` batch. */
+  subscribeSigningProgress = (listener: (progress: SigningProgress) => void): (() => void) => {
+    this.signingProgressListeners.add(listener);
+    return () => {
+      this.signingProgressListeners.delete(listener);
+    };
+  };
+
+  // Display-only: a listener bug must not abort a non-idempotent ceremony
+  // (same contract as the signer's per-YIELD onProgress).
+  private emitSigningProgress(progress: SigningProgress): void {
+    for (const listener of this.signingProgressListeners) {
+      try {
+        listener(progress);
+      } catch {
+        // Swallowed on purpose — progress is cosmetic.
+      }
+    }
+  }
 
   /**
    * ONE AbortController per public sign call (plan D1) — it spans a whole

--- a/services/vault/src/components/deposit/PayoutSignModal/__tests__/usePayoutSigningState.test.tsx
+++ b/services/vault/src/components/deposit/PayoutSignModal/__tests__/usePayoutSigningState.test.tsx
@@ -1648,11 +1648,8 @@ describe("usePayoutSigningState", () => {
     });
 
     it("progress ticks do not flip the claimers-done ref before the SDK reports the round complete", async () => {
-      // A full-count tick during Phase 3 must still be labelled "claimers";
-      // only the SDK's own (N,N) flips the phase. Pin this by re-entering
-      // signPsbts a second time BEFORE the SDK ever reports the round
-      // complete: an implementation that flips the ref from inside the tick
-      // listener would mislabel the second entry as "graph".
+      // Real Phase 3 is one signPsbts call (signPayoutTransactions → signPayoutTransactionsBatch),
+      // where a ref flipped inside the tick listener is invisible; the second entry is a synthetic probe.
       const { settle, tick, signPsbts } = connectProgressWallet();
       mockSignAndSubmitPayouts.mockImplementation(
         async ({
@@ -1666,7 +1663,7 @@ describe("usePayoutSigningState", () => {
         }) => {
           onProgress({ phase: "claimers", completed: 0, total: 2 });
           await btcWallet.signPsbts(["payout-0", "payout-1"]);
-          // Second ceremony, still before the SDK's own (N,N).
+          // Synthetic second entry the SDK never makes, still before its own (N,N).
           await btcWallet.signPsbts(["payout-2", "payout-3"]);
           onProgress({ phase: "claimers", completed: 2, total: 2 });
           onProgress(null);
@@ -1693,18 +1690,9 @@ describe("usePayoutSigningState", () => {
       });
       await waitFor(() => expect(signPsbts).toHaveBeenCalledTimes(2));
 
-      // The second entry must still snapshot "claimers" — not the "graph"
-      // a ref flipped inside the tick listener would have produced.
-      expect(result.current.progress).not.toEqual({
-        phase: "graph",
-        completed: 0,
-        total: 2,
-      });
-      expect(result.current.progress).toEqual({
-        phase: "claimers",
-        completed: 2,
-        total: 2,
-      });
+      // The second entry must still snapshot "claimers"; the count is the stale
+      // last tick and not under test.
+      expect(result.current.progress.phase).toBe("claimers");
 
       await act(async () => {
         settle.resolve(["c", "d"]);
@@ -1712,7 +1700,7 @@ describe("usePayoutSigningState", () => {
       });
     });
 
-    it("does not subscribe on a wallet without the affordance", async () => {
+    it("a wallet without the affordance keeps the SDK-driven 0-to-N jump", async () => {
       const signPsbts = vi.fn().mockResolvedValue(["a", "b"]);
       mockBtcConnector = {
         connectedWallet: {
@@ -1730,6 +1718,11 @@ describe("usePayoutSigningState", () => {
       // Extension-wallet path unchanged: the SDK's own (N,N) lands the counter.
       expect(signPsbts).toHaveBeenCalledTimes(1);
       expect(result.current.isComplete).toBe(true);
+      expect(result.current.progress).toEqual({
+        phase: "claimers",
+        completed: 2,
+        total: 2,
+      });
     });
   });
 });

--- a/services/vault/src/components/deposit/PayoutSignModal/__tests__/usePayoutSigningState.test.tsx
+++ b/services/vault/src/components/deposit/PayoutSignModal/__tests__/usePayoutSigningState.test.tsx
@@ -1410,4 +1410,326 @@ describe("usePayoutSigningState", () => {
       expect(result.current.isComplete).toBe(false);
     });
   });
+
+  describe("per-ceremony signing progress", () => {
+    // Ledger-shaped provider: signPsbts is held open and the test emits
+    // ticks through the captured subscribeSigningProgress listener.
+    function connectProgressWallet() {
+      let listener: ((p: { completed: number; total: number }) => void) | null =
+        null;
+      const unsubscribe = vi.fn();
+      const settle: {
+        resolve: (v: string[]) => void;
+        reject: (e: unknown) => void;
+      } = {
+        resolve: () => {},
+        reject: () => {},
+      };
+      const signPsbts = vi.fn(
+        () =>
+          new Promise<string[]>((resolve, reject) => {
+            settle.resolve = resolve;
+            settle.reject = reject;
+          }),
+      );
+      mockBtcConnector = {
+        connectedWallet: {
+          account: { address: "tb1test" },
+          provider: {
+            signPsbt: vi.fn(),
+            signPsbts,
+            subscribeSigningProgress: vi.fn(
+              (cb: (p: { completed: number; total: number }) => void) => {
+                listener = cb;
+                return unsubscribe;
+              },
+            ),
+          },
+        },
+      };
+      const tick = (completed: number, total: number) =>
+        listener?.({ completed, total });
+      return { settle, tick, unsubscribe, signPsbts };
+    }
+
+    // The SDK's Phase-3 shape: announce the round, then hand the batch over.
+    function armClaimerBatch(total: number) {
+      mockSignAndSubmitPayouts.mockImplementation(
+        async ({
+          btcWallet,
+          onProgress,
+        }: {
+          btcWallet: { signPsbts: (hexes: string[]) => Promise<string[]> };
+          onProgress: (
+            p: { phase: string; completed: number; total: number } | null,
+          ) => void;
+        }) => {
+          onProgress({ phase: "claimers", completed: 0, total });
+          await btcWallet.signPsbts(
+            Array.from({ length: total }, (_, i) => `payout-${i}`),
+          );
+          onProgress({ phase: "claimers", completed: total, total });
+          onProgress(null);
+        },
+      );
+    }
+
+    it('renders claimer ticks from the provider as phase "claimers" while the SDK batch is in flight', async () => {
+      const { settle, tick } = connectProgressWallet();
+      armClaimerBatch(5);
+      const { result } = renderHookWithProps();
+      let done: Promise<void> = Promise.resolve();
+      await act(async () => {
+        done = result.current.handleSign();
+      });
+
+      await act(async () => {
+        tick(2, 5);
+      });
+
+      expect(result.current.progress).toEqual({
+        phase: "claimers",
+        completed: 2,
+        total: 5,
+      });
+      await act(async () => {
+        settle.resolve(["a", "b", "c", "d", "e"]);
+        await done;
+      });
+    });
+
+    it('renders depositor-graph ticks as phase "graph" once the claimers round has completed', async () => {
+      const { settle, tick } = connectProgressWallet();
+      mockSignAndSubmitPayouts.mockImplementation(
+        async ({
+          btcWallet,
+          onProgress,
+        }: {
+          btcWallet: { signPsbts: (hexes: string[]) => Promise<string[]> };
+          onProgress: (
+            p: { phase: string; completed: number; total: number } | null,
+          ) => void;
+        }) => {
+          // Claimers round already reported complete by the SDK → the ref flipped.
+          onProgress({ phase: "claimers", completed: 3, total: 3 });
+          await btcWallet.signPsbts(["payout", "nopayout-1", "nopayout-2"]);
+          onProgress(null);
+        },
+      );
+      const { result } = renderHookWithProps();
+      let done: Promise<void> = Promise.resolve();
+      await act(async () => {
+        done = result.current.handleSign();
+      });
+      expect(result.current.progress).toEqual({
+        phase: "graph",
+        completed: 0,
+        total: 3,
+      });
+
+      await act(async () => {
+        tick(1, 3);
+      });
+
+      expect(result.current.progress).toEqual({
+        phase: "graph",
+        completed: 1,
+        total: 3,
+      });
+      await act(async () => {
+        settle.resolve(["a", "b", "c"]);
+        await done;
+      });
+      expect(result.current.progress).toEqual({
+        phase: "graph",
+        completed: 3,
+        total: 3,
+      });
+    });
+
+    it("unsubscribes from signing progress after the batch resolves", async () => {
+      const { settle, unsubscribe } = connectProgressWallet();
+      armClaimerBatch(2);
+      const { result } = renderHookWithProps();
+      let done: Promise<void> = Promise.resolve();
+      // Separate act blocks: signPsbts (and its settle.resolve reassignment)
+      // only exists once handleSign's own internal awaits have run.
+      await act(async () => {
+        done = result.current.handleSign();
+      });
+      await act(async () => {
+        settle.resolve(["a", "b"]);
+        await done;
+      });
+
+      expect(unsubscribe).toHaveBeenCalledTimes(1);
+    });
+
+    it("unsubscribes from signing progress when the batch rejects", async () => {
+      const { settle, unsubscribe } = connectProgressWallet();
+      armClaimerBatch(2);
+      const { result } = renderHookWithProps();
+      let done: Promise<void> = Promise.resolve();
+      await act(async () => {
+        done = result.current.handleSign();
+      });
+      await act(async () => {
+        settle.reject(new Error("device gone"));
+        await done;
+      });
+
+      expect(unsubscribe).toHaveBeenCalledTimes(1);
+    });
+
+    it("a failed depositor-graph batch keeps the last tick instead of reporting the batch complete", async () => {
+      const { settle, tick } = connectProgressWallet();
+      mockSignAndSubmitPayouts.mockImplementation(
+        async ({
+          btcWallet,
+          onProgress,
+        }: {
+          btcWallet: { signPsbts: (hexes: string[]) => Promise<string[]> };
+          onProgress: (
+            p: { phase: string; completed: number; total: number } | null,
+          ) => void;
+        }) => {
+          onProgress({ phase: "claimers", completed: 3, total: 3 });
+          await btcWallet.signPsbts(["payout", "nopayout-1", "nopayout-2"]);
+        },
+      );
+      const { result } = renderHookWithProps();
+      let done: Promise<void> = Promise.resolve();
+      await act(async () => {
+        done = result.current.handleSign();
+      });
+      await act(async () => {
+        tick(1, 3);
+        settle.reject(new Error("device gone"));
+        await done;
+      });
+
+      // Read the state the wrapper left behind, not the modal's error view.
+      expect(result.current.progress).toEqual({
+        phase: "graph",
+        completed: 1,
+        total: 3,
+      });
+    });
+
+    it("a failed lone depositor-graph signPsbt keeps 0/1 instead of reporting it complete", async () => {
+      // setupHappyPath's signPsbt-only wallet: an empty challenger set makes
+      // the graph a single PSBT, which the SDK routes to signPsbt.
+      BTC_WALLET.signPsbt.mockRejectedValueOnce(new Error("device gone"));
+      mockSignAndSubmitPayouts.mockImplementation(
+        async ({
+          btcWallet,
+          onProgress,
+        }: {
+          btcWallet: { signPsbt: (hex: string) => Promise<string> };
+          onProgress: (
+            p: { phase: string; completed: number; total: number } | null,
+          ) => void;
+        }) => {
+          onProgress({ phase: "claimers", completed: 3, total: 3 });
+          await btcWallet.signPsbt("payout");
+        },
+      );
+      const { result } = renderHookWithProps();
+
+      await act(async () => {
+        await result.current.handleSign();
+      });
+
+      expect(result.current.progress).toEqual({
+        phase: "graph",
+        completed: 0,
+        total: 1,
+      });
+    });
+
+    it("progress ticks do not flip the claimers-done ref before the SDK reports the round complete", async () => {
+      // A full-count tick during Phase 3 must still be labelled "claimers";
+      // only the SDK's own (N,N) flips the phase. Pin this by re-entering
+      // signPsbts a second time BEFORE the SDK ever reports the round
+      // complete: an implementation that flips the ref from inside the tick
+      // listener would mislabel the second entry as "graph".
+      const { settle, tick, signPsbts } = connectProgressWallet();
+      mockSignAndSubmitPayouts.mockImplementation(
+        async ({
+          btcWallet,
+          onProgress,
+        }: {
+          btcWallet: { signPsbts: (hexes: string[]) => Promise<string[]> };
+          onProgress: (
+            p: { phase: string; completed: number; total: number } | null,
+          ) => void;
+        }) => {
+          onProgress({ phase: "claimers", completed: 0, total: 2 });
+          await btcWallet.signPsbts(["payout-0", "payout-1"]);
+          // Second ceremony, still before the SDK's own (N,N).
+          await btcWallet.signPsbts(["payout-2", "payout-3"]);
+          onProgress({ phase: "claimers", completed: 2, total: 2 });
+          onProgress(null);
+        },
+      );
+      const { result } = renderHookWithProps();
+      let done: Promise<void> = Promise.resolve();
+      await act(async () => {
+        done = result.current.handleSign();
+      });
+
+      await act(async () => {
+        tick(2, 2);
+      });
+
+      expect(result.current.progress).toEqual({
+        phase: "claimers",
+        completed: 2,
+        total: 2,
+      });
+
+      await act(async () => {
+        settle.resolve(["a", "b"]);
+      });
+      await waitFor(() => expect(signPsbts).toHaveBeenCalledTimes(2));
+
+      // The second entry must still snapshot "claimers" — not the "graph"
+      // a ref flipped inside the tick listener would have produced.
+      expect(result.current.progress).not.toEqual({
+        phase: "graph",
+        completed: 0,
+        total: 2,
+      });
+      expect(result.current.progress).toEqual({
+        phase: "claimers",
+        completed: 2,
+        total: 2,
+      });
+
+      await act(async () => {
+        settle.resolve(["c", "d"]);
+        await done;
+      });
+    });
+
+    it("does not subscribe on a wallet without the affordance", async () => {
+      const signPsbts = vi.fn().mockResolvedValue(["a", "b"]);
+      mockBtcConnector = {
+        connectedWallet: {
+          account: { address: "tb1test" },
+          provider: { signPsbt: vi.fn(), signPsbts },
+        },
+      };
+      armClaimerBatch(2);
+      const { result } = renderHookWithProps();
+
+      await act(async () => {
+        await result.current.handleSign();
+      });
+
+      // Extension-wallet path unchanged: the SDK's own (N,N) lands the counter.
+      expect(signPsbts).toHaveBeenCalledTimes(1);
+      expect(result.current.isComplete).toBe(true);
+    });
+  });
 });

--- a/services/vault/src/components/deposit/PayoutSignModal/usePayoutSigningState.ts
+++ b/services/vault/src/components/deposit/PayoutSignModal/usePayoutSigningState.ts
@@ -49,6 +49,7 @@ import { supportsCancelSigning } from "../../../utils/cancelSigning";
 import { formatPayoutSignatureError } from "../../../utils/errors/formatting";
 import { isUserCancellation } from "../../../utils/errors/userCancellation";
 import { isVaultLifecycleStateError } from "../../../utils/errors/vaultLifecycleStateError";
+import { observeSigningProgress } from "../../../utils/signingProgress";
 
 export interface SigningError {
   title: string;
@@ -319,39 +320,45 @@ export function usePayoutSigningState({
             }
           },
           signPsbt: async (hex, opts) => {
-            if (claimersDoneRef.current) {
+            // Snapshot: the ref flips only from the SDK's onProgress, after this call returns.
+            const isGraph = claimersDoneRef.current;
+            if (isGraph) {
               setProgress({ phase: "graph", completed: 0, total: 1 });
             }
-            try {
-              return await withDeviceWindow(() => wallet.signPsbt(hex, opts));
-            } finally {
-              if (claimersDoneRef.current) {
-                setProgress({ phase: "graph", completed: 1, total: 1 });
-              }
+            const signed = await withDeviceWindow(() =>
+              wallet.signPsbt(hex, opts),
+            );
+            if (isGraph) {
+              setProgress({ phase: "graph", completed: 1, total: 1 });
             }
+            return signed;
           },
           ...(wallet.signPsbts
             ? {
                 signPsbts: async (hexes, opts) => {
-                  if (claimersDoneRef.current) {
-                    setProgress({
-                      phase: "graph",
-                      completed: 0,
-                      total: hexes.length,
-                    });
+                  // Snapshot: the ref flips only from the SDK's onProgress, after this call returns.
+                  const phase = claimersDoneRef.current ? "graph" : "claimers";
+                  if (phase === "graph") {
+                    setProgress({ phase, completed: 0, total: hexes.length });
                   }
+                  // Per-ceremony ticks from hardware providers; a no-op elsewhere.
+                  const stopObserving = observeSigningProgress(wallet, (tick) =>
+                    setProgress({ phase, ...tick }),
+                  );
                   try {
-                    return await withDeviceWindow(() =>
+                    const signed = await withDeviceWindow(() =>
                       wallet.signPsbts!(hexes, opts),
                     );
-                  } finally {
-                    if (claimersDoneRef.current) {
+                    if (phase === "graph") {
                       setProgress({
-                        phase: "graph",
+                        phase,
                         completed: hexes.length,
                         total: hexes.length,
                       });
                     }
+                    return signed;
+                  } finally {
+                    stopObserving();
                   }
                 },
               }

--- a/services/vault/src/hooks/deposit/__tests__/useDepositFlow.test.tsx
+++ b/services/vault/src/hooks/deposit/__tests__/useDepositFlow.test.tsx
@@ -367,6 +367,16 @@ async function executeDepositFlow(result: {
   return promise;
 }
 
+/** What the Ledger provider rejects with when a requested cancel settles. */
+function signingCanceledError() {
+  return Object.assign(
+    new Error(
+      "Signing canceled after 0 of 1 PSBT(s) — the ceremony restarts from the device approval screens on retry.",
+    ),
+    { code: "CONNECTION_REJECTED" },
+  );
+}
+
 async function setupDefaultMocks() {
   const { useBtcWalletState } = vi.mocked(await import("../useBtcWalletState"));
   const { useProtocolParamsContext } = vi.mocked(
@@ -1535,6 +1545,66 @@ describe("useDepositFlow", () => {
       });
       expect(MOCK_BTC_WALLET.signPsbt).toHaveBeenCalledTimes(2);
     });
+
+    it("peg-in batch ticks update peginSigningProgress per signed PSBT before the batch resolves", async () => {
+      const { preparePeginTransaction } = vi.mocked(
+        await import("@/services/vault/vaultTransactionService"),
+      );
+      let listener: ((p: { completed: number; total: number }) => void) | null =
+        null;
+      const unsubscribe = vi.fn();
+      const settle: { resolve: (v: string[]) => void } = { resolve: () => {} };
+      const nativeSignPsbts = vi.fn(
+        () =>
+          new Promise<string[]>((resolve) => {
+            settle.resolve = resolve;
+          }),
+      );
+      const batchWallet = {
+        ...MOCK_BTC_WALLET,
+        signPsbts: nativeSignPsbts,
+        subscribeSigningProgress: vi.fn(
+          (cb: (p: { completed: number; total: number }) => void) => {
+            listener = cb;
+            return unsubscribe;
+          },
+        ),
+      };
+      vi.mocked(preparePeginTransaction).mockImplementation(async (wallet) => {
+        await wallet.signPsbts(["psbt0", "psbt1"], [{}, {}]);
+        return MOCK_BATCH_RESULT as any;
+      });
+
+      const { result } = renderHook(() =>
+        useDepositFlow({
+          ...MOCK_PARAMS,
+          btcWalletProvider: batchWallet as any,
+        }),
+      );
+      let flow!: Promise<unknown>;
+      act(() => {
+        flow = result.current.executeDeposit();
+      });
+      await waitFor(() => expect(nativeSignPsbts).toHaveBeenCalledTimes(1));
+
+      await act(async () => {
+        listener?.({ completed: 1, total: 2 });
+      });
+      expect(result.current.peginSigningProgress).toEqual({
+        completed: 1,
+        total: 2,
+      });
+
+      await act(async () => {
+        settle.resolve(["signedPsbt0", "signedPsbt1"]);
+        await flow;
+      });
+      expect(result.current.peginSigningProgress).toEqual({
+        completed: 2,
+        total: 2,
+      });
+      expect(unsubscribe).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe("Device-sign cancellation", () => {
@@ -1562,16 +1632,6 @@ describe("useDepositFlow", () => {
         ...(withCancel ? { cancelSigning } : {}),
       };
       return { wallet, settle, cancelSigning };
-    }
-
-    /** What the Ledger provider rejects with when a requested cancel settles. */
-    function signingCanceledError() {
-      return Object.assign(
-        new Error(
-          "Signing canceled after 0 of 1 PSBT(s) — the ceremony restarts from the device approval screens on retry.",
-        ),
-        { code: "CONNECTION_REJECTED" },
-      );
     }
 
     it("exposes canCancelDeviceSign only while a pre-pegin signPsbt is in flight on a provider with cancelSigning", async () => {
@@ -2477,6 +2537,385 @@ describe("useDepositFlow", () => {
 
       expect(result.current.error).toBeTruthy();
       expect(result.current.resumableVaultIds).toBeNull();
+    });
+  });
+
+  describe("per-ceremony payout progress", () => {
+    // Ledger-shaped provider: signPsbts is held open and the test emits
+    // ticks through the captured subscribeSigningProgress listener.
+    function progressWallet() {
+      let listener: ((p: { completed: number; total: number }) => void) | null =
+        null;
+      const unsubscribe = vi.fn();
+      const settle: {
+        resolve: (v: string[]) => void;
+        reject: (e: unknown) => void;
+      } = {
+        resolve: () => {},
+        reject: () => {},
+      };
+      const signPsbts = vi.fn(
+        () =>
+          new Promise<string[]>((resolve, reject) => {
+            settle.resolve = resolve;
+            settle.reject = reject;
+          }),
+      );
+      const wallet = {
+        ...MOCK_BTC_WALLET,
+        signPsbts,
+        subscribeSigningProgress: vi.fn(
+          (cb: (p: { completed: number; total: number }) => void) => {
+            listener = cb;
+            return unsubscribe;
+          },
+        ),
+      };
+      return {
+        wallet,
+        settle,
+        unsubscribe,
+        tick: (c: number, t: number) => listener?.({ completed: c, total: t }),
+      };
+    }
+
+    // Vault 0 announces the round, then hands the batch over. Vault 1 parks
+    // the flow so vault 0's final progress is readable before the post-loop
+    // reset nulls it; release the park to let the flow finish.
+    async function armPayoutRounds(
+      announced: { completed: number; total: number },
+      psbts: string[],
+    ) {
+      const { signAndSubmitPayouts } = vi.mocked(
+        await import("../depositFlowSteps"),
+      );
+      let release: () => void = () => {};
+      const parked = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      vi.mocked(signAndSubmitPayouts).mockImplementation(
+        async ({ vaultId, btcWallet, onProgress }) => {
+          if (vaultId === "0xVault1Id") {
+            await parked;
+            return;
+          }
+          onProgress?.({ phase: "claimers", ...announced });
+          await btcWallet.signPsbts(psbts);
+        },
+      );
+      return { release };
+    }
+
+    it("claimer ticks update payoutSigningProgress without changing the current step", async () => {
+      const { wallet, settle, tick } = progressWallet();
+      const park = await armPayoutRounds({ completed: 0, total: 5 }, [
+        "payout-0",
+        "payout-1",
+        "payout-2",
+        "payout-3",
+        "payout-4",
+      ]);
+
+      const { result } = renderHook(() =>
+        useDepositFlow({ ...MOCK_PARAMS, btcWalletProvider: wallet as any }),
+      );
+      let flow!: Promise<unknown>;
+      act(() => {
+        flow = result.current.executeDeposit();
+      });
+      await waitFor(() => expect(wallet.signPsbts).toHaveBeenCalledTimes(1));
+      expect(result.current.currentStep).toBe(DepositFlowStep.SIGN_PAYOUTS);
+
+      await act(async () => {
+        tick(2, 5);
+      });
+
+      expect(result.current.payoutSigningProgress).toEqual({
+        phase: "claimers",
+        completed: 2,
+        total: 5,
+      });
+      expect(result.current.currentStep).toBe(DepositFlowStep.SIGN_PAYOUTS);
+
+      await act(async () => {
+        settle.resolve(["a", "b", "c", "d", "e"]);
+        park.release();
+        await flow;
+      });
+    });
+
+    it("depositor-graph ticks update payoutSigningProgress on the SIGN_DEPOSITOR_GRAPH step", async () => {
+      const { wallet, settle, tick } = progressWallet();
+      // The SDK already reported the claimers round complete → the ref flipped.
+      const park = await armPayoutRounds({ completed: 3, total: 3 }, [
+        "payout",
+        "nopayout-1",
+        "nopayout-2",
+      ]);
+
+      const { result } = renderHook(() =>
+        useDepositFlow({ ...MOCK_PARAMS, btcWalletProvider: wallet as any }),
+      );
+      let flow!: Promise<unknown>;
+      act(() => {
+        flow = result.current.executeDeposit();
+      });
+      await waitFor(() => expect(wallet.signPsbts).toHaveBeenCalledTimes(1));
+      expect(result.current.payoutSigningProgress).toEqual({
+        phase: "graph",
+        completed: 0,
+        total: 3,
+      });
+      expect(result.current.currentStep).toBe(
+        DepositFlowStep.SIGN_DEPOSITOR_GRAPH,
+      );
+
+      await act(async () => {
+        tick(1, 3);
+      });
+      expect(result.current.payoutSigningProgress).toEqual({
+        phase: "graph",
+        completed: 1,
+        total: 3,
+      });
+
+      await act(async () => {
+        settle.resolve(["a", "b", "c"]);
+      });
+      expect(result.current.payoutSigningProgress).toEqual({
+        phase: "graph",
+        completed: 3,
+        total: 3,
+      });
+
+      await act(async () => {
+        park.release();
+        await flow;
+      });
+    });
+
+    it("a failed depositor-graph batch keeps the last tick and does not report the batch complete", async () => {
+      const { wallet, settle, tick } = progressWallet();
+      const park = await armPayoutRounds({ completed: 3, total: 3 }, [
+        "payout",
+        "nopayout-1",
+        "nopayout-2",
+      ]);
+
+      const { result } = renderHook(() =>
+        useDepositFlow({ ...MOCK_PARAMS, btcWalletProvider: wallet as any }),
+      );
+      let flow!: Promise<unknown>;
+      act(() => {
+        flow = result.current.executeDeposit();
+      });
+      await waitFor(() => expect(wallet.signPsbts).toHaveBeenCalledTimes(1));
+
+      await act(async () => {
+        tick(1, 3);
+      });
+      await act(async () => {
+        settle.reject(new Error("device gone"));
+      });
+
+      expect(result.current.payoutSigningProgress).toEqual({
+        phase: "graph",
+        completed: 1,
+        total: 3,
+      });
+
+      await act(async () => {
+        park.release();
+        await flow;
+      });
+    });
+
+    it("a failed lone depositor-graph signPsbt keeps 0/1 instead of reporting it complete", async () => {
+      // signPsbt-only wallet: an empty challenger set makes the graph one
+      // PSBT, which the SDK routes to signPsbt rather than the batch wrapper.
+      let rejectGraphSign: (e: unknown) => void = () => {};
+      const signPsbt = vi.fn((hex: string) =>
+        hex === "graphPsbt"
+          ? new Promise<string>((_, reject) => {
+              rejectGraphSign = reject;
+            })
+          : Promise.resolve("mockSignedPsbtHex"),
+      );
+      const wallet = { ...MOCK_BTC_WALLET, signPsbt };
+      const { signAndSubmitPayouts } = vi.mocked(
+        await import("../depositFlowSteps"),
+      );
+      // Vault 1 parks the flow so vault 0's progress is readable before the
+      // post-loop reset nulls it.
+      let release: () => void = () => {};
+      const parked = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      vi.mocked(signAndSubmitPayouts).mockImplementation(
+        async ({ vaultId, btcWallet, onProgress }) => {
+          if (vaultId === "0xVault1Id") {
+            await parked;
+            return;
+          }
+          onProgress?.({ phase: "claimers", completed: 3, total: 3 });
+          await btcWallet.signPsbt("graphPsbt");
+        },
+      );
+
+      const { result } = renderHook(() =>
+        useDepositFlow({ ...MOCK_PARAMS, btcWalletProvider: wallet as any }),
+      );
+      let flow!: Promise<unknown>;
+      act(() => {
+        flow = result.current.executeDeposit();
+      });
+      await waitFor(() =>
+        expect(signPsbt).toHaveBeenCalledWith("graphPsbt", undefined),
+      );
+      await act(async () => {
+        rejectGraphSign(new Error("device gone"));
+      });
+
+      expect(result.current.payoutSigningProgress).toEqual({
+        phase: "graph",
+        completed: 0,
+        total: 1,
+      });
+
+      await act(async () => {
+        release();
+        await flow;
+      });
+    });
+
+    it("the signing-progress subscription is torn down on every settle path", async () => {
+      // Resolve.
+      const resolved = progressWallet();
+      const resolvedPark = await armPayoutRounds({ completed: 3, total: 3 }, [
+        "payout",
+        "nopayout-1",
+        "nopayout-2",
+      ]);
+      const resolvedHook = renderHook(() =>
+        useDepositFlow({
+          ...MOCK_PARAMS,
+          btcWalletProvider: resolved.wallet as any,
+        }),
+      );
+      let resolvedFlow!: Promise<unknown>;
+      act(() => {
+        resolvedFlow = resolvedHook.result.current.executeDeposit();
+      });
+      await waitFor(() =>
+        expect(resolved.wallet.signPsbts).toHaveBeenCalledTimes(1),
+      );
+      await act(async () => {
+        resolved.settle.resolve(["a", "b", "c"]);
+        resolvedPark.release();
+        await resolvedFlow;
+      });
+      expect(resolved.unsubscribe).toHaveBeenCalledTimes(1);
+
+      // Reject.
+      const rejected = progressWallet();
+      const rejectedPark = await armPayoutRounds({ completed: 3, total: 3 }, [
+        "payout",
+        "nopayout-1",
+        "nopayout-2",
+      ]);
+      const rejectedHook = renderHook(() =>
+        useDepositFlow({
+          ...MOCK_PARAMS,
+          btcWalletProvider: rejected.wallet as any,
+        }),
+      );
+      let rejectedFlow!: Promise<unknown>;
+      act(() => {
+        rejectedFlow = rejectedHook.result.current.executeDeposit();
+      });
+      await waitFor(() =>
+        expect(rejected.wallet.signPsbts).toHaveBeenCalledTimes(1),
+      );
+      await act(async () => {
+        rejected.settle.reject(new Error("device gone"));
+        rejectedPark.release();
+        await rejectedFlow;
+      });
+      expect(rejected.unsubscribe).toHaveBeenCalledTimes(1);
+
+      // Cancel: the device cancel is requested, then the provider rejects.
+      const canceled = progressWallet();
+      const cancelWallet = { ...canceled.wallet, cancelSigning: vi.fn() };
+      // The settled cancel stops the loop, so vault 1's park is never reached.
+      await armPayoutRounds({ completed: 3, total: 3 }, [
+        "payout",
+        "nopayout-1",
+        "nopayout-2",
+      ]);
+      const canceledHook = renderHook(() =>
+        useDepositFlow({
+          ...MOCK_PARAMS,
+          btcWalletProvider: cancelWallet as any,
+        }),
+      );
+      let canceledFlow!: Promise<unknown>;
+      act(() => {
+        canceledFlow = canceledHook.result.current.executeDeposit();
+      });
+      await waitFor(() =>
+        expect(canceledHook.result.current.canCancelDeviceSign).toBe(true),
+      );
+      act(() => {
+        canceledHook.result.current.cancelDeviceSign();
+      });
+      await act(async () => {
+        canceled.settle.reject(signingCanceledError());
+        await canceledFlow;
+      });
+      expect(canceled.unsubscribe).toHaveBeenCalledTimes(1);
+    });
+
+    it("wallets without the affordance keep the 0-to-N jump on every batch wrapper", async () => {
+      const { preparePeginTransaction } = vi.mocked(
+        await import("@/services/vault/vaultTransactionService"),
+      );
+      const signPsbts = vi.fn().mockResolvedValue(["a", "b", "c"]);
+      const wallet = { ...MOCK_BTC_WALLET, signPsbts };
+      vi.mocked(preparePeginTransaction).mockImplementation(async (w) => {
+        await w.signPsbts(["psbt0", "psbt1"], [{}, {}]);
+        return MOCK_BATCH_RESULT as any;
+      });
+      const park = await armPayoutRounds({ completed: 3, total: 3 }, [
+        "payout",
+        "nopayout-1",
+        "nopayout-2",
+      ]);
+
+      const { result } = renderHook(() =>
+        useDepositFlow({ ...MOCK_PARAMS, btcWalletProvider: wallet as any }),
+      );
+      let flow!: Promise<unknown>;
+      act(() => {
+        flow = result.current.executeDeposit();
+      });
+
+      await waitFor(() =>
+        expect(result.current.payoutSigningProgress).toEqual({
+          phase: "graph",
+          completed: 3,
+          total: 3,
+        }),
+      );
+      expect(result.current.peginSigningProgress).toEqual({
+        completed: 2,
+        total: 2,
+      });
+
+      await act(async () => {
+        park.release();
+        await flow;
+      });
+      expect(result.current.error).toBeNull();
     });
   });
 

--- a/services/vault/src/hooks/deposit/__tests__/useDepositFlow.test.tsx
+++ b/services/vault/src/hooks/deposit/__tests__/useDepositFlow.test.tsx
@@ -2788,91 +2788,88 @@ describe("useDepositFlow", () => {
       });
     });
 
-    it("the signing-progress subscription is torn down on every settle path", async () => {
-      // Resolve.
-      const resolved = progressWallet();
-      const resolvedPark = await armPayoutRounds({ completed: 3, total: 3 }, [
+    it("unsubscribes from signing progress after the payout batch resolves", async () => {
+      const { wallet, settle, unsubscribe } = progressWallet();
+      const park = await armPayoutRounds({ completed: 3, total: 3 }, [
         "payout",
         "nopayout-1",
         "nopayout-2",
       ]);
-      const resolvedHook = renderHook(() =>
-        useDepositFlow({
-          ...MOCK_PARAMS,
-          btcWalletProvider: resolved.wallet as any,
-        }),
-      );
-      let resolvedFlow!: Promise<unknown>;
-      act(() => {
-        resolvedFlow = resolvedHook.result.current.executeDeposit();
-      });
-      await waitFor(() =>
-        expect(resolved.wallet.signPsbts).toHaveBeenCalledTimes(1),
-      );
-      await act(async () => {
-        resolved.settle.resolve(["a", "b", "c"]);
-        resolvedPark.release();
-        await resolvedFlow;
-      });
-      expect(resolved.unsubscribe).toHaveBeenCalledTimes(1);
 
-      // Reject.
-      const rejected = progressWallet();
-      const rejectedPark = await armPayoutRounds({ completed: 3, total: 3 }, [
+      const { result } = renderHook(() =>
+        useDepositFlow({ ...MOCK_PARAMS, btcWalletProvider: wallet as any }),
+      );
+      let flow!: Promise<unknown>;
+      act(() => {
+        flow = result.current.executeDeposit();
+      });
+      await waitFor(() => expect(wallet.signPsbts).toHaveBeenCalledTimes(1));
+      await act(async () => {
+        settle.resolve(["a", "b", "c"]);
+        park.release();
+        await flow;
+      });
+
+      expect(unsubscribe).toHaveBeenCalledTimes(1);
+    });
+
+    it("unsubscribes from signing progress when the payout batch rejects", async () => {
+      const { wallet, settle, unsubscribe } = progressWallet();
+      const park = await armPayoutRounds({ completed: 3, total: 3 }, [
         "payout",
         "nopayout-1",
         "nopayout-2",
       ]);
-      const rejectedHook = renderHook(() =>
-        useDepositFlow({
-          ...MOCK_PARAMS,
-          btcWalletProvider: rejected.wallet as any,
-        }),
-      );
-      let rejectedFlow!: Promise<unknown>;
-      act(() => {
-        rejectedFlow = rejectedHook.result.current.executeDeposit();
-      });
-      await waitFor(() =>
-        expect(rejected.wallet.signPsbts).toHaveBeenCalledTimes(1),
-      );
-      await act(async () => {
-        rejected.settle.reject(new Error("device gone"));
-        rejectedPark.release();
-        await rejectedFlow;
-      });
-      expect(rejected.unsubscribe).toHaveBeenCalledTimes(1);
 
-      // Cancel: the device cancel is requested, then the provider rejects.
-      const canceled = progressWallet();
-      const cancelWallet = { ...canceled.wallet, cancelSigning: vi.fn() };
+      const { result } = renderHook(() =>
+        useDepositFlow({ ...MOCK_PARAMS, btcWalletProvider: wallet as any }),
+      );
+      let flow!: Promise<unknown>;
+      act(() => {
+        flow = result.current.executeDeposit();
+      });
+      await waitFor(() => expect(wallet.signPsbts).toHaveBeenCalledTimes(1));
+      await act(async () => {
+        settle.reject(new Error("device gone"));
+        park.release();
+        await flow;
+      });
+
+      expect(unsubscribe).toHaveBeenCalledTimes(1);
+    });
+
+    it("unsubscribes from signing progress when a requested cancel settles", async () => {
+      const { wallet, settle, unsubscribe } = progressWallet();
+      const cancelWallet = { ...wallet, cancelSigning: vi.fn() };
       // The settled cancel stops the loop, so vault 1's park is never reached.
       await armPayoutRounds({ completed: 3, total: 3 }, [
         "payout",
         "nopayout-1",
         "nopayout-2",
       ]);
-      const canceledHook = renderHook(() =>
+
+      const { result } = renderHook(() =>
         useDepositFlow({
           ...MOCK_PARAMS,
           btcWalletProvider: cancelWallet as any,
         }),
       );
-      let canceledFlow!: Promise<unknown>;
+      let flow!: Promise<unknown>;
       act(() => {
-        canceledFlow = canceledHook.result.current.executeDeposit();
+        flow = result.current.executeDeposit();
       });
       await waitFor(() =>
-        expect(canceledHook.result.current.canCancelDeviceSign).toBe(true),
+        expect(result.current.canCancelDeviceSign).toBe(true),
       );
       act(() => {
-        canceledHook.result.current.cancelDeviceSign();
+        result.current.cancelDeviceSign();
       });
       await act(async () => {
-        canceled.settle.reject(signingCanceledError());
-        await canceledFlow;
+        settle.reject(signingCanceledError());
+        await flow;
       });
-      expect(canceled.unsubscribe).toHaveBeenCalledTimes(1);
+
+      expect(unsubscribe).toHaveBeenCalledTimes(1);
     });
 
     it("wallets without the affordance keep the 0-to-N jump on every batch wrapper", async () => {

--- a/services/vault/src/hooks/deposit/useDepositFlow.ts
+++ b/services/vault/src/hooks/deposit/useDepositFlow.ts
@@ -100,6 +100,7 @@ import {
 } from "@/utils/errors/userCancellation";
 import { formatBtcValue } from "@/utils/formatting";
 import { getVpProxyUrl } from "@/utils/rpc";
+import { observeSigningProgress } from "@/utils/signingProgress";
 
 import {
   DepositFlowStep,
@@ -551,9 +552,9 @@ export function useDepositFlow(
         advanceStep(DepositFlowStep.DERIVE_VAULT_SECRET);
         // A single peg-in PSBT signs via signPsbt (the SDK's
         // signPsbtsWithFallback routes lone PSBTs there), ticking the counter
-        // once. Multi-vault: one native batch popup when the wallet supports
-        // signPsbts — the (x of n) sub-counter jumps 0 -> N around the one
-        // call — else sequential signPsbt ticks it per signature.
+        // once. Multi-vault: one native batch call when the wallet supports
+        // signPsbts — extension wallets sign it in one popup (counter 0 -> N),
+        // hardware providers tick it per device ceremony.
         const signOnePeginPsbt: typeof confirmedBtcWallet.signPsbt = async (
           psbtHex,
           opts,
@@ -569,21 +570,30 @@ export function useDepositFlow(
           );
           return signed;
         };
-        // Native batch path: one popup; the counter jumps 0 -> N around the call.
+        // Native batch path: per-ceremony ticks where the provider reports
+        // them, else the counter lands at N when the one call returns.
         const signPeginBatch: typeof confirmedBtcWallet.signPsbts = async (
           psbtHexes,
           opts,
         ) => {
           advanceStep(DepositFlowStep.SIGN_PEGIN_BTC);
           setPeginSigningProgress({ completed: 0, total: psbtHexes.length });
-          const signed = await runCancellableSign(confirmedBtcWallet, () =>
-            confirmedBtcWallet.signPsbts!(psbtHexes, opts),
+          const stopObserving = observeSigningProgress(
+            confirmedBtcWallet,
+            (tick) => setPeginSigningProgress(tick),
           );
-          setPeginSigningProgress({
-            completed: psbtHexes.length,
-            total: psbtHexes.length,
-          });
-          return signed;
+          try {
+            const signed = await runCancellableSign(confirmedBtcWallet, () =>
+              confirmedBtcWallet.signPsbts!(psbtHexes, opts),
+            );
+            setPeginSigningProgress({
+              completed: psbtHexes.length,
+              total: psbtHexes.length,
+            });
+            return signed;
+          } finally {
+            stopObserving();
+          }
         };
 
         const phaseTrackingBtcWallet: typeof confirmedBtcWallet &
@@ -1127,7 +1137,9 @@ export function useDepositFlow(
             }
           },
           signPsbt: async (psbtHex, opts) => {
-            if (payoutClaimersDoneRef.current) {
+            // Snapshot: the ref flips only from the SDK's onProgress, after this call returns.
+            const isGraph = payoutClaimersDoneRef.current;
+            if (isGraph) {
               advanceStep(DepositFlowStep.SIGN_DEPOSITOR_GRAPH);
               setPayoutSigningProgress({
                 phase: "graph",
@@ -1137,45 +1149,57 @@ export function useDepositFlow(
             }
             setIsWaiting(false);
             try {
-              return await runCancellableSign(confirmedBtcWallet, () =>
+              const signed = await runCancellableSign(confirmedBtcWallet, () =>
                 confirmedBtcWallet.signPsbt(psbtHex, opts),
               );
-            } finally {
-              setIsWaiting(true);
-              if (payoutClaimersDoneRef.current) {
+              if (isGraph) {
                 setPayoutSigningProgress({
                   phase: "graph",
                   completed: 1,
                   total: 1,
                 });
               }
+              return signed;
+            } finally {
+              setIsWaiting(true);
             }
           },
           ...(confirmedBtcWallet.signPsbts
             ? {
                 signPsbts: async (psbtHexes, opts) => {
-                  if (payoutClaimersDoneRef.current) {
+                  // Snapshot: the ref flips only from the SDK's onProgress, after this call returns.
+                  const phase = payoutClaimersDoneRef.current
+                    ? "graph"
+                    : "claimers";
+                  if (phase === "graph") {
                     advanceStep(DepositFlowStep.SIGN_DEPOSITOR_GRAPH);
                     setPayoutSigningProgress({
-                      phase: "graph",
+                      phase,
                       completed: 0,
                       total: psbtHexes.length,
                     });
                   }
+                  const stopObserving = observeSigningProgress(
+                    confirmedBtcWallet,
+                    (tick) => setPayoutSigningProgress({ phase, ...tick }),
+                  );
                   setIsWaiting(false);
                   try {
-                    return await runCancellableSign(confirmedBtcWallet, () =>
-                      confirmedBtcWallet.signPsbts!(psbtHexes, opts),
+                    const signed = await runCancellableSign(
+                      confirmedBtcWallet,
+                      () => confirmedBtcWallet.signPsbts!(psbtHexes, opts),
                     );
-                  } finally {
-                    setIsWaiting(true);
-                    if (payoutClaimersDoneRef.current) {
+                    if (phase === "graph") {
                       setPayoutSigningProgress({
-                        phase: "graph",
+                        phase,
                         completed: psbtHexes.length,
                         total: psbtHexes.length,
                       });
                     }
+                    return signed;
+                  } finally {
+                    setIsWaiting(true);
+                    stopObserving();
                   }
                 },
               }

--- a/services/vault/src/hooks/deposit/useDepositFlow.ts
+++ b/services/vault/src/hooks/deposit/useDepositFlow.ts
@@ -580,7 +580,7 @@ export function useDepositFlow(
           setPeginSigningProgress({ completed: 0, total: psbtHexes.length });
           const stopObserving = observeSigningProgress(
             confirmedBtcWallet,
-            (tick) => setPeginSigningProgress(tick),
+            (tick) => setPeginSigningProgress({ ...tick }),
           );
           try {
             const signed = await runCancellableSign(confirmedBtcWallet, () =>

--- a/services/vault/src/utils/__tests__/signingProgress.test.ts
+++ b/services/vault/src/utils/__tests__/signingProgress.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { observeSigningProgress } from "../signingProgress";
+
+describe("observeSigningProgress", () => {
+  it("subscribes through the provider's affordance and returns its unsubscribe", () => {
+    const unsubscribe = vi.fn();
+    const subscribeSigningProgress = vi.fn(() => unsubscribe);
+    const listener = vi.fn();
+
+    const stop = observeSigningProgress({ subscribeSigningProgress }, listener);
+
+    expect(subscribeSigningProgress).toHaveBeenCalledWith(listener);
+    expect(stop).toBe(unsubscribe);
+  });
+
+  it("calls a prototype-method affordance through the provider so `this` resolves", () => {
+    class PrototypeProvider {
+      readonly listeners = new Set<(p: unknown) => void>();
+      subscribeSigningProgress(listener: (p: unknown) => void) {
+        this.listeners.add(listener);
+        return () => this.listeners.delete(listener);
+      }
+    }
+    const provider = new PrototypeProvider();
+    const listener = vi.fn();
+
+    const stop = observeSigningProgress(provider, listener);
+
+    expect(provider.listeners.has(listener)).toBe(true);
+    stop();
+    expect(provider.listeners.has(listener)).toBe(false);
+  });
+
+  it("returns a no-op for a provider without the affordance", () => {
+    const stop = observeSigningProgress({ signPsbt: vi.fn() }, vi.fn());
+
+    expect(() => stop()).not.toThrow();
+  });
+
+  it("returns a no-op for a null provider", () => {
+    const stop = observeSigningProgress(null, vi.fn());
+
+    expect(() => stop()).not.toThrow();
+  });
+});

--- a/services/vault/src/utils/__tests__/signingProgress.test.ts
+++ b/services/vault/src/utils/__tests__/signingProgress.test.ts
@@ -1,3 +1,4 @@
+import type { BitcoinWallet } from "@babylonlabs-io/ts-sdk/shared";
 import { describe, expect, it, vi } from "vitest";
 
 import { observeSigningProgress } from "../signingProgress";
@@ -8,7 +9,10 @@ describe("observeSigningProgress", () => {
     const subscribeSigningProgress = vi.fn(() => unsubscribe);
     const listener = vi.fn();
 
-    const stop = observeSigningProgress({ subscribeSigningProgress }, listener);
+    const stop = observeSigningProgress(
+      { subscribeSigningProgress } as unknown as BitcoinWallet,
+      listener,
+    );
 
     expect(subscribeSigningProgress).toHaveBeenCalledWith(listener);
     expect(stop).toBe(unsubscribe);
@@ -25,7 +29,10 @@ describe("observeSigningProgress", () => {
     const provider = new PrototypeProvider();
     const listener = vi.fn();
 
-    const stop = observeSigningProgress(provider, listener);
+    const stop = observeSigningProgress(
+      provider as unknown as BitcoinWallet,
+      listener,
+    );
 
     expect(provider.listeners.has(listener)).toBe(true);
     stop();
@@ -33,14 +40,24 @@ describe("observeSigningProgress", () => {
   });
 
   it("returns a no-op for a provider without the affordance", () => {
-    const stop = observeSigningProgress({ signPsbt: vi.fn() }, vi.fn());
+    const stop = observeSigningProgress(
+      { signPsbt: vi.fn() } as unknown as BitcoinWallet,
+      vi.fn(),
+    );
 
     expect(() => stop()).not.toThrow();
   });
 
-  it("returns a no-op for a null provider", () => {
-    const stop = observeSigningProgress(null, vi.fn());
-
-    expect(() => stop()).not.toThrow();
+  it("throws at subscribe time when the affordance returns no unsubscribe function", () => {
+    expect(() =>
+      observeSigningProgress(
+        {
+          subscribeSigningProgress: () => undefined,
+        } as unknown as BitcoinWallet,
+        vi.fn(),
+      ),
+    ).toThrow(
+      "provider.subscribeSigningProgress must return an unsubscribe function; got undefined",
+    );
   });
 });

--- a/services/vault/src/utils/signingProgress.ts
+++ b/services/vault/src/utils/signingProgress.ts
@@ -1,0 +1,30 @@
+/**
+ * Feature detection for `IBTCProvider.subscribeSigningProgress` — the optional
+ * per-ceremony progress affordance only hardware providers implement
+ * (currently the Ledger vault provider). Sibling of `cancelSigning.ts`.
+ */
+
+import type {
+  IBTCProvider,
+  SigningProgress,
+} from "@babylonlabs-io/wallet-connector";
+
+type SigningProgressListener = (progress: SigningProgress) => void;
+
+/**
+ * Subscribes when the provider implements the affordance; otherwise returns a
+ * no-op unsubscribe so callers never branch. Takes `unknown` because callers
+ * hold the signing provider behind an untyped ref.
+ */
+export function observeSigningProgress(
+  provider: unknown,
+  listener: SigningProgressListener,
+): () => void {
+  const candidate = provider as Pick<
+    IBTCProvider,
+    "subscribeSigningProgress"
+  > | null;
+  return typeof candidate?.subscribeSigningProgress === "function"
+    ? candidate.subscribeSigningProgress(listener)
+    : () => {};
+}

--- a/services/vault/src/utils/signingProgress.ts
+++ b/services/vault/src/utils/signingProgress.ts
@@ -4,6 +4,7 @@
  * (currently the Ledger vault provider). Sibling of `cancelSigning.ts`.
  */
 
+import type { BitcoinWallet } from "@babylonlabs-io/ts-sdk/shared";
 import type {
   IBTCProvider,
   SigningProgress,
@@ -13,18 +14,24 @@ type SigningProgressListener = (progress: SigningProgress) => void;
 
 /**
  * Subscribes when the provider implements the affordance; otherwise returns a
- * no-op unsubscribe so callers never branch. Takes `unknown` because callers
- * hold the signing provider behind an untyped ref.
+ * no-op unsubscribe so callers never branch. A subscribe that returns no
+ * function throws here, before any device I/O. The SDK's `BitcoinWallet` type
+ * omits the connector's optional affordance, hence the cast.
  */
 export function observeSigningProgress(
-  provider: unknown,
+  provider: BitcoinWallet,
   listener: SigningProgressListener,
 ): () => void {
-  const candidate = provider as Pick<
-    IBTCProvider,
-    "subscribeSigningProgress"
-  > | null;
-  return typeof candidate?.subscribeSigningProgress === "function"
-    ? candidate.subscribeSigningProgress(listener)
-    : () => {};
+  const candidate = provider as Pick<IBTCProvider, "subscribeSigningProgress">;
+  if (typeof candidate.subscribeSigningProgress !== "function") {
+    return () => {};
+  }
+  const stop = candidate.subscribeSigningProgress(listener);
+  // Callers invoke the handle from `finally`; a throw there would mask the real signing error.
+  if (typeof stop !== "function") {
+    throw new Error(
+      `provider.subscribeSigningProgress must return an unsubscribe function; got ${typeof stop}`,
+    );
+  }
+  return stop;
 }


### PR DESCRIPTION
Ledger signs each PSBT in a `signPsbts` batch as its own device ceremony,
so "(x of n)" jumped 0→N only when the whole batch returned. The provider
now exposes `subscribeSigningProgress` (optional, mirrors `cancelSigning`)
and emits `{completed,total}` after each ceremony commits; the payout,
depositor-graph and split-deposit Pre-PegIn wrappers subscribe for the
duration of the call. Extension wallets don't implement it and keep the
single jump.