### PR TITLE
fix(ts-sdk, vault): break the ts-sdk ↔ ledger-vault-signer devDepende…

### DIFF
--- a/packages/babylon-ts-sdk/package.json
+++ b/packages/babylon-ts-sdk/package.json
@@ -120,7 +120,6 @@
     "viem": "^2.38.2"
   },
   "devDependencies": {
-    "@babylonlabs-io/ledger-vault-signer": "workspace:*",
     "@internal/eslint-config": "workspace:*",
     "@vitest/coverage-v8": "^4.0.8",
     "@vitest/ui": "^4.0.8",

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/__tests__/payout.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/__tests__/payout.test.ts
@@ -12,22 +12,15 @@ import {
   getAssertPayoutScriptInfo,
   type Network,
 } from "@babylonlabs-io/babylon-tbv-rust-wasm";
-import { prepareSignPsbt } from "@babylonlabs-io/ledger-vault-signer";
 import { Psbt, Transaction } from "bitcoinjs-lib";
 import { beforeAll, describe, expect, it } from "vitest";
-import { createTaprootScriptPathSignOptions } from "../../../utils/signing";
 import { deriveLocalChallengers } from "../../challengers";
-import { createPayoutScript } from "../../scripts/payout";
 import {
   deriveBip86ScriptPubKeyHex,
   hexToUint8Array,
 } from "../../utils/bitcoin";
 import { computeTaprootScriptPubKey } from "../../utils/taproot";
-import {
-  DEPOSITOR_SIGNED_INPUT_COUNT,
-  PAYOUT_ANCHOR_DUST_SATS,
-  PAYOUT_TX_VERSION,
-} from "../constants";
+import { PAYOUT_ANCHOR_DUST_SATS, PAYOUT_TX_VERSION } from "../constants";
 import {
   buildPayoutPsbt,
   extractPayoutSignature,
@@ -1913,104 +1906,5 @@ describe("buildPayoutPsbt — fee-band and domain wiring", () => {
         vpCommissionScriptPubKey: CANONICAL_VP_COMMISSION_SCRIPT_HEX,
       }),
     ).rejects.toThrow(/outputs \(200000 sats\) exceed inputs/);
-  });
-});
-
-/**
- * The two halves of the Ledger payout contract meet nowhere else in the repo:
- * the signer package cannot see this builder, and its fixtures are pinned to a
- * pre-#2281 commit. #2281 put a leaf on input 1 so the device can display the
- * terms; the signer's expectation table arms on leaf presence, so it expected a
- * signature the firmware never produces and the ceremony died after the
- * one-shot payout slot was spent (#2321). These tests fail on the builder
- * change itself, which a fixture cannot.
- */
-describe("buildPayoutPsbt — Ledger expected-signature contract", () => {
-  beforeAll(async () => {
-    await initializeWasmForTests();
-  });
-
-  /**
-   * Exactly what the provider derives from the SDK's own sign options, using
-   * the constant every production payout signer passes.
-   */
-  function signInputIndexesFor(publicKey: string): number[] {
-    const options = createTaprootScriptPathSignOptions(
-      publicKey,
-      DEPOSITOR_SIGNED_INPUT_COUNT,
-    );
-    return options.signInputs!.map((input) => input.index);
-  }
-
-  /**
-   * The real PegIn taproot output for {@link baseParams}. The shared harness
-   * pays a dummy P2TR, which the signer rejects on the control-block gate —
-   * that gate is exactly what these tests must exercise, so pay the real one.
-   */
-  async function peginOutputScriptPubKey(): Promise<Buffer> {
-    const params = baseParams({});
-    const { payoutScript, payoutControlBlock } = await createPayoutScript({
-      vaultCoreVersion: params.vaultCoreVersion,
-      depositor: params.depositorBtcPubkey,
-      vaultProvider: params.vaultProviderBtcPubkey,
-      vaultKeepers: params.vaultKeeperBtcPubkeys,
-      universalChallengers: params.universalChallengerBtcPubkeys,
-      timelockPegin: params.timelockPegin,
-      network: params.network,
-    });
-    return computeTaprootScriptPubKey({
-      leafVersion: TAPSCRIPT_LEAF_VERSION,
-      script: hexToUint8Array(payoutScript),
-      controlBlock: hexToUint8Array(payoutControlBlock),
-    });
-  }
-
-  /** PegIn tx whose output 0 is the real vault taproot output. */
-  async function realPeginTxHex(): Promise<string> {
-    const tx = new Transaction();
-    tx.addInput(NULL_TXID, 0xffffffff, SEQUENCE_MAX);
-    tx.addOutput(await peginOutputScriptPubKey(), Number(TEST_PEGIN_VALUE));
-    return tx.toHex();
-  }
-
-  /** The real post-#2281 Payout PSBT, built end-to-end from WASM-derived scripts. */
-  async function buildRealPayoutPsbtHex(): Promise<string> {
-    const peginTxHex = await realPeginTxHex();
-    const assertTxHex = await createTestAssertTransaction();
-    const payoutTxHex = createTestPayoutTransaction(peginTxHex, assertTxHex);
-    const { psbtHex } = await buildPayoutPsbt(
-      baseParams({ payoutTxHex, peginTxHex, assertTxHex }),
-    );
-    return psbtHex;
-  }
-
-  it("expects a signature on input 0 alone under the sign options the SDK passes", async () => {
-    const psbtHex = await buildRealPayoutPsbtHex();
-
-    const { table } = prepareSignPsbt({
-      psbtHex,
-      depositorXOnlyHex: TEST_KEYS.DEPOSITOR,
-      signInputIndexes: signInputIndexesFor(TEST_KEYS.DEPOSITOR),
-    });
-
-    expect([...table.byInput.keys()]).toEqual([0]);
-    expect(table.expectedYieldCount).toBe(1);
-  });
-
-  it("classifies both inputs as tapscript, so input 1 stays fully gated", async () => {
-    // The narrowing only removes an expectation. Input 1's control block, leaf
-    // version and witnessUtxo are still checked, and the flow is still tapscript.
-    const psbtHex = await buildRealPayoutPsbtHex();
-
-    const { table } = prepareSignPsbt({
-      psbtHex,
-      depositorXOnlyHex: TEST_KEYS.DEPOSITOR,
-      signInputIndexes: signInputIndexesFor(TEST_KEYS.DEPOSITOR),
-    });
-
-    expect([...table.classifiedByInput.keys()]).toEqual([0, 1]);
-    for (const expectation of table.classifiedByInput.values()) {
-      expect(expectation.kind).toBe("tapscript");
-    }
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -422,9 +422,6 @@ importers:
         specifier: 6.0.3
         version: 6.0.3
     devDependencies:
-      '@babylonlabs-io/ledger-vault-signer':
-        specifier: workspace:*
-        version: link:../babylon-ledger-vault-signer
       '@internal/eslint-config':
         specifier: workspace:*
         version: link:../../tools/eslint-config
@@ -1085,6 +1082,12 @@ importers:
         specifier: 2.18.1
         version: 2.18.1(@tanstack/query-core@5.90.20)(@tanstack/react-query@5.90.20(react@18.3.1))(@types/react@18.3.23)(bufferutil@4.0.9)(react@18.3.1)(typescript@5.9.2)(utf-8-validate@5.0.10)(viem@2.38.2(bufferutil@4.0.9)(typescript@5.9.2)(utf-8-validate@5.0.10)(zod@3.22.4))(zod@3.22.4)
     devDependencies:
+      '@babylonlabs-io/babylon-tbv-rust-wasm':
+        specifier: workspace:*
+        version: link:../../packages/babylon-tbv-rust-wasm
+      '@babylonlabs-io/ledger-vault-signer':
+        specifier: workspace:*
+        version: link:../../packages/babylon-ledger-vault-signer
       '@eslint/js':
         specifier: ^9.31.0
         version: 9.32.0

--- a/services/vault/package.json
+++ b/services/vault/package.json
@@ -58,6 +58,8 @@
     "wagmi": "2.18.1"
   },
   "devDependencies": {
+    "@babylonlabs-io/babylon-tbv-rust-wasm": "workspace:*",
+    "@babylonlabs-io/ledger-vault-signer": "workspace:*",
     "@eslint/js": "^9.31.0",
     "@playwright/test": "1.56.1",
     "@sentry/vite-plugin": "^2.22.6",

--- a/services/vault/src/services/vault/__tests__/ledgerPayoutSigningContract.test.ts
+++ b/services/vault/src/services/vault/__tests__/ledgerPayoutSigningContract.test.ts
@@ -1,0 +1,252 @@
+// @vitest-environment node
+// The Ledger payout contract has two halves — the SDK's Payout PSBT plus the
+// sign options PayoutManager passes, and the signer's expected-signature table.
+// No package may depend on both without an nx cycle (ts-sdk <-> signer), so the
+// vault, which already depends on both, is where the halves meet.
+
+import {
+  createPayoutConnector,
+  getAssertPayoutScriptInfo,
+  initWasm,
+} from "@babylonlabs-io/babylon-tbv-rust-wasm";
+import {
+  prepareSignPsbt,
+  type ExpectedSignatureTable,
+} from "@babylonlabs-io/ledger-vault-signer";
+import type { BitcoinWallet } from "@babylonlabs-io/ts-sdk/shared";
+import {
+  PayoutManager,
+  type SignPayoutParams,
+} from "@babylonlabs-io/ts-sdk/tbv/core/managers";
+import { deriveBip86ScriptPubKeyHex } from "@babylonlabs-io/ts-sdk/tbv/core/primitives";
+import * as ecc from "@bitcoin-js/tiny-secp256k1-asmjs";
+import { initEccLib, payments, Transaction } from "bitcoinjs-lib";
+import {
+  rootHashFromPath,
+  tapleafHash,
+} from "bitcoinjs-lib/src/payments/bip341";
+import { Buffer } from "buffer";
+import { beforeAll, describe, expect, it } from "vitest";
+
+// Deterministic x-only keys (scalar * G), the same set the SDK's PSBT tests use.
+const DEPOSITOR =
+  "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798";
+const VAULT_PROVIDER =
+  "c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5";
+const VAULT_KEEPER =
+  "f9308a019258c31049344f85f89d5229b531c845836f99b08601f113bce036f9";
+const UNIVERSAL_CHALLENGER =
+  "2f8bde4d1a07209355b4a7250a5c5128e88b84bddc619ab7cba8d569b240efe4";
+
+const VAULT_CORE_VERSION = 1;
+const TIMELOCK_PEGIN = 100;
+const TIMELOCK_ASSERT = 144;
+const COUNCIL_QUORUM = 2;
+const COMMISSION_BPS = 500;
+const PROTOCOL_FEE_RATE = 10n;
+
+const PEGIN_VALUE_SATS = 100_000;
+const ASSERT_VALUE_SATS = 50_000;
+const VP_COMMISSION_SATS = 1_000;
+const CPFP_ANCHOR_SATS = 546;
+const PAYOUT_FEE_SATS = 5_000;
+const DEPOSITOR_PAYOUT_SATS =
+  PEGIN_VALUE_SATS +
+  ASSERT_VALUE_SATS -
+  PAYOUT_FEE_SATS -
+  VP_COMMISSION_SATS -
+  CPFP_ANCHOR_SATS;
+
+const PAYOUT_TX_VERSION = 2;
+const SEQUENCE_MAX = 0xffffffff;
+const TAPSCRIPT_LEAF_VERSION = 0xc0;
+
+// P2WPKH: OP_0 PUSH_20 <hash>; the fill byte only makes the outputs distinct.
+function dummyP2wpkh(fillNibble: string): Buffer {
+  return Buffer.from(`0014${fillNibble.repeat(40)}`, "hex");
+}
+
+/** Sorted x-only keys for scalars offset..offset+count-1 — a valid council. */
+function councilKeys(count: number, offset: number): string[] {
+  const keys: string[] = [];
+  for (let i = 0; i < count; i++) {
+    const scalar = Buffer.alloc(32);
+    scalar.writeUInt32BE(offset + i, 28);
+    const point = ecc.pointFromScalar(scalar, true);
+    if (!point) throw new Error(`invalid scalar ${offset + i}`);
+    keys.push(Buffer.from(point.subarray(1, 33)).toString("hex"));
+  }
+  return keys.sort();
+}
+
+/** BIP-341 fold of a (leaf, control block) pair to the P2TR output it spends. */
+function taprootOutputFor(scriptHex: string, controlBlockHex: string): Buffer {
+  const controlBlock = Buffer.from(controlBlockHex, "hex");
+  const leafHash = tapleafHash({
+    output: Buffer.from(scriptHex, "hex"),
+    version: TAPSCRIPT_LEAF_VERSION,
+  });
+  const output = payments.p2tr({
+    internalPubkey: controlBlock.subarray(1, 33),
+    hash: rootHashFromPath(controlBlock, leafHash),
+  }).output;
+  if (!output) throw new Error("p2tr produced no output script");
+  return output;
+}
+
+const STOP_AFTER_PREPARE = new Error("stop: table captured");
+
+/**
+ * A wallet that does what LedgerVaultProvider does with the SDK's options —
+ * hand the requested input indices to prepareSignPsbt — then bails out, so the
+ * manager never reaches signature extraction.
+ */
+function ledgerTableCapturingWallet(
+  tables: ExpectedSignatureTable[],
+): BitcoinWallet {
+  const notExercised = () => {
+    throw new Error("not exercised by this test");
+  };
+  return {
+    getPublicKeyHex: async () => DEPOSITOR,
+    signPsbt: async (psbtHex, options) => {
+      // Mirrors LedgerVaultProvider.stagePsbt: only the indices are honoured.
+      const signInputIndexes = options?.signInputs?.map((input) => input.index);
+      const { table } = prepareSignPsbt({
+        psbtHex,
+        depositorXOnlyHex: DEPOSITOR,
+        signInputIndexes,
+      });
+      tables.push(table);
+      throw STOP_AFTER_PREPARE;
+    },
+    getAddress: notExercised,
+    signPsbts: notExercised,
+    signMessage: notExercised,
+    getNetwork: notExercised,
+    deriveContextHash: notExercised,
+  };
+}
+
+describe("Ledger payout signing contract", () => {
+  let params: SignPayoutParams;
+
+  beforeAll(async () => {
+    initEccLib(ecc);
+    await initWasm();
+
+    const councilMembers = councilKeys(3, 9_000);
+
+    // PegIn:0 is the real vault output for these participants.
+    const vaultOutput = await createPayoutConnector(
+      {
+        txGraphVersion: VAULT_CORE_VERSION,
+        depositor: DEPOSITOR,
+        vaultProvider: VAULT_PROVIDER,
+        vaultKeepers: [VAULT_KEEPER],
+        universalChallengers: [UNIVERSAL_CHALLENGER],
+        timelockPegin: TIMELOCK_PEGIN,
+      },
+      "signet",
+    );
+    const peginTx = new Transaction();
+    peginTx.addInput(Buffer.alloc(32, 0), 0xffffffff, SEQUENCE_MAX);
+    peginTx.addOutput(
+      Buffer.from(vaultOutput.scriptPubKey, "hex"),
+      PEGIN_VALUE_SATS,
+    );
+
+    // Assert:0 is the taptree the VP-claimer payout leaf lives in. Local
+    // challengers for a VP claimer are ({VP} ∪ VKs) − {VP} (btc-vault graph.rs).
+    const assertLeaf = await getAssertPayoutScriptInfo({
+      txGraphVersion: VAULT_CORE_VERSION,
+      claimer: VAULT_PROVIDER,
+      localChallengers: [VAULT_KEEPER],
+      universalChallengers: [UNIVERSAL_CHALLENGER],
+      timelockAssert: TIMELOCK_ASSERT,
+      councilMembers,
+      councilQuorum: COUNCIL_QUORUM,
+    });
+    const assertTx = new Transaction();
+    assertTx.addInput(Buffer.alloc(32, 2), 0xffffffff, SEQUENCE_MAX);
+    assertTx.addOutput(
+      taprootOutputFor(assertLeaf.payoutScript, assertLeaf.payoutControlBlock),
+      ASSERT_VALUE_SATS,
+    );
+
+    // The VP-claimer Payout shape buildPayoutPsbt validates: depositor payout,
+    // VP commission, CPFP anchor; input sequences carry the CSV timelocks.
+    const payoutTx = new Transaction();
+    payoutTx.version = PAYOUT_TX_VERSION;
+    payoutTx.addInput(
+      Buffer.from(peginTx.getId(), "hex").reverse(),
+      0,
+      TIMELOCK_PEGIN,
+    );
+    payoutTx.addInput(
+      Buffer.from(assertTx.getId(), "hex").reverse(),
+      0,
+      TIMELOCK_ASSERT,
+    );
+    payoutTx.addOutput(dummyP2wpkh("a"), DEPOSITOR_PAYOUT_SATS);
+    payoutTx.addOutput(dummyP2wpkh("e"), VP_COMMISSION_SATS);
+    payoutTx.addOutput(dummyP2wpkh("c"), CPFP_ANCHOR_SATS);
+
+    params = {
+      vaultCoreVersion: VAULT_CORE_VERSION,
+      payoutTxHex: payoutTx.toHex(),
+      peginTxHex: peginTx.toHex(),
+      assertTxHex: assertTx.toHex(),
+      depositorBtcPubkey: DEPOSITOR,
+      vaultProviderBtcPubkey: VAULT_PROVIDER,
+      vaultKeeperBtcPubkeys: [VAULT_KEEPER],
+      universalChallengerBtcPubkeys: [UNIVERSAL_CHALLENGER],
+      timelockPegin: TIMELOCK_PEGIN,
+      timelockAssert: TIMELOCK_ASSERT,
+      claimerBtcPubkey: VAULT_PROVIDER,
+      registeredPayoutScriptPubKey: dummyP2wpkh("a").toString("hex"),
+      commissionBps: COMMISSION_BPS,
+      protocolFeeRate: PROTOCOL_FEE_RATE,
+      councilMembers,
+      councilQuorum: COUNCIL_QUORUM,
+      vkClaimerPayoutScriptPubKeys: {
+        [VAULT_KEEPER]: deriveBip86ScriptPubKeyHex(VAULT_KEEPER),
+      },
+      vpCommissionScriptPubKey: dummyP2wpkh("e").toString("hex"),
+    };
+  });
+
+  it("PayoutManager asks the Ledger signer for input 0 alone on a real Payout PSBT", async () => {
+    const tables: ExpectedSignatureTable[] = [];
+    const manager = new PayoutManager({
+      network: "signet",
+      btcWallet: ledgerTableCapturingWallet(tables),
+    });
+
+    await expect(manager.signPayoutTransaction(params)).rejects.toBe(
+      STOP_AFTER_PREPARE,
+    );
+
+    expect(tables).toHaveLength(1);
+    expect([...tables[0].byInput.keys()]).toEqual([0]);
+    expect(tables[0].expectedYieldCount).toBe(1);
+  });
+
+  it("the Ledger signer still classifies Payout input 1 as a tapscript input it must gate", async () => {
+    const tables: ExpectedSignatureTable[] = [];
+    const manager = new PayoutManager({
+      network: "signet",
+      btcWallet: ledgerTableCapturingWallet(tables),
+    });
+
+    await expect(manager.signPayoutTransaction(params)).rejects.toBe(
+      STOP_AFTER_PREPARE,
+    );
+
+    expect(tables).toHaveLength(1);
+    expect([...tables[0].classifiedByInput.keys()]).toEqual([0, 1]);
+    for (const expectation of tables[0].classifiedByInput.values()) {
+      expect(expectation.kind).toBe("tapscript");
+    }
+  });
+});


### PR DESCRIPTION
#2316 made the signer test-depend on ts-sdk and #2323 the reverse, so nx
refuses every task graph on main. Drop ts-sdk's edge and move the Ledger
payout contract test into the vault app, which may depend on both.