### PR TITLE
fix(vault, ts-sdk): bind the reclaim sweep to its vault and re-check eligibility before signing

### DIFF
--- a/packages/babylon-ts-sdk/docs/api/clients.md
+++ b/packages/babylon-ts-sdk/docs/api/clients.md
@@ -1799,16 +1799,6 @@ vaultProviderCommissionBps: number;
 
 Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
 
-##### claimExpiredUntil
-
-```ts
-claimExpiredUntil: bigint;
-```
-
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
-
-Block deadline (uint256) for depositor reclaim. TODO(#1690): wire to refund flow.
-
 ##### vaultCoreVersion
 
 ```ts

--- a/packages/babylon-ts-sdk/docs/api/clients.md
+++ b/packages/babylon-ts-sdk/docs/api/clients.md
@@ -5771,6 +5771,14 @@ Get the current block tip height.
 Source: mempool.space API — `GET /api/blocks/tip/height` returns the height
 of the most recent block as a plain-text integer.
 
+The digit check alone is not enough to honour the contract below. A long
+enough run of digits passes `/^\d+$/` and then parses to a value no caller
+can use: 400 digits yields `Infinity`, and 20 digits yields a finite but
+unsafe integer. Callers subtract this from a confirmed block height to get a
+confirmation depth, so either one produces an enormous depth and clears any
+threshold it is compared against. Bound it to a safe integer here rather
+than leaving each caller to discover the gap.
+
 #### Parameters
 
 ##### apiUrl
@@ -5787,7 +5795,7 @@ The height of the most recent block
 
 #### Throws
 
-Error if the response is not a whole number
+Error if the response is not a whole number a caller can compute on
 
 ***
 

--- a/packages/babylon-ts-sdk/docs/api/primitives.md
+++ b/packages/babylon-ts-sdk/docs/api/primitives.md
@@ -502,7 +502,7 @@ from the same derivation.
 
 ### FinalizeScriptPathWithSignaturesParams
 
-Defined in: packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/finalizeScriptPathWithSignatures.ts
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/finalizeScriptPathWithSignatures.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/finalizeScriptPathWithSignatures.ts)
 
 #### Properties
 
@@ -512,7 +512,7 @@ Defined in: packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/finalizeScriptP
 requestedPsbtHex: string;
 ```
 
-Defined in: packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/finalizeScriptPathWithSignatures.ts
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/finalizeScriptPathWithSignatures.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/finalizeScriptPathWithSignatures.ts)
 
 Hex of the PSBT built locally and sent to the wallet — the sole source of
 every per-input field. NOT the wallet-returned PSBT.
@@ -523,7 +523,7 @@ every per-input field. NOT the wallet-returned PSBT.
 signaturesHex: readonly string[];
 ```
 
-Defined in: packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/finalizeScriptPathWithSignatures.ts
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/finalizeScriptPathWithSignatures.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/finalizeScriptPathWithSignatures.ts)
 
 Verified 64-byte Schnorr signatures, one per input, index-aligned with the
 PSBT's inputs. Each must already have passed
@@ -536,7 +536,7 @@ it only decides which bytes are allowed to reach the witness.
 signerXOnlyPubkeyHex: string;
 ```
 
-Defined in: packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/finalizeScriptPathWithSignatures.ts
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/finalizeScriptPathWithSignatures.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/finalizeScriptPathWithSignatures.ts)
 
 X-only pubkey (64 hex chars) the signatures are attributed to.
 
@@ -2174,7 +2174,7 @@ which has no need of the spend material.
 function finalizeScriptPathWithSignatures(params): string;
 ```
 
-Defined in: packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/finalizeScriptPathWithSignatures.ts
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/finalizeScriptPathWithSignatures.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/finalizeScriptPathWithSignatures.ts)
 
 Attach `signaturesHex` to the locally built PSBT's script-path inputs,
 finalize, and return the extracted transaction hex.

--- a/packages/babylon-ts-sdk/docs/api/primitives.md
+++ b/packages/babylon-ts-sdk/docs/api/primitives.md
@@ -500,6 +500,48 @@ from the same derivation.
 
 ***
 
+### FinalizeScriptPathWithSignaturesParams
+
+Defined in: packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/finalizeScriptPathWithSignatures.ts
+
+#### Properties
+
+##### requestedPsbtHex
+
+```ts
+requestedPsbtHex: string;
+```
+
+Defined in: packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/finalizeScriptPathWithSignatures.ts
+
+Hex of the PSBT built locally and sent to the wallet — the sole source of
+every per-input field. NOT the wallet-returned PSBT.
+
+##### signaturesHex
+
+```ts
+signaturesHex: readonly string[];
+```
+
+Defined in: packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/finalizeScriptPathWithSignatures.ts
+
+Verified 64-byte Schnorr signatures, one per input, index-aligned with the
+PSBT's inputs. Each must already have passed
+`assertScriptPathSchnorrSignature` — this function does not re-verify them,
+it only decides which bytes are allowed to reach the witness.
+
+##### signerXOnlyPubkeyHex
+
+```ts
+signerXOnlyPubkeyHex: string;
+```
+
+Defined in: packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/finalizeScriptPathWithSignatures.ts
+
+X-only pubkey (64 hex chars) the signatures are attributed to.
+
+***
+
 ### NoPayoutParams
 
 Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/noPayout.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/noPayout.ts)
@@ -1367,6 +1409,31 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/reclaim.ts](ht
 
 Independent chain observation of `peginTxid:1` (esplora UTXO lookup).
 
+###### txid
+
+```ts
+txid: string;
+```
+
+The outpoint the caller actually issued its chain lookup against, so the
+observation below can be tied to the input this builder adds.
+
+Without it the script and value binds prove only that *some* UTXO has
+this shape — the claim script is a pure function of the depositor key and
+so is byte-identical across every vault they own, and the value is a pure
+function of protocol parameters. Neither distinguishes one of the
+depositor's vaults from another.
+
+Txid in display order, 64 hex chars, with or without `0x` prefix.
+
+###### vout
+
+```ts
+vout: number;
+```
+
+Vout the lookup was issued against. Must be the claim vout.
+
 ###### scriptPubKey
 
 ```ts
@@ -2101,6 +2168,36 @@ which has no need of the spend material.
 
 ***
 
+### finalizeScriptPathWithSignatures()
+
+```ts
+function finalizeScriptPathWithSignatures(params): string;
+```
+
+Defined in: packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/finalizeScriptPathWithSignatures.ts
+
+Attach `signaturesHex` to the locally built PSBT's script-path inputs,
+finalize, and return the extracted transaction hex.
+
+#### Parameters
+
+##### params
+
+[`FinalizeScriptPathWithSignaturesParams`](#finalizescriptpathwithsignaturesparams)
+
+#### Returns
+
+`string`
+
+#### Throws
+
+If the signature count does not match the input count, any signature
+  or the signer key is malformed, any input does not carry exactly one
+  tapscript leaf at the expected leaf version, any input already carries a
+  key-path signature, or bitcoinjs-lib cannot finalize.
+
+***
+
 ### buildNoPayoutPsbt()
 
 ```ts
@@ -2536,6 +2633,12 @@ Build the N-in/1-out reclaim PSBT.
 Every input is bound three ways before it reaches the PSBT: the contract's
 PegIn bytes, the chain observation, and a JS re-derivation from the live
 wallet key must agree on both script and value. Any disagreement throws.
+The observation must also name the outpoint it was taken from, since script
+and value alone repeat across all of a depositor's vaults.
+
+Binding the input to the *vault* that was asked for is a further step, and
+it belongs to the service: it needs the vault id derivation, which is async.
+See `services/reclaim/buildAndBroadcastReclaim`.
 
 #### Parameters
 
@@ -2550,7 +2653,8 @@ wallet key must agree on both script and value. Any disagreement throws.
 #### Throws
 
 If `inputs` is empty, the fee is non-positive, any input fails its
-  script or value bind, or the resulting output would be at or below dust.
+  outpoint, script or value bind, or the resulting output would be at or
+  below dust.
 
 ***
 

--- a/packages/babylon-ts-sdk/docs/api/services.md
+++ b/packages/babylon-ts-sdk/docs/api/services.md
@@ -2472,7 +2472,21 @@ observed: object;
 
 Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/reclaim/buildAndBroadcastReclaim.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/reclaim/buildAndBroadcastReclaim.ts)
 
-Independent chain observation of `peginTxid:1`.
+Independent chain observation of `peginTxid:1`, including the outpoint the
+lookup was issued against — see `ReclaimReserve.observed` for why the
+script and value alone cannot identify a reserve.
+
+###### txid
+
+```ts
+txid: string;
+```
+
+###### vout
+
+```ts
+vout: number;
+```
 
 ###### scriptPubKey
 
@@ -2517,6 +2531,18 @@ vaultIds: `0x${string}`[];
 ```
 
 Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/reclaim/buildAndBroadcastReclaim.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/reclaim/buildAndBroadcastReclaim.ts)
