### PR TITLE
ci(release): stop the release test run from failing at random

### DIFF
--- a/.github/workflows/package-release.yml
+++ b/.github/workflows/package-release.yml
@@ -72,6 +72,12 @@ jobs:
 
       - name: Test all
         run: pnpm exec nx run-many --target=test --all
+        env:
+          # One project at a time. nx defaults to 3, and each project's vitest
+          # then spawns a worker per core, which oversubscribes the 4-vCPU runner
+          # and trips vitest's 5s per-test timeout. PRs escape it by testing only
+          # affected projects; `--all` on main does not.
+          NX_PARALLEL: "1"
 
       # Must stay last for its event: the release resolves `workspace:*` deps to
       # concrete versions on disk, which makes the specifiers recorded in

--- a/.github/workflows/service-release-simple-staking.yml
+++ b/.github/workflows/service-release-simple-staking.yml
@@ -34,6 +34,10 @@ jobs:
 
       - name: Test
         run: pnpm run test
+        env:
+          # See package-release.yml: `--all` on a 4-vCPU runner oversubscribes
+          # at nx's default of 3 projects and trips vitest's per-test timeout.
+          NX_PARALLEL: "1"
 
       - name: Build
         run: pnpm run build

--- a/.github/workflows/service-release-vault.yml
+++ b/.github/workflows/service-release-vault.yml
@@ -50,6 +50,10 @@ jobs:
 
       - name: Test
         run: pnpm run test
+        env:
+          # See package-release.yml: `--all` on a 4-vCPU runner oversubscribes
+          # at nx's default of 3 projects and trips vitest's per-test timeout.
+          NX_PARALLEL: "1"
 
       - name: Build
         run: pnpm run build

--- a/packages/babylon-ledger-vault-signer/vitest.config.ts
+++ b/packages/babylon-ledger-vault-signer/vitest.config.ts
@@ -5,6 +5,10 @@ export default defineConfig({
     globals: true,
     environment: "node",
     exclude: ["**/node_modules/**", "**/dist/**"],
+    // 5s (vitest's default) is too tight for a suite whose tests dynamically
+    // import heavy mocked packages on a shared CI runner. Raised so a slow
+    // runner reports a slow test rather than a failed one.
+    testTimeout: 20_000,
     // Only with an emulator attached: the e2e files share ONE Speculos device,
     // and an APDU arriving mid-UX-flow answers 0x6901 (sdk `status_words.h:56`).
     // Predicate matches the suites' own skipIf, which treats "" as unset.

--- a/packages/babylon-ledger-vault-signer/vitest.config.ts
+++ b/packages/babylon-ledger-vault-signer/vitest.config.ts
@@ -1,14 +1,13 @@
 import { defineConfig } from "vitest/config";
 
+import { TEST_TIMEOUT_MS } from "../../vitest.shared";
+
 export default defineConfig({
   test: {
     globals: true,
     environment: "node",
     exclude: ["**/node_modules/**", "**/dist/**"],
-    // 5s (vitest's default) is too tight for a suite whose tests dynamically
-    // import heavy mocked packages on a shared CI runner. Raised so a slow
-    // runner reports a slow test rather than a failed one.
-    testTimeout: 20_000,
+    testTimeout: TEST_TIMEOUT_MS,
     // Only with an emulator attached: the e2e files share ONE Speculos device,
     // and an APDU arriving mid-UX-flow answers 0x6901 (sdk `status_words.h:56`).
     // Predicate matches the suites' own skipIf, which treats "" as unset.

--- a/packages/babylon-ts-sdk/vitest.config.ts
+++ b/packages/babylon-ts-sdk/vitest.config.ts
@@ -1,15 +1,14 @@
 import { defineConfig } from "vitest/config";
 
+import { TEST_TIMEOUT_MS } from "../../vitest.shared";
+
 export default defineConfig({
   test: {
     globals: true,
     environment: "node",
     setupFiles: ["./src/test/setup.ts"],
     exclude: ["**/node_modules/**", "**/dist/**"],
-    // 5s (vitest's default) is too tight for a suite whose tests dynamically
-    // import heavy mocked packages on a shared CI runner. Raised so a slow
-    // runner reports a slow test rather than a failed one.
-    testTimeout: 20_000,
+    testTimeout: TEST_TIMEOUT_MS,
     // Use forked processes for test execution to handle WASM initialization properly.
     // WASM loading is stateful - once initialized in a process, it remains loaded.
     // The babylon-tbv-rust-wasm package uses a singleton initWasm() pattern that

--- a/packages/babylon-ts-sdk/vitest.config.ts
+++ b/packages/babylon-ts-sdk/vitest.config.ts
@@ -6,6 +6,10 @@ export default defineConfig({
     environment: "node",
     setupFiles: ["./src/test/setup.ts"],
     exclude: ["**/node_modules/**", "**/dist/**"],
+    // 5s (vitest's default) is too tight for a suite whose tests dynamically
+    // import heavy mocked packages on a shared CI runner. Raised so a slow
+    // runner reports a slow test rather than a failed one.
+    testTimeout: 20_000,
     // Use forked processes for test execution to handle WASM initialization properly.
     // WASM loading is stateful - once initialized in a process, it remains loaded.
     // The babylon-tbv-rust-wasm package uses a singleton initWasm() pattern that

--- a/vitest.shared.ts
+++ b/vitest.shared.ts
@@ -1,0 +1,9 @@
+/**
+ * Per-test timeout shared by the workspace's node-side vitest suites.
+ *
+ * 5s (vitest's default) is too tight for a suite whose tests dynamically import
+ * heavy mocked packages on a shared CI runner. Raised so a slow runner reports
+ * a slow test rather than a failed one. Kept in one place so the suites that
+ * need it cannot drift apart.
+ */
+export const TEST_TIMEOUT_MS = 20_000;


### PR DESCRIPTION
## What

Makes the automated test run that guards every release stop failing for no reason.

## Why

Four releases in the last two days stopped part-way because a test was reported as
failed when nothing was wrong with it. Each time the work had already been approved
and merged, so someone had to notice the red mark and start the release again by
hand. Today that happened to the Bitcoin engine release and it had to be re-run.

The cause is that the release machine is asked to run every part of the project's
test suite at the same time on a small machine. Tests then wait for a free slot
rather than for the thing they are testing, and the clock they are measured against
runs out. It never shows up on a pull request, because a pull request only runs the
tests for the parts that changed.

Nothing was ever wrong with the code being tested.

## How

- Tell the release machine to work through the project one part at a time, so each
  part gets the whole machine. Building and checking still run in parallel.
- Give the two test suites that ran out of time a longer allowance, so a slow
  machine reports a slow test rather than a broken one.

Verified: both suites pass locally at the same counts CI reports, and the three
workflow files parse.
