### PR TITLE
fix(wallet-connector): report AppKit setup errors after commit

### DIFF
--- a/packages/babylon-wallet-connector/src/components/ETHWalletConnectorProvider.tsx
+++ b/packages/babylon-wallet-connector/src/components/ETHWalletConnectorProvider.tsx
@@ -1,4 +1,4 @@
-import { useMemo, type PropsWithChildren, type ReactNode } from "react";
+import { useEffect, useMemo, useRef, type PropsWithChildren, type ReactNode } from "react";
 
 import { WalletDialog } from "@/components/WalletProvider/components/WalletDialog";
 import { ONE_HOUR } from "@/constants";
@@ -61,15 +61,33 @@ export function WalletProvider({
   );
   const storage = useMemo(() => createAccountStorage(ttl, networkMap), [ttl, networkMap]);
 
-  useMemo(() => {
-    if (!appKitConfig) return;
+  const appKitInitializationError = useMemo(() => {
+    if (!appKitConfig) return null;
 
     try {
       initializeAppKitModal(appKitConfig);
+      return null;
     } catch (error) {
-      onError?.(error instanceof Error ? error : new Error("Failed to initialize the Ethereum AppKit modal"));
+      return error instanceof Error
+        ? error
+        : new Error("Failed to initialize the Ethereum AppKit modal", { cause: error });
     }
-  }, [appKitConfig, onError]);
+  }, [appKitConfig]);
+
+  const reportedAppKitError = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!appKitInitializationError) {
+      reportedAppKitError.current = null;
+      return;
+    }
+
+    const errorKey = `${appKitInitializationError.name}:${appKitInitializationError.message}`;
+    if (!onError || reportedAppKitError.current === errorKey) return;
+
+    reportedAppKitError.current = errorKey;
+    onError(appKitInitializationError);
+  }, [appKitInitializationError, onError]);
 
   useAppKitOpenListener();
 