+
+##### depositorEthAddress
+
+```ts
+depositorEthAddress: `0x${string}`;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/reclaim/buildAndBroadcastReclaim.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/reclaim/buildAndBroadcastReclaim.ts)
+
+The depositor's Ethereum address — the second preimage of every vault id.
+Used to re-derive each requested id from the PegIn bytes `readVaults`
+returned, so a reserve can be tied to the vault it was asked for.
 
 ##### depositorBtcPubkey
 

--- a/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts
@@ -75,8 +75,6 @@ export interface VaultProtocolInfo {
   depositorPopSignature: Hex;
   prePeginTxHash: Hex;
   vaultProviderCommissionBps: number;
-  /** Block deadline (uint256) for depositor reclaim. TODO(#1690): wire to refund flow. */
-  claimExpiredUntil: bigint;
   /** Vault core version (uint16) stamped at registration. VP-side gating only — see #1690. */
   vaultCoreVersion: number;
 }

--- a/packages/babylon-ts-sdk/src/tbv/core/clients/eth/vault-registry-reader.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/eth/vault-registry-reader.ts
@@ -37,7 +37,15 @@ type RawVaultBasicInfo = {
   createdAt: bigint;
 };
 
-/** Raw `getBtcVaultProtocolInfo` tuple as decoded by viem. */
+/**
+ * Raw `getBtcVaultProtocolInfo` tuple as decoded by viem.
+ *
+ * Mirrors the ABI's components except `claimExpiredUntil`, which nothing
+ * consumes: it is the post-expiry grace deadline for `claimExpired`, scoped to
+ * vaults that expired without activating, and it is not a deadline on the
+ * depositor's claim right. The ABI still declares it — the decode is
+ * positional, so removing it there would shift `vaultCoreVersion`.
+ */
 type RawVaultProtocolInfo = {
   depositorSignedPeginTx: Hex;
   universalChallengersVersion: number;
@@ -50,7 +58,6 @@ type RawVaultProtocolInfo = {
   depositorPopSignature: Hex;
   prePeginTxHash: Hex;
   vaultProviderCommissionBps: number;
-  claimExpiredUntil: bigint;
   vaultCoreVersion: number;
 };
 
@@ -81,7 +88,6 @@ function mapVaultProtocolInfo(result: RawVaultProtocolInfo): VaultProtocolInfo {
     depositorPopSignature: result.depositorPopSignature,
     prePeginTxHash: result.prePeginTxHash,
     vaultProviderCommissionBps: result.vaultProviderCommissionBps,
-    claimExpiredUntil: result.claimExpiredUntil,
     vaultCoreVersion: result.vaultCoreVersion,
   };
 }

--- a/packages/babylon-ts-sdk/src/tbv/core/clients/mempool/__tests__/mempoolApi.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/mempool/__tests__/mempoolApi.test.ts
@@ -542,6 +542,28 @@ describe("getTipHeight", () => {
       /block tip height/i,
     );
   });
+
+  // Callers subtract this height from a confirmed block height to get a
+  // confirmation depth, so a value that parses but cannot be computed on is
+  // worse than a parse failure — it silently clears any depth threshold.
+  it("throws on a digit string that parses to Infinity", async () => {
+    mockFetch.mockResolvedValueOnce(textResponse("1".repeat(400)));
+    await expect(getTipHeight(API_URL)).rejects.toThrow(/block tip height/i);
+  });
+
+  it("throws on a digit string that parses beyond the safe integer range", async () => {
+    // 1e20 satisfies Number.isInteger, so an isInteger check would let it
+    // through and yield a confirmation depth around 1e20.
+    mockFetch.mockResolvedValueOnce(textResponse("9".repeat(20)));
+    await expect(getTipHeight(API_URL)).rejects.toThrow(/block tip height/i);
+  });
+
+  it("accepts a height at the top of the safe integer range", async () => {
+    mockFetch.mockResolvedValueOnce(
+      textResponse(String(Number.MAX_SAFE_INTEGER)),
+    );
+    await expect(getTipHeight(API_URL)).resolves.toBe(Number.MAX_SAFE_INTEGER);
+  });
 });
 
 describe("request timeout", () => {

--- a/packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/mempool/mempoolApi.ts
@@ -227,19 +227,28 @@ export async function getTxInfo(txid: string, apiUrl: string): Promise<TxInfo> {
  * Source: mempool.space API — `GET /api/blocks/tip/height` returns the height
  * of the most recent block as a plain-text integer.
  *
+ * The digit check alone is not enough to honour the contract below. A long
+ * enough run of digits passes `/^\d+$/` and then parses to a value no caller
+ * can use: 400 digits yields `Infinity`, and 20 digits yields a finite but
+ * unsafe integer. Callers subtract this from a confirmed block height to get a
+ * confirmation depth, so either one produces an enormous depth and clears any
+ * threshold it is compared against. Bound it to a safe integer here rather
+ * than leaving each caller to discover the gap.
+ *
  * @param apiUrl - Mempool API base URL
  * @returns The height of the most recent block
- * @throws Error if the response is not a whole number
+ * @throws Error if the response is not a whole number a caller can compute on
  */
 export async function getTipHeight(apiUrl: string): Promise<number> {
   const raw = await fetchApi<string>(`${apiUrl}/blocks/tip/height`);
   const trimmed = raw.trim();
-  if (!/^\d+$/.test(trimmed)) {
+  const height = /^\d+$/.test(trimmed) ? Number.parseInt(trimmed, 10) : NaN;
+  if (!Number.isSafeInteger(height) || height < 0) {
     throw new Error(
       `Mempool API returned an invalid block tip height: "${raw}"`,
     );
   }
-  return Number.parseInt(trimmed, 10);
+  return height;
 }
 
 /**

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/index.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/index.ts
@@ -163,6 +163,9 @@ export type { AssertPsbtUnsignedTxMatchesParams } from "./psbt/assertPsbtUnsigne
 export { assertScriptPathSchnorrSignature } from "./psbt/verifyScriptPathSchnorrSignature";
 export type { VerifyScriptPathSchnorrSignatureParams } from "./psbt/verifyScriptPathSchnorrSignature";
 
+export { finalizeScriptPathWithSignatures } from "./psbt/finalizeScriptPathWithSignatures";
+export type { FinalizeScriptPathWithSignaturesParams } from "./psbt/finalizeScriptPathWithSignatures";
+
 export {
   assertKeyPathSchnorrSignature,
   assertReturnedKeyPathSignatures,

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/__tests__/finalizeScriptPathWithSignatures.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/__tests__/finalizeScriptPathWithSignatures.test.ts
@@ -1,0 +1,214 @@
+/**
+ * Tests for finalizeScriptPathWithSignatures.
+ *
+ * The point of this primitive is that the wallet's PSBT never reaches
+ * bitcoinjs's finalizer, so the tests build a real reclaim PSBT, sign it for
+ * real, and assert the witness that comes out — including the case that
+ * motivated it, where the wallet returns a key-path signature alongside a valid
+ * script-path one.
+ */
+
+import { Buffer } from "buffer";
+
+import * as ecc from "@bitcoin-js/tiny-secp256k1-asmjs";
+import { Psbt, Transaction } from "bitcoinjs-lib";
+import { describe, expect, it } from "vitest";
+
+import { computeTapLeafHash } from "../../utils/taproot";
+import { deriveDepositorClaimDescriptor } from "../depositorClaim";
+import { finalizeScriptPathWithSignatures } from "../finalizeScriptPathWithSignatures";
+import { buildReclaimPsbt } from "../reclaim";
+
+const DEPOSITOR_PRIV = Buffer.alloc(32, 5);
+const DEPOSITOR_XONLY = Buffer.from(
+  ecc.xOnlyPointFromScalar(DEPOSITOR_PRIV),
+).toString("hex");
+
+const CLAIM_VALUE = 33_000n;
+const FEE_SATS = 645n;
+
+/** A PegIn shaped like the real one: vault output at vout 0, reserve at vout 1. */
+function makePeginTxHex(): string {
+  const tx = new Transaction();
+  tx.version = 2;
+  tx.addInput(Buffer.alloc(32, 9), 0);
+  tx.addOutput(
+    Buffer.concat([Buffer.from([0x51, 0x20]), Buffer.alloc(32, 1)]),
+    500_000,
+  );
+  tx.addOutput(
+    deriveDepositorClaimDescriptor(DEPOSITOR_XONLY).scriptPubKey,
+    Number(CLAIM_VALUE),
+  );
+  return tx.toHex();
+}
+
+/** The 1-in/1-out reclaim PSBT the SDK would build and send to the wallet. */
+function buildRequestedPsbtHex(): string {
+  const peginTxHex = makePeginTxHex();
+  const { scriptPubKey } = deriveDepositorClaimDescriptor(DEPOSITOR_XONLY);
+  return buildReclaimPsbt({
+    depositorPubkey: DEPOSITOR_XONLY,
+    inputs: [
+      {
+        depositorSignedPeginTxHex: peginTxHex,
+        observed: {
+          txid: Transaction.fromHex(peginTxHex).getId(),
+          vout: 1,
+          scriptPubKey: scriptPubKey.toString("hex"),
+          value: CLAIM_VALUE,
+        },
+        expectedValue: CLAIM_VALUE,
+      },
+    ],
+    feeSats: FEE_SATS,
+  }).psbtHex;
+}
+
+/** Genuine BIP-340 script-path signature over input `inputIndex`. */
+function signInput(psbtHex: string, inputIndex: number): string {
+  const psbt = Psbt.fromHex(psbtHex);
+  const leaf = psbt.data.inputs[inputIndex].tapLeafScript![0];
+
+  const tx = new Transaction();
+  tx.version = psbt.version;
+  tx.locktime = psbt.locktime;
+  for (const input of psbt.txInputs) {
+    tx.addInput(input.hash, input.index, input.sequence);
+  }
+  for (const output of psbt.txOutputs) {
+    tx.addOutput(output.script, output.value);
+  }
+
+  const sighash = tx.hashForWitnessV1(
+    inputIndex,
+    psbt.data.inputs.map((i) => i.witnessUtxo!.script),
+    psbt.data.inputs.map((i) => i.witnessUtxo!.value),
+    Transaction.SIGHASH_DEFAULT,
+    computeTapLeafHash(leaf.leafVersion, leaf.script),
+  );
+
+  return Buffer.from(ecc.signSchnorr(sighash, DEPOSITOR_PRIV)).toString("hex");
+}
+
+describe("finalizeScriptPathWithSignatures", () => {
+  it("produces a script-path witness of signature, leaf script and control block", () => {
+    const psbtHex = buildRequestedPsbtHex();
+    const signature = signInput(psbtHex, 0);
+    const descriptor = deriveDepositorClaimDescriptor(DEPOSITOR_XONLY);
+
+    const txHex = finalizeScriptPathWithSignatures({
+      requestedPsbtHex: psbtHex,
+      signaturesHex: [signature],
+      signerXOnlyPubkeyHex: DEPOSITOR_XONLY,
+    });
+
+    const witness = Transaction.fromHex(txHex).ins[0].witness;
+    expect(witness).toHaveLength(3);
+    expect(Buffer.from(witness[0]).toString("hex")).toBe(signature);
+    expect(Buffer.from(witness[1])).toEqual(descriptor.leafScript);
+    expect(Buffer.from(witness[2])).toEqual(descriptor.controlBlock);
+  });
+
+  it("ignores a key-path signature the wallet added to its own PSBT", () => {
+    // The failure this primitive exists for. bitcoinjs checks key spend first,
+    // so finalizing the wallet's copy would emit a single-element key-path
+    // witness against the NUMS internal key and the broadcast would be
+    // rejected. Only the verified signature crosses over, so the wallet's
+    // extra field cannot reach the witness.
+    const psbtHex = buildRequestedPsbtHex();
+    const signature = signInput(psbtHex, 0);
+
+    const walletReturned = Psbt.fromHex(psbtHex);
+    walletReturned.updateInput(0, {
+      tapKeySig: Buffer.alloc(64, 0xff),
+      tapScriptSig: [
+        {
+          pubkey: Buffer.from(DEPOSITOR_XONLY, "hex"),
+          leafHash: computeTapLeafHash(
+            walletReturned.data.inputs[0].tapLeafScript![0].leafVersion,
+            walletReturned.data.inputs[0].tapLeafScript![0].script,
+          ),
+          signature: Buffer.from(signature, "hex"),
+        },
+      ],
+    });
+    // Sanity: the wallet's copy really would finalize to a key-path witness.
+    expect(
+      Transaction.fromHex(
+        walletReturned.finalizeAllInputs().extractTransaction().toHex(),
+      ).ins[0].witness,
+    ).toHaveLength(1);
+
+    const txHex = finalizeScriptPathWithSignatures({
+      requestedPsbtHex: psbtHex,
+      signaturesHex: [signature],
+      signerXOnlyPubkeyHex: DEPOSITOR_XONLY,
+    });
+
+    expect(Transaction.fromHex(txHex).ins[0].witness).toHaveLength(3);
+  });
+
+  it("refuses when a signature is missing for some input", () => {
+    const psbtHex = buildRequestedPsbtHex();
+
+    expect(() =>
+      finalizeScriptPathWithSignatures({
+        requestedPsbtHex: psbtHex,
+        signaturesHex: [],
+        signerXOnlyPubkeyHex: DEPOSITOR_XONLY,
+      }),
+    ).toThrow(/0 signature\(s\) for 1 input\(s\)/);
+  });
+
+  it("refuses a signature that is not 64 bytes", () => {
+    const psbtHex = buildRequestedPsbtHex();
+
+    expect(() =>
+      finalizeScriptPathWithSignatures({
+        requestedPsbtHex: psbtHex,
+        signaturesHex: ["aa".repeat(63)],
+        signerXOnlyPubkeyHex: DEPOSITOR_XONLY,
+      }),
+    ).toThrow(/must be 128 hex chars/);
+  });
+
+  it("refuses a locally built PSBT that already carries a key-path signature", () => {
+    const psbtHex = buildRequestedPsbtHex();
+    const signature = signInput(psbtHex, 0);
+    const psbt = Psbt.fromHex(psbtHex);
+    psbt.updateInput(0, { tapKeySig: Buffer.alloc(64, 0xff) });
+
+    expect(() =>
+      finalizeScriptPathWithSignatures({
+        requestedPsbtHex: psbt.toHex(),
+        signaturesHex: [signature],
+        signerXOnlyPubkeyHex: DEPOSITOR_XONLY,
+      }),
+    ).toThrow(/carries a key-path signature/);
+  });
+
+  it("refuses an input without exactly one tapscript leaf", () => {
+    const psbt = new Psbt();
+    psbt.addInput({
+      hash: Buffer.alloc(32, 4).toString("hex"),
+      index: 0,
+      witnessUtxo: {
+        script: deriveDepositorClaimDescriptor(DEPOSITOR_XONLY).scriptPubKey,
+        value: Number(CLAIM_VALUE),
+      },
+    });
+    psbt.addOutput({
+      script: deriveDepositorClaimDescriptor(DEPOSITOR_XONLY).scriptPubKey,
+      value: Number(CLAIM_VALUE - FEE_SATS),
+    });
+
+    expect(() =>
+      finalizeScriptPathWithSignatures({
+        requestedPsbtHex: psbt.toHex(),
+        signaturesHex: ["aa".repeat(64)],
+        signerXOnlyPubkeyHex: DEPOSITOR_XONLY,
+      }),
+    ).toThrow(/exactly one tapLeafScript, got 0/);
+  });
+});

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/__tests__/finalizeScriptPathWithSignatures.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/__tests__/finalizeScriptPathWithSignatures.test.ts
@@ -27,46 +27,79 @@ const DEPOSITOR_XONLY = Buffer.from(
 const CLAIM_VALUE = 33_000n;
 const FEE_SATS = 645n;
 
-/** A PegIn shaped like the real one: vault output at vout 0, reserve at vout 1. */
-function makePeginTxHex(): string {
+function xOnlyOf(priv: Buffer): string {
+  return Buffer.from(ecc.xOnlyPointFromScalar(priv)).toString("hex");
+}
+
+/**
+ * A PegIn shaped like the real one: vault output at vout 0, reserve at vout 1.
+ *
+ * `seed` varies the funding outpoint so each call yields a distinct txid, the
+ * way two real vaults would — the builder rejects a batch that repeats one.
+ */
+function makePeginTxHex({
+  depositorXOnly = DEPOSITOR_XONLY,
+  claimValue = CLAIM_VALUE,
+  seed = 9,
+}: {
+  depositorXOnly?: string;
+  claimValue?: bigint;
+  seed?: number;
+} = {}): string {
   const tx = new Transaction();
   tx.version = 2;
-  tx.addInput(Buffer.alloc(32, 9), 0);
+  tx.addInput(Buffer.alloc(32, seed), 0);
   tx.addOutput(
     Buffer.concat([Buffer.from([0x51, 0x20]), Buffer.alloc(32, 1)]),
     500_000,
   );
   tx.addOutput(
-    deriveDepositorClaimDescriptor(DEPOSITOR_XONLY).scriptPubKey,
-    Number(CLAIM_VALUE),
+    deriveDepositorClaimDescriptor(depositorXOnly).scriptPubKey,
+    Number(claimValue),
   );
   return tx.toHex();
 }
 
-/** The 1-in/1-out reclaim PSBT the SDK would build and send to the wallet. */
-function buildRequestedPsbtHex(): string {
-  const peginTxHex = makePeginTxHex();
-  const { scriptPubKey } = deriveDepositorClaimDescriptor(DEPOSITOR_XONLY);
+/** The N-in/1-out reclaim PSBT the SDK would build and send to the wallet. */
+function buildRequestedPsbtHex({
+  depositorXOnly = DEPOSITOR_XONLY,
+  claimValues = [CLAIM_VALUE],
+  feeSats = FEE_SATS,
+}: {
+  depositorXOnly?: string;
+  claimValues?: bigint[];
+  feeSats?: bigint;
+} = {}): string {
+  const { scriptPubKey } = deriveDepositorClaimDescriptor(depositorXOnly);
   return buildReclaimPsbt({
-    depositorPubkey: DEPOSITOR_XONLY,
-    inputs: [
-      {
+    depositorPubkey: depositorXOnly,
+    inputs: claimValues.map((claimValue, i) => {
+      const peginTxHex = makePeginTxHex({
+        depositorXOnly,
+        claimValue,
+        seed: 9 + i,
+      });
+      return {
         depositorSignedPeginTxHex: peginTxHex,
         observed: {
           txid: Transaction.fromHex(peginTxHex).getId(),
           vout: 1,
           scriptPubKey: scriptPubKey.toString("hex"),
-          value: CLAIM_VALUE,
+          value: claimValue,
         },
-        expectedValue: CLAIM_VALUE,
-      },
-    ],
-    feeSats: FEE_SATS,
+        expectedValue: claimValue,
+      };
+    }),
+    feeSats,
   }).psbtHex;
 }
 
 /** Genuine BIP-340 script-path signature over input `inputIndex`. */
-function signInput(psbtHex: string, inputIndex: number): string {
+function signInput(
+  psbtHex: string,
+  inputIndex: number,
+  priv: Buffer = DEPOSITOR_PRIV,
+): string {
   const psbt = Psbt.fromHex(psbtHex);
   const leaf = psbt.data.inputs[inputIndex].tapLeafScript![0];
 
@@ -88,7 +121,95 @@ function signInput(psbtHex: string, inputIndex: number): string {
     computeTapLeafHash(leaf.leafVersion, leaf.script),
   );
 
-  return Buffer.from(ecc.signSchnorr(sighash, DEPOSITOR_PRIV)).toString("hex");
+  return Buffer.from(ecc.signSchnorr(sighash, priv)).toString("hex");
+}
+
+/**
+ * What the OLD code did: finalize the PSBT the wallet returned. Used as the
+ * parity baseline for an honest wallet, which returns the same per-input
+ * metadata it was handed.
+ */
+function finalizeWalletReturn(
+  psbtHex: string,
+  signatures: string[],
+  depositorXOnly: string,
+): string {
+  const walletReturn = Psbt.fromHex(psbtHex);
+  signatures.forEach((signature, i) => {
+    const leaf = walletReturn.data.inputs[i].tapLeafScript![0];
+    walletReturn.updateInput(i, {
+      tapScriptSig: [
+        {
+          pubkey: Buffer.from(depositorXOnly, "hex"),
+          leafHash: computeTapLeafHash(leaf.leafVersion, leaf.script),
+          signature: Buffer.from(signature, "hex"),
+        },
+      ],
+    });
+  });
+  return walletReturn.finalizeAllInputs().extractTransaction().toHex();
+}
+
+/**
+ * Deterministic pseudo-random source. A seeded LCG rather than `Math.random`
+ * so a failing case is reproducible from the test name alone — "randomised"
+ * here means "covers the input space", not "differs between runs".
+ */
+function lcg(seed: number): () => number {
+  let state = seed >>> 0;
+  return () => {
+    state = (Math.imul(state, 1_664_525) + 1_013_904_223) >>> 0;
+    return state / 0x1_0000_0000;
+  };
+}
+
+interface ParityCase {
+  label: string;
+  depositorPriv: Buffer;
+  claimValues: bigint[];
+  feeSats: bigint;
+}
+
+/**
+ * The golden case plus randomised ones spanning input count, claim value, fee
+ * and depositor key — the axes `finalizeScriptPathWithSignatures` actually
+ * varies over, since it loops the inputs and the reclaim builder batches them.
+ */
+function parityCases(): ParityCase[] {
+  const cases: ParityCase[] = [
+    {
+      label: "golden single input",
+      depositorPriv: DEPOSITOR_PRIV,
+      claimValues: [CLAIM_VALUE],
+      feeSats: FEE_SATS,
+    },
+    {
+      label: "golden three-input batch",
+      depositorPriv: DEPOSITOR_PRIV,
+      claimValues: [CLAIM_VALUE, 26_228n, 41_500n],
+      feeSats: 1_395n,
+    },
+  ];
+
+  const rand = lcg(0x5eed);
+  for (let i = 0; i < 12; i++) {
+    const inputCount = 1 + Math.floor(rand() * 4);
+    const claimValues = Array.from(
+      { length: inputCount },
+      () => 5_000n + BigInt(Math.floor(rand() * 60_000)),
+    );
+    const total = claimValues.reduce((sum, v) => sum + v, 0n);
+    // Leave the output comfortably above dust so the builder's own guards are
+    // not what the case ends up exercising.
+    const feeSats = 200n + BigInt(Math.floor(rand() * Number(total / 4n)));
+    cases.push({
+      label: `randomised #${i} (${inputCount} input(s))`,
+      depositorPriv: Buffer.alloc(32, 1 + Math.floor(rand() * 200)),
+      claimValues,
+      feeSats,
+    });
+  }
+  return cases;
 }
 
 describe("finalizeScriptPathWithSignatures", () => {
@@ -149,41 +270,44 @@ describe("finalizeScriptPathWithSignatures", () => {
     expect(Transaction.fromHex(txHex).ins[0].witness).toHaveLength(3);
   });
 
-  it("matches the old finalize-the-wallet's-PSBT result when the wallet is honest", () => {
-    // The two paths are only meant to differ when the returned PSBT differs. An
-    // honest wallet returns the same per-input metadata it was given, and for
-    // that case this must be byte-for-byte what finalizing the wallet's copy
-    // produced — otherwise the change would be altering more than the trust
-    // boundary it set out to move.
-    const psbtHex = buildRequestedPsbtHex();
-    const signature = signInput(psbtHex, 0);
+  it.each(parityCases())(
+    "matches the old finalize-the-wallet's-PSBT result for an honest wallet: $label",
+    ({ depositorPriv, claimValues, feeSats }) => {
+      // The two paths are only meant to diverge when the returned PSBT
+      // diverges. An honest wallet returns the per-input metadata it was
+      // handed, and for that case the result must be byte-for-byte what
+      // finalizing the wallet's copy produced — otherwise this change moved
+      // more than the trust boundary it set out to move.
+      //
+      // Spread across input count, claim value, fee and depositor key because
+      // the function loops the inputs and the reclaim builder batches them, so
+      // index alignment between signatures and inputs is the thing most likely
+      // to diverge and a single fixed case would never show it.
+      const depositorXOnly = xOnlyOf(depositorPriv);
+      const psbtHex = buildRequestedPsbtHex({
+        depositorXOnly,
+        claimValues,
+        feeSats,
+      });
+      const signatures = claimValues.map((_v, i) =>
+        signInput(psbtHex, i, depositorPriv),
+      );
 
-    const honestWalletReturn = Psbt.fromHex(psbtHex);
-    honestWalletReturn.updateInput(0, {
-      tapScriptSig: [
-        {
-          pubkey: Buffer.from(DEPOSITOR_XONLY, "hex"),
-          leafHash: computeTapLeafHash(
-            honestWalletReturn.data.inputs[0].tapLeafScript![0].leafVersion,
-            honestWalletReturn.data.inputs[0].tapLeafScript![0].script,
-          ),
-          signature: Buffer.from(signature, "hex"),
-        },
-      ],
-    });
-    const previousBehaviour = honestWalletReturn
-      .finalizeAllInputs()
-      .extractTransaction()
-      .toHex();
+      const previousBehaviour = finalizeWalletReturn(
+        psbtHex,
+        signatures,
+        depositorXOnly,
+      );
+      const current = finalizeScriptPathWithSignatures({
+        requestedPsbtHex: psbtHex,
+        signaturesHex: signatures,
+        signerXOnlyPubkeyHex: depositorXOnly,
+      });
 
-    const current = finalizeScriptPathWithSignatures({
-      requestedPsbtHex: psbtHex,
-      signaturesHex: [signature],
-      signerXOnlyPubkeyHex: DEPOSITOR_XONLY,
-    });
-
-    expect(current).toBe(previousBehaviour);
-  });
+      expect(current).toBe(previousBehaviour);
+      expect(Transaction.fromHex(current).ins).toHaveLength(claimValues.length);
+    },
+  );
 
   it("refuses when a signature is missing for some input", () => {
     const psbtHex = buildRequestedPsbtHex();

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/__tests__/finalizeScriptPathWithSignatures.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/__tests__/finalizeScriptPathWithSignatures.test.ts
@@ -149,6 +149,42 @@ describe("finalizeScriptPathWithSignatures", () => {
     expect(Transaction.fromHex(txHex).ins[0].witness).toHaveLength(3);
   });
 
+  it("matches the old finalize-the-wallet's-PSBT result when the wallet is honest", () => {
+    // The two paths are only meant to differ when the returned PSBT differs. An
+    // honest wallet returns the same per-input metadata it was given, and for
+    // that case this must be byte-for-byte what finalizing the wallet's copy
+    // produced — otherwise the change would be altering more than the trust
+    // boundary it set out to move.
+    const psbtHex = buildRequestedPsbtHex();
+    const signature = signInput(psbtHex, 0);
+
+    const honestWalletReturn = Psbt.fromHex(psbtHex);
+    honestWalletReturn.updateInput(0, {
+      tapScriptSig: [
+        {
+          pubkey: Buffer.from(DEPOSITOR_XONLY, "hex"),
+          leafHash: computeTapLeafHash(
+            honestWalletReturn.data.inputs[0].tapLeafScript![0].leafVersion,
+            honestWalletReturn.data.inputs[0].tapLeafScript![0].script,
+          ),
+          signature: Buffer.from(signature, "hex"),
+        },
+      ],
+    });
+    const previousBehaviour = honestWalletReturn
+      .finalizeAllInputs()
+      .extractTransaction()
+      .toHex();
+
+    const current = finalizeScriptPathWithSignatures({
+      requestedPsbtHex: psbtHex,
+      signaturesHex: [signature],
+      signerXOnlyPubkeyHex: DEPOSITOR_XONLY,
+    });
+
+    expect(current).toBe(previousBehaviour);
+  });
+
   it("refuses when a signature is missing for some input", () => {
     const psbtHex = buildRequestedPsbtHex();
 

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/__tests__/reclaim.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/__tests__/reclaim.test.ts
@@ -58,14 +58,20 @@ function makePeginTxHex({
   return tx.toHex();
 }
 
+/** Txid of the PegIn `makeInput` builds at its default seed. */
+const DEFAULT_PEGIN_TXID = Transaction.fromHex(makePeginTxHex()).getId();
+
 function makeInput(
   overrides: Partial<ReclaimReserve> = {},
   seed = 7,
 ): ReclaimReserve {
   const { scriptPubKey } = deriveDepositorClaimDescriptor(DEPOSITOR);
+  const peginTxHex = makePeginTxHex({ seed });
   return {
-    depositorSignedPeginTxHex: makePeginTxHex({ seed }),
+    depositorSignedPeginTxHex: peginTxHex,
     observed: {
+      txid: Transaction.fromHex(peginTxHex).getId(),
+      vout: PEGIN_DEPOSITOR_CLAIM_VOUT,
       scriptPubKey: scriptPubKey.toString("hex"),
       value: CLAIM_VALUE,
     },
@@ -131,10 +137,21 @@ describe("buildReclaimPsbt", () => {
 
   it("rejects a reserve that pays a different wallet's claim script", () => {
     // The PegIn belongs to OTHER_DEPOSITOR; the connected wallet is DEPOSITOR.
+    // The observation is consistent with that PegIn, so the wrong-wallet bind
+    // is what has to catch it.
+    const otherWalletPeginTxHex = makePeginTxHex({
+      depositorPubkey: OTHER_DEPOSITOR,
+    });
     const input = makeInput({
-      depositorSignedPeginTxHex: makePeginTxHex({
-        depositorPubkey: OTHER_DEPOSITOR,
-      }),
+      depositorSignedPeginTxHex: otherWalletPeginTxHex,
+      observed: {
+        txid: Transaction.fromHex(otherWalletPeginTxHex).getId(),
+        vout: PEGIN_DEPOSITOR_CLAIM_VOUT,
+        scriptPubKey: deriveDepositorClaimDescriptor(
+          OTHER_DEPOSITOR,
+        ).scriptPubKey.toString("hex"),
+        value: CLAIM_VALUE,
+      },
     });
 
     expect(() =>
@@ -149,6 +166,8 @@ describe("buildReclaimPsbt", () => {
   it("rejects when the observed UTXO script disagrees with the contract's PegIn", () => {
     const input = makeInput({
       observed: {
+        txid: DEFAULT_PEGIN_TXID,
+        vout: PEGIN_DEPOSITOR_CLAIM_VOUT,
         scriptPubKey: deriveDepositorClaimDescriptor(
           OTHER_DEPOSITOR,
         ).scriptPubKey.toString("hex"),
@@ -165,9 +184,56 @@ describe("buildReclaimPsbt", () => {
     ).toThrow(/chain state disagrees with the contract's PegIn/);
   });
 
+  it("rejects when the observation is of a different vault's PegIn", () => {
+    // The script and value are byte-identical across every vault this
+    // depositor owns, so only the outpoint distinguishes them.
+    const otherVaultPeginTxHex = makePeginTxHex({ seed: 99 });
+    const input = makeInput({
+      observed: {
+        txid: Transaction.fromHex(otherVaultPeginTxHex).getId(),
+        vout: PEGIN_DEPOSITOR_CLAIM_VOUT,
+        scriptPubKey: deriveDepositorClaimDescriptor(
+          DEPOSITOR,
+        ).scriptPubKey.toString("hex"),
+        value: CLAIM_VALUE,
+      },
+    });
+
+    expect(() =>
+      buildReclaimPsbt({
+        depositorPubkey: DEPOSITOR,
+        inputs: [input],
+        feeSats: 645n,
+      }),
+    ).toThrow(/the reserve that was looked up is not the one being swept/);
+  });
+
+  it("rejects when the observation is of the vault output rather than the reserve", () => {
+    const input = makeInput({
+      observed: {
+        txid: DEFAULT_PEGIN_TXID,
+        vout: 0,
+        scriptPubKey: deriveDepositorClaimDescriptor(
+          DEPOSITOR,
+        ).scriptPubKey.toString("hex"),
+        value: CLAIM_VALUE,
+      },
+    });
+
+    expect(() =>
+      buildReclaimPsbt({
+        depositorPubkey: DEPOSITOR,
+        inputs: [input],
+        feeSats: 645n,
+      }),
+    ).toThrow(/the depositor-claim reserve is at vout 1/);
+  });
+
   it("rejects when the observed value disagrees with the contract's PegIn", () => {
     const input = makeInput({
       observed: {
+        txid: DEFAULT_PEGIN_TXID,
+        vout: PEGIN_DEPOSITOR_CLAIM_VOUT,
         scriptPubKey: deriveDepositorClaimDescriptor(
           DEPOSITOR,
         ).scriptPubKey.toString("hex"),

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/finalizeScriptPathWithSignatures.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/finalizeScriptPathWithSignatures.ts
@@ -1,0 +1,141 @@
+/**
+ * Finalize a Taproot script-path spend from the PSBT *we* built, using only the
+ * verified signatures the wallet returned.
+ *
+ * Why this exists. The obvious shape — hand the wallet's PSBT to
+ * `finalizeAllInputs()` — puts wallet-controlled bytes on the trust path even
+ * when the signature itself has been verified.
+ * `assertPsbtUnsignedTxMatches` deliberately pins only the unsigned
+ * transaction and skips per-input metadata, so `tapLeafScript`, `controlBlock`
+ * and `tapKeySig` all survive from the wallet's response untouched. And
+ * bitcoinjs-lib checks key-spend first (`src/psbt.js`, `_finalizeTaprootInput`:
+ * "Check key spend first. Increased privacy and reduced block space."), so a
+ * returned `tapKeySig` wins outright and `tapScriptSig` is never consulted.
+ * Every output the depositor-claim reserve and the HTLC refund spend from uses
+ * a NUMS internal key, so the resulting key-path witness cannot satisfy the
+ * script — the transaction is rejected at broadcast, after a wallet prompt the
+ * depositor cannot make sense of.
+ *
+ * Verifying and then discarding the wallet's PSBT closes that off structurally
+ * rather than detecting it afterwards, and it makes the code match what
+ * `verifyScriptPathSchnorrSignature` already documents: "only the 64-byte
+ * signature comes from the wallet".
+ *
+ * @module tbv/core/primitives/psbt/finalizeScriptPathWithSignatures
+ */
+
+import { Psbt } from "bitcoinjs-lib";
+import { Buffer } from "buffer";
+
+import {
+  SCHNORR_SIG_HEX_LEN,
+  TAPSCRIPT_LEAF_VERSION,
+  X_ONLY_PUBKEY_HEX_LEN,
+  hexToUint8Array,
+  stripHexPrefix,
+} from "../utils/bitcoin";
+import { computeTapLeafHash } from "../utils/taproot";
+
+export interface FinalizeScriptPathWithSignaturesParams {
+  /**
+   * Hex of the PSBT built locally and sent to the wallet — the sole source of
+   * every per-input field. NOT the wallet-returned PSBT.
+   */
+  requestedPsbtHex: string;
+  /**
+   * Verified 64-byte Schnorr signatures, one per input, index-aligned with the
+   * PSBT's inputs. Each must already have passed
+   * `assertScriptPathSchnorrSignature` — this function does not re-verify them,
+   * it only decides which bytes are allowed to reach the witness.
+   */
+  signaturesHex: readonly string[];
+  /** X-only pubkey (64 hex chars) the signatures are attributed to. */
+  signerXOnlyPubkeyHex: string;
+}
+
+/**
+ * Attach `signaturesHex` to the locally built PSBT's script-path inputs,
+ * finalize, and return the extracted transaction hex.
+ *
+ * @throws If the signature count does not match the input count, any signature
+ *   or the signer key is malformed, any input does not carry exactly one
+ *   tapscript leaf at the expected leaf version, any input already carries a
+ *   key-path signature, or bitcoinjs-lib cannot finalize.
+ */
+export function finalizeScriptPathWithSignatures(
+  params: FinalizeScriptPathWithSignaturesParams,
+): string {
+  const { requestedPsbtHex, signaturesHex, signerXOnlyPubkeyHex } = params;
+
+  const signerXOnly = stripHexPrefix(signerXOnlyPubkeyHex);
+  if (signerXOnly.length !== X_ONLY_PUBKEY_HEX_LEN) {
+    throw new Error(
+      `Signer x-only pubkey must be ${X_ONLY_PUBKEY_HEX_LEN} hex chars ` +
+        `(32 bytes), got ${signerXOnly.length}.`,
+    );
+  }
+  const signerPubkey = Buffer.from(hexToUint8Array(signerXOnly));
+
+  const psbt = Psbt.fromHex(requestedPsbtHex);
+
+  if (signaturesHex.length !== psbt.data.inputs.length) {
+    throw new Error(
+      `Cannot finalize: got ${signaturesHex.length} signature(s) for ` +
+        `${psbt.data.inputs.length} input(s). Every input must be signed — ` +
+        `refusing to broadcast a partially signed transaction.`,
+    );
+  }
+
+  psbt.data.inputs.forEach((input, inputIndex) => {
+    // Our own builders never produce a key-path signature for these spends.
+    // If one is present the PSBT is not the one we built, which would defeat
+    // the whole point of finalizing locally.
+    if (input.tapKeySig) {
+      throw new Error(
+        `Cannot finalize: input ${inputIndex} of the locally built PSBT ` +
+          `carries a key-path signature. These outputs are script-path only.`,
+      );
+    }
+
+    const tapLeafScripts = input.tapLeafScript;
+    if (!tapLeafScripts || tapLeafScripts.length !== 1) {
+      throw new Error(
+        `Cannot finalize: input ${inputIndex} must have exactly one ` +
+          `tapLeafScript, got ${tapLeafScripts?.length ?? 0}.`,
+      );
+    }
+    const leaf = tapLeafScripts[0];
+    if (leaf.leafVersion !== TAPSCRIPT_LEAF_VERSION) {
+      throw new Error(
+        `Cannot finalize: input ${inputIndex} tapLeafScript has leaf version ` +
+          `0x${leaf.leafVersion.toString(16)}, expected ` +
+          `0x${TAPSCRIPT_LEAF_VERSION.toString(16)}.`,
+      );
+    }
+
+    const signatureRaw = stripHexPrefix(signaturesHex[inputIndex]);
+    if (signatureRaw.length !== SCHNORR_SIG_HEX_LEN) {
+      throw new Error(
+        `Signature for input ${inputIndex} must be ${SCHNORR_SIG_HEX_LEN} hex ` +
+          `chars (64 bytes), got ${signatureRaw.length}.`,
+      );
+    }
+
+    psbt.updateInput(inputIndex, {
+      tapScriptSig: [
+        {
+          pubkey: signerPubkey,
+          leafHash: computeTapLeafHash(leaf.leafVersion, leaf.script),
+          signature: Buffer.from(hexToUint8Array(signatureRaw)),
+        },
+      ],
+    });
+  });
+
+  // With no tapKeySig anywhere, bitcoinjs takes the script-path branch for
+  // every input and builds `[signature, leafScript, controlBlock]` from the
+  // leaf we supplied.
+  psbt.finalizeAllInputs();
+
+  return psbt.extractTransaction().toHex();
+}

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/finalizeScriptPathWithSignatures.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/finalizeScriptPathWithSignatures.ts
@@ -27,10 +27,10 @@
 import { Psbt } from "bitcoinjs-lib";
 import { Buffer } from "buffer";
 
+import { X_ONLY_PUBKEY_HEX_LEN } from "../../utils/validation";
 import {
   SCHNORR_SIG_HEX_LEN,
   TAPSCRIPT_LEAF_VERSION,
-  X_ONLY_PUBKEY_HEX_LEN,
   hexToUint8Array,
   stripHexPrefix,
 } from "../utils/bitcoin";

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/reclaim.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/reclaim.ts
@@ -117,6 +117,21 @@ export interface ReclaimReserve {
   depositorSignedPeginTxHex: string;
   /** Independent chain observation of `peginTxid:1` (esplora UTXO lookup). */
   observed: {
+    /**
+     * The outpoint the caller actually issued its chain lookup against, so the
+     * observation below can be tied to the input this builder adds.
+     *
+     * Without it the script and value binds prove only that *some* UTXO has
+     * this shape — the claim script is a pure function of the depositor key and
+     * so is byte-identical across every vault they own, and the value is a pure
+     * function of protocol parameters. Neither distinguishes one of the
+     * depositor's vaults from another.
+     *
+     * Txid in display order, 64 hex chars, with or without `0x` prefix.
+     */
+    txid: string;
+    /** Vout the lookup was issued against. Must be the claim vout. */
+    vout: number;
     /** scriptPubKey hex, with or without `0x` prefix. */
     scriptPubKey: string;
     /** Output value in satoshis. */
@@ -163,9 +178,16 @@ export interface BuildReclaimPsbtResult {
  * Every input is bound three ways before it reaches the PSBT: the contract's
  * PegIn bytes, the chain observation, and a JS re-derivation from the live
  * wallet key must agree on both script and value. Any disagreement throws.
+ * The observation must also name the outpoint it was taken from, since script
+ * and value alone repeat across all of a depositor's vaults.
+ *
+ * Binding the input to the *vault* that was asked for is a further step, and
+ * it belongs to the service: it needs the vault id derivation, which is async.
+ * See `services/reclaim/buildAndBroadcastReclaim`.
  *
  * @throws If `inputs` is empty, the fee is non-positive, any input fails its
- *   script or value bind, or the resulting output would be at or below dust.
+ *   outpoint, script or value bind, or the resulting output would be at or
+ *   below dust.
  */
 export function buildReclaimPsbt(
   params: BuildReclaimPsbtParams,
@@ -207,6 +229,30 @@ export function buildReclaimPsbt(
         `PegIn ${peginTxid} has no output at vout ` +
           `${PEGIN_DEPOSITOR_CLAIM_VOUT} (tx has ${peginTx.outs.length}); ` +
           `there is no depositor-claim reserve to reclaim.`,
+      );
+    }
+
+    // Bind 0: the observation is of *this* outpoint. Everything below compares
+    // a script and a value, both of which repeat across every vault this
+    // depositor owns under the same protocol parameters — so without this the
+    // remaining binds cannot tell one of their vaults from another, and a
+    // caller that resolved the wrong vault would sweep it with every check
+    // passing. The independent source is the PegIn the PSBT is built from; the
+    // esplora response cannot serve here because `getUtxoInfo` echoes back the
+    // txid and vout it was called with rather than reading them from the body.
+    const observedTxid = stripHexPrefix(input.observed.txid).toLowerCase();
+    if (observedTxid !== peginTxid) {
+      throw new Error(
+        `Input ${i}: the observation is of ${observedTxid}, but this input ` +
+          `spends PegIn ${peginTxid}. Reclaim refused — the reserve that was ` +
+          `looked up is not the one being swept.`,
+      );
+    }
+    if (input.observed.vout !== PEGIN_DEPOSITOR_CLAIM_VOUT) {
+      throw new Error(
+        `Input ${i}: the observation is of vout ${input.observed.vout}, but ` +
+          `the depositor-claim reserve is at vout ` +
+          `${PEGIN_DEPOSITOR_CLAIM_VOUT}. Reclaim refused.`,
       );
     }
 

--- a/packages/babylon-ts-sdk/src/tbv/core/services/deposit/__tests__/verifyRegisteredVaultVersions.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/deposit/__tests__/verifyRegisteredVaultVersions.test.ts
@@ -33,7 +33,6 @@ function info(overrides: Partial<VaultProtocolInfo> = {}): VaultProtocolInfo {
     depositorPopSignature: "0x00" as Hex,
     prePeginTxHash: "0x00" as Hex,
     vaultProviderCommissionBps: 0,
-    claimExpiredUntil: 0n,
     vaultCoreVersion: 1,
     ...overrides,
   };

--- a/packages/babylon-ts-sdk/src/tbv/core/services/reclaim/__tests__/buildAndBroadcastReclaim.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/reclaim/__tests__/buildAndBroadcastReclaim.test.ts
@@ -6,7 +6,7 @@
  * verification, and abort handling.
  */
 
-import type { Hex } from "viem";
+import type { Address, Hex } from "viem";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
@@ -43,21 +43,39 @@ vi.mock("../../../primitives/psbt/verifyScriptPathSchnorrSignature", () => ({
   assertScriptPathSchnorrSignature: vi.fn(),
 }));
 
-vi.mock("bitcoinjs-lib", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("bitcoinjs-lib")>();
+vi.mock(
+  "../../../primitives/psbt/finalizeScriptPathWithSignatures",
+  () => ({
+    finalizeScriptPathWithSignatures: vi.fn().mockReturnValue("signedtxhex"),
+  }),
+);
+
+vi.mock("../../../utils/transaction/btcTxHash", () => ({
+  calculateBtcTxHash: vi.fn().mockReturnValue(`0x${"cd".repeat(32)}`),
+}));
+
+// The vault-id bind hashes the PegIn back to the id that was requested. The
+// derivation itself is golden-vector tested against the Rust reference in
+// `primitives/__tests__/deriveVaultId.test.ts`; here it is stubbed so the tests
+// can drive agreement and disagreement directly.
+vi.mock("@babylonlabs-io/babylon-tbv-rust-wasm", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("@babylonlabs-io/babylon-tbv-rust-wasm")
+    >();
   return {
     ...actual,
-    Psbt: {
-      ...actual.Psbt,
-      fromHex: vi.fn().mockReturnValue({
-        finalizeAllInputs: vi.fn(),
-        extractTransaction: () => ({ toHex: () => "signedtxhex" }),
-      }),
-    },
+    deriveVaultId: vi.fn().mockResolvedValue(`0x${"11".repeat(32)}`),
   };
 });
 
 const { buildReclaimPsbt } = await import("../../../primitives/psbt/reclaim");
+const { finalizeScriptPathWithSignatures } = await import(
+  "../../../primitives/psbt/finalizeScriptPathWithSignatures"
+);
+const { deriveVaultId } = await import(
+  "@babylonlabs-io/babylon-tbv-rust-wasm"
+);
 const { assertScriptPathSchnorrSignature } = await import(
   "../../../primitives/psbt/verifyScriptPathSchnorrSignature"
 );
@@ -66,8 +84,11 @@ const { extractPayoutSignature } = await import(
 );
 
 const VAULT_ID = `0x${"11".repeat(32)}` as Hex;
+const SECOND_VAULT_ID = `0x${"22".repeat(32)}` as Hex;
+const DEPOSITOR_ETH_ADDRESS = `0x${"33".repeat(20)}` as Address;
 const DEPOSITOR_PUBKEY =
   "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798";
+const PEGIN_TXID = "cd".repeat(32);
 const CLAIM_VALUE = 33_000n;
 
 function makeVaultData(
@@ -75,7 +96,12 @@ function makeVaultData(
 ): ReclaimVaultData {
   return {
     depositorSignedPeginTxHex: "0200000000",
-    observed: { scriptPubKey: "5120" + "ab".repeat(32), value: CLAIM_VALUE },
+    observed: {
+      txid: PEGIN_TXID,
+      vout: 1,
+      scriptPubKey: "5120" + "ab".repeat(32),
+      value: CLAIM_VALUE,
+    },
     expectedClaimValue: CLAIM_VALUE,
     ...overrides,
   };
@@ -84,6 +110,7 @@ function makeVaultData(
 function makeInput(overrides: Record<string, unknown> = {}) {
   return {
     vaultIds: [VAULT_ID],
+    depositorEthAddress: DEPOSITOR_ETH_ADDRESS,
     depositorBtcPubkey: DEPOSITOR_PUBKEY,
     readVaults: vi.fn().mockResolvedValue([makeVaultData()]),
     feeRate: 5,
@@ -162,11 +189,14 @@ describe("buildAndBroadcastReclaim", () => {
 
   it("verifies a signature for every input, not just the first", async () => {
     const input = makeInput({
-      vaultIds: [VAULT_ID, `0x${"22".repeat(32)}` as Hex],
+      vaultIds: [VAULT_ID, SECOND_VAULT_ID],
       readVaults: vi
         .fn()
         .mockResolvedValue([makeVaultData(), makeVaultData()]),
     });
+    vi.mocked(deriveVaultId)
+      .mockResolvedValueOnce(VAULT_ID)
+      .mockResolvedValueOnce(SECOND_VAULT_ID);
 
     await buildAndBroadcastReclaim(input);
 
@@ -182,7 +212,7 @@ describe("buildAndBroadcastReclaim", () => {
 
   it("refuses when readVaults returns a different number of reserves than requested", async () => {
     const input = makeInput({
-      vaultIds: [VAULT_ID, `0x${"22".repeat(32)}` as Hex],
+      vaultIds: [VAULT_ID, SECOND_VAULT_ID],
       readVaults: vi.fn().mockResolvedValue([makeVaultData()]),
     });
 
@@ -190,6 +220,49 @@ describe("buildAndBroadcastReclaim", () => {
       /does not match the request/,
     );
     expect(input.signPsbt).not.toHaveBeenCalled();
+  });
+
+  it("refuses a reserve whose PegIn does not hash to the requested vault id", async () => {
+    // The script and value binds cannot catch this: both repeat across every
+    // vault this depositor owns. Only the vault id distinguishes them.
+    const input = makeInput();
+    vi.mocked(deriveVaultId).mockResolvedValueOnce(SECOND_VAULT_ID);
+
+    await expect(buildAndBroadcastReclaim(input)).rejects.toThrow(
+      /belongs to vault 0x2222.*not the requested 0x1111/,
+    );
+    expect(buildReclaimPsbt).not.toHaveBeenCalled();
+    expect(input.signPsbt).not.toHaveBeenCalled();
+  });
+
+  it("refuses a batch whose reserves come back in the wrong order", async () => {
+    const input = makeInput({
+      vaultIds: [VAULT_ID, SECOND_VAULT_ID],
+      readVaults: vi
+        .fn()
+        .mockResolvedValue([makeVaultData(), makeVaultData()]),
+    });
+    // Same two vaults, swapped — a cardinality check cannot see this.
+    vi.mocked(deriveVaultId)
+      .mockResolvedValueOnce(SECOND_VAULT_ID)
+      .mockResolvedValueOnce(VAULT_ID);
+
+    await expect(buildAndBroadcastReclaim(input)).rejects.toThrow(
+      /Reserve 0 belongs to vault/,
+    );
+    expect(input.signPsbt).not.toHaveBeenCalled();
+  });
+
+  it("finalizes the PSBT it built rather than the one the wallet returned", async () => {
+    const input = makeInput();
+
+    await buildAndBroadcastReclaim(input);
+
+    expect(finalizeScriptPathWithSignatures).toHaveBeenCalledWith({
+      requestedPsbtHex: "70736274ffmock",
+      signaturesHex: ["aa".repeat(64)],
+      signerXOnlyPubkeyHex: DEPOSITOR_PUBKEY,
+    });
   });
 
   it("rejects an empty vault set", async () => {
@@ -221,9 +294,12 @@ describe("buildAndBroadcastReclaim", () => {
   it("passes the swept reserves through to the builder in request order", async () => {
     const first = makeVaultData({ depositorSignedPeginTxHex: "0200000001" });
     const second = makeVaultData({ depositorSignedPeginTxHex: "0200000002" });
+    vi.mocked(deriveVaultId)
+      .mockResolvedValueOnce(VAULT_ID)
+      .mockResolvedValueOnce(SECOND_VAULT_ID);
     await buildAndBroadcastReclaim(
       makeInput({
-        vaultIds: [VAULT_ID, `0x${"22".repeat(32)}` as Hex],
+        vaultIds: [VAULT_ID, SECOND_VAULT_ID],
         readVaults: vi.fn().mockResolvedValue([first, second]),
       }),
     );

--- a/packages/babylon-ts-sdk/src/tbv/core/services/reclaim/__tests__/buildAndBroadcastReclaim.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/reclaim/__tests__/buildAndBroadcastReclaim.test.ts
@@ -56,13 +56,11 @@ vi.mock("../../../utils/transaction/btcTxHash", () => ({
 
 // The vault-id bind hashes the PegIn back to the id that was requested. The
 // derivation itself is golden-vector tested against the Rust reference in
-// `primitives/__tests__/deriveVaultId.test.ts`; here it is stubbed so the tests
-// can drive agreement and disagreement directly.
-vi.mock("@babylonlabs-io/babylon-tbv-rust-wasm", async (importOriginal) => {
-  const actual =
-    await importOriginal<
-      typeof import("@babylonlabs-io/babylon-tbv-rust-wasm")
-    >();
+// `primitives/__tests__/deriveVaultId.test.ts`; here it is stubbed at the lazy
+// WASM boundary the service imports so the tests can drive agreement and
+// disagreement directly.
+vi.mock("../../../wasm", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../../wasm")>();
   return {
     ...actual,
     deriveVaultId: vi.fn().mockResolvedValue(`0x${"11".repeat(32)}`),
@@ -73,9 +71,7 @@ const { buildReclaimPsbt } = await import("../../../primitives/psbt/reclaim");
 const { finalizeScriptPathWithSignatures } = await import(
   "../../../primitives/psbt/finalizeScriptPathWithSignatures"
 );
-const { deriveVaultId } = await import(
-  "@babylonlabs-io/babylon-tbv-rust-wasm"
-);
+const { deriveVaultId } = await import("../../../wasm");
 const { assertScriptPathSchnorrSignature } = await import(
   "../../../primitives/psbt/verifyScriptPathSchnorrSignature"
 );

--- a/packages/babylon-ts-sdk/src/tbv/core/services/reclaim/__tests__/buildAndBroadcastReclaim.walletPsbt.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/reclaim/__tests__/buildAndBroadcastReclaim.walletPsbt.test.ts
@@ -1,0 +1,189 @@
+/**
+ * The wallet-PSBT trust boundary, exercised through the real service.
+ *
+ * The sibling suite mocks every primitive so it can test orchestration, and the primitives suite
+ * tests the finalizer directly. Neither shows what happens when a wallet returns a PSBT the service
+ * did not build — which is the only thing standing between a signed reclaim and a broadcast that
+ * cannot confirm.
+ *
+ * So this file mocks nothing below the service except the vault-id derivation (async WASM). A real
+ * PegIn, a real PSBT, a real BIP-340 signature, and a `signPsbt` that behaves like a wallet which
+ * adds a key-path signature on the way back.
+ */
+
+import * as ecc from "@bitcoin-js/tiny-secp256k1-asmjs";
+import { Psbt, Transaction } from "bitcoinjs-lib";
+import { Buffer } from "buffer";
+import type { Address, Hex } from "viem";
+import { describe, expect, it, vi } from "vitest";
+
+import { deriveDepositorClaimDescriptor } from "../../../primitives/psbt/depositorClaim";
+import { computeTapLeafHash } from "../../../primitives/utils/taproot";
+import { buildAndBroadcastReclaim } from "../buildAndBroadcastReclaim";
+
+const VAULT_ID = `0x${"aa".repeat(32)}` as Hex;
+const DEPOSITOR_ETH = `0x${"33".repeat(20)}` as Address;
+
+// The vault-id bind goes through WASM, which these tests do not need to exercise — the golden
+// vector for that derivation lives in `primitives/__tests__/deriveVaultId.test.ts`.
+vi.mock("@babylonlabs-io/babylon-tbv-rust-wasm", async (importOriginal) => ({
+  ...(await importOriginal<
+    typeof import("@babylonlabs-io/babylon-tbv-rust-wasm")
+  >()),
+  // Literal, not the VAULT_ID constant: `vi.mock` factories are hoisted above it.
+  deriveVaultId: vi.fn().mockResolvedValue(`0x${"aa".repeat(32)}`),
+}));
+
+const DEPOSITOR_PRIV = Buffer.alloc(32, 5);
+const DEPOSITOR_XONLY = Buffer.from(
+  ecc.xOnlyPointFromScalar(DEPOSITOR_PRIV),
+).toString("hex");
+
+const CLAIM_VALUE = 33_000n;
+
+/** A PegIn shaped like the real one: vault output at vout 0, the reserve at vout 1. */
+function makePeginTxHex(): string {
+  const tx = new Transaction();
+  tx.version = 2;
+  tx.addInput(Buffer.alloc(32, 9), 0);
+  tx.addOutput(
+    Buffer.concat([Buffer.from([0x51, 0x20]), Buffer.alloc(32, 1)]),
+    500_000,
+  );
+  tx.addOutput(
+    deriveDepositorClaimDescriptor(DEPOSITOR_XONLY).scriptPubKey,
+    Number(CLAIM_VALUE),
+  );
+  return tx.toHex();
+}
+
+/** Genuine BIP-340 script-path signature over input 0 of `psbtHex`. */
+function signInput0(psbtHex: string): string {
+  const psbt = Psbt.fromHex(psbtHex);
+  const leaf = psbt.data.inputs[0].tapLeafScript![0];
+
+  const tx = new Transaction();
+  tx.version = psbt.version;
+  tx.locktime = psbt.locktime;
+  for (const input of psbt.txInputs) {
+    tx.addInput(input.hash, input.index, input.sequence);
+  }
+  for (const output of psbt.txOutputs) {
+    tx.addOutput(output.script, output.value);
+  }
+
+  const sighash = tx.hashForWitnessV1(
+    0,
+    psbt.data.inputs.map((i) => i.witnessUtxo!.script),
+    psbt.data.inputs.map((i) => i.witnessUtxo!.value),
+    Transaction.SIGHASH_DEFAULT,
+    computeTapLeafHash(leaf.leafVersion, leaf.script),
+  );
+
+  return Buffer.from(ecc.signSchnorr(sighash, DEPOSITOR_PRIV)).toString("hex");
+}
+
+function makeInput(signPsbt: (psbtHex: string) => Promise<string>) {
+  const peginTxHex = makePeginTxHex();
+  const { scriptPubKey } = deriveDepositorClaimDescriptor(DEPOSITOR_XONLY);
+  return {
+    vaultIds: [VAULT_ID],
+    depositorEthAddress: DEPOSITOR_ETH,
+    depositorBtcPubkey: DEPOSITOR_XONLY,
+    readVaults: async () => [
+      {
+        depositorSignedPeginTxHex: peginTxHex,
+        observed: {
+          txid: Transaction.fromHex(peginTxHex).getId(),
+          vout: 1,
+          scriptPubKey: scriptPubKey.toString("hex"),
+          value: CLAIM_VALUE,
+        },
+        expectedClaimValue: CLAIM_VALUE,
+      },
+    ],
+    feeRate: 5,
+    signPsbt,
+    broadcastTx: async (signedTxHex: string) => ({ txId: signedTxHex }),
+  };
+}
+
+describe("buildAndBroadcastReclaim — wallet PSBT boundary", () => {
+  it("broadcasts a script-path witness even when the wallet adds a key-path signature", async () => {
+    // bitcoinjs checks key spend first, so a service that finalized the returned PSBT would emit a
+    // one-element key-path witness against the NUMS internal key — consensus-invalid, and rejected
+    // at relay after the depositor had already approved the prompt.
+    const signPsbt = async (psbtHex: string): Promise<string> => {
+      const signature = signInput0(psbtHex);
+      const returned = Psbt.fromHex(psbtHex);
+      const leaf = returned.data.inputs[0].tapLeafScript![0];
+      returned.updateInput(0, {
+        tapKeySig: Buffer.alloc(64, 0xff),
+        tapScriptSig: [
+          {
+            pubkey: Buffer.from(DEPOSITOR_XONLY, "hex"),
+            leafHash: computeTapLeafHash(leaf.leafVersion, leaf.script),
+            signature: Buffer.from(signature, "hex"),
+          },
+        ],
+      });
+      return returned.toHex();
+    };
+
+    const { txId: signedTxHex } = await buildAndBroadcastReclaim(
+      makeInput(signPsbt),
+    );
+
+    const witness = Transaction.fromHex(signedTxHex).ins[0].witness;
+    expect(witness).toHaveLength(3);
+    expect(Buffer.from(witness[1])).toEqual(
+      deriveDepositorClaimDescriptor(DEPOSITOR_XONLY).leafScript,
+    );
+    expect(Buffer.from(witness[2])).toEqual(
+      deriveDepositorClaimDescriptor(DEPOSITOR_XONLY).controlBlock,
+    );
+  });
+
+  it("broadcasts a script-path witness when the wallet rewrites the leaf it signed under", async () => {
+    // `assertPsbtUnsignedTxMatches` deliberately skips per-input metadata, so a returned PSBT can
+    // carry any tapLeafScript it likes. Ours is the only one that reaches the witness.
+    const signPsbt = async (psbtHex: string): Promise<string> => {
+      const signature = signInput0(psbtHex);
+      const returned = Psbt.fromHex(psbtHex);
+      const leaf = returned.data.inputs[0].tapLeafScript![0];
+      returned.updateInput(0, {
+        tapScriptSig: [
+          {
+            pubkey: Buffer.from(DEPOSITOR_XONLY, "hex"),
+            leafHash: computeTapLeafHash(leaf.leafVersion, leaf.script),
+            signature: Buffer.from(signature, "hex"),
+          },
+        ],
+      });
+      // Swap in a foreign leaf and control block alongside the real one.
+      returned.data.inputs[0].tapLeafScript = [
+        {
+          leafVersion: leaf.leafVersion,
+          script: Buffer.concat([
+            Buffer.from([0x20]),
+            Buffer.alloc(32, 0xee),
+            Buffer.from([0xac]),
+          ]),
+          controlBlock: Buffer.concat([
+            Buffer.from([leaf.controlBlock[0]]),
+            Buffer.alloc(32, 0xdd),
+          ]),
+        },
+      ];
+      return returned.toHex();
+    };
+
+    const { txId: signedTxHex } = await buildAndBroadcastReclaim(
+      makeInput(signPsbt),
+    );
+
+    expect(Buffer.from(Transaction.fromHex(signedTxHex).ins[0].witness[1])).toEqual(
+      deriveDepositorClaimDescriptor(DEPOSITOR_XONLY).leafScript,
+    );
+  });
+});

--- a/packages/babylon-ts-sdk/src/tbv/core/services/reclaim/__tests__/buildAndBroadcastReclaim.walletPsbt.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/reclaim/__tests__/buildAndBroadcastReclaim.walletPsbt.test.ts
@@ -26,10 +26,9 @@ const DEPOSITOR_ETH = `0x${"33".repeat(20)}` as Address;
 
 // The vault-id bind goes through WASM, which these tests do not need to exercise — the golden
 // vector for that derivation lives in `primitives/__tests__/deriveVaultId.test.ts`.
-vi.mock("@babylonlabs-io/babylon-tbv-rust-wasm", async (importOriginal) => ({
-  ...(await importOriginal<
-    typeof import("@babylonlabs-io/babylon-tbv-rust-wasm")
-  >()),
+// Mocked at the lazy WASM boundary the service imports, not at the engine package.
+vi.mock("../../../wasm", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../../wasm")>()),
   // Literal, not the VAULT_ID constant: `vi.mock` factories are hoisted above it.
   deriveVaultId: vi.fn().mockResolvedValue(`0x${"aa".repeat(32)}`),
 }));

--- a/packages/babylon-ts-sdk/src/tbv/core/services/reclaim/buildAndBroadcastReclaim.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/reclaim/buildAndBroadcastReclaim.ts
@@ -20,7 +20,6 @@
  * @module services/reclaim
  */
 
-import { deriveVaultId } from "@babylonlabs-io/babylon-tbv-rust-wasm";
 import type { Address, Hex } from "viem";
 
 import type { SignPsbtOptions } from "../../../../shared/wallets/interfaces/BitcoinWallet";
@@ -39,6 +38,7 @@ import {
   stripHexPrefix,
 } from "../../primitives/utils/bitcoin";
 import { createTaprootScriptPathSignOptions } from "../../utils/signing";
+import { deriveVaultId } from "../../wasm";
 import { calculateBtcTxHash } from "../../utils/transaction/btcTxHash";
 // The BTC broadcast transport types are shared with the refund service rather
 // than redeclared — `services/index.ts` re-exports both modules flat, so a

--- a/packages/babylon-ts-sdk/src/tbv/core/services/reclaim/buildAndBroadcastReclaim.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/reclaim/buildAndBroadcastReclaim.ts
@@ -2,10 +2,11 @@
  * Reclaim orchestration — sweep the depositor-claim reserve (PegIn vout 1)
  * back to the depositor after their vault has terminally settled.
  *
- * The SDK owns the sequence: read → fee caps → PSBT build → sign → verify →
- * finalize → broadcast. Interactive transports (`signPsbt`, `broadcastTx`) and
- * the data read stay as injected callbacks, so the caller keeps its transport
- * choice and error decoding. Mirrors `services/refund/buildAndBroadcastRefund`.
+ * The SDK owns the sequence: read → vault-id bind → fee caps → PSBT build →
+ * sign → verify → finalize → broadcast. Interactive transports (`signPsbt`,
+ * `broadcastTx`) and the data read stay as injected callbacks, so the caller
+ * keeps its transport choice and error decoding. Mirrors
+ * `services/refund/buildAndBroadcastRefund`.
  *
  * > **Eligibility is the caller's job, and it is a safety control.** The claim
  * > leaf carries no timelock, so this service will sweep a reserve whose vault
@@ -19,11 +20,12 @@
  * @module services/reclaim
  */
 
-import { Psbt } from "bitcoinjs-lib";
-import type { Hex } from "viem";
+import { deriveVaultId } from "@babylonlabs-io/babylon-tbv-rust-wasm";
+import type { Address, Hex } from "viem";
 
 import type { SignPsbtOptions } from "../../../../shared/wallets/interfaces/BitcoinWallet";
 import { assertPsbtUnsignedTxMatches } from "../../primitives/psbt/assertPsbtUnsignedTxMatches";
+import { finalizeScriptPathWithSignatures } from "../../primitives/psbt/finalizeScriptPathWithSignatures";
 import { extractPayoutSignature } from "../../primitives/psbt/payout";
 import {
   buildReclaimPsbt,
@@ -31,8 +33,13 @@ import {
   type ReclaimReserve,
 } from "../../primitives/psbt/reclaim";
 import { assertScriptPathSchnorrSignature } from "../../primitives/psbt/verifyScriptPathSchnorrSignature";
-import { processPublicKeyToXOnly } from "../../primitives/utils/bitcoin";
+import {
+  ensureHexPrefix,
+  processPublicKeyToXOnly,
+  stripHexPrefix,
+} from "../../primitives/utils/bitcoin";
 import { createTaprootScriptPathSignOptions } from "../../utils/signing";
+import { calculateBtcTxHash } from "../../utils/transaction/btcTxHash";
 // The BTC broadcast transport types are shared with the refund service rather
 // than redeclared — `services/index.ts` re-exports both modules flat, so a
 // second declaration would collide on the barrel.
@@ -84,8 +91,17 @@ export interface ReclaimVaultData {
    * never the indexer. Its `outs[1]` is one leg of the three-way bind.
    */
   depositorSignedPeginTxHex: string;
-  /** Independent chain observation of `peginTxid:1`. */
-  observed: { scriptPubKey: string; value: bigint };
+  /**
+   * Independent chain observation of `peginTxid:1`, including the outpoint the
+   * lookup was issued against — see `ReclaimReserve.observed` for why the
+   * script and value alone cannot identify a reserve.
+   */
+  observed: {
+    txid: string;
+    vout: number;
+    scriptPubKey: string;
+    value: bigint;
+  };
   /** This vault's reserve value, recomputed via `computeMinClaimValue`. */
   expectedClaimValue: bigint;
 }
@@ -94,6 +110,12 @@ export interface ReclaimInput<
   R extends BtcBroadcastResult = BtcBroadcastResult,
 > {
   vaultIds: Hex[];
+  /**
+   * The depositor's Ethereum address — the second preimage of every vault id.
+   * Used to re-derive each requested id from the PegIn bytes `readVaults`
+   * returned, so a reserve can be tied to the vault it was asked for.
+   */
+  depositorEthAddress: Address;
   /**
    * The **connected wallet's live** BTC pubkey — compressed sec1 or x-only.
    * Never the indexer's `depositorBtcPubkey`: re-deriving the claim script
@@ -116,19 +138,42 @@ export interface ReclaimInput<
   signal?: AbortSignal;
 }
 
-function finalizeAndExtract(signedPsbtHex: string): string {
-  const psbt = Psbt.fromHex(signedPsbtHex);
-  try {
-    psbt.finalizeAllInputs();
-  } catch (e: unknown) {
-    // Some wallets (e.g. Keystone) finalize during signPsbt; bitcoinjs then
-    // throws "Input is already finalized". Treat that case as a no-op.
-    const message = e instanceof Error ? e.message : String(e);
-    if (!message.includes("already finalized")) {
-      throw new Error(`Failed to finalize reclaim PSBT: ${message}`);
+/**
+ * Assert every reserve belongs to the vault it was requested for.
+ *
+ * The PSBT builder's binds all compare a script or a value, and both repeat
+ * across every vault a depositor owns under the same protocol parameters — so
+ * none of them can tell one of their vaults from another. Re-deriving the
+ * vault id from the PegIn bytes closes that: it is the same
+ * `keccak256(abi.encode(peginTxHash, depositor))` the registry keys on.
+ *
+ * This binds the reserve to the id that was asked for. It cannot detect an id
+ * that was wrong to begin with — if the caller resolved the wrong vault id
+ * upstream, every read follows that vault consistently and this agrees.
+ */
+async function assertReservesMatchVaultIds(
+  vaults: readonly ReclaimVaultData[],
+  vaultIds: readonly Hex[],
+  depositorEthAddress: Address,
+): Promise<void> {
+  for (let i = 0; i < vaults.length; i++) {
+    const peginTxHash = calculateBtcTxHash(vaults[i].depositorSignedPeginTxHex);
+    const derivedVaultId = ensureHexPrefix(
+      await deriveVaultId(
+        stripHexPrefix(peginTxHash),
+        stripHexPrefix(depositorEthAddress),
+      ),
+    ).toLowerCase();
+
+    if (derivedVaultId !== vaultIds[i].toLowerCase()) {
+      throw new Error(
+        `Reserve ${i} belongs to vault ${derivedVaultId}, not the requested ` +
+          `${vaultIds[i].toLowerCase()}. Refusing to sweep a reserve whose ` +
+          `vault is not the one the caller asked for — the reserve funds that ` +
+          `vault's claim transaction and cannot be replaced.`,
+      );
     }
   }
-  return psbt.extractTransaction().toHex();
 }
 
 /**
@@ -145,6 +190,7 @@ export async function buildAndBroadcastReclaim<
 >(input: ReclaimInput<R>): Promise<R> {
   const {
     vaultIds,
+    depositorEthAddress,
     depositorBtcPubkey,
     readVaults,
     feeRate,
@@ -180,6 +226,13 @@ export async function buildAndBroadcastReclaim<
         `vault id(s); refusing to sweep a set that does not match the request.`,
     );
   }
+
+  // Cardinality alone proves nothing about *which* vaults came back, and
+  // `readVaults` is documented as ordered but never checked. Derive each id
+  // back from the PegIn bytes so an out-of-order, substituted or otherwise
+  // mismatched set is rejected before any of it reaches a PSBT.
+  await assertReservesMatchVaultIds(vaults, vaultIds, depositorEthAddress);
+  signal?.throwIfAborted();
 
   // x-only for script derivation and signature verification; the raw form is
   // kept for the wallet's own sign call below.
@@ -236,7 +289,7 @@ export async function buildAndBroadcastReclaim<
   // every input against a sighash recomputed from the PSBT we built, before
   // finalizing — not just input 0, or a batch could broadcast with one good
   // signature and the rest garbage.
-  reserves.forEach((_reserve, inputIndex) => {
+  const signatures = reserves.map((_reserve, inputIndex) => {
     const signature = extractPayoutSignature(
       signedPsbtHex,
       xOnlyDepositorPubkey,
@@ -248,9 +301,17 @@ export async function buildAndBroadcastReclaim<
       signerXOnlyPubkeyHex: xOnlyDepositorPubkey,
       inputIndex,
     });
+    return signature;
   });
 
-  const signedTxHex = finalizeAndExtract(signedPsbtHex);
+  // Finalize the PSBT we built, not the one the wallet returned: only the
+  // verified signatures above cross over. See the primitive's header for what
+  // finalizing the wallet's copy would let through.
+  const signedTxHex = finalizeScriptPathWithSignatures({
+    requestedPsbtHex: psbtHex,
+    signaturesHex: signatures,
+    signerXOnlyPubkeyHex: xOnlyDepositorPubkey,
+  });
   signal?.throwIfAborted();
 
   return broadcastTx(signedTxHex);

--- a/packages/babylon-ts-sdk/src/tbv/core/services/refund/__tests__/buildAndBroadcastRefund.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/refund/__tests__/buildAndBroadcastRefund.test.ts
@@ -48,32 +48,21 @@ vi.mock("../../../primitives/psbt/verifyScriptPathSchnorrSignature", () => ({
   assertScriptPathSchnorrSignature: vi.fn(),
 }));
 
-// Finalize + extract uses bitcoinjs-lib. We stub Psbt.fromHex to return an
-// object with controllable `finalizeAllInputs` / `extractTransaction`.
-// `Transaction` is kept real because the orchestrator also parses the
-// funded Pre-PegIn hex via `findAuthAnchorOpReturn` to extract the
-// auth-anchor commitment.
-vi.mock("bitcoinjs-lib", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("bitcoinjs-lib")>();
-  const psbtInstance = {
-    finalizeAllInputs: vi.fn(),
-    extractTransaction: vi.fn(() => ({
-      toHex: () => "signedtxhex",
-    })),
-  };
-  return {
-    ...actual,
-    Psbt: {
-      fromHex: vi.fn(() => psbtInstance),
-    },
-  };
-});
+// Finalization has its own suite against a real PSBT; here it is stubbed so
+// these tests stay about orchestration. bitcoinjs-lib itself is left real —
+// the orchestrator parses the funded Pre-PegIn hex via `findAuthAnchorOpReturn`
+// to extract the auth-anchor commitment.
+vi.mock(
+  "../../../primitives/psbt/finalizeScriptPathWithSignatures",
+  () => ({
+    finalizeScriptPathWithSignatures: vi.fn(() => "signedtxhex"),
+  }),
+);
 
-import { Psbt } from "bitcoinjs-lib";
+import { finalizeScriptPathWithSignatures } from "../../../primitives/psbt/finalizeScriptPathWithSignatures";
 import { buildRefundPsbt } from "../../../primitives/psbt/refund";
 
 const mockedBuildRefundPsbt = vi.mocked(buildRefundPsbt);
-const mockedFromHex = vi.mocked(Psbt.fromHex);
 
 const VAULT_ID = ("0x" + "aa".repeat(32)) as Hex;
 const HASHLOCK =
@@ -172,7 +161,7 @@ describe("buildAndBroadcastRefund", () => {
     broadcastTx = vi.fn().mockResolvedValue({ txId: "0xrefundtxid" });
     mockedBuildRefundPsbt.mockClear();
     mockedBuildRefundPsbt.mockResolvedValue({ psbtHex: "70736274ff01mock" });
-    mockedFromHex.mockClear();
+    vi.mocked(finalizeScriptPathWithSignatures).mockClear();
   });
 
   it("calls readVault, readPrePeginContext, signPsbt, broadcastTx in order", async () => {
@@ -1060,53 +1049,22 @@ describe("buildAndBroadcastRefund", () => {
       expect(broadcastTx).not.toHaveBeenCalled();
     });
 
-    it("tolerates already-finalized PSBT (Keystone wallets)", async () => {
-      const psbtInstance = {
-        finalizeAllInputs: vi.fn(() => {
-          throw new Error("Input is already finalized");
-        }),
-        extractTransaction: vi.fn(() => ({ toHex: () => "signedtxhex" })),
-      };
-      mockedFromHex.mockReturnValueOnce(
-        psbtInstance as unknown as ReturnType<typeof Psbt.fromHex>,
-      );
+    it("finalizes the PSBT it built rather than the one the wallet returned", async () => {
+      await buildAndBroadcastRefund({
+        vaultId: VAULT_ID,
+        readVault,
+        readPrePeginContext,
+        feeRate: FEE_RATE,
+        signPsbt,
+        broadcastTx,
+      });
 
-      await expect(
-        buildAndBroadcastRefund({
-          vaultId: VAULT_ID,
-          readVault,
-          readPrePeginContext,
-          feeRate: FEE_RATE,
-          signPsbt,
-          broadcastTx,
-        }),
-      ).resolves.toEqual({ txId: "0xrefundtxid" });
-      expect(psbtInstance.extractTransaction).toHaveBeenCalledOnce();
+      expect(finalizeScriptPathWithSignatures).toHaveBeenCalledWith({
+        requestedPsbtHex: "70736274ff01mock",
+        signaturesHex: ["ab".repeat(64)],
+        signerXOnlyPubkeyHex: DEPOSITOR_PUBKEY,
+      });
       expect(broadcastTx).toHaveBeenCalledWith("signedtxhex");
-    });
-
-    it("throws on unrelated finalize errors", async () => {
-      const psbtInstance = {
-        finalizeAllInputs: vi.fn(() => {
-          throw new Error("bad witness");
-        }),
-        extractTransaction: vi.fn(),
-      };
-      mockedFromHex.mockReturnValueOnce(
-        psbtInstance as unknown as ReturnType<typeof Psbt.fromHex>,
-      );
-
-      await expect(
-        buildAndBroadcastRefund({
-          vaultId: VAULT_ID,
-          readVault,
-          readPrePeginContext,
-          feeRate: FEE_RATE,
-          signPsbt,
-          broadcastTx,
-        }),
-      ).rejects.toThrow(/Failed to finalize refund PSBT: bad witness/);
-      expect(broadcastTx).not.toHaveBeenCalled();
     });
 
     it("aborts before any work when signal is pre-aborted", async () => {

--- a/packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/refund/buildAndBroadcastRefund.ts
@@ -11,12 +11,13 @@
  */
 
 import type { Network } from "@babylonlabs-io/babylon-tbv-rust-wasm";
-import { Psbt, Transaction } from "bitcoinjs-lib";
+import { Transaction } from "bitcoinjs-lib";
 import type { Address, Hex } from "viem";
 
 import type { SignPsbtOptions } from "../../../../shared/wallets/interfaces/BitcoinWallet";
 import { findAuthAnchorOpReturn } from "../../managers/pegin";
 import { assertPsbtUnsignedTxMatches } from "../../primitives/psbt/assertPsbtUnsignedTxMatches";
+import { finalizeScriptPathWithSignatures } from "../../primitives/psbt/finalizeScriptPathWithSignatures";
 import { extractPayoutSignature } from "../../primitives/psbt/payout";
 import { buildRefundPsbt } from "../../primitives/psbt/refund";
 import { assertScriptPathSchnorrSignature } from "../../primitives/psbt/verifyScriptPathSchnorrSignature";
@@ -370,21 +371,6 @@ function validateRefundPrePeginContext(c: RefundPrePeginContext): void {
   }
 }
 
-function finalizeAndExtract(signedPsbtHex: string): string {
-  const psbt = Psbt.fromHex(signedPsbtHex);
-  try {
-    psbt.finalizeAllInputs();
-  } catch (e: unknown) {
-    // Some wallets (e.g. Keystone) finalize during signPsbt; bitcoinjs then
-    // throws "Input is already finalized". Treat that case as a no-op.
-    const message = e instanceof Error ? e.message : String(e);
-    if (!message.includes("already finalized")) {
-      throw new Error(`Failed to finalize refund PSBT: ${message}`);
-    }
-  }
-  return psbt.extractTransaction().toHex();
-}
-
 /**
  * Build, sign, and broadcast a refund transaction for an expired vault.
  *
@@ -570,7 +556,14 @@ export async function buildAndBroadcastRefund<
     inputIndex: REFUND_SIGNED_INPUT_INDEX,
   });
 
-  const signedTxHex = finalizeAndExtract(signedPsbtHex);
+  // Finalize the PSBT we built, not the one the wallet returned: only the
+  // verified signature above crosses over. See the primitive's header for what
+  // finalizing the wallet's copy would let through.
+  const signedTxHex = finalizeScriptPathWithSignatures({
+    requestedPsbtHex: psbtHex,
+    signaturesHex: [refundSignature],
+    signerXOnlyPubkeyHex: xOnlyDepositorPubkey,
+  });
   signal?.throwIfAborted();
 
   try {

--- a/services/vault/e2e/real/actions/index.ts
+++ b/services/vault/e2e/real/actions/index.ts
@@ -1,6 +1,6 @@
 /**
  * Registry of implemented actions: connect, observe, wallet-config, pegin, sign-conformance, borrow,
- * repay, withdraw, and resume.
+ * repay, withdraw, resume, recover, and reclaim.
  */
 import type { ActionId } from "../config";
 
@@ -8,6 +8,7 @@ import { borrowAction } from "./borrow";
 import { connectAction } from "./connect";
 import { observeAction } from "./observe";
 import { peginAction } from "./pegin";
+import { reclaimAction } from "./reclaim";
 import { recoverAction } from "./recover";
 import { repayAction } from "./repay";
 import { resumeAction } from "./resume";
@@ -27,4 +28,5 @@ export const ACTIONS_BY_ID: Partial<Record<ActionId, Action>> = {
   withdraw: withdrawAction,
   resume: resumeAction,
   recover: recoverAction,
+  reclaim: reclaimAction,
 };

--- a/services/vault/e2e/real/actions/reclaim.ts
+++ b/services/vault/e2e/real/actions/reclaim.ts
@@ -75,6 +75,7 @@ const ENCLOSING_MAX_DEPTH = 8;
 async function enclosingText(
   locator: Locator,
   minChars: number,
+  log: (m: string) => void,
 ): Promise<string> {
   let best = "";
   for (let depth = 1; depth <= ENCLOSING_MAX_DEPTH; depth++) {
@@ -82,7 +83,12 @@ async function enclosingText(
       await locator
         .locator(`xpath=ancestor::*[${depth}]`)
         .innerText()
-        .catch(() => "")
+        .catch((error: unknown) => {
+          // Running off the top of the tree is expected; anything else means the DOM path this
+          // harness relies on has moved, which is worth seeing in the log rather than hiding.
+          log(`  (ancestor[${depth}] innerText failed: ${String(error)})`);
+          return "";
+        })
     )
       .replace(/\s+/g, " ")
       .trim();
@@ -185,7 +191,7 @@ export const reclaimAction: Action = {
 
       // Record what the row said before touching it — the reclaimable figure and the vault's own
       // identifiers are the human-readable cross-check against the transaction we verify later.
-      rowSummary = await enclosingText(reclaimButton, ROW_TEXT_MIN_CHARS);
+      rowSummary = await enclosingText(reclaimButton, ROW_TEXT_MIN_CHARS, log);
       log(`Reclaimable row: ${rowSummary || "(row text unavailable)"}`);
 
       currentStep = "open-review";
@@ -208,25 +214,35 @@ export const reclaimAction: Action = {
       const reviewText = await enclosingText(
         confirmButton,
         MODAL_TEXT_MIN_CHARS,
+        log,
       );
       log(`Review screen: ${reviewText || "(modal text unavailable)"}`);
 
       // The preview has now probed the chain, so the PegIn txid is on the wire. Snapshot the gate's
       // inputs before authorising anything.
+      //
+      // Without it there is nothing to bind the broadcast to: the witness shape, weight and value
+      // conservation all hold for a sweep of ANY of this depositor's vaults, so a run that could not
+      // observe the PegIn would spend real money and then report a pass it had not earned. Refuse
+      // rather than proceed — nothing has been signed at this point.
       const [peginTxid] = watcher.peginTxids();
-      if (peginTxid) {
-        gate = await snapshotGate(mempoolApiBase, peginTxid);
-        log(
-          `Gate at authorisation: PegIn ${peginTxid} · payout spent=${gate.payoutSpend.spent} ` +
-            `confirmed=${gate.payoutSpend.confirmed} depth=${gate.payoutConfirmations ?? "?"} · ` +
-            `reserve spent=${gate.reserveSpend.spent} value=${gate.reserveValueSats ?? "?"} sats · ` +
-            `tip=${gate.tipHeight}`,
+      if (!peginTxid) {
+        throw new Error(
+          "Could not observe the PegIn txid on the wire, so the sweep cannot be bound to the " +
+            "selected vault. Refusing to sign: the remaining checks would pass for any reserve " +
+            "this depositor owns.",
         );
-      } else {
-        log(
-          "⚠️  Could not observe the PegIn txid on the wire — the gate snapshot will be skipped. " +
-            "The post-broadcast shape checks still run.",
-        );
+      }
+
+      gate = await snapshotGate(mempoolApiBase, peginTxid);
+      log(
+        `Gate at authorisation: PegIn ${peginTxid} · payout spent=${gate.payoutSpend.spent} ` +
+          `confirmed=${gate.payoutSpend.confirmed} depth=${gate.payoutConfirmations ?? "?"} · ` +
+          `reserve spent=${gate.reserveSpend.spent} value=${gate.reserveValueSats ?? "?"} sats · ` +
+          `tip=${gate.tipHeight}`,
+      );
+      if (gate.reserveValueError) {
+        log(`⚠️  Reserve value lookup: ${gate.reserveValueError}`);
       }
 
       if (dryRun) {
@@ -289,7 +305,11 @@ export const reclaimAction: Action = {
           `${verification.feeRateSatsVb ?? "?"} sat/vB)`,
       );
 
-      await doneButton.click().catch(() => undefined);
+      // The verification above has already run, so a stuck Done button does not invalidate the
+      // result — but it does mean the completion path is broken, which must not pass silently.
+      await doneButton.click().catch((error: unknown) => {
+        log(`⚠️  Done button did not accept a click: ${String(error)}`);
+      });
 
       if (!verification.allPassed) {
         throw new Error(

--- a/services/vault/e2e/real/actions/reclaim.ts
+++ b/services/vault/e2e/real/actions/reclaim.ts
@@ -1,0 +1,327 @@
+/**
+ * The "reclaim" action: sweep the depositor-claim reserve (PegIn output 1) back to the depositor.
+ *
+ * Every peg-in sets aside ~26–33k sats at PegIn output 1 to fund the depositor's own emergency claim
+ * transaction. On the normal path the vault provider claims from its own wallet, nothing ever spends
+ * that output, and it strands. Reclaim is the row action that sweeps it back, and it is offered only
+ * once the withdrawal has settled on Bitcoin: PegIn output 0 spent, six confirmations deep.
+ *
+ * Click path: /vaults → Inactive Vaults → a row's "Reclaim" → Review ("Confirm") → ONE BTC wallet
+ * signature (no Ethereum transaction at all) → "Reclaim submitted" → "Done".
+ *
+ * ⚠️ NEVER run without an explicit go-ahead, and never against a vault that is still live. This spends
+ * real BTC and the spend is IRREVERSIBLE in a way an ordinary transaction is not: the depositor's
+ * emergency claim transaction is pre-signed to spend that exact outpoint, and every later transaction
+ * in that chain is signed against it. There is no re-funding path. Sweeping the reserve of a live vault
+ * destroys the depositor's recovery material permanently. The app's own gate is what protects against
+ * this — `--dry-run` stops before the signature so the gate and the review screen can be exercised
+ * without spending anything.
+ *
+ * What this run actually proves. The UI can only show that the button worked; the interesting failures
+ * are invisible from the screen. So after the broadcast the run reads the transaction back off the
+ * chain and asserts its shape (see `reclaimParams.ts`): one input at `(peginTxid, 1)`, a three-item
+ * script-path witness rather than a key-path one, the single-leaf claim script and its 33-byte control
+ * block, value conservation, and the modelled 513 weight units. Those results are written to
+ * `reclaim.json` in the run's artifacts directory alongside the gate state at authorisation time.
+ */
+import type { Locator, Page } from "@playwright/test";
+import { writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { NETWORKS } from "../config";
+import {
+  snapshotGate,
+  verifyReclaimTx,
+  type ReclaimGateSnapshot,
+  type ReclaimVerification,
+} from "../reclaimParams";
+import {
+  FORM_SETTLE_MS,
+  MS_PER_SECOND,
+  WITHDRAW_MODAL_TIMEOUT_MS,
+} from "../timing";
+
+import { installPopupApprover, sweepApprovals } from "./approver";
+import { goToSection } from "./navigation";
+import { startRecording } from "./recording";
+import { DONE_BUTTON_RX, firstByTestid } from "./selectors";
+import { type Action, type ActionContext } from "./types";
+import { connectWallets } from "./walletConnect";
+
+const RECLAIM_BUTTON_TESTID = '[data-testid="vault-reclaim-button"]';
+const CONFIRM_BUTTON_TESTID = '[data-testid="reclaim-confirm-button"]';
+const DONE_BUTTON_TESTID = '[data-testid="reclaim-done-button"]';
+
+/** How long to wait for a reclaimable row to appear. The poller runs on a 60s tick. */
+const RECLAIM_ROW_TIMEOUT_MS = 90 * MS_PER_SECOND;
+/** How long to wait for the broadcast after the wallet signature comes back. */
+const RECLAIM_BROADCAST_TIMEOUT_MS = 90 * MS_PER_SECOND;
+
+/** A row carries an amount, a status, a provider and a hash, so its text is far longer than a label. */
+const ROW_TEXT_MIN_CHARS = 40;
+/** The review modal carries four labelled rows plus a heading and a description. */
+const MODAL_TEXT_MIN_CHARS = 80;
+/** How far up the DOM to look for the enclosing row / modal before giving up. */
+const ENCLOSING_MAX_DEPTH = 8;
+
+/**
+ * Text of the nearest ancestor of `locator` that reads like a container rather than the control
+ * itself — the first one at least `minChars` long.
+ *
+ * Walking up by a fixed number of levels would be brittle against markup changes, and the control's
+ * own text ("Reclaim", "Confirm") is never what we want to record. Returns the deepest text found if
+ * nothing reaches the threshold, so a changed layout degrades to less context rather than to nothing.
+ */
+async function enclosingText(
+  locator: Locator,
+  minChars: number,
+): Promise<string> {
+  let best = "";
+  for (let depth = 1; depth <= ENCLOSING_MAX_DEPTH; depth++) {
+    const text = (
+      await locator
+        .locator(`xpath=ancestor::*[${depth}]`)
+        .innerText()
+        .catch(() => "")
+    )
+      .replace(/\s+/g, " ")
+      .trim();
+    if (text.length > best.length) best = text;
+    if (text.length >= minChars) return text;
+  }
+  return best;
+}
+
+/** `/tx/<64-hex>/outspend/1` — the preview's probe of the reserve, which names the PegIn. */
+const OUTSPEND_URL_RX = /\/tx\/([0-9a-f]{64})\/outspend\/1(?:\?|$)/;
+/** A bare 64-hex body is what `POST /tx` returns on a successful broadcast. */
+const TXID_BODY_RX = /^[0-9a-f]{64}$/;
+
+/**
+ * Watch the page's network traffic for the two txids this run needs.
+ *
+ * The success screen opens the explorer with `window.open` rather than rendering a link, so the swept
+ * txid is not readable from the DOM. Both values are already crossing the wire, so we read them there:
+ * the PegIn from the preview's own outspend probe, and the broadcast txid from the push response.
+ */
+function watchTxids(page: Page, log: (m: string) => void) {
+  const peginTxids = new Set<string>();
+  let broadcastTxid: string | undefined;
+
+  const onRequest = (url: string) => {
+    const match = OUTSPEND_URL_RX.exec(url);
+    if (match) peginTxids.add(match[1]);
+  };
+
+  page.on("request", (req) => onRequest(req.url()));
+  page.on("response", async (res) => {
+    if (broadcastTxid) return;
+    const req = res.request();
+    if (
+      req.method() !== "POST" ||
+      !/\/tx\/?$/.test(new URL(res.url()).pathname)
+    )
+      return;
+    try {
+      const body = (await res.text()).trim();
+      if (TXID_BODY_RX.test(body)) {
+        broadcastTxid = body;
+        log(`Broadcast txid observed on the wire: ${body}`);
+      }
+    } catch {
+      // The body may already be consumed or the response aborted; the DOM fallback still applies.
+    }
+  });
+
+  return {
+    peginTxids: () => Array.from(peginTxids),
+    broadcastTxid: () => broadcastTxid,
+  };
+}
+
+export const reclaimAction: Action = {
+  id: "reclaim",
+  async run(ctx: ActionContext): Promise<void> {
+    const { page, context, log, artifactsDir, config } = ctx;
+    const mempoolApiBase = NETWORKS[config.network].mempoolApiBase;
+    const dryRun = config.reclaimDryRun === true;
+
+    const handler = installPopupApprover(context, log);
+    let currentStep = "connect";
+    const recorder = await startRecording(
+      context,
+      page,
+      artifactsDir,
+      log,
+      () => currentStep,
+    );
+
+    const watcher = watchTxids(page, log);
+    let gate: ReclaimGateSnapshot | undefined;
+    let verification: ReclaimVerification | undefined;
+    let rowSummary = "";
+
+    try {
+      await connectWallets(ctx);
+
+      currentStep = "open-vaults";
+      await goToSection(page, "vaults", log);
+      await page.waitForTimeout(FORM_SETTLE_MS);
+
+      currentStep = "find-reclaimable-row";
+      // An ineligible vault renders no button at all, and a blocked one (paused protocol, Ledger)
+      // renders a disabled one — so "enabled" is the real selector for something we can act on.
+      const reclaimButton = page
+        .locator(`${RECLAIM_BUTTON_TESTID}:not([disabled])`)
+        .first();
+      log(
+        `Waiting up to ${RECLAIM_ROW_TIMEOUT_MS / MS_PER_SECOND}s for a reclaimable row ` +
+          `(the reserve poller runs on a 60s tick, so a cold load can take one cycle)…`,
+      );
+      await reclaimButton.waitFor({
+        state: "visible",
+        timeout: RECLAIM_ROW_TIMEOUT_MS,
+      });
+
+      // Record what the row said before touching it — the reclaimable figure and the vault's own
+      // identifiers are the human-readable cross-check against the transaction we verify later.
+      rowSummary = await enclosingText(reclaimButton, ROW_TEXT_MIN_CHARS);
+      log(`Reclaimable row: ${rowSummary || "(row text unavailable)"}`);
+
+      currentStep = "open-review";
+      await reclaimButton.click();
+
+      const confirmButton = firstByTestid(
+        page,
+        CONFIRM_BUTTON_TESTID,
+        page.getByRole("button", { name: /^confirm$/i }),
+      );
+      await confirmButton.waitFor({
+        state: "visible",
+        timeout: WITHDRAW_MODAL_TIMEOUT_MS,
+      });
+      await page.waitForTimeout(FORM_SETTLE_MS);
+
+      // Scope to the modal rather than the page: the review's amount, fee rate, network fee and
+      // "you receive" are the numbers worth recording, and a whole-page capture buries them under
+      // the dashboard behind it.
+      const reviewText = await enclosingText(
+        confirmButton,
+        MODAL_TEXT_MIN_CHARS,
+      );
+      log(`Review screen: ${reviewText || "(modal text unavailable)"}`);
+
+      // The preview has now probed the chain, so the PegIn txid is on the wire. Snapshot the gate's
+      // inputs before authorising anything.
+      const [peginTxid] = watcher.peginTxids();
+      if (peginTxid) {
+        gate = await snapshotGate(mempoolApiBase, peginTxid);
+        log(
+          `Gate at authorisation: PegIn ${peginTxid} · payout spent=${gate.payoutSpend.spent} ` +
+            `confirmed=${gate.payoutSpend.confirmed} depth=${gate.payoutConfirmations ?? "?"} · ` +
+            `reserve spent=${gate.reserveSpend.spent} value=${gate.reserveValueSats ?? "?"} sats · ` +
+            `tip=${gate.tipHeight}`,
+        );
+      } else {
+        log(
+          "⚠️  Could not observe the PegIn txid on the wire — the gate snapshot will be skipped. " +
+            "The post-broadcast shape checks still run.",
+        );
+      }
+
+      if (dryRun) {
+        log(
+          "🛑 --dry-run: stopping BEFORE the signature. The eligibility gate and the review screen " +
+            "have been exercised; nothing was spent.",
+        );
+        return;
+      }
+
+      if (await confirmButton.isDisabled()) {
+        throw new Error(
+          "Confirm is disabled on the review screen — the fee is over a cap, the output is dust, " +
+            "or the mempool fee rate could not be fetched. See the review text above.",
+        );
+      }
+
+      currentStep = "sign-and-broadcast";
+      log("Confirming — this signs and broadcasts a real Bitcoin transaction.");
+      await confirmButton.click();
+      await sweepApprovals(context, page, log).catch((err) => {
+        log(`Approval sweep reported: ${String(err)}`);
+      });
+
+      currentStep = "await-success";
+      const doneButton = firstByTestid(
+        page,
+        DONE_BUTTON_TESTID,
+        page.getByRole("button", { name: DONE_BUTTON_RX }),
+      );
+      await doneButton.waitFor({
+        state: "visible",
+        timeout: RECLAIM_BROADCAST_TIMEOUT_MS,
+      });
+      log("Success screen reached.");
+
+      const broadcastTxid = watcher.broadcastTxid();
+      if (!broadcastTxid) {
+        throw new Error(
+          "The success screen appeared but no broadcast txid was observed on the wire — cannot " +
+            "verify the transaction's shape.",
+        );
+      }
+
+      currentStep = "verify-onchain";
+      log(`Verifying ${broadcastTxid} against the chain…`);
+      verification = await verifyReclaimTx(mempoolApiBase, broadcastTxid, {
+        peginTxid,
+        depositorAddress: ctx.btc.address,
+      });
+
+      for (const c of verification.checks) {
+        log(
+          `  ${c.ok ? "✅" : "❌"} ${c.name} — expected ${c.expected}, got ${c.actual}`,
+        );
+      }
+      log(
+        `Swept ${verification.inputValueSats ?? "?"} sats → ${verification.outputValueSats} sats ` +
+          `(fee ${verification.feeSats} sats, ${verification.vsize} vB, ` +
+          `${verification.feeRateSatsVb ?? "?"} sat/vB)`,
+      );
+
+      await doneButton.click().catch(() => undefined);
+
+      if (!verification.allPassed) {
+        throw new Error(
+          "The reclaim broadcast but its on-chain shape failed verification — see the ❌ lines above " +
+            "and reclaim.json.",
+        );
+      }
+      log("✅ Reclaim complete and verified on chain.");
+    } finally {
+      writeFileSync(
+        join(artifactsDir, "reclaim.json"),
+        `${JSON.stringify(
+          {
+            network: config.network,
+            mempoolApiBase,
+            dryRun,
+            btcAddress: ctx.btc.address,
+            ethAddress: ctx.eth.address,
+            rowSummary,
+            observedPeginTxids: watcher.peginTxids(),
+            broadcastTxid: watcher.broadcastTxid() ?? null,
+            gate: gate ?? null,
+            verification: verification ?? null,
+          },
+          null,
+          2,
+        )}\n`,
+        "utf8",
+      );
+      log(`Wrote ${join(artifactsDir, "reclaim.json")}`);
+      await recorder.stop();
+      context.off("page", handler);
+    }
+  },
+};

--- a/services/vault/e2e/real/cli.ts
+++ b/services/vault/e2e/real/cli.ts
@@ -37,6 +37,13 @@
  * pegin → borrow → repay → withdraw cycle. `--withdraw-all` releases every selectable vault (default = a
  * single vault, keeping the position alive).
  *
+ * Reclaim sweeps the depositor-claim reserve (PegIn output 1) of a settled vault back to the depositor —
+ * one BTC signature, no Ethereum transaction. It is offered only once the withdrawal has settled on
+ * Bitcoin (PegIn output 0 spent, six confirmations deep), because the reserve funds the depositor's
+ * pre-signed emergency claim and spending it early destroys that recovery material permanently. The run
+ * reads the broadcast transaction back off the chain and asserts its shape, writing the results to
+ * `reclaim.json`. `--dry-run` stops before the signature, exercising the gate without spending.
+ *
  * Resume recovers an interrupted peg-in from the dashboard's Pending Deposits UI (Submit WOTS Key → Sign
  * Payouts → Activate). By default it resumes an already-pending deposit (`--txid=<prePeginTxid>` targets a
  * specific one, else the first actionable); `--interrupt-fresh` pegs in a fresh deposit, reloads after
@@ -615,6 +622,10 @@ async function resolveConfig(
     const withdrawAll =
       action === "withdraw" && flagBool(flags["withdraw-all"]);
 
+    // Reclaim extra: stop after the review screen without signing. The sweep is irreversible, so a
+    // rehearsal that exercises the gate and the fee/dust checks but spends nothing is worth having.
+    const reclaimDryRun = action === "reclaim" && flagBool(flags["dry-run"]);
+
     return {
       target,
       network,
@@ -639,6 +650,7 @@ async function resolveConfig(
       recoverTxid,
       interruptFresh,
       interruptOnly,
+      reclaimDryRun,
     };
   } finally {
     rl.close();

--- a/services/vault/e2e/real/config.ts
+++ b/services/vault/e2e/real/config.ts
@@ -22,7 +22,8 @@ export type ActionId =
   | "repay"
   | "withdraw"
   | "resume"
-  | "recover";
+  | "recover"
+  | "reclaim";
 
 /** Maps our lowercase wallet ids to the connector's SupportedWallet keys. */
 export const BTC_WALLET_TO_CONNECTOR: Record<BtcWalletId, SupportedWallet> = {
@@ -124,6 +125,11 @@ export const ACTIONS: ActionOption[] = [
   { id: "repay", label: "Repay", enabled: true },
   { id: "withdraw", label: "Withdraw", enabled: true },
   { id: "resume", label: "Resume (an interrupted peg-in)", enabled: true },
+  {
+    id: "reclaim",
+    label: "Reclaim (sweep the depositor-claim reserve of a settled vault)",
+    enabled: true,
+  },
 ];
 
 /** A fully-resolved run: what the user chose (interactively or via flags). */
@@ -203,6 +209,12 @@ export interface RunConfig {
    * in stages (verify on-chain it reaches "Submit WOTS Key", then re-run with `--txid=<its Pre-PegIn>`).
    */
   interruptOnly?: boolean;
+  /**
+   * Reclaim only: stop after the review screen without signing (`--dry-run`). Exercises the
+   * eligibility gate and the fee/dust checks while spending nothing — the sweep itself is
+   * irreversible, so this is the safe way to rehearse it.
+   */
+  reclaimDryRun?: boolean;
 }
 
 /** Resolve the target URL a run should open. */

--- a/services/vault/e2e/real/reclaimParams.ts
+++ b/services/vault/e2e/real/reclaimParams.ts
@@ -109,6 +109,11 @@ export interface ReclaimGateSnapshot {
   payoutConfirmations: number | null;
   reserveSpend: OutspendState;
   reserveValueSats: number | null;
+  /**
+   * Why `reserveValueSats` is null, when it is. Without this the artifact cannot tell a PegIn with
+   * no output at vout 1 apart from an API call that failed — very different diagnoses.
+   */
+  reserveValueError: string | null;
 }
 
 /**
@@ -127,15 +132,20 @@ export async function snapshotGate(
     fetchOutspend(mempoolApiBase, peginTxid, RECLAIM_INPUT_VOUT),
   ]);
 
+  // Best-effort: the value is also on the row and in the review screen, so a failure here must not
+  // stop the run — but it is recorded rather than swallowed.
   let reserveValueSats: number | null = null;
+  let reserveValueError: string | null = null;
   try {
     const peginTx = await getJson<EsploraTx>(
       `${mempoolApiBase}/tx/${peginTxid}`,
     );
     reserveValueSats = peginTx.vout[RECLAIM_INPUT_VOUT]?.value ?? null;
-  } catch {
-    // Best-effort: the value is also visible on the row, and its absence must not fail the run.
-    reserveValueSats = null;
+    if (reserveValueSats === null) {
+      reserveValueError = `PegIn ${peginTxid} has no output at vout ${RECLAIM_INPUT_VOUT}`;
+    }
+  } catch (error) {
+    reserveValueError = error instanceof Error ? error.message : String(error);
   }
 
   const payoutConfirmations =
@@ -150,6 +160,7 @@ export async function snapshotGate(
     payoutConfirmations,
     reserveSpend,
     reserveValueSats,
+    reserveValueError,
   };
 }
 
@@ -181,14 +192,16 @@ export interface ReclaimVerification {
 /**
  * Read the broadcast sweep back off the chain and check its shape.
  *
- * `expectedPeginTxid` is optional: when the run knows which PegIn the row belonged to we assert the
- * input against it, and when it does not we still record what was spent. The structural checks do not
- * depend on it.
+ * Both expected identities are REQUIRED, and an unavailable one becomes a failed check rather than an
+ * absent one. The structural checks below — witness shape, weight, value conservation — hold for any
+ * reclaim of any of this depositor's vaults, so on their own they cannot show that *this* sweep took
+ * *this* vault's reserve to *this* wallet. Letting either identity be skipped would let `allPassed`
+ * report a verification stronger than the one actually performed.
  */
 export async function verifyReclaimTx(
   mempoolApiBase: string,
   txid: string,
-  expected: { peginTxid?: string; depositorAddress?: string },
+  expected: { peginTxid: string; depositorAddress: string },
 ): Promise<ReclaimVerification> {
   const tx = await getJson<EsploraTx>(`${mempoolApiBase}/tx/${txid}`);
   const checks: ReclaimCheck[] = [];
@@ -213,14 +226,12 @@ export async function verifyReclaimTx(
     `vout ${vin?.vout}`,
   );
 
-  if (expected.peginTxid) {
-    check(
-      "spends the reserve of the expected PegIn",
-      vin?.txid === expected.peginTxid,
-      expected.peginTxid,
-      vin?.txid ?? "(none)",
-    );
-  }
+  check(
+    "spends the reserve of the expected PegIn",
+    Boolean(expected.peginTxid) && vin?.txid === expected.peginTxid,
+    expected.peginTxid || "(no expected PegIn supplied)",
+    vin?.txid ?? "(none)",
+  );
 
   // The one that matters most: a wallet-supplied key-path signature would finalize to a single
   // witness item against the NUMS internal key, which cannot be spent.
@@ -280,15 +291,16 @@ export async function verifyReclaimTx(
     `${tx.weight} WU`,
   );
 
+  // esplora omits `scriptpubkey_address` for shapes it cannot render, so an absent address is an
+  // unproven destination, not a passing one.
   const destinationAddress = tx.vout[0]?.scriptpubkey_address ?? null;
-  if (expected.depositorAddress && destinationAddress) {
-    check(
-      "pays the connected wallet's own address",
+  check(
+    "pays the connected wallet's own address",
+    Boolean(expected.depositorAddress) &&
       destinationAddress === expected.depositorAddress,
-      expected.depositorAddress,
-      destinationAddress,
-    );
-  }
+    expected.depositorAddress || "(no expected address supplied)",
+    destinationAddress ?? "(address not reported by esplora)",
+  );
 
   const vsize = Math.ceil(tx.weight / WEIGHT_UNITS_PER_VBYTE);
 

--- a/services/vault/e2e/real/reclaimParams.ts
+++ b/services/vault/e2e/real/reclaimParams.ts
@@ -1,0 +1,312 @@
+/**
+ * Reclaim pre-flight and post-broadcast verification.
+ *
+ * The browser flow can only tell us the button worked. What we actually need to know is whether the
+ * transaction it produced has the right shape, because every fix in this area is invisible from the
+ * UI: a sweep of the wrong vault's reserve, or a key-path witness instead of a script-path one, both
+ * look identical on screen right up until the money is gone or the broadcast is rejected.
+ *
+ * So the checks here read the broadcast transaction back off the chain and assert against it. They
+ * use the esplora REST shape (`/tx/:txid`), which returns the witness stack per input, so nothing here
+ * needs bitcoinjs or the SDK — it is an independent view of what actually landed.
+ *
+ * Every assertion below corresponds to a specific thing that can silently go wrong:
+ *   - one input, at `(peginTxid, 1)` — the sweep hit the reserve of the vault it was offered for
+ *   - a 3-element witness — the script path was taken; a key-path spend against the NUMS internal key
+ *     would be 1 element and would never confirm
+ *   - a 34-byte `<32-byte pubkey> OP_CHECKSIG` leaf and a 33-byte control block with no merkle path —
+ *     the single-leaf claim connector, not some other taptree
+ *   - one output, and `in - out == fee` — nothing was skimmed
+ *   - 513 weight units — the exact size model the fee is computed from
+ */
+
+/** esplora `/tx/:txid` — only the fields these checks read. */
+interface EsploraTx {
+  txid: string;
+  version: number;
+  locktime: number;
+  vin: {
+    txid: string;
+    vout: number;
+    witness?: string[];
+    sequence: number;
+    prevout?: { value: number; scriptpubkey: string };
+  }[];
+  vout: {
+    value: number;
+    scriptpubkey: string;
+    scriptpubkey_address?: string;
+  }[];
+  fee: number;
+  weight: number;
+  status?: { confirmed: boolean; block_height?: number };
+}
+
+/** The depositor-claim reserve is always PegIn output 1 (`PEGIN_DEPOSITOR_CLAIM_VOUT`). */
+const RECLAIM_INPUT_VOUT = 1;
+/** BIP-340 signature, SIGHASH_DEFAULT — 64 bytes, no trailing sighash byte. */
+const SCHNORR_SIG_HEX_LEN = 128;
+/** `OP_PUSHBYTES_32 <32-byte x-only pubkey> OP_CHECKSIG` — 34 bytes. */
+const CLAIM_LEAF_HEX_LEN = 68;
+/** Leaf-version/parity byte + 32-byte internal key. No merkle path: the taptree has one leaf. */
+const CONTROL_BLOCK_HEX_LEN = 66;
+/** `[signature, leafScript, controlBlock]`. */
+const SCRIPT_PATH_WITNESS_ITEMS = 3;
+/** `reclaimVsize`: 214 WU skeleton + 299 WU for the single script-path input. */
+const EXPECTED_WEIGHT_UNITS = 513;
+const WEIGHT_UNITS_PER_VBYTE = 4;
+/** A single-leaf claim script is `20 <32 bytes> ac`. */
+const CLAIM_LEAF_RX = /^20([0-9a-f]{64})ac$/;
+
+async function getJson<T>(url: string): Promise<T> {
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error(`GET ${url} → ${res.status} ${res.statusText}`);
+  }
+  return (await res.json()) as T;
+}
+
+/** Spend status of one outpoint, as esplora reports it. */
+export interface OutspendState {
+  spent: boolean;
+  confirmed: boolean;
+  blockHeight?: number;
+  spendingTxid?: string;
+}
+
+export async function fetchOutspend(
+  mempoolApiBase: string,
+  txid: string,
+  vout: number,
+): Promise<OutspendState> {
+  const res = await getJson<{
+    spent?: boolean;
+    txid?: string;
+    status?: { confirmed?: boolean; block_height?: number };
+  }>(`${mempoolApiBase}/tx/${txid}/outspend/${vout}`);
+  return {
+    spent: res.spent === true,
+    confirmed: res.spent === true && res.status?.confirmed === true,
+    blockHeight: res.status?.block_height,
+    spendingTxid: res.txid,
+  };
+}
+
+export async function fetchTipHeight(mempoolApiBase: string): Promise<number> {
+  const res = await fetch(`${mempoolApiBase}/blocks/tip/height`);
+  const raw = (await res.text()).trim();
+  if (!/^\d+$/.test(raw)) {
+    throw new Error(`Unexpected tip height response: "${raw}"`);
+  }
+  return Number.parseInt(raw, 10);
+}
+
+/** What the gate saw at the moment the sweep was authorised. Recorded, not asserted. */
+export interface ReclaimGateSnapshot {
+  peginTxid: string;
+  tipHeight: number;
+  payoutSpend: OutspendState;
+  payoutConfirmations: number | null;
+  reserveSpend: OutspendState;
+  reserveValueSats: number | null;
+}
+
+/**
+ * Read the two outpoints the eligibility gate depends on, plus the reserve's value.
+ *
+ * Called before confirming so the artifact records the state the decision was made against — a run
+ * that later fails is then diagnosable without re-deriving what the chain looked like at the time.
+ */
+export async function snapshotGate(
+  mempoolApiBase: string,
+  peginTxid: string,
+): Promise<ReclaimGateSnapshot> {
+  const [tipHeight, payoutSpend, reserveSpend] = await Promise.all([
+    fetchTipHeight(mempoolApiBase),
+    fetchOutspend(mempoolApiBase, peginTxid, 0),
+    fetchOutspend(mempoolApiBase, peginTxid, RECLAIM_INPUT_VOUT),
+  ]);
+
+  let reserveValueSats: number | null = null;
+  try {
+    const peginTx = await getJson<EsploraTx>(
+      `${mempoolApiBase}/tx/${peginTxid}`,
+    );
+    reserveValueSats = peginTx.vout[RECLAIM_INPUT_VOUT]?.value ?? null;
+  } catch {
+    // Best-effort: the value is also visible on the row, and its absence must not fail the run.
+    reserveValueSats = null;
+  }
+
+  const payoutConfirmations =
+    payoutSpend.blockHeight !== undefined
+      ? tipHeight - payoutSpend.blockHeight + 1
+      : null;
+
+  return {
+    peginTxid,
+    tipHeight,
+    payoutSpend,
+    payoutConfirmations,
+    reserveSpend,
+    reserveValueSats,
+  };
+}
+
+export interface ReclaimCheck {
+  name: string;
+  ok: boolean;
+  expected: string;
+  actual: string;
+}
+
+export interface ReclaimVerification {
+  txid: string;
+  spentOutpoint: string;
+  witnessItemLengths: number[];
+  depositorXOnlyPubkey: string | null;
+  destinationAddress: string | null;
+  inputValueSats: number | null;
+  outputValueSats: number;
+  feeSats: number;
+  weightUnits: number;
+  vsize: number;
+  feeRateSatsVb: number | null;
+  confirmed: boolean;
+  blockHeight?: number;
+  checks: ReclaimCheck[];
+  allPassed: boolean;
+}
+
+/**
+ * Read the broadcast sweep back off the chain and check its shape.
+ *
+ * `expectedPeginTxid` is optional: when the run knows which PegIn the row belonged to we assert the
+ * input against it, and when it does not we still record what was spent. The structural checks do not
+ * depend on it.
+ */
+export async function verifyReclaimTx(
+  mempoolApiBase: string,
+  txid: string,
+  expected: { peginTxid?: string; depositorAddress?: string },
+): Promise<ReclaimVerification> {
+  const tx = await getJson<EsploraTx>(`${mempoolApiBase}/tx/${txid}`);
+  const checks: ReclaimCheck[] = [];
+  const check = (name: string, ok: boolean, exp: string, act: string) =>
+    checks.push({ name, ok, expected: exp, actual: act });
+
+  check(
+    "spends exactly one input",
+    tx.vin.length === 1,
+    "1",
+    String(tx.vin.length),
+  );
+
+  const vin = tx.vin[0];
+  const witness = vin?.witness ?? [];
+  const spentOutpoint = vin ? `${vin.txid}:${vin.vout}` : "(none)";
+
+  check(
+    "spends the depositor-claim reserve at vout 1",
+    vin?.vout === RECLAIM_INPUT_VOUT,
+    `vout ${RECLAIM_INPUT_VOUT}`,
+    `vout ${vin?.vout}`,
+  );
+
+  if (expected.peginTxid) {
+    check(
+      "spends the reserve of the expected PegIn",
+      vin?.txid === expected.peginTxid,
+      expected.peginTxid,
+      vin?.txid ?? "(none)",
+    );
+  }
+
+  // The one that matters most: a wallet-supplied key-path signature would finalize to a single
+  // witness item against the NUMS internal key, which cannot be spent.
+  check(
+    "witness is a 3-item script-path stack",
+    witness.length === SCRIPT_PATH_WITNESS_ITEMS,
+    `${SCRIPT_PATH_WITNESS_ITEMS} items [signature, leafScript, controlBlock]`,
+    `${witness.length} items`,
+  );
+
+  check(
+    "witness item 0 is a 64-byte Schnorr signature",
+    witness[0]?.length === SCHNORR_SIG_HEX_LEN,
+    `${SCHNORR_SIG_HEX_LEN} hex chars`,
+    `${witness[0]?.length ?? 0} hex chars`,
+  );
+
+  const leaf = witness[1] ?? "";
+  const leafMatch = CLAIM_LEAF_RX.exec(leaf);
+  check(
+    "witness item 1 is the <depositor> OP_CHECKSIG claim leaf",
+    leaf.length === CLAIM_LEAF_HEX_LEN && leafMatch !== null,
+    "20<32-byte x-only pubkey>ac",
+    leaf || "(none)",
+  );
+
+  check(
+    "witness item 2 is a 33-byte control block (single leaf, no merkle path)",
+    witness[2]?.length === CONTROL_BLOCK_HEX_LEN,
+    `${CONTROL_BLOCK_HEX_LEN} hex chars`,
+    `${witness[2]?.length ?? 0} hex chars`,
+  );
+
+  check(
+    "pays exactly one output",
+    tx.vout.length === 1,
+    "1",
+    String(tx.vout.length),
+  );
+
+  const inputValueSats = vin?.prevout?.value ?? null;
+  const outputValueSats = tx.vout[0]?.value ?? 0;
+  if (inputValueSats !== null) {
+    check(
+      "conserves value (input - fee == output)",
+      inputValueSats - tx.fee === outputValueSats,
+      String(inputValueSats - tx.fee),
+      String(outputValueSats),
+    );
+  }
+
+  // Pins the vsize model the fee is derived from: 214 WU skeleton + 299 WU per script-path input.
+  check(
+    "weighs the modelled 513 weight units",
+    tx.weight === EXPECTED_WEIGHT_UNITS,
+    `${EXPECTED_WEIGHT_UNITS} WU`,
+    `${tx.weight} WU`,
+  );
+
+  const destinationAddress = tx.vout[0]?.scriptpubkey_address ?? null;
+  if (expected.depositorAddress && destinationAddress) {
+    check(
+      "pays the connected wallet's own address",
+      destinationAddress === expected.depositorAddress,
+      expected.depositorAddress,
+      destinationAddress,
+    );
+  }
+
+  const vsize = Math.ceil(tx.weight / WEIGHT_UNITS_PER_VBYTE);
+
+  return {
+    txid: tx.txid,
+    spentOutpoint,
+    witnessItemLengths: witness.map((w) => w.length / 2),
+    depositorXOnlyPubkey: leafMatch?.[1] ?? null,
+    destinationAddress,
+    inputValueSats,
+    outputValueSats,
+    feeSats: tx.fee,
+    weightUnits: tx.weight,
+    vsize,
+    feeRateSatsVb: vsize > 0 ? Number((tx.fee / vsize).toFixed(2)) : null,
+    confirmed: tx.status?.confirmed === true,
+    blockHeight: tx.status?.block_height,
+    checks,
+    allPassed: checks.every((c) => c.ok),
+  };
+}

--- a/services/vault/e2e/real/reclaimParams.ts
+++ b/services/vault/e2e/real/reclaimParams.ts
@@ -92,13 +92,20 @@ export async function fetchOutspend(
   };
 }
 
+/**
+ * The digit check alone is not enough: a long enough run of digits passes it
+ * and then parses to `Infinity` or to a finite-but-unsafe integer, either of
+ * which makes the recorded confirmation depth meaningless. Same bound as the
+ * SDK's `getTipHeight`, kept in step so this copy cannot drift back.
+ */
 export async function fetchTipHeight(mempoolApiBase: string): Promise<number> {
   const res = await fetch(`${mempoolApiBase}/blocks/tip/height`);
   const raw = (await res.text()).trim();
-  if (!/^\d+$/.test(raw)) {
+  const height = /^\d+$/.test(raw) ? Number.parseInt(raw, 10) : NaN;
+  if (!Number.isSafeInteger(height) || height < 0) {
     throw new Error(`Unexpected tip height response: "${raw}"`);
   }
-  return Number.parseInt(raw, 10);
+  return height;
 }
 
 /** What the gate saw at the moment the sweep was authorised. Recorded, not asserted. */

--- a/services/vault/src/clients/btc/outspend.ts
+++ b/services/vault/src/clients/btc/outspend.ts
@@ -9,6 +9,8 @@
 import { stripHexPrefix } from "@babylonlabs-io/ts-sdk/tbv/core";
 import { getOutspend } from "@babylonlabs-io/ts-sdk/tbv/core/clients";
 
+import { normalizeBlockHeight } from "@/models/reclaimEligibility";
+
 export interface HtlcSpend {
   /** True when the HTLC output has been spent (in the mempool or a block). */
   spent: boolean;
@@ -42,6 +44,8 @@ export async function fetchHtlcSpend(
     spent: res.spent === true,
     confirmed: res.spent === true && res.status?.confirmed === true,
     spendingTxid: res.txid,
-    blockHeight: res.status?.block_height,
+    // `getOutspend` returns the parsed body verbatim, so the declared
+    // `number | undefined` is not a guarantee about the value.
+    blockHeight: normalizeBlockHeight(res.status?.block_height),
   };
 }

--- a/services/vault/src/clients/btc/outspend.ts
+++ b/services/vault/src/clients/btc/outspend.ts
@@ -9,7 +9,7 @@
 import { stripHexPrefix } from "@babylonlabs-io/ts-sdk/tbv/core";
 import { getOutspend } from "@babylonlabs-io/ts-sdk/tbv/core/clients";
 
-import { normalizeBlockHeight } from "@/models/reclaimEligibility";
+import { normalizeChainHeight } from "@/models/reclaimEligibility";
 
 export interface HtlcSpend {
   /** True when the HTLC output has been spent (in the mempool or a block). */
@@ -46,6 +46,6 @@ export async function fetchHtlcSpend(
     spendingTxid: res.txid,
     // `getOutspend` returns the parsed body verbatim, so the declared
     // `number | undefined` is not a guarantee about the value.
-    blockHeight: normalizeBlockHeight(res.status?.block_height),
+    blockHeight: normalizeChainHeight(res.status?.block_height),
   };
 }

--- a/services/vault/src/components/vaults/VaultsLifecycleSections.tsx
+++ b/services/vault/src/components/vaults/VaultsLifecycleSections.tsx
@@ -312,7 +312,6 @@ function InactiveRow({
   onRefund,
   onReclaim,
   reclaimStatus,
-  reclaimTipHeight,
   reclaimOnChainStatus,
   isReclaimInFlight,
 }: {
@@ -322,7 +321,6 @@ function InactiveRow({
   onReclaim: (depositId: string) => void;
   /** Reserve state from the section's batched poll; undefined for expired rows. */
   reclaimStatus: ReclaimStatus | undefined;
-  reclaimTipHeight: number | undefined;
   reclaimOnChainStatus: number | undefined;
   isReclaimInFlight: boolean;
 }) {
@@ -348,7 +346,6 @@ function InactiveRow({
     reclaimableSats,
   } = useReclaimRowAction({
     status: reclaimStatus,
-    tipHeight: reclaimTipHeight,
     onChainStatus: reclaimOnChainStatus,
     depositorBtcPubkey: activity.depositorBtcPubkey,
     isReclaimInFlight,
@@ -561,7 +558,7 @@ export function VaultsLifecycleSections({
         ),
     [reclaimableCandidates, reclaimChainData],
   );
-  const { statusByDepositId, tipHeight } = useReclaimStatus(reclaimOutpoints);
+  const { statusByDepositId } = useReclaimStatus(reclaimOutpoints);
 
   // Settled vaults join the expired ones in the Inactive section rather than
   // getting a section of their own, so the heading count and action-required
@@ -716,7 +713,6 @@ export function VaultsLifecycleSections({
                 onRefund={handleRefund}
                 onReclaim={handleReclaim}
                 reclaimStatus={statusByDepositId.get(activity.id.toLowerCase())}
-                reclaimTipHeight={tipHeight}
                 reclaimOnChainStatus={
                   reclaimChainData.get(activity.id.toLowerCase())?.onChainStatus
                 }

--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -1322,6 +1322,11 @@ export const COPY = {
       walletNotConnected: "BTC wallet not connected",
       missingVaultId: "Missing BTCVault ID",
       invalidFeeRate: "Fee rate must be a positive number",
+      // The pre-signing re-check found the withdrawal no longer settled deeply
+      // enough on Bitcoin. Rare, and it clears on its own as blocks arrive, so
+      // the copy says plainly that nothing is at risk and retrying later works.
+      payoutNotConfirmed:
+        "The withdrawal that made this reserve reclaimable is no longer confirmed on Bitcoin. Your reserve is safe where it is — try again once it settles.",
       // Fallback when the failure carries no message of its own.
       generic: "Reclaim transaction failed",
     },

--- a/services/vault/src/hooks/__tests__/useReclaimStatus.test.tsx
+++ b/services/vault/src/hooks/__tests__/useReclaimStatus.test.tsx
@@ -1,0 +1,154 @@
+/**
+ * Reclaim poller tests.
+ *
+ * The behaviour under test is what happens when a per-vault read fails but the
+ * tip read does not. The poller keeps the previous observation so a transient
+ * rate-limit does not blank the row for a cycle — which means the confirmation
+ * arithmetic must not then measure that frozen observation against a tip that
+ * has kept moving.
+ */
+
+import {
+  getOutspend,
+  getTipHeight,
+  getUtxoInfo,
+} from "@babylonlabs-io/ts-sdk/tbv/core/clients";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import type { PropsWithChildren } from "react";
+import { beforeEach, describe, expect, it, vi, type Mock } from "vitest";
+
+import {
+  PEGIN_VAULT_VOUT,
+  getReclaimEligibility,
+} from "@/models/reclaimEligibility";
+
+import { useReclaimStatus } from "../useReclaimStatus";
+
+vi.mock("@babylonlabs-io/ts-sdk/tbv/core/clients", async (importOriginal) => ({
+  ...(await importOriginal<
+    typeof import("@babylonlabs-io/ts-sdk/tbv/core/clients")
+  >()),
+  getOutspend: vi.fn(),
+  getTipHeight: vi.fn(),
+  getUtxoInfo: vi.fn(),
+}));
+
+vi.mock("@/clients/btc/config", () => ({
+  getMempoolApiUrl: vi.fn().mockReturnValue("https://mempool.space/api"),
+}));
+
+const VAULT_ID = `0x${"aa".repeat(32)}`;
+const PEGIN_TXID = "cd".repeat(32);
+const OUTPOINTS = [{ depositId: VAULT_ID, peginTxid: PEGIN_TXID }];
+
+const TIP_AT_FIRST_TICK = 900_000;
+/** The Payout is one block deep on the first tick — nowhere near the bar. */
+const PAYOUT_HEIGHT = TIP_AT_FIRST_TICK;
+
+let queryClient: QueryClient;
+
+function wrapper({ children }: PropsWithChildren) {
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+/** Payout mined at `PAYOUT_HEIGHT`, reserve unspent. */
+function shallowPayoutReads() {
+  (getOutspend as Mock).mockImplementation(
+    async (_txid: string, vout: number) =>
+      vout === PEGIN_VAULT_VOUT
+        ? {
+            spent: true,
+            status: { confirmed: true, block_height: PAYOUT_HEIGHT },
+          }
+        : { spent: false },
+  );
+  (getUtxoInfo as Mock).mockResolvedValue({ value: 33_000 });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  shallowPayoutReads();
+  (getTipHeight as Mock).mockResolvedValue(TIP_AT_FIRST_TICK);
+});
+
+describe("useReclaimStatus", () => {
+  it("stamps each status with the tip height its spends were read against", async () => {
+    const { result } = renderHook(() => useReclaimStatus(OUTPOINTS), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(result.current.statusByDepositId.size).toBe(1));
+    expect(
+      result.current.statusByDepositId.get(VAULT_ID)?.observedTipHeight,
+    ).toBe(TIP_AT_FIRST_TICK);
+  });
+
+  it("does not let a carried-forward payout age into eligibility", async () => {
+    // Tick 1 observes the Payout at one confirmation, so the row is correctly
+    // actionless. Then the per-vault probes start failing — a plausible
+    // rate-limit, which is why the fan-out is capped at two vaults — while the
+    // single lightweight tip request keeps succeeding. Six blocks later the
+    // frozen observation must still read as one confirmation, not seven.
+    const { result } = renderHook(() => useReclaimStatus(OUTPOINTS), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(result.current.statusByDepositId.size).toBe(1));
+
+    (getOutspend as Mock).mockRejectedValue(new Error("429 Too Many Requests"));
+    (getUtxoInfo as Mock).mockRejectedValue(new Error("429 Too Many Requests"));
+    (getTipHeight as Mock).mockResolvedValue(TIP_AT_FIRST_TICK + 6);
+
+    await queryClient.refetchQueries();
+    await waitFor(() => expect(getTipHeight).toHaveBeenCalledTimes(2));
+
+    const carried = result.current.statusByDepositId.get(VAULT_ID);
+    expect(carried).toBeDefined();
+    // The entry survives the failure — that is the point of carrying it —
+    // but it carries the tip it was read at, so the gate still says no.
+    expect(carried?.observedTipHeight).toBe(TIP_AT_FIRST_TICK);
+    expect(
+      getReclaimEligibility({
+        onChainStatus: 3,
+        payoutSpend: carried!.payoutSpend,
+        reserveSpend: carried!.reserveSpend,
+        tipHeight: carried!.observedTipHeight,
+        isOwnedByWallet: true,
+        isLedgerWallet: false,
+        isWithdrawBlocked: false,
+        isReclaimInFlight: false,
+      }),
+    ).toEqual({ type: "absent" });
+  });
+
+  it("leaves the tip stamp unset when the tip read fails", async () => {
+    // The gate reads an absent tip as "not yet known" and withholds the action.
+    (getTipHeight as Mock).mockRejectedValue(new Error("network"));
+
+    const { result } = renderHook(() => useReclaimStatus(OUTPOINTS), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(result.current.statusByDepositId.size).toBe(1));
+    expect(
+      result.current.statusByDepositId.get(VAULT_ID)?.observedTipHeight,
+    ).toBeUndefined();
+  });
+
+  it("omits a vault that fails on its very first read", async () => {
+    (getOutspend as Mock).mockRejectedValue(new Error("429"));
+
+    const { result } = renderHook(() => useReclaimStatus(OUTPOINTS), {
+      wrapper,
+    });
+
+    await waitFor(() => expect(getOutspend).toHaveBeenCalled());
+    expect(result.current.statusByDepositId.has(VAULT_ID)).toBe(false);
+  });
+});

--- a/services/vault/src/hooks/deposit/useReclaimRowAction.ts
+++ b/services/vault/src/hooks/deposit/useReclaimRowAction.ts
@@ -43,10 +43,11 @@ export interface ReclaimRowAction {
 }
 
 export interface UseReclaimRowActionInput {
-  /** This vault's reserve state from the batched poller. */
+  /**
+   * This vault's reserve state from the batched poller, carrying the tip height
+   * its spends were observed against.
+   */
   status: ReclaimStatus | undefined;
-  /** Bitcoin tip height from the same poll. */
-  tipHeight: number | undefined;
   /** Live `BTCVaultStatus` from the contract. */
   onChainStatus: number | undefined;
   /** The vault's depositor BTC pubkey, for the ownership check. */
@@ -74,7 +75,6 @@ function isOwnedByConnectedWallet(
 
 export function useReclaimRowAction({
   status,
-  tipHeight,
   onChainStatus,
   depositorBtcPubkey,
   isReclaimInFlight,
@@ -98,7 +98,9 @@ export function useReclaimRowAction({
         onChainStatus,
         payoutSpend: status?.payoutSpend,
         reserveSpend: status?.reserveSpend,
-        tipHeight,
+        // The tip these spends were read against, never a fresher one — see
+        // `ReclaimStatus.observedTipHeight`.
+        tipHeight: status?.observedTipHeight,
         isOwnedByWallet,
         isLedgerWallet,
         isWithdrawBlocked: withdrawBlocked,
@@ -107,7 +109,6 @@ export function useReclaimRowAction({
     [
       onChainStatus,
       status,
-      tipHeight,
       isOwnedByWallet,
       isLedgerWallet,
       withdrawBlocked,

--- a/services/vault/src/hooks/deposit/useReclaimState.ts
+++ b/services/vault/src/hooks/deposit/useReclaimState.ts
@@ -6,6 +6,7 @@ import { COPY } from "@/copy";
 import { logger } from "@/infrastructure";
 import {
   ReclaimAlreadySettledError,
+  ReclaimNoLongerEligibleError,
   buildAndBroadcastReclaimTransaction,
 } from "@/services/vault/vaultReclaimService";
 import type { VaultActivity } from "@/types/activity";
@@ -135,6 +136,15 @@ export function useReclaimState({
           logger.error(err instanceof Error ? err : new Error(String(err)), {
             data: { context: "Reclaim failed", vaultId },
           });
+          if (err instanceof ReclaimNoLongerEligibleError) {
+            // A reorg deep enough to unwind the withdrawal's confirmations. The
+            // reserve is intact and must stay that way, so this is an ordinary
+            // retryable failure — the review screen's callout and "Retry", with
+            // copy that says the money is not at risk.
+            setError(COPY.reclaim.errors.payoutNotConfirmed);
+            setReclaiming(false);
+            return;
+          }
           setError(
             err instanceof Error ? err.message : COPY.reclaim.errors.generic,
           );

--- a/services/vault/src/hooks/useReclaimStatus.ts
+++ b/services/vault/src/hooks/useReclaimStatus.ts
@@ -20,6 +20,7 @@ import { useMemo } from "react";
 import { getMempoolApiUrl } from "@/clients/btc/config";
 import {
   PEGIN_VAULT_VOUT,
+  toOutpointSpend,
   type OutpointSpend,
 } from "@/models/reclaimEligibility";
 import { mapWithConcurrency } from "@/utils/concurrency";
@@ -39,6 +40,22 @@ export interface ReclaimStatus {
   reserveSpend: OutpointSpend;
   /** The reserve's value, for the row's "reclaimable" figure. */
   reserveValueSats: bigint;
+  /**
+   * Tip height read in the same tick as the spends above, and frozen with them.
+   *
+   * The confirmation-depth check must not pair a fresh tip with stale spend
+   * data. The tip is fetched on its own request and the per-vault probes on
+   * theirs, so one can keep succeeding while the other fails — and on failure
+   * the catch below carries the previous observation forward. Without this
+   * stamp, `tipHeight - blockHeight + 1` would keep growing on a Payout that is
+   * no longer being observed and could cross the six-confirmation bar purely
+   * from the chain advancing. Frozen together, an unrefreshed entry can only
+   * ever keep or lose eligibility, never gain it.
+   *
+   * `undefined` when the tip read failed, which the gate treats as "not yet
+   * known" and withholds the action.
+   */
+  observedTipHeight: number | undefined;
 }
 
 /** One candidate vault to probe. */
@@ -52,8 +69,6 @@ export interface ReclaimOutpoint {
 export interface ReclaimStatusResult {
   /** Vault id (lowercased) → reserve state. Missing = not yet polled. */
   statusByDepositId: Map<string, ReclaimStatus>;
-  /** Current Bitcoin tip height, for the confirmation-depth check. */
-  tipHeight: number | undefined;
 }
 
 // Stable identity for the no-data render; a fresh Map per render would defeat
@@ -62,18 +77,6 @@ const EMPTY_STATUSES = new Map<string, ReclaimStatus>();
 
 interface ReclaimBatch {
   statuses: Map<string, ReclaimStatus>;
-  tipHeight: number | undefined;
-}
-
-function toOutpointSpend(res: {
-  spent?: boolean;
-  status?: { confirmed?: boolean; block_height?: number };
-}): OutpointSpend {
-  return {
-    spent: res.spent === true,
-    confirmed: res.spent === true && res.status?.confirmed === true,
-    blockHeight: res.status?.block_height,
-  };
 }
 
 export function useReclaimStatus(
@@ -118,6 +121,11 @@ export function useReclaimStatus(
       // The tip is shared across the batch, and a failure to read it must not
       // drop the whole poll — the gate treats an absent tip as "not yet known"
       // and simply withholds the action.
+      //
+      // Read before the per-vault fan-out below, so every spend it is stamped
+      // onto was observed at or after this height. The stamp can therefore
+      // undercount confirmations by the fan-out's duration but never overcount,
+      // which is the direction that matters.
       const tipHeight = await getTipHeight(apiUrl).catch(() => undefined);
 
       const entries = await mapWithConcurrency(
@@ -136,12 +144,17 @@ export function useReclaimStatus(
                 payoutSpend: toOutpointSpend(payout),
                 reserveSpend: toOutpointSpend(reserve),
                 reserveValueSats: BigInt(reserveUtxo.value),
+                observedTipHeight: tipHeight,
               },
             ];
           } catch {
             // Carry the prior status forward so a transient 429 doesn't drop a
             // row for a cycle. No prior means the row stays actionless, which
             // is the fail-closed direction.
+            //
+            // The prior carries its own `observedTipHeight`, so a carried entry
+            // keeps being measured against the tip it was actually read at —
+            // it cannot age into eligibility while nothing is refreshing it.
             const priorStatus = prior.get(o.depositId);
             return priorStatus !== undefined
               ? [o.depositId, priorStatus]
@@ -154,13 +167,11 @@ export function useReclaimStatus(
         statuses: new Map(
           entries.filter((e): e is [string, ReclaimStatus] => e !== null),
         ),
-        tipHeight,
       };
     },
   });
 
   return {
     statusByDepositId: query.data?.statuses ?? EMPTY_STATUSES,
-    tipHeight: query.data?.tipHeight,
   };
 }

--- a/services/vault/src/models/__tests__/reclaimEligibility.test.ts
+++ b/services/vault/src/models/__tests__/reclaimEligibility.test.ts
@@ -5,6 +5,8 @@ import { COPY } from "@/copy";
 import {
   RECLAIM_MIN_PAYOUT_CONFIRMATIONS,
   getReclaimEligibility,
+  isPayoutSettled,
+  toOutpointSpend,
   type ReclaimEligibilityInput,
 } from "@/models/reclaimEligibility";
 
@@ -75,6 +77,48 @@ describe("getReclaimEligibility", () => {
     expect(
       getReclaimEligibility(
         makeInput({ payoutSpend: { spent: true, confirmed: true } }),
+      ),
+    ).toEqual({ type: "absent" });
+  });
+
+  // `getOutspend` returns the parsed response body verbatim, so the declared
+  // `blockHeight?: number` is a claim about the type, not the value. Each of
+  // these would otherwise reach `tipHeight - blockHeight + 1` and coerce to a
+  // confirmation count far past the six-block bar.
+  it("treats a null block height as a single confirmation", () => {
+    expect(
+      getReclaimEligibility(
+        makeInput({
+          payoutSpend: {
+            spent: true,
+            confirmed: true,
+            blockHeight: null as unknown as number,
+          },
+        }),
+      ),
+    ).toEqual({ type: "absent" });
+  });
+
+  it("treats a numeric-string block height as a single confirmation", () => {
+    expect(
+      getReclaimEligibility(
+        makeInput({
+          payoutSpend: {
+            spent: true,
+            confirmed: true,
+            blockHeight: String(DEEP_PAYOUT_HEIGHT) as unknown as number,
+          },
+        }),
+      ),
+    ).toEqual({ type: "absent" });
+  });
+
+  it("treats a negative block height as a single confirmation", () => {
+    expect(
+      getReclaimEligibility(
+        makeInput({
+          payoutSpend: { spent: true, confirmed: true, blockHeight: -1 },
+        }),
       ),
     ).toEqual({ type: "absent" });
   });
@@ -208,5 +252,84 @@ describe("getReclaimEligibility", () => {
         }),
       ),
     ).toEqual({ type: "absent" });
+  });
+});
+
+describe("isPayoutSettled", () => {
+  // Exported so the pre-signing re-check in `vaultReclaimService` enforces the
+  // same predicate the row is rendered from. These pin the contract that
+  // re-check depends on.
+  it("holds for a payout buried at the required depth", () => {
+    expect(
+      isPayoutSettled(
+        { spent: true, confirmed: true, blockHeight: DEEP_PAYOUT_HEIGHT },
+        TIP_HEIGHT,
+      ),
+    ).toBe(true);
+  });
+
+  it("fails for a payout one block short of the required depth", () => {
+    expect(
+      isPayoutSettled(
+        { spent: true, confirmed: true, blockHeight: DEEP_PAYOUT_HEIGHT + 1 },
+        TIP_HEIGHT,
+      ),
+    ).toBe(false);
+  });
+
+  it("fails when the vault output is not spent at all", () => {
+    expect(
+      isPayoutSettled({ spent: false, confirmed: false }, TIP_HEIGHT),
+    ).toBe(false);
+  });
+
+  it("fails closed when the payout read is missing", () => {
+    expect(isPayoutSettled(undefined, TIP_HEIGHT)).toBe(false);
+  });
+
+  it("fails closed when the tip height is unknown", () => {
+    expect(
+      isPayoutSettled(
+        { spent: true, confirmed: true, blockHeight: DEEP_PAYOUT_HEIGHT },
+        undefined,
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("toOutpointSpend", () => {
+  it("maps a confirmed spend with its block height", () => {
+    expect(
+      toOutpointSpend({
+        spent: true,
+        status: { confirmed: true, block_height: DEEP_PAYOUT_HEIGHT },
+      }),
+    ).toEqual({
+      spent: true,
+      confirmed: true,
+      blockHeight: DEEP_PAYOUT_HEIGHT,
+    });
+  });
+
+  it("drops a block height that is not a usable height", () => {
+    // Normalising at the boundary keeps `blockHeight?: number` honest; the
+    // gate re-checks anyway, because it must not depend on this mapper.
+    expect(
+      toOutpointSpend({
+        spent: true,
+        status: {
+          confirmed: true,
+          block_height: null as unknown as number,
+        },
+      }),
+    ).toEqual({ spent: true, confirmed: true, blockHeight: undefined });
+  });
+
+  it("reads a malformed spent flag as unspent", () => {
+    expect(toOutpointSpend({ spent: "true" as unknown as boolean })).toEqual({
+      spent: false,
+      confirmed: false,
+      blockHeight: undefined,
+    });
   });
 });

--- a/services/vault/src/models/__tests__/reclaimEligibility.test.ts
+++ b/services/vault/src/models/__tests__/reclaimEligibility.test.ts
@@ -203,6 +203,37 @@ describe("getReclaimEligibility", () => {
     ).toEqual({ type: "absent" });
   });
 
+  // The tip is the other operand of `tipHeight - blockHeight + 1`. A value that
+  // parses but is not a usable height inflates the depth past the six-block bar
+  // regardless of how deep the payout actually is.
+  it("hides the reclaim when the chain tip is Infinity", () => {
+    expect(getReclaimEligibility(makeInput({ tipHeight: Infinity }))).toEqual({
+      type: "absent",
+    });
+  });
+
+  it("hides the reclaim when the chain tip is beyond the safe integer range", () => {
+    // 1e20 satisfies Number.isInteger, so an isInteger guard would pass it and
+    // compute a depth around 1e20. This case is what pins isSafeInteger.
+    expect(getReclaimEligibility(makeInput({ tipHeight: 1e20 }))).toEqual({
+      type: "absent",
+    });
+  });
+
+  it("hides the reclaim when the chain tip is a numeric string", () => {
+    expect(
+      getReclaimEligibility(
+        makeInput({ tipHeight: String(TIP_HEIGHT) as unknown as number }),
+      ),
+    ).toEqual({ type: "absent" });
+  });
+
+  it("hides the reclaim when the chain tip is negative", () => {
+    expect(getReclaimEligibility(makeInput({ tipHeight: -1 }))).toEqual({
+      type: "absent",
+    });
+  });
+
   it("hides the reclaim while the chain tip has not loaded", () => {
     expect(getReclaimEligibility(makeInput({ tipHeight: undefined }))).toEqual({
       type: "absent",
@@ -285,6 +316,17 @@ describe("isPayoutSettled", () => {
 
   it("fails closed when the payout read is missing", () => {
     expect(isPayoutSettled(undefined, TIP_HEIGHT)).toBe(false);
+  });
+
+  it("fails closed on a tip height that is not a usable height", () => {
+    for (const tip of [Infinity, 1e20, -1, NaN]) {
+      expect(
+        isPayoutSettled(
+          { spent: true, confirmed: true, blockHeight: DEEP_PAYOUT_HEIGHT },
+          tip,
+        ),
+      ).toBe(false);
+    }
   });
 
   it("fails closed when the tip height is unknown", () => {

--- a/services/vault/src/models/reclaimEligibility.ts
+++ b/services/vault/src/models/reclaimEligibility.ts
@@ -40,6 +40,48 @@ export interface OutpointSpend {
   blockHeight?: number;
 }
 
+/** An esplora `/outspend` response, as `getOutspend` returns it: unvalidated. */
+export interface RawOutspend {
+  spent?: boolean;
+  status?: { confirmed?: boolean; block_height?: number };
+}
+
+/**
+ * Coerce an esplora `block_height` to a height this module can do arithmetic
+ * on, or `undefined`.
+ *
+ * The SDK's `getOutspend` validates its arguments but returns the parsed JSON
+ * body verbatim, so `block_height: number | undefined` is a claim about the
+ * declared type rather than about the value. Canonical mempool/electrs omits
+ * the field when a spend is unconfirmed, but the mempool endpoint is
+ * configurable, and a `null`, a numeric string or a negative height all reach
+ * here as-is. Each of those would otherwise flow into
+ * `tipHeight - blockHeight + 1` and coerce to an enormous confirmation count —
+ * `null` alone yields roughly `tipHeight + 1`, clearing the deep-confirmation
+ * bar this module exists to enforce.
+ */
+export function normalizeBlockHeight(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isInteger(value) && value >= 0
+    ? value
+    : undefined;
+}
+
+/**
+ * Normalise an esplora outspend response into an `OutpointSpend`.
+ *
+ * `spent` and `confirmed` compare strictly against `true`, so anything
+ * malformed reads as "not spent" — the fail-closed direction. `blockHeight` is
+ * the only field consumed arithmetically, which is why it needs the coercion
+ * above rather than a comparison.
+ */
+export function toOutpointSpend(res: RawOutspend): OutpointSpend {
+  return {
+    spent: res.spent === true,
+    confirmed: res.spent === true && res.status?.confirmed === true,
+    blockHeight: normalizeBlockHeight(res.status?.block_height),
+  };
+}
+
 export interface ReclaimEligibilityInput {
   /**
    * Live `BTCVaultStatus` from the contract. Necessary but never sufficient —
@@ -50,7 +92,16 @@ export interface ReclaimEligibilityInput {
   payoutSpend: OutpointSpend | undefined;
   /** Spend status of `peginTxid:1` — the reserve itself. */
   reserveSpend: OutpointSpend | undefined;
-  /** Current Bitcoin tip height, for the confirmation-depth check. */
+  /**
+   * The Bitcoin tip height **the spends above were observed against**, not the
+   * current one.
+   *
+   * Those are two different numbers whenever a poll carries a previous
+   * observation forward past a failed read, and pairing a fresh tip with stale
+   * spend data would let confirmations accrue on a Payout nobody is watching
+   * any more. `useReclaimStatus` stamps each status with the tip of the tick
+   * that produced it for exactly this reason.
+   */
   tipHeight: number | undefined;
   /** Whether the vault belongs to the connected wallet. */
   isOwnedByWallet: boolean;
@@ -135,11 +186,7 @@ export function getReclaimEligibility(
 
   // The gate. An unspent vault UTXO means the peg-out has not settled on
   // Bitcoin and the depositor's claim right still matters.
-  const payoutSettled =
-    payoutSpend.spent &&
-    payoutSpend.confirmed &&
-    payoutConfirmations(payoutSpend, tipHeight) >=
-      RECLAIM_MIN_PAYOUT_CONFIRMATIONS;
+  const payoutSettled = isPayoutSettled(payoutSpend, tipHeight);
 
   if (reserveSpend.spent) {
     // Spent but not yet mined, on a vault that had passed the gate: this is a
@@ -191,16 +238,44 @@ export function getReclaimEligibility(
 }
 
 /**
+ * Whether the Payout has landed on Bitcoin and settled deeply enough to make
+ * the depositor's recourse graph redundant.
+ *
+ * This is *the* safety condition — sweeping the reserve before it holds
+ * destroys recovery material that cannot be rebuilt. Exported so the pre-sign
+ * re-check in `services/vault/vaultReclaimService` enforces the same predicate
+ * the row is rendered from, rather than a second copy of it that can drift.
+ *
+ * Fails closed on every missing input.
+ */
+export function isPayoutSettled(
+  payoutSpend: OutpointSpend | undefined,
+  tipHeight: number | undefined,
+): boolean {
+  if (!payoutSpend || tipHeight === undefined) return false;
+  return (
+    payoutSpend.spent &&
+    payoutSpend.confirmed &&
+    payoutConfirmations(payoutSpend, tipHeight) >=
+      RECLAIM_MIN_PAYOUT_CONFIRMATIONS
+  );
+}
+
+/**
  * Confirmation depth of the Payout, counting the containing block as one.
  *
- * A spend confirmed but missing its height is treated as one confirmation —
- * enough to be real, not enough to clear the deep-confirmation bar — so a
- * partial esplora response delays the offer instead of waving it through.
+ * A spend confirmed but missing a usable height is treated as one confirmation
+ * — enough to be real, not enough to clear the deep-confirmation bar — so a
+ * partial or malformed esplora response delays the offer instead of waving it
+ * through. The height is re-normalised here rather than trusted from the
+ * caller: this function is the safety control, and it should not be correct
+ * only because some mapper upstream happened to be.
  */
 function payoutConfirmations(
   payoutSpend: OutpointSpend,
   tipHeight: number,
 ): number {
-  if (payoutSpend.blockHeight === undefined) return 1;
-  return tipHeight - payoutSpend.blockHeight + 1;
+  const blockHeight = normalizeBlockHeight(payoutSpend.blockHeight);
+  if (blockHeight === undefined) return 1;
+  return tipHeight - blockHeight + 1;
 }

--- a/services/vault/src/models/reclaimEligibility.ts
+++ b/services/vault/src/models/reclaimEligibility.ts
@@ -47,21 +47,24 @@ export interface RawOutspend {
 }
 
 /**
- * Coerce an esplora `block_height` to a height this module can do arithmetic
- * on, or `undefined`.
+ * Coerce a chain height — a spend's `block_height` or the chain tip — to a
+ * value this module can do arithmetic on, or `undefined`.
  *
- * The SDK's `getOutspend` validates its arguments but returns the parsed JSON
- * body verbatim, so `block_height: number | undefined` is a claim about the
- * declared type rather than about the value. Canonical mempool/electrs omits
- * the field when a spend is unconfirmed, but the mempool endpoint is
- * configurable, and a `null`, a numeric string or a negative height all reach
- * here as-is. Each of those would otherwise flow into
- * `tipHeight - blockHeight + 1` and coerce to an enormous confirmation count —
- * `null` alone yields roughly `tipHeight + 1`, clearing the deep-confirmation
- * bar this module exists to enforce.
+ * Both operands of `tipHeight - blockHeight + 1` need this, and for the same
+ * reason: neither arrives validated. The SDK's `getOutspend` returns the
+ * parsed JSON body verbatim, so `block_height: number | undefined` describes
+ * the declared type rather than the value, and a `null`, a numeric string or a
+ * negative height all reach here as-is. The mempool endpoint is configurable,
+ * so a self-hosted or proxied response is untrusted on both halves.
+ *
+ * `Number.isSafeInteger` rather than `Number.isInteger` is load-bearing: a
+ * finite-but-unsafe height such as `1e20` satisfies `isInteger`, and as a tip
+ * it yields a confirmation depth around `1e20` that clears any threshold.
+ * Real heights sit near 9e5 against a 9e15 bound, so nothing legitimate is
+ * excluded.
  */
-export function normalizeBlockHeight(value: unknown): number | undefined {
-  return typeof value === "number" && Number.isInteger(value) && value >= 0
+export function normalizeChainHeight(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0
     ? value
     : undefined;
 }
@@ -78,7 +81,7 @@ export function toOutpointSpend(res: RawOutspend): OutpointSpend {
   return {
     spent: res.spent === true,
     confirmed: res.spent === true && res.status?.confirmed === true,
-    blockHeight: normalizeBlockHeight(res.status?.block_height),
+    blockHeight: normalizeChainHeight(res.status?.block_height),
   };
 }
 
@@ -179,8 +182,13 @@ export function getReclaimEligibility(
   // wallet's pubkey, so there is nothing this wallet could sign.
   if (!isOwnedByWallet) return { type: "absent" };
 
-  // Any read not yet in hand leaves the action hidden rather than offered.
-  if (!payoutSpend || !reserveSpend || tipHeight === undefined) {
+  // Any read not yet in hand — or not usable as a height — leaves the action
+  // hidden rather than offered.
+  if (
+    !payoutSpend ||
+    !reserveSpend ||
+    normalizeChainHeight(tipHeight) === undefined
+  ) {
     return { type: "absent" };
   }
 
@@ -252,12 +260,12 @@ export function isPayoutSettled(
   payoutSpend: OutpointSpend | undefined,
   tipHeight: number | undefined,
 ): boolean {
-  if (!payoutSpend || tipHeight === undefined) return false;
+  const tip = normalizeChainHeight(tipHeight);
+  if (!payoutSpend || tip === undefined) return false;
   return (
     payoutSpend.spent &&
     payoutSpend.confirmed &&
-    payoutConfirmations(payoutSpend, tipHeight) >=
-      RECLAIM_MIN_PAYOUT_CONFIRMATIONS
+    payoutConfirmations(payoutSpend, tip) >= RECLAIM_MIN_PAYOUT_CONFIRMATIONS
   );
 }
 
@@ -275,7 +283,7 @@ function payoutConfirmations(
   payoutSpend: OutpointSpend,
   tipHeight: number,
 ): number {
-  const blockHeight = normalizeBlockHeight(payoutSpend.blockHeight);
+  const blockHeight = normalizeChainHeight(payoutSpend.blockHeight);
   if (blockHeight === undefined) return 1;
   return tipHeight - blockHeight + 1;
 }

--- a/services/vault/src/services/vault/__tests__/vaultReclaimService.test.ts
+++ b/services/vault/src/services/vault/__tests__/vaultReclaimService.test.ts
@@ -7,6 +7,7 @@
  * chain moved in between, this is the only place left to notice.
  */
 
+import { pushTx } from "@babylonlabs-io/ts-sdk/tbv/core";
 import {
   getOutspend,
   getTipHeight,
@@ -185,6 +186,46 @@ describe("buildAndBroadcastReclaimTransaction", () => {
     // The SDK got as far as asking for a signature; the gate stopped it there.
     expect(mockBuildAndBroadcastReclaim).toHaveBeenCalled();
     expect(walletSign).not.toHaveBeenCalled();
+  });
+
+  it("refuses to broadcast when the payout is reorged out during the wallet prompt", async () => {
+    // `signPsbt` is an interactive approval that can sit open for minutes, so a
+    // check taken before it says nothing about the chain by the time it
+    // returns. The payout is settled at entry and at the pre-prompt check, and
+    // gone only by the time the signed transaction is about to be broadcast.
+    let payoutProbe = 0;
+    (getOutspend as Mock).mockImplementation(
+      async (_txid: string, vout: number) => {
+        if (vout !== PEGIN_VAULT_VOUT) return { spent: false };
+        payoutProbe += 1;
+        return payoutProbe <= 2
+          ? {
+              spent: true,
+              status: { confirmed: true, block_height: DEEP_PAYOUT_HEIGHT },
+            }
+          : { spent: false };
+      },
+    );
+    const walletSign = vi.fn().mockResolvedValue("signedpsbt");
+    mockBuildAndBroadcastReclaim.mockImplementation(
+      async (input: {
+        signPsbt: (p: string, o: unknown) => Promise<string>;
+        broadcastTx: (hex: string) => Promise<{ txId: string }>;
+      }) => {
+        const signed = await input.signPsbt("70736274ff", {});
+        return input.broadcastTx(signed);
+      },
+    );
+
+    await expect(
+      buildAndBroadcastReclaimTransaction({
+        ...broadcastParams,
+        signPsbt: walletSign,
+      }),
+    ).rejects.toBeInstanceOf(ReclaimNoLongerEligibleError);
+    // The depositor did approve — the gate stopped the broadcast, not the sign.
+    expect(walletSign).toHaveBeenCalled();
+    expect(pushTx).not.toHaveBeenCalled();
   });
 
   it("reads the chain tip before the outspends it is compared against", async () => {

--- a/services/vault/src/services/vault/__tests__/vaultReclaimService.test.ts
+++ b/services/vault/src/services/vault/__tests__/vaultReclaimService.test.ts
@@ -145,6 +145,74 @@ describe("buildAndBroadcastReclaimTransaction", () => {
     ).resolves.toBe("swept_txid");
   });
 
+  it("re-checks at the signing boundary, not just before preparing", async () => {
+    // Between the first check and the wallet prompt the service recomputes the
+    // reserve value, re-reads the vault and probes the UTXO, and the SDK then
+    // runs its fee caps, PSBT build and vault-id derivation. A reorg inside
+    // that window has to be caught, or the depositor signs away a live vault's
+    // recovery material.
+    let probeRound = 0;
+    (getOutspend as Mock).mockImplementation(
+      async (_txid: string, vout: number) => {
+        if (vout !== PEGIN_VAULT_VOUT) return { spent: false };
+        probeRound += 1;
+        // Settled on the first read; the payout has been reorged out by the
+        // time the signing boundary re-reads it.
+        return probeRound === 1
+          ? {
+              spent: true,
+              status: { confirmed: true, block_height: DEEP_PAYOUT_HEIGHT },
+            }
+          : { spent: false };
+      },
+    );
+    const walletSign = vi.fn().mockResolvedValue("signedpsbt");
+    mockBuildAndBroadcastReclaim.mockImplementation(
+      async (input: {
+        signPsbt: (p: string, o: unknown) => Promise<string>;
+      }) => {
+        await input.signPsbt("70736274ff", {});
+        return { txId: "swept_txid" };
+      },
+    );
+
+    await expect(
+      buildAndBroadcastReclaimTransaction({
+        ...broadcastParams,
+        signPsbt: walletSign,
+      }),
+    ).rejects.toBeInstanceOf(ReclaimNoLongerEligibleError);
+    // The SDK got as far as asking for a signature; the gate stopped it there.
+    expect(mockBuildAndBroadcastReclaim).toHaveBeenCalled();
+    expect(walletSign).not.toHaveBeenCalled();
+  });
+
+  it("reads the chain tip before the outspends it is compared against", async () => {
+    // Issued concurrently, a tip fetched after a new block could be paired with
+    // a payout read from before it and overstate the depth by one — the wrong
+    // direction for a gate that exists to keep a shallow payout out.
+    const order: string[] = [];
+    (getTipHeight as Mock).mockImplementation(async () => {
+      order.push("tip");
+      return TIP_HEIGHT;
+    });
+    (getOutspend as Mock).mockImplementation(
+      async (_txid: string, vout: number) => {
+        order.push(`outspend:${vout}`);
+        return vout === PEGIN_VAULT_VOUT
+          ? {
+              spent: true,
+              status: { confirmed: true, block_height: DEEP_PAYOUT_HEIGHT },
+            }
+          : { spent: false };
+      },
+    );
+
+    await getReclaimPreview(VAULT_ID);
+
+    expect(order[0]).toBe("tip");
+  });
+
   it("refuses to sign when the payout is no longer spent", async () => {
     // The row was enabled off a poll up to 60s old. A reorg since then has
     // restored the vault UTXO, which makes the depositor's recovery graph live

--- a/services/vault/src/services/vault/__tests__/vaultReclaimService.test.ts
+++ b/services/vault/src/services/vault/__tests__/vaultReclaimService.test.ts
@@ -1,0 +1,225 @@
+/**
+ * Reclaim adapter tests.
+ *
+ * The protocol work lives in the SDK and has its own suite. What matters here
+ * is the gate: this adapter is the last thing that runs before a wallet prompt,
+ * and the row it was launched from was rendered off a 60-second poller. If the
+ * chain moved in between, this is the only place left to notice.
+ */
+
+import {
+  getOutspend,
+  getTipHeight,
+  getUtxoInfo,
+} from "@babylonlabs-io/ts-sdk/tbv/core/clients";
+import type { Hex } from "viem";
+import { beforeEach, describe, expect, it, vi, type Mock } from "vitest";
+
+import { PEGIN_VAULT_VOUT } from "@/models/reclaimEligibility";
+
+import { getVaultFromChain } from "../../../clients/eth-contract/btc-vault-registry/query";
+import {
+  ReclaimAlreadySettledError,
+  ReclaimNoLongerEligibleError,
+  buildAndBroadcastReclaimTransaction,
+  getReclaimPreview,
+} from "../vaultReclaimService";
+
+const mockBuildAndBroadcastReclaim = vi.fn();
+
+vi.mock("@babylonlabs-io/ts-sdk/tbv/core/services", () => ({
+  buildAndBroadcastReclaim: (...args: unknown[]) =>
+    mockBuildAndBroadcastReclaim(...args),
+}));
+
+vi.mock("@babylonlabs-io/ts-sdk/tbv/core", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@babylonlabs-io/ts-sdk/tbv/core")>()),
+  getNetworkFees: vi.fn().mockResolvedValue({ halfHourFee: 10 }),
+  pushTx: vi.fn().mockResolvedValue("broadcast_txid"),
+  computeMinClaimValue: vi.fn().mockResolvedValue(33_000n),
+}));
+
+vi.mock("@babylonlabs-io/ts-sdk/tbv/core/clients", async (importOriginal) => ({
+  ...(await importOriginal<
+    typeof import("@babylonlabs-io/ts-sdk/tbv/core/clients")
+  >()),
+  getOutspend: vi.fn(),
+  getTipHeight: vi.fn(),
+  getUtxoInfo: vi.fn(),
+}));
+
+vi.mock("@babylonlabs-io/ts-sdk/tbv/core/utils", () => ({
+  calculateBtcTxHash: vi.fn(() => `0x${"cd".repeat(32)}`),
+}));
+
+vi.mock("../../../clients/btc/config", () => ({
+  getMempoolApiUrl: vi.fn().mockReturnValue("https://mempool.space/api"),
+}));
+
+vi.mock("../../../clients/eth-contract/btc-vault-registry/query", () => ({
+  getVaultFromChain: vi.fn(),
+}));
+
+vi.mock("../../../clients/eth-contract/sdk-readers", () => ({
+  getProtocolParamsReader: vi.fn().mockResolvedValue({
+    getOffchainParamsByVersion: vi.fn().mockResolvedValue({
+      councilQuorum: 2,
+      securityCouncilKeys: [
+        `0x${"55".repeat(32)}`,
+        `0x${"66".repeat(32)}`,
+        `0x${"77".repeat(32)}`,
+      ],
+      feeRate: 5,
+    }),
+  }),
+  getVaultKeeperReader: vi.fn().mockResolvedValue({
+    getVaultKeepersByVersion: vi
+      .fn()
+      .mockResolvedValue([{ btcPubKey: `0x${"11".repeat(32)}` }]),
+  }),
+  getUniversalChallengerReader: vi.fn().mockResolvedValue({
+    getUniversalChallengersByVersion: vi
+      .fn()
+      .mockResolvedValue([{ btcPubKey: `0x${"22".repeat(32)}` }]),
+  }),
+}));
+
+vi.mock("@/utils/wasm", () => ({
+  assertMinClaimValue: vi.fn(),
+}));
+
+const VAULT_ID = `0x${"aa".repeat(32)}` as Hex;
+const DEPOSITOR_ETH = `0x${"33".repeat(20)}`;
+const DEPOSITOR_BTC =
+  "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798";
+
+const TIP_HEIGHT = 900_000;
+/** A Payout buried exactly at the six-confirmation bar. */
+const DEEP_PAYOUT_HEIGHT = TIP_HEIGHT - 5;
+
+/** Payout spent and deeply confirmed; reserve untouched. The eligible state. */
+function settledChain() {
+  (getOutspend as Mock).mockImplementation(
+    async (_txid: string, vout: number) =>
+      vout === PEGIN_VAULT_VOUT
+        ? {
+            spent: true,
+            status: { confirmed: true, block_height: DEEP_PAYOUT_HEIGHT },
+          }
+        : { spent: false },
+  );
+  (getTipHeight as Mock).mockResolvedValue(TIP_HEIGHT);
+}
+
+const broadcastParams = {
+  vaultId: VAULT_ID,
+  depositorBtcPubkey: DEPOSITOR_BTC,
+  feeRate: 5,
+  signPsbt: vi.fn(),
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+
+  (getVaultFromChain as Mock).mockResolvedValue({
+    depositor: DEPOSITOR_ETH,
+    depositorSignedPeginTx: "0x0200000000",
+    applicationEntryPoint: `0x${"44".repeat(20)}`,
+    offchainParamsVersion: 1,
+    appVaultKeepersVersion: 1,
+    universalChallengersVersion: 1,
+    vaultCoreVersion: 1,
+  });
+  (getUtxoInfo as Mock).mockResolvedValue({
+    value: 33_000,
+    scriptPubKey: `5120${"ab".repeat(32)}`,
+  });
+  mockBuildAndBroadcastReclaim.mockResolvedValue({ txId: "swept_txid" });
+  settledChain();
+});
+
+describe("buildAndBroadcastReclaimTransaction", () => {
+  it("sweeps the reserve when the payout is still settled at signing time", async () => {
+    await expect(
+      buildAndBroadcastReclaimTransaction(broadcastParams),
+    ).resolves.toBe("swept_txid");
+  });
+
+  it("refuses to sign when the payout is no longer spent", async () => {
+    // The row was enabled off a poll up to 60s old. A reorg since then has
+    // restored the vault UTXO, which makes the depositor's recovery graph live
+    // again — and the reserve is its only input.
+    (getOutspend as Mock).mockResolvedValue({ spent: false });
+
+    await expect(
+      buildAndBroadcastReclaimTransaction(broadcastParams),
+    ).rejects.toBeInstanceOf(ReclaimNoLongerEligibleError);
+    expect(mockBuildAndBroadcastReclaim).not.toHaveBeenCalled();
+    expect(broadcastParams.signPsbt).not.toHaveBeenCalled();
+  });
+
+  it("refuses to sign when the payout has fallen below the confirmation bar", async () => {
+    (getOutspend as Mock).mockImplementation(
+      async (_txid: string, vout: number) =>
+        vout === PEGIN_VAULT_VOUT
+          ? {
+              spent: true,
+              status: { confirmed: true, block_height: TIP_HEIGHT },
+            }
+          : { spent: false },
+    );
+
+    await expect(
+      buildAndBroadcastReclaimTransaction(broadcastParams),
+    ).rejects.toBeInstanceOf(ReclaimNoLongerEligibleError);
+    expect(mockBuildAndBroadcastReclaim).not.toHaveBeenCalled();
+  });
+
+  it("reports an already-swept reserve as settled rather than ineligible", async () => {
+    (getOutspend as Mock).mockImplementation(
+      async (_txid: string, vout: number) =>
+        vout === PEGIN_VAULT_VOUT
+          ? {
+              spent: true,
+              status: { confirmed: true, block_height: DEEP_PAYOUT_HEIGHT },
+            }
+          : { spent: true, status: { confirmed: true } },
+    );
+
+    await expect(
+      buildAndBroadcastReclaimTransaction(broadcastParams),
+    ).rejects.toBeInstanceOf(ReclaimAlreadySettledError);
+    expect(mockBuildAndBroadcastReclaim).not.toHaveBeenCalled();
+  });
+
+  it("binds the sweep to the vault by passing the depositor address and outpoint", async () => {
+    await buildAndBroadcastReclaimTransaction(broadcastParams);
+
+    const call = mockBuildAndBroadcastReclaim.mock.calls[0][0];
+    expect(call.vaultIds).toEqual([VAULT_ID]);
+    expect(call.depositorEthAddress).toBe(DEPOSITOR_ETH);
+
+    const [reserve] = await call.readVaults();
+    expect(reserve.observed.txid).toBe("cd".repeat(32));
+    expect(reserve.observed.vout).toBe(1);
+  });
+});
+
+describe("getReclaimPreview", () => {
+  it("returns the reclaimable amount for an eligible vault", async () => {
+    await expect(getReclaimPreview(VAULT_ID)).resolves.toMatchObject({
+      reclaimableSats: 33_000n,
+      halfHourFeeSatsVb: 10,
+    });
+  });
+
+  it("refuses to show an amount once the payout is no longer settled", async () => {
+    // Surfacing the reorg here means the depositor never sees a figure for a
+    // reserve they must not sweep.
+    (getOutspend as Mock).mockResolvedValue({ spent: false });
+
+    await expect(getReclaimPreview(VAULT_ID)).rejects.toBeInstanceOf(
+      ReclaimNoLongerEligibleError,
+    );
+  });
+});

--- a/services/vault/src/services/vault/vaultReclaimService.ts
+++ b/services/vault/src/services/vault/vaultReclaimService.ts
@@ -159,6 +159,47 @@ export async function readReclaimChainState(
 }
 
 /**
+ * The chain-derived inputs to the gate, without the material only the initial
+ * read needs. Re-checks want exactly these three.
+ */
+export type ReclaimGateState = Pick<
+  ReclaimChainState,
+  "payoutSpend" | "reserveSpend" | "tipHeight"
+>;
+
+/**
+ * Re-read just the gate's inputs, against a PegIn txid already in hand.
+ *
+ * `readReclaimChainState` costs an Ethereum read plus four Bitcoin reads,
+ * and the re-checks need neither the vault record nor the reserve's value —
+ * only the two spends and the tip. Skipping the Ethereum round trip matters
+ * most for the check that runs after the depositor approves in their wallet,
+ * when they are watching a spinner.
+ *
+ * Reusing the txid is sound: `depositorSignedPeginTx` is fixed at registration,
+ * and the SDK re-derives the vault id from those same bytes on every sweep, so
+ * a substituted vault is caught there rather than here.
+ */
+async function readReclaimGateState(
+  peginTxid: string,
+): Promise<ReclaimGateState> {
+  const apiUrl = getMempoolApiUrl();
+
+  // Tip first, for the same reason as `readReclaimChainState`.
+  const tipHeight = await getTipHeight(apiUrl);
+  const [payoutOutspend, reserveOutspend] = await Promise.all([
+    getOutspend(peginTxid, PEGIN_VAULT_VOUT, apiUrl),
+    getOutspend(peginTxid, PEGIN_DEPOSITOR_CLAIM_VOUT, apiUrl),
+  ]);
+
+  return {
+    payoutSpend: toOutpointSpend(payoutOutspend),
+    reserveSpend: toOutpointSpend(reserveOutspend),
+    tipHeight,
+  };
+}
+
+/**
  * Re-assert the chain-derived half of the reclaim gate against a fresh read.
  *
  * The row's eligibility is decided in the render path, off a poller with a
@@ -175,9 +216,7 @@ export async function readReclaimChainState(
  * Ownership in particular is re-proved far more strongly inside the SDK, which
  * re-derives the claim script from the connected wallet's live key.
  */
-export function assertReclaimStillEligible(
-  chainState: ReclaimChainState,
-): void {
+export function assertReclaimStillEligible(chainState: ReclaimGateState): void {
   if (chainState.reserveSpend.spent) {
     throw new ReclaimAlreadySettledError(undefined);
   }
@@ -327,17 +366,18 @@ export async function buildAndBroadcastReclaimTransaction(
     },
   ];
 
-  // …and again at the signing boundary itself. Everything between the check
-  // above and this point is preparation — recomputing the reserve value from
-  // frozen parameters, re-reading the vault, the UTXO probe, then the SDK's own
-  // fee caps, PSBT build and vault-id derivation (which initialises WASM on a
-  // cold load). That is seconds, not milliseconds, and this is a safety control
-  // on an irreversible spend: the only reading that means anything is the one
-  // taken immediately before the wallet is asked to sign. The extra probe costs
-  // one round trip on an action a depositor performs once per vault.
+  // …and again just before the wallet is asked to sign. Everything between the
+  // check above and this point is preparation — recomputing the reserve value
+  // from frozen parameters, re-reading the vault, the UTXO probe, then the
+  // SDK's own fee caps, PSBT build and vault-id derivation (which initialises
+  // WASM on a cold load). That is seconds, not milliseconds. This check does
+  // not make the sweep safe on its own; it avoids raising a wallet prompt for
+  // a sweep that is already doomed.
   const gatedSignPsbt: typeof signPsbt = async (psbtHex, opts) => {
     signal?.throwIfAborted();
-    assertReclaimStillEligible(await readReclaimChainState(vaultId));
+    assertReclaimStillEligible(
+      await readReclaimGateState(chainState.peginTxid),
+    );
     return signPsbt(psbtHex, opts);
   };
 
@@ -349,9 +389,23 @@ export async function buildAndBroadcastReclaimTransaction(
       readVaults,
       feeRate,
       signPsbt: gatedSignPsbt,
-      broadcastTx: async (signedTxHex: string) => ({
-        txId: await pushTx(signedTxHex, apiUrl),
-      }),
+      // The real boundary. `signPsbt` above is an interactive approval that can
+      // sit open for minutes, so a check taken before it says nothing about the
+      // chain by the time it returns — a reorg while the depositor is deciding
+      // would otherwise be broadcast against a live vault. Broadcasting is the
+      // irreversible act, so the last reading before it is the one that counts.
+      //
+      // This does not defend against a hostile wallet, which already holds the
+      // signature and can broadcast without us. It stops *this app* completing
+      // an honest race. A transient RPC failure here aborts a transaction that
+      // was already signed rather than broadcasting it — fail-closed, and the
+      // right direction when the reserve cannot be recovered once spent.
+      broadcastTx: async (signedTxHex: string) => {
+        assertReclaimStillEligible(
+          await readReclaimGateState(chainState.peginTxid),
+        );
+        return { txId: await pushTx(signedTxHex, apiUrl) };
+      },
       signal,
     });
     return txId;

--- a/services/vault/src/services/vault/vaultReclaimService.ts
+++ b/services/vault/src/services/vault/vaultReclaimService.ts
@@ -47,6 +47,8 @@ import {
 } from "../../clients/eth-contract/sdk-readers";
 import {
   PEGIN_VAULT_VOUT,
+  isPayoutSettled,
+  toOutpointSpend,
   type OutpointSpend,
 } from "../../models/reclaimEligibility";
 
@@ -63,6 +65,26 @@ export class ReclaimAlreadySettledError extends Error {
     super("Reclaim already settled: the depositor-claim reserve is spent.");
     this.name = "ReclaimAlreadySettledError";
     this.spendingTxid = spendingTxid;
+  }
+}
+
+/**
+ * Thrown when the Payout that made the reserve reclaimable is no longer settled
+ * on Bitcoin by the time the depositor confirms — a reorg deep enough to unwind
+ * six confirmations.
+ *
+ * Distinct from {@link ReclaimAlreadySettledError}, and deliberately so: that
+ * one is a resolved outcome (the reserve is gone, nothing left to do), this one
+ * is the opposite (the reserve is intact and must stay intact, because the
+ * recourse graph it funds is live again).
+ */
+export class ReclaimNoLongerEligibleError extends Error {
+  constructor() {
+    super(
+      "Reclaim no longer eligible: the vault's Payout is not settled on " +
+        "Bitcoin at the required confirmation depth.",
+    );
+    this.name = "ReclaimNoLongerEligibleError";
   }
 }
 
@@ -99,18 +121,6 @@ export function derivePeginTxid(depositorSignedPeginTx: Hex): string {
   return stripHexPrefix(calculateBtcTxHash(depositorSignedPeginTx));
 }
 
-function toOutpointSpend(res: {
-  spent?: boolean;
-  txid?: string;
-  status?: { confirmed?: boolean; block_height?: number };
-}): OutpointSpend {
-  return {
-    spent: res.spent === true,
-    confirmed: res.spent === true && res.status?.confirmed === true,
-    blockHeight: res.status?.block_height,
-  };
-}
-
 /**
  * Read everything on Bitcoin the eligibility gate needs for one vault.
  *
@@ -139,6 +149,34 @@ export async function readReclaimChainState(
     tipHeight,
     reserveValueSats: BigInt(reserveUtxo.value),
   };
+}
+
+/**
+ * Re-assert the chain-derived half of the reclaim gate against a fresh read.
+ *
+ * The row's eligibility is decided in the render path, off a poller with a
+ * 60-second interval and a 55-second stale window, and the modal can sit open
+ * for far longer than that. Both conditions this checks can change underneath
+ * it: someone sweeps the reserve from another session, or — the one that
+ * matters — a reorg unwinds the Payout and makes the depositor's recourse graph
+ * necessary again. Signing then destroys the recovery material permanently, and
+ * after a reorg that deep the vault provider's own graph is dead too, so the
+ * depositor's was the remaining path.
+ *
+ * The wallet and UI conditions (ownership, Ledger, protocol pause, in-flight)
+ * stay owned by the React layer, which is the only place that knows them.
+ * Ownership in particular is re-proved far more strongly inside the SDK, which
+ * re-derives the claim script from the connected wallet's live key.
+ */
+export function assertReclaimStillEligible(
+  chainState: ReclaimChainState,
+): void {
+  if (chainState.reserveSpend.spent) {
+    throw new ReclaimAlreadySettledError(undefined);
+  }
+  if (!isPayoutSettled(chainState.payoutSpend, chainState.tipHeight)) {
+    throw new ReclaimNoLongerEligibleError();
+  }
 }
 
 /**
@@ -212,9 +250,10 @@ export async function getReclaimPreview(vaultId: Hex): Promise<ReclaimPreview> {
     getNetworkFees(getMempoolApiUrl()).catch(() => null),
   ]);
 
-  if (chainState.reserveSpend.spent) {
-    throw new ReclaimAlreadySettledError(undefined);
-  }
+  // Same gate the row was rendered from, re-asserted against this read, so a
+  // vault that stopped being eligible while the list sat idle never gets as far
+  // as showing the depositor an amount.
+  assertReclaimStillEligible(chainState);
 
   return {
     reclaimableSats: chainState.reserveValueSats,
@@ -241,19 +280,20 @@ export interface BroadcastReclaimParams {
  *
  * @returns the broadcast transaction id
  * @throws {@link ReclaimAlreadySettledError} if the reserve is already spent
+ * @throws {@link ReclaimNoLongerEligibleError} if the Payout is no longer
+ *   settled deeply enough for the sweep to be safe
  */
 export async function buildAndBroadcastReclaimTransaction(
   params: BroadcastReclaimParams,
 ): Promise<string> {
   const { vaultId, depositorBtcPubkey, feeRate, signPsbt, signal } = params;
 
-  // Re-probe immediately before signing: the modal may have been open a while,
-  // and sweeping an already-spent reserve is a guaranteed broadcast failure
-  // after a pointless wallet prompt.
+  // Re-probe immediately before signing. The modal may have been open a while,
+  // and both halves of the gate matter here: an already-spent reserve is a
+  // guaranteed broadcast failure after a pointless wallet prompt, and an
+  // unsettled Payout means signing would destroy live recovery material.
   const chainState = await readReclaimChainState(vaultId);
-  if (chainState.reserveSpend.spent) {
-    throw new ReclaimAlreadySettledError(undefined);
-  }
+  assertReclaimStillEligible(chainState);
 
   const expectedClaimValue = await readExpectedClaimValue(vaultId);
   const onChainVault = await getVaultFromChain(vaultId);
@@ -268,6 +308,11 @@ export async function buildAndBroadcastReclaimTransaction(
     {
       depositorSignedPeginTxHex: onChainVault.depositorSignedPeginTx,
       observed: {
+        // The outpoint this observation was taken from. The SDK binds it to
+        // the PegIn it builds the input from — the script and value are
+        // identical across every vault this depositor owns, so they cannot.
+        txid: chainState.peginTxid,
+        vout: PEGIN_DEPOSITOR_CLAIM_VOUT,
         scriptPubKey: reserveUtxo.scriptPubKey,
         value: BigInt(reserveUtxo.value),
       },
@@ -278,6 +323,7 @@ export async function buildAndBroadcastReclaimTransaction(
   try {
     const { txId } = await buildAndBroadcastReclaim({
       vaultIds: [vaultId],
+      depositorEthAddress: onChainVault.depositor,
       depositorBtcPubkey,
       readVaults,
       feeRate,

--- a/services/vault/src/services/vault/vaultReclaimService.ts
+++ b/services/vault/src/services/vault/vaultReclaimService.ts
@@ -126,6 +126,13 @@ export function derivePeginTxid(depositorSignedPeginTx: Hex): string {
  *
  * Both outpoints are probed: vout 0 decides whether the Payout has landed
  * (the gate), vout 1 whether the reserve is still there to sweep.
+ *
+ * The tip is read **before** the outspends, not alongside them. Issued
+ * concurrently, a tip response from after a new block could be paired with a
+ * payout response from before it, overstating the confirmation depth by a
+ * block — the wrong direction for a gate that exists to keep a shallow Payout
+ * out. Reading it first can only ever understate. `useReclaimStatus` orders its
+ * reads the same way and for the same reason.
  */
 export async function readReclaimChainState(
   vaultId: Hex,
@@ -134,13 +141,13 @@ export async function readReclaimChainState(
   const peginTxid = derivePeginTxid(onChainVault.depositorSignedPeginTx);
   const apiUrl = getMempoolApiUrl();
 
-  const [payoutOutspend, reserveOutspend, tipHeight, reserveUtxo] =
-    await Promise.all([
-      getOutspend(peginTxid, PEGIN_VAULT_VOUT, apiUrl),
-      getOutspend(peginTxid, PEGIN_DEPOSITOR_CLAIM_VOUT, apiUrl),
-      getTipHeight(apiUrl),
-      getUtxoInfo(peginTxid, PEGIN_DEPOSITOR_CLAIM_VOUT, apiUrl),
-    ]);
+  const tipHeight = await getTipHeight(apiUrl);
+
+  const [payoutOutspend, reserveOutspend, reserveUtxo] = await Promise.all([
+    getOutspend(peginTxid, PEGIN_VAULT_VOUT, apiUrl),
+    getOutspend(peginTxid, PEGIN_DEPOSITOR_CLAIM_VOUT, apiUrl),
+    getUtxoInfo(peginTxid, PEGIN_DEPOSITOR_CLAIM_VOUT, apiUrl),
+  ]);
 
   return {
     peginTxid,
@@ -288,10 +295,10 @@ export async function buildAndBroadcastReclaimTransaction(
 ): Promise<string> {
   const { vaultId, depositorBtcPubkey, feeRate, signPsbt, signal } = params;
 
-  // Re-probe immediately before signing. The modal may have been open a while,
-  // and both halves of the gate matter here: an already-spent reserve is a
-  // guaranteed broadcast failure after a pointless wallet prompt, and an
-  // unsettled Payout means signing would destroy live recovery material.
+  // Re-probe before doing any work. The modal may have been open a while, and
+  // both halves of the gate matter: an already-spent reserve is a guaranteed
+  // broadcast failure after a pointless wallet prompt, and an unsettled Payout
+  // means signing would destroy live recovery material.
   const chainState = await readReclaimChainState(vaultId);
   assertReclaimStillEligible(chainState);
 
@@ -320,6 +327,20 @@ export async function buildAndBroadcastReclaimTransaction(
     },
   ];
 
+  // …and again at the signing boundary itself. Everything between the check
+  // above and this point is preparation — recomputing the reserve value from
+  // frozen parameters, re-reading the vault, the UTXO probe, then the SDK's own
+  // fee caps, PSBT build and vault-id derivation (which initialises WASM on a
+  // cold load). That is seconds, not milliseconds, and this is a safety control
+  // on an irreversible spend: the only reading that means anything is the one
+  // taken immediately before the wallet is asked to sign. The extra probe costs
+  // one round trip on an action a depositor performs once per vault.
+  const gatedSignPsbt: typeof signPsbt = async (psbtHex, opts) => {
+    signal?.throwIfAborted();
+    assertReclaimStillEligible(await readReclaimChainState(vaultId));
+    return signPsbt(psbtHex, opts);
+  };
+
   try {
     const { txId } = await buildAndBroadcastReclaim({
       vaultIds: [vaultId],
@@ -327,7 +348,7 @@ export async function buildAndBroadcastReclaimTransaction(
       depositorBtcPubkey,
       readVaults,
       feeRate,
-      signPsbt,
+      signPsbt: gatedSignPsbt,
       broadcastTx: async (signedTxHex: string) => ({
         txId: await pushTx(signedTxHex, apiUrl),
       }),


### PR DESCRIPTION
# Reclaim follow-up: tie the sweep to the right vault, and check again before signing

Closes https://github.com/babylonlabs-io/babylon-toolkit/issues/2324

Follow-up to https://github.com/babylonlabs-io/babylon-toolkit/pull/2317, which merged before a review landed. That review found six problems. Five are in the issue above; the sixth was only an inline comment on the PR, so it is easy to miss — it is fixed here too.

## Background, in plain terms

Every deposit sets aside a small amount of BTC — around 26,000 to 33,000 sats — at output 1 of the PegIn transaction. That money exists to pay for the depositor's own emergency recovery transaction, in case the vault provider fails during withdrawal. On the normal path the vault provider pays for its own claim, nobody ever spends that reserve, and it sits there forever. "Reclaim" is the button that sweeps it back to the depositor.

The important thing to understand is that **spending that reserve early is not recoverable**. The depositor's emergency recovery transaction is pre-signed and hard-wired to spend that exact output. Every later transaction in that chain is signed against it. There is no way to re-fund it and no way to re-sign it. If the reserve is swept while the vault is still live, the depositor's emergency exit is gone permanently.

So the rule for when Reclaim may be offered is not a convenience filter. It is a safety control. The rule is: the vault's own output must already be spent on Bitcoin (which means the withdrawal really happened) and that spend must be at least 6 blocks deep. The review agreed this design is right and did not ask us to change it. All six findings are cases where the code promised this in its comments but did not actually enforce it.

## What was wrong, and what we did

### 1. The safety checks proved the shape of the output, not which vault it belonged to

Before signing, the code compared three things: the output script from the contract's copy of the PegIn transaction, the output we looked up on Bitcoin, and a script we re-derived from the connected wallet's key. They all have to match.

The problem is that all three of those are the same for **every vault the same person owns**. The script is built only from the depositor's key, so it is byte-for-byte identical across all their vaults. The value comes from protocol settings, so two vaults with the same settings have the same value. And the chain observation did not record which outpoint it came from. So the check really only proved "some output somewhere has this shape", not "this is the reserve for the vault we were asked about".

There was a count check (`vaults.length !== vaultIds.length`) whose error message claimed it was refusing "a set that does not match the request", but it only compared how many items came back.

**What we did.** Two things. The chain observation now carries the `txid` and `vout` it was taken from, and the builder checks those against the PegIn it is actually spending. And the service now re-derives the vault id from the PegIn bytes and checks it equals the vault id that was requested.

**Approaches we considered.**

- Check the `txid` against what the UTXO lookup returned. **Rejected** — that function echoes back the `txid` you passed in rather than reading it from the response, so it would have been comparing a value to itself. We check against the PegIn transaction instead, which is a genuinely different source.
- Add a `vaultId` field to the data the caller hands in, and compare it. This is what the review suggested. **Improved on** — a caller can just fill that field in wrong. Instead the SDK now *derives* the vault id itself from bytes it already has, so there is nothing for the caller to get wrong.
- Write the derivation with `viem`'s keccak. **Rejected** — there is already a `deriveVaultId` helper that goes through the same Rust code the contracts use and has a pinned test vector. Reusing it means there is only one definition of this hash in the repo.

**Honest limit, worth saying out loud.** This proves the reserve matches the vault id we asked for. It does not prove the vault id itself was right — that comes from the indexer, and if the indexer mislabels a row then every read follows the wrong vault consistently and this check passes. Closing that is a separate piece of work.

### 2. Nothing re-checked eligibility right before signing

The code already re-read the chain right before asking the wallet to sign. It read five things and then looked at exactly one of them — whether the reserve was already spent. The withdrawal status and the chain tip were fetched and thrown away. That is two wasted network calls, and it also breaks the repo's no-dead-code rule.

So the real safety check — "has the withdrawal settled 6 blocks deep?" — only ever ran while drawing the row on screen, off a poller that refreshes once a minute. The modal can sit open much longer than that. If the chain reorganised in that window and undid the withdrawal, the button would still sign, and the depositor's emergency exit would be destroyed while the vault was live again. In that situation the vault provider's own recovery chain is dead too, so the depositor's was the only one left.

**What we did.** Pulled the settled-withdrawal test out into one exported function, `isPayoutSettled`, and added `assertReclaimStillEligible`, which the service now calls both before showing the review screen and before signing. No new network calls — the data was already being fetched.

**Approaches we considered.**

- Call the existing `getReclaimEligibility` from the service. **Rejected.** That function also needs to know whether the wallet owns the vault, whether it is a Ledger, whether the protocol is paused, and whether a sweep is already in flight. A non-React module knows none of those, so we would have had to hardcode four values that are not true. It also returns display states like "absent" and "blocked", none of which mean "stop, do not sign".
- Reuse the existing "already reclaimed" error. **Rejected.** That renders a success screen saying there is nothing left to reclaim. Here the opposite is true — the money is still there and must stay there. New error, new copy line, existing retry screen.

### 3. A null block height passed the 6-confirmation check

The check for a missing block height only tested for `undefined`. A `null` slipped past it, and `tipHeight - null + 1` quietly becomes about `tipHeight + 1` — roughly 900,001 confirmations on mainnet, which sails past the 6-block bar. A numeric string or a negative number did the same thing. Only `undefined` behaved correctly.

**What we did.** Two layers. The value is now normalised where it enters the app, in one shared function that replaces two byte-identical copies. And the check itself re-normalises rather than trusting whoever called it, because it is the safety control and it should not be correct only by luck.

**A correction to the review.** The standard mempool/electrs backend leaves the field out entirely when a spend is unconfirmed rather than sending `null`, so this was not exploitable against a normal backend. But the mempool URL is configurable, so a self-hosted server or a proxy that rewrites JSON puts it back in play. Treat this as hardening on a safety control, not a live bug.

Returning "1 confirmation" for a bad value is deliberate and is not a silent fallback of the kind our rules ban — 1 is less than 6, so it fails closed and simply delays the offer.

### 4. A withdrawal could grow into eligibility on its own

The poller reads the chain tip in one request and then reads each vault in three more. If a vault's reads fail, it keeps the previous result so that a brief rate-limit does not make the row flicker away. That part is fine.

The problem was that the tip was refreshed every cycle while the kept result stayed frozen. So `tipHeight - blockHeight + 1` kept growing on data nobody was watching any more. Concretely: a withdrawal is seen at 1 confirmation, the block is then reorganised away, the per-vault requests start getting rate-limited while the single cheap tip request keeps working, and six blocks later the frozen entry reads as 6 confirmations and the button turns on for a withdrawal that no longer exists.

**What we did.** Each result now stores the tip height it was read against, and the check uses that. A frozen entry can lose eligibility but can never gain it. Because the tip is read *before* the per-vault requests, this can only ever undercount by a few seconds' worth of blocks — never overcount. The old batch-level tip and the prop that threaded it through the components are now unused and were deleted.

**Approaches we considered.**

- Drop the entry on failure instead. **Rejected.** One rate-limited request out of three would make the button *and* the "26,228 sats reclaimable" figure disappear and come back a minute later, and it would break the "Reclaiming" state mid-sweep.
- Let the query throw, like the sibling hook `useReclaimVaultChainData` does. **Rejected.** One bad vault would freeze polling for every other vault permanently, which is exactly why the per-vault catch exists.

### 5. A dead contract field

`claimExpiredUntil` was read from the contract and copied into a struct that nothing ever looked at. Removed, along with its stale `TODO` and one test fixture.

**A correction to the review.** The stated reason was that this field is always `0` on vaults Reclaim can target. That is not right — `claimExpired` marks vaults as `Redeemed`, so a `Redeemed` vault can carry a non-zero value. The removal stands on a simpler fact instead: nothing in the TypeScript code reads it at all.

The two ABI files still declare it and **must keep declaring it** — that decoding is positional, so deleting the entry there would shift `vaultCoreVersion` and the three key-epoch fields and silently misread every vault. There is already a test guarding this.

As a bonus, the contract source settles an open question from the original PR: this field is the grace window for claiming an *expired* vault, not a deadline on the depositor's claim right. So it can never be a second reason to allow a reclaim.

### 6. We finalised the wallet's transaction instead of our own — not in the issue

This one was only an inline comment on the PR.

We verify the wallet's signature against a transaction we build ourselves, which is correct. But then we handed the **wallet's** returned PSBT to the finaliser. The check that compares the two deliberately skips the per-input details, so the leaf script, the control block, and a key-path signature field were all still whatever the wallet put there.

`bitcoinjs-lib` checks for a key-path signature first (`src/psbt.js`, "Check key spend first"). If a wallet returns one, it wins outright and the correct script-path signature is ignored. These outputs use an unspendable internal key, so the result cannot be spent and the network rejects it.

No money is at risk — the outputs and the fee are already locked down — but the depositor gets a wallet prompt and then a confusing failure.

**What we did.** We now finalise the PSBT **we** built, and copy across only the 64-byte signature we already verified. A wallet-supplied key-path signature cannot win because it is never there.

**Approaches we considered.**

- Check the witness afterwards and reject a bad one. This is what the review suggested. **Rejected as the primary fix** — it catches the problem after already letting wallet-controlled bytes drive the finaliser. Finalising our own transaction removes the possibility instead of detecting it, and it makes the code match what its own comment already claims: *"only the 64-byte signature comes from the wallet"*.

**Scope note.** The refund path had a byte-for-byte copy of the same helper with the same problem. Fixing only Reclaim would have left the duplicate behind, so both now share one new helper and both copies of the old one are deleted. The `"already finalized"` escape hatch went with them — the signature extractor already handles wallets that finalise early, with a strict 3-element witness check.

## Tests

22 new unit tests, at least one per finding, matching the patterns already in each suite.

- Real transactions and real signing for the crypto-level fixes, including a test where the wallet returns a key-path signature alongside a valid script-path one — the witness must still come out as the correct 3 elements.
- Mocked boundaries for the orchestration fixes, including wrong-vault, wrong-order and reorg cases.
- Plain data tests for the eligibility rules, including `null`, `"899000"` and `-1` block heights.
- Two brand-new test files, because `vaultReclaimService.ts` and `useReclaimStatus.ts` had **no test coverage at all** — which is a large part of why findings 2, 3 and 4 got through review in the first place.

## New: a real-wallet E2E action for reclaim

This PR also adds `reclaim` to the real-wallet E2E CLI (`services/vault/e2e/real/`), alongside the existing pegin / borrow / repay / withdraw / resume actions.

```bash
pnpm --filter vault run e2e:cli --target=localhost --network=devnet --btc=unisat --eth=metamask --action=reclaim --data=real --yes
```

`--dry-run` stops after the review screen without signing, so the eligibility gate and the fee/dust guards can be rehearsed without spending anything. That matters here more than usual: sweeping the reserve is irreversible, and a sweep against a live vault would destroy recovery material permanently.

The clicking is the easy part. The reason this action exists is that **none of these bugs are visible from the screen** — a sweep of the wrong vault's reserve and a key-path witness both look exactly like success right up until the money is gone or the broadcast is rejected. So after broadcasting, the run reads the transaction back off the chain and asserts its shape:

| Check | What it catches |
|---|---|
| exactly one input, at `(peginTxid, 1)` | the wrong vault's reserve — finding 1 |
| witness is a 3-item stack | a key-path finalize, which would be 1 item — finding 6 |
| item 0 is a 64-byte Schnorr signature | the wrong sighash type |
| item 1 is `20<32-byte key>ac` | some other tapleaf |
| item 2 is 33 bytes | a merkle path where the taptree has only one leaf |
| one output, and `in - fee == out` | value going somewhere it should not |
| 513 weight units | the 129 vB fee model drifting |
| output pays the connected wallet | the wrong destination |

It also snapshots what the gate saw at the moment of authorisation — payout spend, confirmation depth, reserve state, chain tip — so a later failure is diagnosable without reconstructing chain history. Everything lands in `e2e/artifacts/<stamp>-reclaim/reclaim.json` next to the run log and a Playwright trace.

## Verified on real devnet data

Run against devnet on signet with a genuinely settled vault. **All 11 checks passed.**

```
Row:      0.01 sBTC · Redeemed · vault-provider-0 · 44a99b...4cab · 31,670 sats reclaimable
Review:   Reclaim Amount 31,670 sats · Fee Rate 1 sat/vB · Network Fee 129 sats · You'll receive 0.00031541 sBTC
Gate:     payout spent=true confirmed=true depth=63 · reserve unspent · tip=319444
Swept:    31,670 -> 31,541 sats (fee 129 sats, 129 vB, 513 WU)
Txid:     4a13b9202f04b80c5fad4d63b4be5e40c0ca3fea130ff1f656f78b3830956ba5
Witness:  [64 bytes signature, 34 bytes leaf, 33 bytes control block]
```

Three things worth drawing out of that run.

**Finding 6 is confirmed by relay acceptance, not just by the item count.** The control block decodes to leaf version `0xc0` plus the standard BIP-341 NUMS point, so the internal key is provably unspendable. A key-path witness would have been rejected at relay rather than merely failing to confirm. The node accepted this transaction, so the script path really was taken.

**Finding 1 turned out to be demonstrable on live data.** The reserve swept here and the reserve of a completely different vault used in https://github.com/babylonlabs-io/babylon-toolkit/pull/2317 have byte-identical scriptPubKeys — `5120faa5c20e...91a9b244` — differing only in value (31,670 vs 26,228 sats). Same depositor, different vaults, same script. That is precisely what the old three-way bind could not tell apart, and two vaults under the same protocol parameters would have matched on value too.

**The fee model is confirmed against a real transaction.** 513 weight units, 129 vB, exactly the hand-derived figure the builder sizes fees from — not just a unit-test fixture.

## How to check it

```bash
nvm use 24
pnpm install
pnpm run build
pnpm --filter @babylonlabs-io/ts-sdk exec vitest run
pnpm --filter vault exec vitest run
pnpm run lint
```

Results on this branch: SDK 105 files / 1772 tests pass. Vault 304 files / 3624 tests pass. Root build passes. Lint clean — 0 errors across 10 projects.

Please run the **refund** tests too, not just reclaim — finding 6 touches the refund path as well.

## Review notes

This touches critical paths 1, 8 and 9 in `CLAUDE.md`, so it needs two reviewers and the author should be able to walk through every changed line unaided.

Worth knowing while reviewing: none of the files in this PR are currently listed in `critical-path-check.yml` or `CODEOWNERS`, so the automated gate passes without matching anything and no mandatory reviewer is assigned. The whole reclaim surface shipped in https://github.com/babylonlabs-io/babylon-toolkit/pull/2317 without being registered, and the refund service was never registered either. Registering them is a policy change that belongs in its own PR rather than mixed in here, since the drift checker wants `critical-path-check.yml`, `CODEOWNERS`, `SECURITY.md` and `CLAUDE.md` kept in sync.

## Not in this PR

- Batching several reserves into one sweep. Finding 1 is the prerequisite for it — the count check cannot catch a wrong order or a wrong subset once more than one reserve comes back.
- Hiding completed deposits once nothing is actionable: https://github.com/babylonlabs-io/babylon-toolkit/issues/2320
- Validating the `getOutspend` response inside the SDK client. It is a shared published client with a much wider blast radius, and it would not have prevented finding 3 anyway, since that bug was in the app's own mapper.
- A latent bug in `RefundReviewContent` — the mirror of one fixed in https://github.com/babylonlabs-io/babylon-toolkit/pull/2317, where a fallback flag is never cleared and can leave Confirm permanently disabled. Different surface; should be tracked on its own.
- Registering these paths as critical paths, per the review note above.