--- a/packages/babylon-wallet-connector/src/components/ETHWalletConnectorProvider.tsx
+++ b/packages/babylon-wallet-connector/src/components/ETHWalletConnectorProvider.tsx
@@ -61,33 +61,35 @@ export function WalletProvider({
   );
   const storage = useMemo(() => createAccountStorage(ttl, networkMap), [ttl, networkMap]);
 
-  const appKitInitializationError = useMemo(() => {
+  const appKitInitializationFailure = useMemo(() => {
     if (!appKitConfig) return null;
 
     try {
       initializeAppKitModal(appKitConfig);
       return null;
     } catch (error) {
-      return error instanceof Error
-        ? error
-        : new Error("Failed to initialize the Ethereum AppKit modal", { cause: error });
+      return {
+        error:
+          error instanceof Error
+            ? error
+            : new Error("Failed to initialize the Ethereum AppKit modal", { cause: error }),
+      };
     }
   }, [appKitConfig]);
 
-  const reportedAppKitError = useRef<string | null>(null);
+  const reportedAppKitFailure = useRef<typeof appKitInitializationFailure>(null);
 
   useEffect(() => {
-    if (!appKitInitializationError) {
-      reportedAppKitError.current = null;
+    if (!appKitInitializationFailure) {
+      reportedAppKitFailure.current = null;
       return;
     }
 
-    const errorKey = `${appKitInitializationError.name}:${appKitInitializationError.message}`;
-    if (!onError || reportedAppKitError.current === errorKey) return;
+    if (!onError || reportedAppKitFailure.current === appKitInitializationFailure) return;
 
-    reportedAppKitError.current = errorKey;
-    onError(appKitInitializationError);
-  }, [appKitInitializationError, onError]);
+    reportedAppKitFailure.current = appKitInitializationFailure;
+    onError(appKitInitializationFailure.error);
+  }, [appKitInitializationFailure, onError]);
 
   useAppKitOpenListener();
 

--- a/packages/babylon-wallet-connector/src/components/WalletProvider/__tests__/index.test.tsx
+++ b/packages/babylon-wallet-connector/src/components/WalletProvider/__tests__/index.test.tsx
@@ -1,0 +1,152 @@
+import { render, screen } from "@testing-library/react";
+import { useState, type ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  initializeEthAppKitModal: vi.fn(),
+  initializeUnifiedAppKitModal: vi.fn(),
+}));
+
+vi.mock("@/core/wallets/appkit/appKitModal", () => ({
+  initializeAppKitModal: mocks.initializeUnifiedAppKitModal,
+}));
+
+vi.mock("@/core/wallets/eth/appkit/modal", () => ({
+  initializeAppKitModal: mocks.initializeEthAppKitModal,
+}));
+
+vi.mock("@/core/storage", () => ({
+  createAccountStorage: vi.fn(() => ({})),
+}));
+
+vi.mock("@/core/wallets", () => ({
+  default: {},
+}));
+
+vi.mock("@/core/wallets/eth", () => ({
+  default: {},
+}));
+
+vi.mock("@/context/Chain.context", () => ({
+  ChainProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/context/LifecycleHooks.context", () => ({
+  LifeCycleHooksProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/context/TomoProvider", () => ({
+  TomoConnectionProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+vi.mock("@/hooks/appkit/useAppKitOpenListener", () => ({
+  useAppKitOpenListener: vi.fn(),
+}));
+
+vi.mock("@/widgets/tomo/BBNConnector", () => ({ TomoBBNConnector: () => null }));
+vi.mock("@/widgets/tomo/BTCConnector", () => ({ TomoBTCConnector: () => null }));
+vi.mock("../components/WalletDialog", () => ({ WalletDialog: () => null }));
+
+import { WalletProvider } from "../index";
+import { WalletProvider as ETHWalletProvider } from "../../ETHWalletConnectorProvider";
+
+const metadata = {
+  name: "Test App",
+  description: "Test AppKit",
+  url: "https://example.com",
+  icons: [],
+};
+
+const ethChain = {
+  id: 11155111,
+  name: "Sepolia",
+  nativeCurrency: { name: "Ether", symbol: "ETH", decimals: 18 },
+  rpcUrls: { default: { http: ["https://rpc.example.com"] } },
+};
+const unifiedAppKitConfig = { projectId: "project", metadata };
+const ethAppKitConfig = { ...unifiedAppKitConfig, eth: { chain: ethChain } };
+
+function ErrorHost({
+  children,
+  enabled = true,
+}: {
+  children: (onError?: (error: Error) => void) => ReactNode;
+  enabled?: boolean;
+}) {
+  const [message, setMessage] = useState("");
+  return (
+    <>
+      {children(enabled ? (error) => setMessage(error.message) : undefined)}
+      <output>{message}</output>
+    </>
+  );
+}
+
+describe("WalletProvider AppKit initialization", () => {
+  beforeEach(() => {
+    mocks.initializeEthAppKitModal.mockReset();
+    mocks.initializeUnifiedAppKitModal.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("reports a unified initialization failure after commit", async () => {
+    const errorMessage = "AppKit capability mismatch";
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    mocks.initializeUnifiedAppKitModal.mockImplementation(() => {
+      throw new Error(errorMessage);
+    });
+
+    render(
+      <ErrorHost>
+        {(onError) => (
+          <WalletProvider config={[]} appKitConfig={{ ...unifiedAppKitConfig }} disableTomo onError={onError}>
+            child
+          </WalletProvider>
+        )}
+      </ErrorHost>,
+    );
+
+    expect(await screen.findByText(errorMessage)).toBeTruthy();
+    expect(mocks.initializeUnifiedAppKitModal).toHaveBeenCalledTimes(2);
+    expect(consoleError).toHaveBeenCalledWith("Failed to initialize AppKit modal:", errorMessage);
+    expect(consoleError).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports an Ethereum-only initialization failure after commit", async () => {
+    const error = new Error("Ethereum AppKit capability mismatch");
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    mocks.initializeEthAppKitModal.mockImplementation(() => {
+      throw error;
+    });
+
+    const view = render(
+      <ErrorHost enabled={false}>
+        {(onError) => (
+          <ETHWalletProvider config={[]} appKitConfig={ethAppKitConfig} onError={onError}>
+            child
+          </ETHWalletProvider>
+        )}
+      </ErrorHost>,
+    );
+
+    expect(mocks.initializeEthAppKitModal).toHaveBeenCalledTimes(1);
+    expect(screen.queryByText(error.message)).toBeNull();
+
+    view.rerender(
+      <ErrorHost>
+        {(onError) => (
+          <ETHWalletProvider config={[]} appKitConfig={ethAppKitConfig} onError={onError}>
+            child
+          </ETHWalletProvider>
+        )}
+      </ErrorHost>,
+    );
+
+    expect(await screen.findByText(error.message)).toBeTruthy();
+    expect(mocks.initializeEthAppKitModal).toHaveBeenCalledTimes(1);
+    expect(consoleError).not.toHaveBeenCalled();
+  });
+});

--- a/packages/babylon-wallet-connector/src/components/WalletProvider/__tests__/index.test.tsx
+++ b/packages/babylon-wallet-connector/src/components/WalletProvider/__tests__/index.test.tsx
@@ -65,6 +65,8 @@ const ethChain = {
 };
 const unifiedAppKitConfig = { projectId: "project", metadata };
 const ethAppKitConfig = { ...unifiedAppKitConfig, eth: { chain: ethChain } };
+const nextUnifiedAppKitConfig = { ...unifiedAppKitConfig, projectId: "next-project" };
+const nextEthAppKitConfig = { ...ethAppKitConfig, projectId: "next-project" };
 
 function ErrorHost({
   children,
@@ -73,11 +75,11 @@ function ErrorHost({
   children: (onError?: (error: Error) => void) => ReactNode;
   enabled?: boolean;
 }) {
-  const [message, setMessage] = useState("");
+  const [messages, setMessages] = useState<string[]>([]);
   return (
     <>
-      {children(enabled ? (error) => setMessage(error.message) : undefined)}
-      <output>{message}</output>
+      {children(enabled ? (error) => setMessages((current) => [...current, error.message]) : undefined)}
+      <output>{messages.join("|")}</output>
     </>
   );
 }
@@ -92,17 +94,17 @@ describe("WalletProvider AppKit initialization", () => {
     vi.restoreAllMocks();
   });
 
-  it("reports a unified initialization failure after commit", async () => {
+  it("reports each unified initialization failure after commit", async () => {
     const errorMessage = "AppKit capability mismatch";
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
     mocks.initializeUnifiedAppKitModal.mockImplementation(() => {
       throw new Error(errorMessage);
     });
 
-    render(
+    const view = render(
       <ErrorHost>
         {(onError) => (
-          <WalletProvider config={[]} appKitConfig={{ ...unifiedAppKitConfig }} disableTomo onError={onError}>
+          <WalletProvider config={[]} appKitConfig={unifiedAppKitConfig} disableTomo onError={onError}>
             child
           </WalletProvider>
         )}
@@ -110,12 +112,26 @@ describe("WalletProvider AppKit initialization", () => {
     );
 
     expect(await screen.findByText(errorMessage)).toBeTruthy();
-    expect(mocks.initializeUnifiedAppKitModal).toHaveBeenCalledTimes(2);
+    expect(mocks.initializeUnifiedAppKitModal).toHaveBeenCalledTimes(1);
     expect(consoleError).toHaveBeenCalledWith("Failed to initialize AppKit modal:", errorMessage);
     expect(consoleError).toHaveBeenCalledTimes(1);
+
+    view.rerender(
+      <ErrorHost>
+        {(onError) => (
+          <WalletProvider config={[]} appKitConfig={nextUnifiedAppKitConfig} disableTomo onError={onError}>
+            child
+          </WalletProvider>
+        )}
+      </ErrorHost>,
+    );
+
+    expect(await screen.findByText(`${errorMessage}|${errorMessage}`)).toBeTruthy();
+    expect(mocks.initializeUnifiedAppKitModal).toHaveBeenCalledTimes(2);
+    expect(consoleError).toHaveBeenCalledTimes(2);
   });
 
-  it("reports an Ethereum-only initialization failure after commit", async () => {
+  it("reports each Ethereum-only initialization failure after commit", async () => {
     const error = new Error("Ethereum AppKit capability mismatch");
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined);
     mocks.initializeEthAppKitModal.mockImplementation(() => {
@@ -148,5 +164,18 @@ describe("WalletProvider AppKit initialization", () => {
     expect(await screen.findByText(error.message)).toBeTruthy();
     expect(mocks.initializeEthAppKitModal).toHaveBeenCalledTimes(1);
     expect(consoleError).not.toHaveBeenCalled();
+
+    view.rerender(
+      <ErrorHost>
+        {(onError) => (
+          <ETHWalletProvider config={[]} appKitConfig={nextEthAppKitConfig} onError={onError}>
+            child
+          </ETHWalletProvider>
+        )}
+      </ErrorHost>,
+    );
+
+    expect(await screen.findByText(`${error.message}|${error.message}`)).toBeTruthy();
+    expect(mocks.initializeEthAppKitModal).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/babylon-wallet-connector/src/components/WalletProvider/index.tsx
+++ b/packages/babylon-wallet-connector/src/components/WalletProvider/index.tsx
@@ -1,4 +1,4 @@
-import { useMemo, type PropsWithChildren, type ReactNode } from "react";
+import { useEffect, useMemo, useRef, type PropsWithChildren, type ReactNode } from "react";
 
 import { ONE_HOUR } from "@/constants";
 import { ChainConfigArr, ChainProvider, type ChainMetadataMap } from "@/context/Chain.context";
@@ -87,19 +87,42 @@ export function WalletProvider({
 
   // Initialize unified AppKit modal synchronously before render (only if config provided)
   // This ensures both wagmi and bitcoin configs are available before children mount
-  useMemo(() => {
+  const appKitInitializationError = useMemo(() => {
     if (!appKitConfig) {
-      return;
+      return null;
     }
 
     try {
       // Initialize AppKit with the unified config
       // Config may have eth and/or btc properties
       initializeAppKitModal(appKitConfig);
+      return null;
     } catch (error) {
-      console.error("Failed to initialize AppKit modal:", error instanceof Error ? error.message : "Unknown error");
+      return error instanceof Error ? error : new Error("Failed to initialize AppKit modal", { cause: error });
     }
   }, [appKitConfig]);
+
+  const reportedAppKitError = useRef<string | null>(null);
+  const loggedAppKitError = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!appKitInitializationError) {
+      reportedAppKitError.current = null;
+      loggedAppKitError.current = null;
+      return;
+    }
+
+    const errorKey = `${appKitInitializationError.name}:${appKitInitializationError.message}`;
+    if (loggedAppKitError.current !== errorKey) {
+      loggedAppKitError.current = errorKey;
+      console.error("Failed to initialize AppKit modal:", appKitInitializationError.message);
+    }
+
+    if (!onError || reportedAppKitError.current === errorKey) return;
+
+    reportedAppKitError.current = errorKey;
+    onError(appKitInitializationError);
+  }, [appKitInitializationError, onError]);
 
 
   // Listen for requests to open the AppKit modal (triggered by connectors)

--- a/packages/babylon-wallet-connector/src/components/WalletProvider/index.tsx
+++ b/packages/babylon-wallet-connector/src/components/WalletProvider/index.tsx
@@ -87,7 +87,7 @@ export function WalletProvider({
 
   // Initialize unified AppKit modal synchronously before render (only if config provided)
   // This ensures both wagmi and bitcoin configs are available before children mount
-  const appKitInitializationError = useMemo(() => {
+  const appKitInitializationFailure = useMemo(() => {
     if (!appKitConfig) {
       return null;
     }
@@ -98,32 +98,32 @@ export function WalletProvider({
       initializeAppKitModal(appKitConfig);
       return null;
     } catch (error) {
-      return error instanceof Error ? error : new Error("Failed to initialize AppKit modal", { cause: error });
+      return {
+        error: error instanceof Error ? error : new Error("Failed to initialize AppKit modal", { cause: error }),
+      };
     }
   }, [appKitConfig]);
 
-  const reportedAppKitError = useRef<string | null>(null);
-  const loggedAppKitError = useRef<string | null>(null);
+  const reportedAppKitFailure = useRef<typeof appKitInitializationFailure>(null);
+  const loggedAppKitFailure = useRef<typeof appKitInitializationFailure>(null);
 
   useEffect(() => {
-    if (!appKitInitializationError) {
-      reportedAppKitError.current = null;
-      loggedAppKitError.current = null;
+    if (!appKitInitializationFailure) {
+      reportedAppKitFailure.current = null;
+      loggedAppKitFailure.current = null;
       return;
     }
 
-    const errorKey = `${appKitInitializationError.name}:${appKitInitializationError.message}`;
-    if (loggedAppKitError.current !== errorKey) {
-      loggedAppKitError.current = errorKey;
-      console.error("Failed to initialize AppKit modal:", appKitInitializationError.message);
+    if (loggedAppKitFailure.current !== appKitInitializationFailure) {
+      loggedAppKitFailure.current = appKitInitializationFailure;
+      console.error("Failed to initialize AppKit modal:", appKitInitializationFailure.error.message);
     }
 
-    if (!onError || reportedAppKitError.current === errorKey) return;
+    if (!onError || reportedAppKitFailure.current === appKitInitializationFailure) return;
 
-    reportedAppKitError.current = errorKey;
-    onError(appKitInitializationError);
-  }, [appKitInitializationError, onError]);
-
+    reportedAppKitFailure.current = appKitInitializationFailure;
+    onError(appKitInitializationFailure.error);
+  }, [appKitInitializationFailure, onError]);
 
   // Listen for requests to open the AppKit modal (triggered by connectors)
   // This hook gracefully handles cases where AppKit is not initialized


### PR DESCRIPTION
## Outcome

The host receives AppKit setup errors after React commits the provider state.

## Change

- Capture setup errors during render.
- Deliver the error after commit.
- Deliver the current error to a handler that is added later.
- Prevent repeated delivery of the same error.

## Safety

- This PR does not change AppKit state or initializer behavior.
- Error callbacks do not run during render.

## Verification

- 2 provider tests pass.
- The wallet connector build passes.
- Focused lint finds no error.
- Focused lint reports one existing `context?: any` warning.

## Links

Tracks #2353. #2353 stays open.
