### PR TITLE
feat(wallet-connector, ledger-vault): make Refund signable on device

### DIFF
--- a/packages/babylon-ledger-vault-signer/src/__tests__/e2e/peginFixture.ts
+++ b/packages/babylon-ledger-vault-signer/src/__tests__/e2e/peginFixture.ts
@@ -478,6 +478,74 @@ export function computePeginSighash(psbtHex: string, fixture: PeginPsbtFixture):
   );
 }
 
+// ---------------------------------------------------------------------------
+// Refund PSBT (#2371) — Leaf 1 spend back to the depositor's BIP-86 address
+// ---------------------------------------------------------------------------
+
+const REFUND_FEE_SATS = 10_000;
+
+export interface RefundPsbtFixture {
+  readonly psbtHex: string;
+  readonly htlcScriptPubKey: Buffer;
+  readonly leaf1Script: Buffer;
+  readonly leaf1Hash: Buffer;
+}
+
+/**
+ * Refund PSBTv0, SDK-shaped (ts-sdk `buildRefundPsbt`): tx v2, locktime 0, ONE
+ * input spending the HTLC at (prepegin_txid, vout 0) via Leaf 1 with
+ * sequence = {@link HTLC_REFUND_TIMELOCK}, ONE output paying the depositor's
+ * own BIP-86 P2TR. Derivation fields are NOT set here — the augmentation under
+ * test ({@link import("../../refundPsbt").augmentPsbtForRefund}) adds them.
+ */
+export function buildRefundPsbtFixture(hashlock: Buffer, prepeginTxidInternal: Buffer): RefundPsbtFixture {
+  const depositor = hexToBuffer(DEPOSITOR_XONLY_HEX);
+  const vp = hexToBuffer(VP_KEY_HEX);
+  const keepers = [hexToBuffer(KEEPER_KEY_HEX)];
+  const challengers = [hexToBuffer(CHALLENGER_KEY_HEX)];
+
+  const leaf0 = htlcLeaf0(depositor, vp, keepers, challengers, hashlock);
+  const leaf1 = htlcLeaf1(depositor, HTLC_REFUND_TIMELOCK);
+  const leaf0Hash = tapLeafHash(TAPSCRIPT_LEAF_VERSION, leaf0);
+  const leaf1Hash = tapLeafHash(TAPSCRIPT_LEAF_VERSION, leaf1);
+  const merkleRoot = tapBranch(leaf0Hash, leaf1Hash);
+  const { parity, xOnly: htlcTweaked } = tweakNums(merkleRoot);
+  const htlcScriptPubKey = Buffer.concat([Buffer.from([0x51, PUSH_32]), htlcTweaked]);
+  // Control block for spending Leaf 1: sibling hash is Leaf 0's hash.
+  const controlBlock = Buffer.concat([Buffer.from([TAPSCRIPT_LEAF_VERSION | parity]), NUMS_XONLY, leaf0Hash]);
+
+  const psbt = new Psbt();
+  psbt.setVersion(2);
+  psbt.setLocktime(0);
+  psbt.addInput({
+    hash: prepeginTxidInternal,
+    index: HTLC_VOUT,
+    sequence: HTLC_REFUND_TIMELOCK,
+    witnessUtxo: { script: htlcScriptPubKey, value: HTLC_VALUE_SATS },
+    tapInternalKey: NUMS_XONLY,
+    tapLeafScript: [{ leafVersion: TAPSCRIPT_LEAF_VERSION, script: leaf1, controlBlock }],
+  });
+  psbt.addOutput({
+    script: payments.p2tr({ internalPubkey: depositor }).output!,
+    value: HTLC_VALUE_SATS - REFUND_FEE_SATS,
+  });
+
+  return { psbtHex: psbt.toHex(), htlcScriptPubKey, leaf1Script: leaf1, leaf1Hash };
+}
+
+/** BIP-341 script-path sighash for the refund's single input at SIGHASH_DEFAULT. */
+export function computeRefundSighash(psbtHex: string, fixture: RefundPsbtFixture): Buffer {
+  const psbt = Psbt.fromHex(psbtHex);
+  const tx = Transaction.fromBuffer(psbt.data.globalMap.unsignedTx.toBuffer());
+  return tx.hashForWitnessV1(
+    0,
+    [fixture.htlcScriptPubKey],
+    [HTLC_VALUE_SATS],
+    Transaction.SIGHASH_DEFAULT,
+    fixture.leaf1Hash,
+  );
+}
+
 /** BIP-340 verification via the package's own ecc backend. */
 export function verifySchnorrSignature(sighash: Buffer, xOnlyKeyHex: string, signature: Uint8Array): boolean {
   return ecc.verifySchnorr(sighash, hexToBuffer(xOnlyKeyHex), signature);

--- a/packages/babylon-ledger-vault-signer/src/__tests__/e2e/speculos.e2e.test.ts
+++ b/packages/babylon-ledger-vault-signer/src/__tests__/e2e/speculos.e2e.test.ts
@@ -47,6 +47,7 @@ import { bip86OutputScript } from "../../expectedSignatures";
 import { augmentPsbtForWalletPolicy, deriveChangeXOnlyHex } from "../../policyPsbt";
 import { bip322ToSpendTxid, buildPopPsbtHex } from "../../popPsbt";
 import { SW_CAP_EXCEEDED } from "../../rawApdu";
+import { augmentPsbtForRefund } from "../../refundPsbt";
 import { signPreparedVaultPsbt, signVaultPsbt, type SignVaultPsbtResult } from "../../signPsbt";
 import { prepareSignPsbt, type PreparedSignPsbt } from "../../signPsbtPrepare";
 import { approveVaultIntent, deriveContextHash } from "../../vaultCommands";
@@ -56,7 +57,9 @@ import {
   buildDepositTerms,
   buildPeginPsbt,
   buildPrePeginPsbt,
+  buildRefundPsbtFixture,
   computePeginSighash,
+  computeRefundSighash,
   DEPOSITOR_PATH,
   DEPOSITOR_XONLY_HEX,
   DERIVE_CONTEXT,
@@ -69,6 +72,7 @@ import {
   verifySchnorrSignature,
   type PeginPsbtFixture,
   type PrePeginPsbtFixture,
+  type RefundPsbtFixture,
 } from "./peginFixture";
 import {
   approveOnScreen,
@@ -759,6 +763,140 @@ describe.skipIf(SPECULOS_URL === "")("Speculos end-to-end vault signing", () => 
             ),
           ).toBe(true);
         }
+      },
+      CEREMONY_TIMEOUT_MS,
+    );
+  });
+
+  describe("(13) standalone Refund (#2371): Leaf 1 back to the depositor, with and without a loaded intent", () => {
+    /** "Sign refund\ntransaction?" is the finish page (`display.c:134-136`); the
+     * review intro is the same words WITHOUT the "?" — target the unique "?". */
+    const REFUND_APPROVAL_TEXT = "transaction?";
+    const REFUND_INPUT = 0;
+    /** A prevout txid the loaded intent does NOT hold — the no-intent discriminator. */
+    const FOREIGN_PREPEGIN_TXID_INTERNAL = Buffer.alloc(32, 0x99);
+    let refund: RefundPsbtFixture | undefined;
+    let augmentedRefundHex: string | undefined;
+    let foreignRefund: RefundPsbtFixture | undefined;
+    let augmentedForeignRefundHex: string | undefined;
+
+    /** Fresh prepare over an augmented refund — prepared objects are single-use. */
+    function prepareAugmentedRefund(psbtHex: string): PreparedSignPsbt {
+      // `signInputIndexes: [0]` mirrors the SDK's script-path sign options.
+      return prepareSignPsbt({
+        psbtHex,
+        depositorXOnlyHex: DEPOSITOR_XONLY_HEX,
+        signInputIndexes: [REFUND_INPUT],
+      });
+    }
+
+    /** One refund ceremony: drive the review screens, then verify the yield far-side. */
+    async function signRefundWithApproval(psbtHex: string, fixture: RefundPsbtFixture): Promise<void> {
+      await waitForIdleScreen();
+      const signPending = signPreparedVaultPsbt(sendRaw, prepareAugmentedRefund(psbtHex), {
+        signal: AbortSignal.timeout(SIGNING_ABORT_MS),
+      });
+      signPending.catch(() => undefined); // handled at the await below
+      const refundScreens = await approveOnScreen(SPECULOS_URL, REFUND_APPROVAL_TEXT);
+      const result = await signPending;
+      console.log(`[speculos-e2e] refund screens: ${refundScreens.join(" || ")}`);
+
+      expect(result.yields).toHaveLength(1);
+      const yielded = result.yields[0];
+      expect(yielded.kind).toBe("tapscript");
+      if (yielded.kind !== "tapscript") throw new Error("stage (13) asserted tapscript");
+      expect(yielded.inputIndex).toBe(REFUND_INPUT);
+      expect(yielded.signerXOnlyHex).toBe(DEPOSITOR_XONLY_HEX);
+      expect(yielded.leafHashHex).toBe(fixture.leaf1Hash.toString("hex"));
+      expect(yielded.signature).toHaveLength(SCHNORR_SIG_BYTES);
+      const sighash = computeRefundSighash(psbtHex, fixture);
+      expect(verifySchnorrSignature(sighash, DEPOSITOR_XONLY_HEX, yielded.signature)).toBe(true);
+      // Merge writes input 0's tapScriptSig for the depositor key over Leaf 1.
+      const merged = Psbt.fromHex(result.signedPsbtHex);
+      const tapScriptSig = merged.data.inputs[REFUND_INPUT].tapScriptSig;
+      expect(tapScriptSig).toHaveLength(1);
+      expect((tapScriptSig ?? [])[0].pubkey.toString("hex")).toBe(DEPOSITOR_XONLY_HEX);
+    }
+
+    it(
+      "builds the SDK-shaped refund and augments it with the two ASYMMETRIC derivation entries",
+      () => {
+        expect(contextRoot, "derive stage must have produced a root").toBeDefined();
+        expect(prePegin, "policy-context stage must have built the Pre-PegIn").toBeDefined();
+        expect(masterFingerprintHex, "policy-context stage must have read the fingerprint").toBeDefined();
+        refund = buildRefundPsbtFixture(
+          vaultHashlock(contextRoot as Uint8Array, HTLC_VOUT),
+          (prePegin as PrePeginPsbtFixture).txidInternal,
+        );
+        augmentedRefundHex = augmentPsbtForRefund({
+          psbtHex: refund.psbtHex,
+          depositorXOnlyHex: DEPOSITOR_XONLY_HEX,
+          masterFingerprintHex: masterFingerprintHex as string,
+          depositorPath: DEPOSITOR_PATH,
+        });
+        // Same refund shape over a prevout the intent does NOT hold: signable
+        // ONLY with no intent loaded — the no-intent proof for the last test.
+        foreignRefund = buildRefundPsbtFixture(
+          vaultHashlock(contextRoot as Uint8Array, HTLC_VOUT),
+          FOREIGN_PREPEGIN_TXID_INTERNAL,
+        );
+        augmentedForeignRefundHex = augmentPsbtForRefund({
+          psbtHex: foreignRefund.psbtHex,
+          depositorXOnlyHex: DEPOSITOR_XONLY_HEX,
+          masterFingerprintHex: masterFingerprintHex as string,
+          depositorPath: DEPOSITOR_PATH,
+        });
+        const augmented = Psbt.fromHex(augmentedRefundHex);
+        // Input 0: the UNTWEAKED depositor key; output 0: the TWEAKED witness
+        // program from the scriptPubKey (`fw:sign_psbt_validate.c:905-950,1005-1057`).
+        expect(augmented.data.inputs[REFUND_INPUT].tapBip32Derivation![0].pubkey.toString("hex")).toBe(
+          DEPOSITOR_XONLY_HEX,
+        );
+        expect(augmented.data.outputs[0].tapBip32Derivation![0].pubkey).toEqual(
+          Buffer.from(augmented.txOutputs[0].script).subarray(P2TR_WITNESS_PROGRAM_OFFSET),
+        );
+      },
+      SANITY_TIMEOUT_MS,
+    );
+
+    it(
+      "signs under the still-loaded intent (same vault): leaf CSV and prevout match the approved terms",
+      async () => {
+        expect(augmentedRefundHex, "refund fixture stage must have augmented the PSBT").toBeDefined();
+        await signRefundWithApproval(augmentedRefundHex as string, refund as RefundPsbtFixture);
+      },
+      CEREMONY_TIMEOUT_MS,
+    );
+
+    it(
+      "the refund left the intent loaded and its caps alone: a Pre-PegIn resubmission still answers SW_CAP_EXCEEDED (which nullifies the session)",
+      async () => {
+        // CAP_EXCEEDED (not a state reject) proves the validator ran under
+        // INTENT_LOADED — the refund ceremony above kept the intent. Its
+        // failure path invalidates the session (`sign_psbt_validate.c:728-730`
+        // @ ff1e1ce17); the foreign-prevout refund below independently proves
+        // the nullification either way.
+        const failure = await signPreparedVaultPsbt(sendRaw, prepareAugmentedPrePegin(), {
+          signal: AbortSignal.timeout(SIGNING_ABORT_MS),
+        }).then(
+          () => null,
+          (error: unknown) => error,
+        );
+        if (!isLedgerDeviceError(failure)) throw new Error("expected a LedgerDeviceError");
+        expect(failure.statusWord).toBe(SW_CAP_EXCEEDED);
+      },
+      SIGNING_TIMEOUT_MS,
+    );
+
+    it(
+      "signs with NO intent loaded — the intent requirement was host-side only (#2371 blocker 1)",
+      async () => {
+        expect(augmentedForeignRefundHex, "refund fixture stage must have augmented the foreign PSBT").toBeDefined();
+        // The discriminator: under INTENT_LOADED the device pins input 0's
+        // prevout to the intent's txid (`sign_psbt_validate.c:1076-1081`) and
+        // would reject this foreign-prevout refund — so this ceremony
+        // completing proves the IDLE/HASH_DERIVED branch (`:898-903`) signed it.
+        await signRefundWithApproval(augmentedForeignRefundHex as string, foreignRefund as RefundPsbtFixture);
       },
       CEREMONY_TIMEOUT_MS,
     );

--- a/packages/babylon-ledger-vault-signer/src/__tests__/e2e/speculos.e2e.test.ts
+++ b/packages/babylon-ledger-vault-signer/src/__tests__/e2e/speculos.e2e.test.ts
@@ -61,6 +61,7 @@ import {
   computePeginSighash,
   computeRefundSighash,
   DEPOSITOR_PATH,
+  HTLC_VALUE_SATS,
   DEPOSITOR_XONLY_HEX,
   DERIVE_CONTEXT,
   HTLC_VOUT,
@@ -780,6 +781,11 @@ describe.skipIf(SPECULOS_URL === "")("Speculos end-to-end vault signing", () => 
     let foreignRefund: RefundPsbtFixture | undefined;
     let augmentedForeignRefundHex: string | undefined;
 
+    /** Satoshis → the device's BTC display string: 8 decimals, trailing zeros trimmed. */
+    function formatSats(sats: number): string {
+      return (sats / 1e8).toFixed(8).replace(/0+$/, "").replace(/\.$/, "");
+    }
+
     /** Fresh prepare over an augmented refund — prepared objects are single-use. */
     function prepareAugmentedRefund(psbtHex: string): PreparedSignPsbt {
       // `signInputIndexes: [0]` mirrors the SDK's script-path sign options.
@@ -800,6 +806,15 @@ describe.skipIf(SPECULOS_URL === "")("Speculos end-to-end vault signing", () => 
       const refundScreens = await approveOnScreen(SPECULOS_URL, REFUND_APPROVAL_TEXT);
       const result = await signPending;
       console.log(`[speculos-e2e] refund screens: ${refundScreens.join(" || ")}`);
+
+      // The review flow is the only control on a no-intent refund: pin that the
+      // reclaimed amount and the implied fee the device computed from the PSBT
+      // actually appeared on-screen (display units: sBTC with trimmed zeros).
+      const psbt = Psbt.fromHex(psbtHex);
+      const outValue = psbt.txOutputs[0].value;
+      const allScreens = refundScreens.join(" || ");
+      expect(allScreens).toContain(formatSats(outValue));
+      expect(allScreens).toContain(formatSats(HTLC_VALUE_SATS - outValue));
 
       expect(result.yields).toHaveLength(1);
       const yielded = result.yields[0];

--- a/packages/babylon-ledger-vault-signer/src/__tests__/refundPsbt.test.ts
+++ b/packages/babylon-ledger-vault-signer/src/__tests__/refundPsbt.test.ts
@@ -18,7 +18,12 @@ import { Buffer } from "buffer";
 import { describe, expect, it } from "vitest";
 
 import { HARDENED } from "../bip86Path";
-import { augmentPsbtForRefund, classifyRefundPsbt, parseRefundLeafScript } from "../refundPsbt";
+import {
+  assertRefundPsbtSignable,
+  augmentPsbtForRefund,
+  classifyRefundPsbt,
+  parseRefundLeafScript,
+} from "../refundPsbt";
 
 initEccLib(ecc);
 
@@ -64,20 +69,25 @@ function buildRefundShapedPsbt(
     leaves?: readonly Buffer[];
     leafVersion?: number;
     outScript?: Buffer;
+    outValue?: number;
     extraOutput?: boolean;
     extraInput?: boolean;
     dropLeaf?: boolean;
+    dropWitnessUtxo?: boolean;
+    version?: number;
+    locktime?: number;
+    sequence?: number;
   } = {},
 ): string {
   const leaf = overrides.leaf ?? refundLeaf(DEPOSITOR_XONLY, PUSH_2016);
   const psbt = new Psbt();
-  psbt.setVersion(2);
-  psbt.setLocktime(0);
+  psbt.setVersion(overrides.version ?? 2);
+  psbt.setLocktime(overrides.locktime ?? 0);
   psbt.addInput({
     hash: PREV_HASH,
     index: 0,
-    sequence: CSV_2016,
-    witnessUtxo: { script: htlcSpk, value: HTLC_VALUE_SATS },
+    sequence: overrides.sequence ?? CSV_2016,
+    ...(overrides.dropWitnessUtxo ? {} : { witnessUtxo: { script: htlcSpk, value: HTLC_VALUE_SATS } }),
     ...(overrides.dropLeaf
       ? {}
       : {
@@ -107,7 +117,7 @@ function buildRefundShapedPsbt(
       tapInternalKey: Buffer.from(NUMS_XONLY, "hex"),
     });
   }
-  psbt.addOutput({ script: overrides.outScript ?? depositorSpk, value: REFUND_VALUE_SATS });
+  psbt.addOutput({ script: overrides.outScript ?? depositorSpk, value: overrides.outValue ?? REFUND_VALUE_SATS });
   if (overrides.extraOutput) {
     psbt.addOutput({ script: depositorSpk, value: 1_000 });
   }
@@ -210,7 +220,7 @@ describe("parseRefundLeafScript (firmware-grammar mirror)", () => {
 describe("classifyRefundPsbt", () => {
   it("classifies a 1-in/1-out PSBT carrying one refund leaf, returning the leaf terms and prevout txid", () => {
     const classified = classifyRefundPsbt(buildRefundShapedPsbt());
-    expect(classified).toEqual({
+    expect(classified).toMatchObject({
       leafKeyHex: DEPOSITOR_XONLY,
       csv: 2016,
       inputTxidInternalHex: PREV_HASH.toString("hex"),
@@ -224,14 +234,78 @@ describe("classifyRefundPsbt", () => {
     ["two TAP_LEAF_SCRIPT entries", { leaves: [refundLeaf(DEPOSITOR_XONLY, PUSH_2016), refundLeaf(FOREIGN_XONLY, PUSH_2016)] }],
     ["a non-refund leaf script", { leaf: Buffer.from([OP_PUSHBYTES_32, ...Buffer.alloc(32, 5), 0xac]) }],
     ["a non-tapscript leaf version", { leafVersion: 0xc2 }],
+    ["a version-1 transaction (the device requires version >= 2)", { version: 1 }],
+    ["a non-zero locktime", { locktime: 1 }],
   ] as const)("returns undefined for %s", (_label, overrides) => {
     expect(classifyRefundPsbt(buildRefundShapedPsbt(overrides))).toBeUndefined();
+  });
+
+  it("carries the sequence, witnessUtxo and output terms the validator pins", () => {
+    const classified = classifyRefundPsbt(buildRefundShapedPsbt());
+    expect(classified?.sequence).toBe(CSV_2016);
+    expect(classified?.witnessUtxo).toEqual({ scriptLength: 34, value: HTLC_VALUE_SATS });
+    expect(classified?.outputScriptHex).toBe(depositorSpk.toString("hex"));
+    expect(classified?.outputValue).toBe(REFUND_VALUE_SATS);
   });
 
   it("returns undefined for malformed hex instead of throwing (error precedence stays with the caller)", () => {
     expect(classifyRefundPsbt("zz")).toBeUndefined();
     expect(classifyRefundPsbt("abcd")).toBeUndefined();
     expect(classifyRefundPsbt("")).toBeUndefined();
+  });
+});
+
+describe("assertRefundPsbtSignable", () => {
+  function classified(overrides: Parameters<typeof buildRefundShapedPsbt>[0] = {}) {
+    const c = classifyRefundPsbt(buildRefundShapedPsbt(overrides));
+    if (c === undefined) throw new Error("fixture must classify as a refund");
+    return c;
+  }
+
+  it("accepts the canonical refund terms", () => {
+    expect(() => assertRefundPsbtSignable(classified())).not.toThrow();
+  });
+
+  it("accepts the device floor exactly (CSV 72)", () => {
+    expect(() =>
+      assertRefundPsbtSignable(classified({ leaf: refundLeaf(DEPOSITOR_XONLY, Buffer.from([0x01, 0x48])), sequence: 72 })),
+    ).not.toThrow();
+  });
+
+  it("rejects a CSV below the device floor of 72", () => {
+    expect(() =>
+      assertRefundPsbtSignable(classified({ leaf: refundLeaf(DEPOSITOR_XONLY, Buffer.from([0x01, 0x47])), sequence: 71 })),
+    ).toThrow(/72/);
+  });
+
+  it("rejects a sequence with the BIP-68 disable flag set", () => {
+    expect(() => assertRefundPsbtSignable(classified({ sequence: 0x80000000 + CSV_2016 }))).toThrow(/sequence/);
+  });
+
+  it("rejects a sequence with the BIP-68 time-based flag set", () => {
+    expect(() => assertRefundPsbtSignable(classified({ sequence: 0x00400000 + CSV_2016 }))).toThrow(/sequence/);
+  });
+
+  it("rejects a sequence that does not encode exactly the leaf CSV", () => {
+    expect(() => assertRefundPsbtSignable(classified({ sequence: 144 }))).toThrow(/sequence/);
+  });
+
+  it("rejects an input without a witnessUtxo", () => {
+    expect(() => assertRefundPsbtSignable(classified({ dropWitnessUtxo: true }))).toThrow(/witnessUtxo/);
+  });
+
+  it("rejects an output value above the HTLC value", () => {
+    expect(() => assertRefundPsbtSignable(classified({ outValue: HTLC_VALUE_SATS + 1 }))).toThrow(/exceed/);
+  });
+
+  it("rejects an output paying a FOREIGN P2TR address — ownership, not just shape", () => {
+    const foreignSpk = payments.p2tr({ internalPubkey: Buffer.from(FOREIGN_XONLY, "hex") }).output!;
+    expect(() => assertRefundPsbtSignable(classified({ outScript: foreignSpk }))).toThrow(/BIP-86/);
+  });
+
+  it("rejects a non-P2TR output", () => {
+    const p2wpkh = Buffer.concat([Buffer.from([0x00, 0x14]), Buffer.alloc(20, 7)]);
+    expect(() => assertRefundPsbtSignable(classified({ outScript: p2wpkh }))).toThrow(/BIP-86/);
   });
 });
 
@@ -273,8 +347,14 @@ describe("augmentPsbtForRefund", () => {
   });
 
   it("throws when the refund leaf key is not the depositor key", () => {
+    // A coherent foreign refund: leaf AND destination belong to the foreign key,
+    // so only the depositor-equality check can be what rejects it.
+    const foreignSpk = payments.p2tr({ internalPubkey: Buffer.from(FOREIGN_XONLY, "hex") }).output!;
     expect(() =>
-      augmentPsbtForRefund({ ...params, psbtHex: buildRefundShapedPsbt({ leaf: refundLeaf(FOREIGN_XONLY, PUSH_2016) }) }),
+      augmentPsbtForRefund({
+        ...params,
+        psbtHex: buildRefundShapedPsbt({ leaf: refundLeaf(FOREIGN_XONLY, PUSH_2016), outScript: foreignSpk }),
+      }),
     ).toThrow(/depositor/);
   });
 
@@ -284,10 +364,10 @@ describe("augmentPsbtForRefund", () => {
     );
   });
 
-  it("throws when output 0 is not P2TR (the device compares against the witness program)", () => {
+  it("runs the signability validator — an unowned output is rejected here too", () => {
     const p2wpkh = Buffer.concat([Buffer.from([0x00, 0x14]), Buffer.alloc(20, 7)]);
     expect(() => augmentPsbtForRefund({ ...params, psbtHex: buildRefundShapedPsbt({ outScript: p2wpkh }) })).toThrow(
-      /P2TR/,
+      /BIP-86/,
     );
   });
 
@@ -305,7 +385,7 @@ describe("augmentPsbtForRefund", () => {
     expect(() =>
       augmentPsbtForRefund({
         ...params,
-        psbtHex: buildRefundShapedPsbt({ leaf: refundLeaf(DEPOSITOR_XONLY, Buffer.from([0x01, 0x47])) }),
+        psbtHex: buildRefundShapedPsbt({ leaf: refundLeaf(DEPOSITOR_XONLY, Buffer.from([0x01, 0x47])), sequence: 71 }),
       }),
     ).toThrow(/72/);
   });
@@ -314,7 +394,7 @@ describe("augmentPsbtForRefund", () => {
     expect(() =>
       augmentPsbtForRefund({
         ...params,
-        psbtHex: buildRefundShapedPsbt({ leaf: refundLeaf(DEPOSITOR_XONLY, Buffer.from([0x01, 0x48])) }),
+        psbtHex: buildRefundShapedPsbt({ leaf: refundLeaf(DEPOSITOR_XONLY, Buffer.from([0x01, 0x48])), sequence: 72 }),
       }),
     ).not.toThrow();
   });

--- a/packages/babylon-ledger-vault-signer/src/__tests__/refundPsbt.test.ts
+++ b/packages/babylon-ledger-vault-signer/src/__tests__/refundPsbt.test.ts
@@ -1,0 +1,321 @@
+/**
+ * Refund-PSBT classification and augmentation (#2371).
+ *
+ * The leaf grammar mirrors the firmware's own parser byte-for-byte —
+ * `fw:sign_psbt_validate_helpers.c:77-148` (`parse_refund_leaf_script`) @
+ * `ff1e1ce17` — so every accept/reject vector here is a firmware-grammar pin,
+ * including the shapes the firmware is deliberately loose about (OP_PUSHDATA1,
+ * a non-minimal positive CScriptNum).
+ */
+
+// @vitest-environment node
+// Same rationale as provider.test.ts: the asmjs ECC backend fails bitcoinjs's
+// verifyEcc fixtures under jsdom but passes under node.
+
+import * as ecc from "@bitcoin-js/tiny-secp256k1-asmjs";
+import { initEccLib, payments, Psbt } from "bitcoinjs-lib";
+import { Buffer } from "buffer";
+import { describe, expect, it } from "vitest";
+
+import { HARDENED } from "../bip86Path";
+import { augmentPsbtForRefund, classifyRefundPsbt, parseRefundLeafScript } from "../refundPsbt";
+
+initEccLib(ecc);
+
+/** BIP-86 test-vector depositor key (same as the provider/e2e fixtures). */
+const DEPOSITOR_XONLY = "dc8d2f9eff0c4f4dbde070a48e330efc908b62a766568d91e658f284b324b878";
+const FOREIGN_XONLY = "cc8a4bc64d897bddc5fbc2f670f7a8ba0b386779106cf1223c6fc5d7cd6fc115";
+/** BIP-341 NUMS point — the HTLC's unspendable internal key. */
+const NUMS_XONLY = "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0";
+const MASTER_FINGERPRINT = "73c5da0a";
+const DEPOSITOR_PATH: readonly number[] = [86 + HARDENED, 1 + HARDENED, 0 + HARDENED, 0, 0];
+
+const OP_PUSHBYTES_32 = 0x20;
+const OP_CHECKSIGVERIFY = 0xad;
+const OP_CSV = 0xb2;
+const TAPSCRIPT_LEAF_VERSION = 0xc0;
+
+/** Minimal CScriptNum push of 2016: `02 e0 07`. */
+const PUSH_2016 = Buffer.from([0x02, 0xe0, 0x07]);
+const CSV_2016 = 2016;
+
+const HTLC_VALUE_SATS = 1_000_000;
+const REFUND_VALUE_SATS = 990_000;
+const PREV_HASH = Buffer.alloc(32, 0x11);
+
+function refundLeaf(keyHex: string, csvPush: Buffer): Buffer {
+  return Buffer.concat([
+    Buffer.from([OP_PUSHBYTES_32]),
+    Buffer.from(keyHex, "hex"),
+    Buffer.from([OP_CHECKSIGVERIFY]),
+    csvPush,
+    Buffer.from([OP_CSV]),
+  ]);
+}
+
+const depositorSpk = payments.p2tr({ internalPubkey: Buffer.from(DEPOSITOR_XONLY, "hex") }).output!;
+/** Any P2TR-shaped previous output — classification never re-derives it. */
+const htlcSpk = Buffer.concat([Buffer.from([0x51, 0x20]), Buffer.alloc(32, 0x22)]);
+const controlBlock = Buffer.concat([Buffer.from([TAPSCRIPT_LEAF_VERSION]), Buffer.from(NUMS_XONLY, "hex")]);
+
+function buildRefundShapedPsbt(
+  overrides: {
+    leaf?: Buffer;
+    leaves?: readonly Buffer[];
+    leafVersion?: number;
+    outScript?: Buffer;
+    extraOutput?: boolean;
+    extraInput?: boolean;
+    dropLeaf?: boolean;
+  } = {},
+): string {
+  const leaf = overrides.leaf ?? refundLeaf(DEPOSITOR_XONLY, PUSH_2016);
+  const psbt = new Psbt();
+  psbt.setVersion(2);
+  psbt.setLocktime(0);
+  psbt.addInput({
+    hash: PREV_HASH,
+    index: 0,
+    sequence: CSV_2016,
+    witnessUtxo: { script: htlcSpk, value: HTLC_VALUE_SATS },
+    ...(overrides.dropLeaf
+      ? {}
+      : {
+          tapLeafScript: (overrides.leaves ?? [leaf]).map((script, i) => {
+            // bip174 requires controlBlock[0]'s version bits to equal leafVersion.
+            const versionedControlBlock = Buffer.concat([
+              Buffer.from([overrides.leafVersion ?? TAPSCRIPT_LEAF_VERSION]),
+              controlBlock.subarray(1),
+            ]);
+            return {
+              leafVersion: overrides.leafVersion ?? TAPSCRIPT_LEAF_VERSION,
+              script,
+              // Distinct per entry — bip174 keys TAP_LEAF_SCRIPT by control block.
+              controlBlock: i === 0 ? versionedControlBlock : Buffer.concat([versionedControlBlock, Buffer.alloc(32, 0x44)]),
+            };
+          }),
+        }),
+    tapInternalKey: Buffer.from(NUMS_XONLY, "hex"),
+  });
+  if (overrides.extraInput) {
+    psbt.addInput({
+      hash: Buffer.alloc(32, 0x33),
+      index: 1,
+      sequence: CSV_2016,
+      witnessUtxo: { script: htlcSpk, value: HTLC_VALUE_SATS },
+      tapLeafScript: [{ leafVersion: TAPSCRIPT_LEAF_VERSION, script: leaf, controlBlock }],
+      tapInternalKey: Buffer.from(NUMS_XONLY, "hex"),
+    });
+  }
+  psbt.addOutput({ script: overrides.outScript ?? depositorSpk, value: REFUND_VALUE_SATS });
+  if (overrides.extraOutput) {
+    psbt.addOutput({ script: depositorSpk, value: 1_000 });
+  }
+  return psbt.toHex();
+}
+
+describe("parseRefundLeafScript (firmware-grammar mirror)", () => {
+  it("parses the canonical leaf: <key32> OP_CHECKSIGVERIFY <2-byte CScriptNum> OP_CSV", () => {
+    const parsed = parseRefundLeafScript(refundLeaf(DEPOSITOR_XONLY, PUSH_2016));
+    expect(parsed).toEqual({ leafKeyHex: DEPOSITOR_XONLY, csv: 2016 });
+  });
+
+  it("parses a 1-byte CScriptNum push (CSV 72, the device floor)", () => {
+    expect(parseRefundLeafScript(refundLeaf(DEPOSITOR_XONLY, Buffer.from([0x01, 0x48])))).toEqual({
+      leafKeyHex: DEPOSITOR_XONLY,
+      csv: 72,
+    });
+  });
+
+  it("parses OP_1..OP_16 with the value in the opcode (firmware accepts them)", () => {
+    expect(parseRefundLeafScript(refundLeaf(DEPOSITOR_XONLY, Buffer.from([0x60])))).toEqual({
+      leafKeyHex: DEPOSITOR_XONLY,
+      csv: 16,
+    });
+  });
+
+  it("parses an OP_PUSHDATA1 CSV push (firmware accepts the non-minimal opcode)", () => {
+    expect(parseRefundLeafScript(refundLeaf(DEPOSITOR_XONLY, Buffer.from([0x4c, 0x02, 0xe0, 0x07])))).toEqual({
+      leafKeyHex: DEPOSITOR_XONLY,
+      csv: 2016,
+    });
+  });
+
+  it("parses a non-minimal positive CScriptNum (trailing zero byte, firmware accepts)", () => {
+    expect(parseRefundLeafScript(refundLeaf(DEPOSITOR_XONLY, Buffer.from([0x02, 0x48, 0x00])))).toEqual({
+      leafKeyHex: DEPOSITOR_XONLY,
+      csv: 72,
+    });
+  });
+
+  it("parses the maximum 4-byte CScriptNum the firmware admits", () => {
+    expect(parseRefundLeafScript(refundLeaf(DEPOSITOR_XONLY, Buffer.from([0x04, 0xff, 0xff, 0xff, 0x7f])))).toEqual({
+      leafKeyHex: DEPOSITOR_XONLY,
+      csv: 0x7fffffff,
+    });
+  });
+
+  it.each([
+    ["OP_0 push", Buffer.from([0x00])],
+    ["OP_1NEGATE push", Buffer.from([0x4f])],
+    ["negative CScriptNum (sign bit set)", Buffer.from([0x01, 0x80])],
+    ["zero CScriptNum", Buffer.from([0x01, 0x00])],
+    ["5-byte CScriptNum", Buffer.from([0x05, 0x01, 0x00, 0x00, 0x00, 0x00])],
+    ["OP_PUSHDATA1 with a 5-byte length", Buffer.from([0x4c, 0x05, 0x01, 0x00, 0x00, 0x00, 0x00])],
+    ["push extending past the script end", Buffer.from([0x04, 0x01])],
+  ])("rejects a %s exactly like the firmware", (_label, csvPush) => {
+    expect(parseRefundLeafScript(refundLeaf(DEPOSITOR_XONLY, csvPush))).toBeUndefined();
+  });
+
+  it("rejects a script that does not start with OP_PUSHBYTES_32", () => {
+    const leaf = refundLeaf(DEPOSITOR_XONLY, PUSH_2016);
+    leaf[0] = 0x21;
+    expect(parseRefundLeafScript(leaf)).toBeUndefined();
+  });
+
+  it("rejects a missing OP_CHECKSIGVERIFY after the key", () => {
+    const leaf = refundLeaf(DEPOSITOR_XONLY, PUSH_2016);
+    leaf[33] = 0xac; // OP_CHECKSIG
+    expect(parseRefundLeafScript(leaf)).toBeUndefined();
+  });
+
+  it("rejects a final opcode other than OP_CHECKSEQUENCEVERIFY", () => {
+    const leaf = refundLeaf(DEPOSITOR_XONLY, PUSH_2016);
+    leaf[leaf.length - 1] = 0xb1; // OP_CLTV
+    expect(parseRefundLeafScript(leaf)).toBeUndefined();
+  });
+
+  it("rejects trailing bytes after OP_CSV (firmware requires exact consumption)", () => {
+    const leaf = Buffer.concat([refundLeaf(DEPOSITOR_XONLY, PUSH_2016), Buffer.from([0x51])]);
+    expect(parseRefundLeafScript(leaf)).toBeUndefined();
+  });
+
+  it("rejects a script below the 36-byte minimum", () => {
+    expect(parseRefundLeafScript(refundLeaf(DEPOSITOR_XONLY, PUSH_2016).subarray(0, 35))).toBeUndefined();
+  });
+
+  it("rejects the NoPayout leaf shape (second key push is 32 bytes, over the CScriptNum cap)", () => {
+    const noPayout = Buffer.concat([
+      Buffer.from([OP_PUSHBYTES_32]),
+      Buffer.from(DEPOSITOR_XONLY, "hex"),
+      Buffer.from([OP_CHECKSIGVERIFY]),
+      Buffer.from([OP_PUSHBYTES_32]),
+      Buffer.from(FOREIGN_XONLY, "hex"),
+      Buffer.from([0xac]), // OP_CHECKSIG
+    ]);
+    expect(parseRefundLeafScript(noPayout)).toBeUndefined();
+  });
+});
+
+describe("classifyRefundPsbt", () => {
+  it("classifies a 1-in/1-out PSBT carrying one refund leaf, returning the leaf terms and prevout txid", () => {
+    const classified = classifyRefundPsbt(buildRefundShapedPsbt());
+    expect(classified).toEqual({
+      leafKeyHex: DEPOSITOR_XONLY,
+      csv: 2016,
+      inputTxidInternalHex: PREV_HASH.toString("hex"),
+    });
+  });
+
+  it.each([
+    ["a second output", { extraOutput: true }],
+    ["a second input", { extraInput: true }],
+    ["no tapLeafScript on the input", { dropLeaf: true }],
+    ["two TAP_LEAF_SCRIPT entries", { leaves: [refundLeaf(DEPOSITOR_XONLY, PUSH_2016), refundLeaf(FOREIGN_XONLY, PUSH_2016)] }],
+    ["a non-refund leaf script", { leaf: Buffer.from([OP_PUSHBYTES_32, ...Buffer.alloc(32, 5), 0xac]) }],
+    ["a non-tapscript leaf version", { leafVersion: 0xc2 }],
+  ] as const)("returns undefined for %s", (_label, overrides) => {
+    expect(classifyRefundPsbt(buildRefundShapedPsbt(overrides))).toBeUndefined();
+  });
+
+  it("returns undefined for malformed hex instead of throwing (error precedence stays with the caller)", () => {
+    expect(classifyRefundPsbt("zz")).toBeUndefined();
+    expect(classifyRefundPsbt("abcd")).toBeUndefined();
+    expect(classifyRefundPsbt("")).toBeUndefined();
+  });
+});
+
+describe("augmentPsbtForRefund", () => {
+  const params = {
+    psbtHex: buildRefundShapedPsbt(),
+    depositorXOnlyHex: DEPOSITOR_XONLY,
+    masterFingerprintHex: MASTER_FINGERPRINT,
+    depositorPath: DEPOSITOR_PATH,
+  };
+
+  it("keys input 0 by the UNTWEAKED depositor key and output 0 by the TWEAKED output key", () => {
+    const augmented = Psbt.fromHex(augmentPsbtForRefund(params));
+
+    const inputDeriv = augmented.data.inputs[0].tapBip32Derivation;
+    expect(inputDeriv).toHaveLength(1);
+    expect(inputDeriv![0].pubkey.toString("hex")).toBe(DEPOSITOR_XONLY);
+    expect(inputDeriv![0].masterFingerprint.toString("hex")).toBe(MASTER_FINGERPRINT);
+    expect(inputDeriv![0].path).toBe("m/86'/1'/0'/0/0");
+    expect(inputDeriv![0].leafHashes).toEqual([]);
+
+    // The asymmetry the device demands (`fw:sign_psbt_validate.c:1005-1057`):
+    // the output entry is keyed by the scriptPubKey's witness program, which
+    // is the BIP-86 TWEAK of the depositor key — never the depositor key itself.
+    const outputDeriv = augmented.data.outputs[0].tapBip32Derivation;
+    expect(outputDeriv).toHaveLength(1);
+    expect(outputDeriv![0].pubkey).toEqual(depositorSpk.subarray(2));
+    expect(outputDeriv![0].pubkey.toString("hex")).not.toBe(DEPOSITOR_XONLY);
+    expect(outputDeriv![0].masterFingerprint.toString("hex")).toBe(MASTER_FINGERPRINT);
+    expect(outputDeriv![0].path).toBe("m/86'/1'/0'/0/0");
+    expect(outputDeriv![0].leafHashes).toEqual([]);
+  });
+
+  it("never touches the unsigned transaction", () => {
+    const augmented = augmentPsbtForRefund(params);
+    const before = Psbt.fromHex(params.psbtHex).data.globalMap.unsignedTx.toBuffer();
+    const after = Psbt.fromHex(augmented).data.globalMap.unsignedTx.toBuffer();
+    expect(after.equals(before)).toBe(true);
+  });
+
+  it("throws when the refund leaf key is not the depositor key", () => {
+    expect(() =>
+      augmentPsbtForRefund({ ...params, psbtHex: buildRefundShapedPsbt({ leaf: refundLeaf(FOREIGN_XONLY, PUSH_2016) }) }),
+    ).toThrow(/depositor/);
+  });
+
+  it("throws on a PSBT that is not refund-shaped", () => {
+    expect(() => augmentPsbtForRefund({ ...params, psbtHex: buildRefundShapedPsbt({ extraOutput: true }) })).toThrow(
+      /refund/,
+    );
+  });
+
+  it("throws when output 0 is not P2TR (the device compares against the witness program)", () => {
+    const p2wpkh = Buffer.concat([Buffer.from([0x00, 0x14]), Buffer.alloc(20, 7)]);
+    expect(() => augmentPsbtForRefund({ ...params, psbtHex: buildRefundShapedPsbt({ outScript: p2wpkh }) })).toThrow(
+      /P2TR/,
+    );
+  });
+
+  it("rejects a malformed depositor path before touching the PSBT", () => {
+    expect(() => augmentPsbtForRefund({ ...params, depositorPath: [86 + HARDENED, 1 + HARDENED, 0 + HARDENED, 0] })).toThrow(
+      /5 levels|depositorPath/,
+    );
+  });
+
+  it("rejects a malformed master fingerprint", () => {
+    expect(() => augmentPsbtForRefund({ ...params, masterFingerprintHex: "73c5da" })).toThrow(/fingerprint/);
+  });
+
+  it("throws on a CSV below the device floor of 72 — the device never signs it in any state", () => {
+    expect(() =>
+      augmentPsbtForRefund({
+        ...params,
+        psbtHex: buildRefundShapedPsbt({ leaf: refundLeaf(DEPOSITOR_XONLY, Buffer.from([0x01, 0x47])) }),
+      }),
+    ).toThrow(/72/);
+  });
+
+  it("accepts the device floor exactly (CSV 72)", () => {
+    expect(() =>
+      augmentPsbtForRefund({
+        ...params,
+        psbtHex: buildRefundShapedPsbt({ leaf: refundLeaf(DEPOSITOR_XONLY, Buffer.from([0x01, 0x48])) }),
+      }),
+    ).not.toThrow();
+  });
+});

--- a/packages/babylon-ledger-vault-signer/src/__tests__/refundPsbt.wasmGrammar.test.ts
+++ b/packages/babylon-ledger-vault-signer/src/__tests__/refundPsbt.wasmGrammar.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Binds the refund-leaf grammar to the REAL WASM builder (PR #2378 review).
+ *
+ * Every other accept-vector is hand-rolled; this is the one place the repo
+ * asserts that the leaf `buildRefundPsbt` actually attaches — WASM's
+ * `getRefundScript()` — parses under the host grammar. If the WASM shape ever
+ * drifts, `classifyRefundPsbt` would silently stop recognising refunds and
+ * every Ledger refund would fail as "no approved intent"; this test makes that
+ * drift a red build instead.
+ *
+ * Imports the WASM package's dist lazily (same boundary as the e2e fixtures);
+ * `@babylonlabs-io/babylon-tbv-rust-wasm` must be built first — already a
+ * prerequisite of this package's test target.
+ */
+
+// @vitest-environment node
+
+import { Buffer } from "buffer";
+import { describe, expect, it } from "vitest";
+
+import { parseRefundLeafScript } from "../refundPsbt";
+
+const DEPOSITOR_XONLY = "dc8d2f9eff0c4f4dbde070a48e330efc908b62a766568d91e658f284b324b878";
+const VP_XONLY = "79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798";
+const KEEPER_XONLY = "25d1dff95105f5253c4022f628a996ad3a0d95fbf21d468a1b33f8c160d8f517";
+const CHALLENGER_XONLY = "2f01e5e15cca351daff3843fb70f3c2f0a1bdd05e5af888a67784ef3e10a2a01";
+const TIMELOCK_REFUND = 144;
+const TX_GRAPH_VERSION = 2;
+
+describe("refund-leaf grammar ↔ WASM builder contract", () => {
+  it("parses the WASM-built refund leaf byte-for-byte", async () => {
+    const { getPrePeginHtlcConnectorInfo } = await import("@babylonlabs-io/babylon-tbv-rust-wasm");
+    const info = await getPrePeginHtlcConnectorInfo({
+      txGraphVersion: TX_GRAPH_VERSION,
+      depositorPubkey: DEPOSITOR_XONLY,
+      vaultProviderPubkey: VP_XONLY,
+      vaultKeeperPubkeys: [KEEPER_XONLY],
+      universalChallengerPubkeys: [CHALLENGER_XONLY],
+      hashlock: "ab".repeat(32),
+      timelockRefund: TIMELOCK_REFUND,
+      network: "signet",
+    });
+    const script = Buffer.from(info.refundScript.replace(/^0x/, ""), "hex");
+    expect(parseRefundLeafScript(script)).toEqual({ leafKeyHex: DEPOSITOR_XONLY, csv: TIMELOCK_REFUND });
+  });
+});

--- a/packages/babylon-ledger-vault-signer/src/index.ts
+++ b/packages/babylon-ledger-vault-signer/src/index.ts
@@ -57,6 +57,7 @@ export {
 } from "./policyPsbt";
 export { buildPopPsbtHex, type BuildPopPsbtParams } from "./popPsbt";
 export {
+  assertRefundPsbtSignable,
   augmentPsbtForRefund,
   classifyRefundPsbt,
   type AugmentPsbtForRefundParams,

--- a/packages/babylon-ledger-vault-signer/src/index.ts
+++ b/packages/babylon-ledger-vault-signer/src/index.ts
@@ -57,6 +57,12 @@ export {
 } from "./policyPsbt";
 export { buildPopPsbtHex, type BuildPopPsbtParams } from "./popPsbt";
 export {
+  augmentPsbtForRefund,
+  classifyRefundPsbt,
+  type AugmentPsbtForRefundParams,
+  type RefundPsbtClassification,
+} from "./refundPsbt";
+export {
   SW_BAD_STATE,
   SW_CAP_EXCEEDED,
   SW_CLA_NOT_SUPPORTED,

--- a/packages/babylon-ledger-vault-signer/src/refundPsbt.ts
+++ b/packages/babylon-ledger-vault-signer/src/refundPsbt.ts
@@ -21,6 +21,7 @@ import { Buffer } from "buffer";
 
 import { assertBip86Path, bip86PathToString } from "./bip86Path";
 import { DEVICE_TIMELOCK_MIN_BLOCKS } from "./deviceCaps";
+import { bip86OutputScript } from "./expectedSignatures";
 
 const X_ONLY_HEX_RE = /^[0-9a-f]{64}$/;
 const MASTER_FINGERPRINT_HEX_RE = /^[0-9a-f]{8}$/;
@@ -50,11 +51,22 @@ const SCRIPT_NUM_SIGN_BIT = 0x80;
 /** `OP_PUSHBYTES_32 ‖ key(32) ‖ OP_CHECKSIGVERIFY ‖ push(1) ‖ OP_CSV` (`fw:…helpers.c:33-34`). */
 const REFUND_SCRIPT_MIN_LEN = 1 + X_ONLY_KEY_BYTES + 1 + 1 + 1;
 
-/** P2TR scriptPubKey: OP_1 ‖ push-32 ‖ witness program(32) (BIP-341). */
-const P2TR_SCRIPT_BYTES = 34;
-const P2TR_OP_1 = 0x51;
-const P2TR_PUSH_32 = 0x20;
+/** P2TR scriptPubKey: OP_1 ‖ push-32 ‖ witness program(32); program starts here. */
 const P2TR_WITNESS_PROGRAM_OFFSET = 2;
+/** The device requires the refund's witnessUtxo scriptPubKey to be exactly this
+ * long — `VAULT_P2TR_SCRIPTPUBKEY_LEN` (`fw:sign_psbt_validate.c:836-854`). */
+const P2TR_SCRIPT_BYTES = 34;
+
+// BIP-68 sequence semantics the device pins on the refund input
+// (`fw:sign_psbt_validate.c:956-979`; values from `fw:vault_constants.h:126-128`).
+const BIP68_DISABLE_FLAG = 0x80000000;
+const BIP68_TIME_BASED_FLAG = 0x00400000;
+const BIP68_SEQUENCE_MASK = 0x0000ffff;
+
+/** Refund transactions are v2 with locktime 0 (`fw:sign_psbt_validate.c:806-809`);
+ * version 0 never even reaches refund dispatch — it routes to PoP (`:3551`). */
+const MIN_REFUND_TX_VERSION = 2;
+const REFUND_TX_LOCKTIME = 0;
 
 /** The terms a refund leaf commits to: signer key and CSV timelock. */
 export interface RefundLeafTerms {
@@ -69,6 +81,13 @@ export interface RefundLeafTerms {
  * OP_PUSHDATA1 and a non-minimal positive CScriptNum are accepted, because a
  * host grammar stricter than the device's would strand a refund the device
  * would sign. Returns `undefined` where the firmware returns false.
+ *
+ * NOTE: the device's DISPATCH is looser still — it routes any conforming
+ * prefix whose last byte is `OP_CSV` to the refund validator
+ * (`fw:sign_psbt_validate.c:3643-3691`) and only then runs this grammar. Using
+ * the full grammar for host classification (see {@link classifyRefundPsbt}) is
+ * the deliberate, fail-safe divergence: under-classification falls back to
+ * requiring an approved intent.
  */
 export function parseRefundLeafScript(script: Uint8Array): RefundLeafTerms | undefined {
   if (script.length < REFUND_SCRIPT_MIN_LEN) return undefined;
@@ -111,20 +130,38 @@ export function parseRefundLeafScript(script: Uint8Array): RefundLeafTerms | und
   return { leafKeyHex, csv };
 }
 
-/** What {@link classifyRefundPsbt} pins: the leaf terms plus input 0's prevout. */
+/** What {@link classifyRefundPsbt} pins: the leaf terms plus every transaction
+ * field the device validates on the refund path. */
 export interface RefundPsbtClassification extends RefundLeafTerms {
   /** Input 0's previous txid in INTERNAL byte order (lowercase hex) — the
    * order the device compares against the loaded intent's `prepegin_txid`
    * (`fw:sign_psbt_validate.c:1076-1081`). */
   readonly inputTxidInternalHex: string;
+  /** Input 0's nSequence as encoded in the unsigned transaction. */
+  readonly sequence: number;
+  /** Input 0's witnessUtxo terms, when the map carries one. */
+  readonly witnessUtxo: { readonly scriptLength: number; readonly value: number } | undefined;
+  /** Output 0's scriptPubKey (lowercase hex). */
+  readonly outputScriptHex: string;
+  readonly outputValue: number;
 }
 
 /**
  * Classify a PSBT as a standalone refund from the PROVIDER'S OWN PARSE —
- * never from a caller flag: exactly 1 input and 1 output, and input 0 carries
- * exactly one tapscript leaf matching the firmware's refund grammar. Anything
- * else — including hex that does not parse — returns `undefined`, so the
- * caller's ordinary gates keep their error precedence.
+ * never from a caller flag: version ≥ 2 with locktime 0, exactly 1 input and
+ * 1 output, and input 0 carrying exactly one tapscript leaf matching the
+ * firmware's refund grammar. Anything else — including hex that does not
+ * parse — returns `undefined`, so the caller's ordinary gates keep their
+ * error precedence.
+ *
+ * DELIBERATELY a strict subset of the device's own routing: the firmware
+ * dispatches on the leaf's shape prefix and terminal `OP_CSV` byte alone
+ * (`fw:sign_psbt_validate.c:3643-3691`) and only then validates the full
+ * grammar, version and locktime inside the refund validator. Host
+ * under-classification is the fail-safe direction — an unrecognised PSBT
+ * falls back to requiring an approved intent, so neither the intent gate nor
+ * the replay guard can be waived for something the device would not treat as
+ * a conforming refund.
  */
 export function classifyRefundPsbt(psbtHex: string): RefundPsbtClassification | undefined {
   let psbt: Psbt;
@@ -133,13 +170,66 @@ export function classifyRefundPsbt(psbtHex: string): RefundPsbtClassification | 
   } catch {
     return undefined;
   }
+  if (psbt.version < MIN_REFUND_TX_VERSION || psbt.locktime !== REFUND_TX_LOCKTIME) return undefined;
   if (psbt.data.inputs.length !== 1 || psbt.data.outputs.length !== 1) return undefined;
-  const leaves = psbt.data.inputs[0].tapLeafScript ?? [];
+  const input = psbt.data.inputs[0];
+  const leaves = input.tapLeafScript ?? [];
   if (leaves.length !== 1) return undefined;
   if (leaves[0].leafVersion !== TAPSCRIPT_LEAF_VERSION) return undefined;
   const terms = parseRefundLeafScript(leaves[0].script);
   if (terms === undefined) return undefined;
-  return { ...terms, inputTxidInternalHex: Buffer.from(psbt.txInputs[0].hash).toString("hex") };
+  return {
+    ...terms,
+    inputTxidInternalHex: Buffer.from(psbt.txInputs[0].hash).toString("hex"),
+    sequence: psbt.txInputs[0].sequence ?? 0,
+    witnessUtxo: input.witnessUtxo
+      ? { scriptLength: input.witnessUtxo.script.length, value: input.witnessUtxo.value }
+      : undefined,
+    outputScriptHex: Buffer.from(psbt.txOutputs[0].script).toString("hex"),
+    outputValue: psbt.txOutputs[0].value,
+  };
+}
+
+/**
+ * Pure signability pins for a classified refund — every term the device
+ * validates that needs NO device data, so a caller can reject before any
+ * device I/O (not even a liveness probe). Mirrors, in order: the witnessUtxo
+ * requirement (`fw:sign_psbt_validate.c:836-854`), the output-value cap
+ * (`:1059-1062`), destination ownership (the device derives, BIP-86-tweaks
+ * and compares — `:1005-1057`; host-side the leaf key is the derivation
+ * anchor, so the output must pay ITS BIP-86 address), the no-intent CSV floor
+ * (`:898-903`, `vault_constants.h:103`), and the BIP-68 sequence pins
+ * (`:956-979` — present, flags clear, low bits encoding exactly the CSV).
+ */
+export function assertRefundPsbtSignable(refund: RefundPsbtClassification): void {
+  if (refund.witnessUtxo === undefined || refund.witnessUtxo.scriptLength !== P2TR_SCRIPT_BYTES) {
+    throw new Error(
+      "refund input must carry a P2TR witnessUtxo — the device rejects a missing or non-34-byte scriptPubKey",
+    );
+  }
+  if (refund.outputValue > refund.witnessUtxo.value) {
+    throw new Error(
+      `refund output value ${refund.outputValue} exceeds the HTLC value ${refund.witnessUtxo.value} — the device rejects it`,
+    );
+  }
+  if (refund.outputScriptHex !== bip86OutputScript(refund.leafKeyHex).toString("hex")) {
+    throw new Error("refund output does not pay the refund leaf key's own BIP-86 address");
+  }
+  if (refund.csv < DEVICE_TIMELOCK_MIN_BLOCKS) {
+    throw new Error(
+      `refund leaf CSV ${refund.csv} is below the device's timelock floor of ${DEVICE_TIMELOCK_MIN_BLOCKS} blocks`,
+    );
+  }
+  if ((refund.sequence & BIP68_DISABLE_FLAG) !== 0 || (refund.sequence & BIP68_TIME_BASED_FLAG) !== 0) {
+    throw new Error(
+      "refund input sequence must be a plain block-count relative timelock (BIP-68 disable/time flags clear)",
+    );
+  }
+  if ((refund.sequence & BIP68_SEQUENCE_MASK) !== (refund.csv & BIP68_SEQUENCE_MASK)) {
+    throw new Error(
+      `refund input sequence ${refund.sequence} must encode exactly the leaf CSV ${refund.csv} — a mismatch signs but can never broadcast`,
+    );
+  }
 }
 
 export interface AugmentPsbtForRefundParams {
@@ -173,26 +263,13 @@ export function augmentPsbtForRefund(params: AugmentPsbtForRefundParams): string
   if (classified === undefined) {
     throw new Error("not a refund-shaped PSBT (expected 1 input, 1 output, and one refund tapscript leaf)");
   }
+  assertRefundPsbtSignable(classified);
   if (classified.leafKeyHex !== depositorXOnlyHex) {
     throw new Error("refund leaf key does not equal the depositor key — this device cannot sign this refund");
   }
-  // The device never signs a refund below this floor in any state
-  // (`fw:sign_psbt_validate.c:898-903`, IDLE/HASH_DERIVED branch;
-  // `vault_constants.h:103`) — pre-empt its opaque SW_INCORRECT_DATA.
-  if (classified.csv < DEVICE_TIMELOCK_MIN_BLOCKS) {
-    throw new Error(
-      `refund leaf CSV ${classified.csv} is below the device's timelock floor of ${DEVICE_TIMELOCK_MIN_BLOCKS} blocks`,
-    );
-  }
   const psbt = Psbt.fromHex(psbtHex);
+  // Validated by {@link assertRefundPsbtSignable}: the depositor's own BIP-86 P2TR.
   const outScript = Buffer.from(psbt.txOutputs[0].script);
-  if (
-    outScript.length !== P2TR_SCRIPT_BYTES ||
-    outScript[0] !== P2TR_OP_1 ||
-    outScript[1] !== P2TR_PUSH_32
-  ) {
-    throw new Error("refund output is not P2TR — the device compares its derivation entry against the witness program");
-  }
   const masterFingerprint = Buffer.from(masterFingerprintHex, "hex");
   const path = bip86PathToString(depositorPath);
   psbt.updateInput(0, {

--- a/packages/babylon-ledger-vault-signer/src/refundPsbt.ts
+++ b/packages/babylon-ledger-vault-signer/src/refundPsbt.ts
@@ -1,0 +1,224 @@
+/**
+ * Refund-PSBT classification and derivation-field augmentation (#2371).
+ *
+ * The device signs a standalone refund from ANY vault state — the intent
+ * requirement is host-side only — but it demands two TAP_BIP32_DERIVATION
+ * entries the SDK builder does not set, keyed ASYMMETRICALLY: input 0 by the
+ * untweaked depositor key inside the refund leaf (derived and compared
+ * directly), output 0 by the BIP-86 TWEAKED key — the scriptPubKey's witness
+ * program (derived, tweaked, then compared).
+ *
+ * Firmware citations: `fw:` = LedgerHQ/app-babylon-vault @ `ff1e1ce17`
+ * (`fix/feedback`, v0.10.0). Leaf grammar: `fw:sign_psbt_validate_helpers.c:77-148`
+ * (`parse_refund_leaf_script`); input entry: `fw:sign_psbt_validate.c:905-950`;
+ * output entry: `fw:sign_psbt_validate.c:1005-1057`; both entries are REQUIRED —
+ * a missing lookup rejects with SW_INCORRECT_DATA.
+ *
+ * @module ledger-vault-signer/refundPsbt
+ */
+import { Psbt } from "bitcoinjs-lib";
+import { Buffer } from "buffer";
+
+import { assertBip86Path, bip86PathToString } from "./bip86Path";
+import { DEVICE_TIMELOCK_MIN_BLOCKS } from "./deviceCaps";
+
+const X_ONLY_HEX_RE = /^[0-9a-f]{64}$/;
+const MASTER_FINGERPRINT_HEX_RE = /^[0-9a-f]{8}$/;
+
+/** BIP-341 tapscript leaf version — the only one the vault builders emit. */
+const TAPSCRIPT_LEAF_VERSION = 0xc0;
+const X_ONLY_KEY_BYTES = 32;
+
+// Script opcodes the firmware parser dispatches on
+// (`fw:sign_psbt_validate_helpers.c:104-139`).
+const OP_0 = 0x00;
+const OP_PUSHBYTES_1 = 0x01;
+const OP_PUSHBYTES_32 = 0x20;
+const OP_PUSHBYTES_75 = 0x4b;
+const OP_PUSHDATA1 = 0x4c;
+const OP_1NEGATE = 0x4f;
+const OP_RESERVED = 0x50;
+const OP_1 = 0x51;
+const OP_16 = 0x60;
+const OP_CHECKSIGVERIFY = 0xad;
+const OP_CHECKSEQUENCEVERIFY = 0xb2;
+
+/** CScriptNum caps, per the firmware (`fw:sign_psbt_validate_helpers.c:28-30`). */
+const SCRIPT_NUM_MAX_LEN = 4;
+const SCRIPT_NUM_SIGN_BIT = 0x80;
+
+/** `OP_PUSHBYTES_32 ‖ key(32) ‖ OP_CHECKSIGVERIFY ‖ push(1) ‖ OP_CSV` (`fw:…helpers.c:33-34`). */
+const REFUND_SCRIPT_MIN_LEN = 1 + X_ONLY_KEY_BYTES + 1 + 1 + 1;
+
+/** P2TR scriptPubKey: OP_1 ‖ push-32 ‖ witness program(32) (BIP-341). */
+const P2TR_SCRIPT_BYTES = 34;
+const P2TR_OP_1 = 0x51;
+const P2TR_PUSH_32 = 0x20;
+const P2TR_WITNESS_PROGRAM_OFFSET = 2;
+
+/** The terms a refund leaf commits to: signer key and CSV timelock. */
+export interface RefundLeafTerms {
+  /** UNTWEAKED x-only key inside the leaf (lowercase hex). */
+  readonly leafKeyHex: string;
+  readonly csv: number;
+}
+
+/**
+ * Byte-for-byte mirror of the firmware's refund-leaf parser
+ * (`fw:sign_psbt_validate_helpers.c:77-148`) — deliberately EXACTLY as loose:
+ * OP_PUSHDATA1 and a non-minimal positive CScriptNum are accepted, because a
+ * host grammar stricter than the device's would strand a refund the device
+ * would sign. Returns `undefined` where the firmware returns false.
+ */
+export function parseRefundLeafScript(script: Uint8Array): RefundLeafTerms | undefined {
+  if (script.length < REFUND_SCRIPT_MIN_LEN) return undefined;
+  let pos = 0;
+  if (script[pos++] !== OP_PUSHBYTES_32) return undefined;
+  const leafKeyHex = Buffer.from(script.subarray(pos, pos + X_ONLY_KEY_BYTES)).toString("hex");
+  pos += X_ONLY_KEY_BYTES;
+  if (script[pos++] !== OP_CHECKSIGVERIFY) return undefined;
+
+  if (pos >= script.length) return undefined;
+  const pushOp = script[pos++];
+  let csv = 0;
+  if (pushOp === OP_0 || pushOp === OP_1NEGATE) {
+    return undefined; // not a positive timelock
+  } else if (pushOp >= OP_PUSHBYTES_1 && pushOp <= OP_PUSHBYTES_75) {
+    const dataLen = pushOp;
+    if (dataLen > SCRIPT_NUM_MAX_LEN || pos + dataLen > script.length) return undefined;
+    if ((script[pos + dataLen - 1] & SCRIPT_NUM_SIGN_BIT) !== 0) return undefined; // negative
+    for (let i = 0; i < dataLen; i++) csv |= script[pos + i] << (8 * i);
+    pos += dataLen;
+  } else if (pushOp === OP_PUSHDATA1) {
+    if (pos >= script.length) return undefined;
+    const dataLen = script[pos++];
+    if (dataLen > SCRIPT_NUM_MAX_LEN || pos + dataLen > script.length) return undefined;
+    if ((script[pos + dataLen - 1] & SCRIPT_NUM_SIGN_BIT) !== 0) return undefined; // negative
+    for (let i = 0; i < dataLen; i++) csv |= script[pos + i] << (8 * i);
+    pos += dataLen;
+  } else if (pushOp >= OP_1 && pushOp <= OP_16) {
+    csv = pushOp - OP_RESERVED;
+  } else {
+    return undefined;
+  }
+  // The sign-bit rejections above cap csv at 0x7fffffff — no uint32 wrap.
+  if (csv === 0) return undefined;
+
+  if (pos >= script.length) return undefined;
+  if (script[pos++] !== OP_CHECKSEQUENCEVERIFY) return undefined;
+  if (pos !== script.length) return undefined; // exact consumption
+
+  return { leafKeyHex, csv };
+}
+
+/** What {@link classifyRefundPsbt} pins: the leaf terms plus input 0's prevout. */
+export interface RefundPsbtClassification extends RefundLeafTerms {
+  /** Input 0's previous txid in INTERNAL byte order (lowercase hex) — the
+   * order the device compares against the loaded intent's `prepegin_txid`
+   * (`fw:sign_psbt_validate.c:1076-1081`). */
+  readonly inputTxidInternalHex: string;
+}
+
+/**
+ * Classify a PSBT as a standalone refund from the PROVIDER'S OWN PARSE —
+ * never from a caller flag: exactly 1 input and 1 output, and input 0 carries
+ * exactly one tapscript leaf matching the firmware's refund grammar. Anything
+ * else — including hex that does not parse — returns `undefined`, so the
+ * caller's ordinary gates keep their error precedence.
+ */
+export function classifyRefundPsbt(psbtHex: string): RefundPsbtClassification | undefined {
+  let psbt: Psbt;
+  try {
+    psbt = Psbt.fromHex(psbtHex);
+  } catch {
+    return undefined;
+  }
+  if (psbt.data.inputs.length !== 1 || psbt.data.outputs.length !== 1) return undefined;
+  const leaves = psbt.data.inputs[0].tapLeafScript ?? [];
+  if (leaves.length !== 1) return undefined;
+  if (leaves[0].leafVersion !== TAPSCRIPT_LEAF_VERSION) return undefined;
+  const terms = parseRefundLeafScript(leaves[0].script);
+  if (terms === undefined) return undefined;
+  return { ...terms, inputTxidInternalHex: Buffer.from(psbt.txInputs[0].hash).toString("hex") };
+}
+
+export interface AugmentPsbtForRefundParams {
+  readonly psbtHex: string;
+  /** The connected device's depositor x-only key (64 lowercase hex). */
+  readonly depositorXOnlyHex: string;
+  /** The device's master fingerprint (8 lowercase hex) — both entries carry it. */
+  readonly masterFingerprintHex: string;
+  /** The depositor's 5-level BIP-86 path — both entries carry it. */
+  readonly depositorPath: readonly number[];
+}
+
+/**
+ * Add the two TAP_BIP32_DERIVATION entries the device requires on a refund.
+ * Re-classifies internally and requires the leaf key to be the depositor's —
+ * augmenting anything that is not this device's refund is a caller bug, not a
+ * shape to paper over. `leafHashes: []` is fine: the device's value parser
+ * skips the hashes (`fw:sign_psbt_validate_helpers.c:58-63`). Never touches
+ * the unsigned transaction.
+ */
+export function augmentPsbtForRefund(params: AugmentPsbtForRefundParams): string {
+  const { psbtHex, depositorXOnlyHex, masterFingerprintHex, depositorPath } = params;
+  if (!X_ONLY_HEX_RE.test(depositorXOnlyHex)) {
+    throw new Error("depositorXOnlyHex must be 64 lowercase hex characters");
+  }
+  if (!MASTER_FINGERPRINT_HEX_RE.test(masterFingerprintHex)) {
+    throw new Error("masterFingerprintHex must be 8 lowercase hex characters (the 4-byte master fingerprint)");
+  }
+  assertBip86Path("depositorPath", depositorPath);
+  const classified = classifyRefundPsbt(psbtHex);
+  if (classified === undefined) {
+    throw new Error("not a refund-shaped PSBT (expected 1 input, 1 output, and one refund tapscript leaf)");
+  }
+  if (classified.leafKeyHex !== depositorXOnlyHex) {
+    throw new Error("refund leaf key does not equal the depositor key — this device cannot sign this refund");
+  }
+  // The device never signs a refund below this floor in any state
+  // (`fw:sign_psbt_validate.c:898-903`, IDLE/HASH_DERIVED branch;
+  // `vault_constants.h:103`) — pre-empt its opaque SW_INCORRECT_DATA.
+  if (classified.csv < DEVICE_TIMELOCK_MIN_BLOCKS) {
+    throw new Error(
+      `refund leaf CSV ${classified.csv} is below the device's timelock floor of ${DEVICE_TIMELOCK_MIN_BLOCKS} blocks`,
+    );
+  }
+  const psbt = Psbt.fromHex(psbtHex);
+  const outScript = Buffer.from(psbt.txOutputs[0].script);
+  if (
+    outScript.length !== P2TR_SCRIPT_BYTES ||
+    outScript[0] !== P2TR_OP_1 ||
+    outScript[1] !== P2TR_PUSH_32
+  ) {
+    throw new Error("refund output is not P2TR — the device compares its derivation entry against the witness program");
+  }
+  const masterFingerprint = Buffer.from(masterFingerprintHex, "hex");
+  const path = bip86PathToString(depositorPath);
+  psbt.updateInput(0, {
+    tapBip32Derivation: [
+      {
+        masterFingerprint,
+        pubkey: Buffer.from(depositorXOnlyHex, "hex"),
+        path,
+        leafHashes: [],
+      },
+    ],
+  });
+  psbt.updateOutput(0, {
+    tapBip32Derivation: [
+      {
+        masterFingerprint,
+        // The BIP-86 TWEAKED key, verbatim from the scriptPubKey — the device
+        // looks the entry up by these exact bytes, then derives at `path`,
+        // applies the BIP-86 tweak and compares (`fw:sign_psbt_validate.c:1005-1057`).
+        // BIP-371 permits the output key as the map key ("It may be the output
+        // key, the internal key, or a key present in a leaf script").
+        pubkey: outScript.subarray(P2TR_WITNESS_PROGRAM_OFFSET),
+        path,
+        leafHashes: [],
+      },
+    ],
+  });
+  return psbt.toHex();
+}

--- a/packages/babylon-ts-sdk/docs/api/primitives.md
+++ b/packages/babylon-ts-sdk/docs/api/primitives.md
@@ -2669,7 +2669,9 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/refund.ts](htt
 Build a PSBT for signing the refund transaction.
 
 The refund transaction spends the Pre-PegIn HTLC output via leaf 1
-(the refund script: `<timelockRefund> CSV DROP <depositorPubkey> CHECKSIG`).
+(the refund script: `<depositorPubkey> OP_CHECKSIGVERIFY <timelockRefund>
+OP_CHECKSEQUENCEVERIFY` — btc-vault `connectors/prepegin_htlc.rs`
+`generate_refund_script`).
 The PSBT includes the tapLeafScript entry so the depositor's wallet can
 sign using Taproot script-path spending.
 

--- a/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/refund.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/refund.ts
@@ -57,7 +57,9 @@ export interface BuildRefundPsbtResult {
  * Build a PSBT for signing the refund transaction.
  *
  * The refund transaction spends the Pre-PegIn HTLC output via leaf 1
- * (the refund script: `<timelockRefund> CSV DROP <depositorPubkey> CHECKSIG`).
+ * (the refund script: `<depositorPubkey> OP_CHECKSIGVERIFY <timelockRefund>
+ * OP_CHECKSEQUENCEVERIFY` — btc-vault `connectors/prepegin_htlc.rs`
+ * `generate_refund_script`).
  * The PSBT includes the tapLeafScript entry so the depositor's wallet can
  * sign using Taproot script-path spending.
  *

--- a/packages/babylon-wallet-connector/src/core/wallets/btc/ledger-vault/__tests__/provider.test.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/ledger-vault/__tests__/provider.test.ts
@@ -1378,6 +1378,164 @@ describe("LedgerVaultProvider", () => {
     });
   });
 
+  describe("standalone refund (#2371)", () => {
+    const NUMS_XONLY_HEX = "50929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac0";
+    const OP_CHECKSIGVERIFY = 0xad;
+    const OP_CSV = 0xb2;
+    const LEAF_VERSION = 0xc0;
+    /** Internal-order prevout of {@link TERMS}'s Pre-PegIn — the loaded intent's vault. */
+    const INTENT_TXID_INTERNAL = Buffer.from(TERMS.prepeginTxid, "hex").reverse();
+
+    /** Minimal positive CScriptNum push (opcode-length form, like the WASM builder emits). */
+    function csvPush(value: number): Buffer {
+      const bytes: number[] = [];
+      for (let v = value; v > 0; v >>= 8) bytes.push(v & 0xff);
+      if ((bytes[bytes.length - 1] & 0x80) !== 0) bytes.push(0);
+      return Buffer.from([bytes.length, ...bytes]);
+    }
+
+    /** SDK-shaped refund PSBT: 1-in (refund leaf, NUMS internal key), 1-out (depositor BIP-86). */
+    function refundPsbtHex(
+      overrides: { leafKeyHex?: string; csv?: number; prevHashInternal?: Buffer } = {},
+    ): string {
+      initEccLib(ecc);
+      const leafKeyHex = overrides.leafKeyHex ?? DEVICE_XONLY;
+      const csv = overrides.csv ?? TERMS.timelockRefund;
+      const leaf = Buffer.concat([
+        Buffer.from([0x20]),
+        Buffer.from(leafKeyHex, "hex"),
+        Buffer.from([OP_CHECKSIGVERIFY]),
+        csvPush(csv),
+        Buffer.from([OP_CSV]),
+      ]);
+      const nums = Buffer.from(NUMS_XONLY_HEX, "hex");
+      const psbt = new Psbt();
+      psbt.setVersion(2);
+      psbt.setLocktime(0);
+      psbt.addInput({
+        hash: overrides.prevHashInternal ?? INTENT_TXID_INTERNAL,
+        index: 0,
+        sequence: csv,
+        witnessUtxo: { script: Buffer.concat([Buffer.from([0x51, 0x20]), Buffer.alloc(32, 0x22)]), value: 1_000_000 },
+        tapLeafScript: [
+          { leafVersion: LEAF_VERSION, script: leaf, controlBlock: Buffer.concat([Buffer.from([LEAF_VERSION]), nums]) },
+        ],
+        tapInternalKey: nums,
+      });
+      psbt.addOutput({
+        script: payments.p2tr({ internalPubkey: Buffer.from(DEVICE_XONLY, "hex") }).output!,
+        value: 990_000,
+      });
+      return psbt.toHex();
+    }
+
+    async function approved() {
+      const provider = await derived();
+      await provider.approveDepositTerms(TERMS);
+      return provider;
+    }
+
+    it("signs a standalone refund with NO approved intent — the device accepts a no-intent refund", async () => {
+      const provider = await connected();
+
+      const hex = refundPsbtHex();
+      await expect(provider.signPsbt(hex)).resolves.toMatch(/^signed:/);
+      expect(signMock.signPreparedVaultPsbt).toHaveBeenCalledTimes(1);
+    });
+
+    it("stages the AUGMENTED hex: input 0 keyed by the untweaked depositor key, output 0 by the tweaked output key", async () => {
+      const provider = await connected();
+
+      await provider.signPsbt(refundPsbtHex());
+
+      const staged = Psbt.fromHex(signMock.prepareSignPsbt.mock.calls[0][0].psbtHex);
+      const inputDeriv = staged.data.inputs[0].tapBip32Derivation;
+      expect(inputDeriv).toHaveLength(1);
+      expect(inputDeriv![0].pubkey.toString("hex")).toBe(DEVICE_XONLY);
+      expect(inputDeriv![0].masterFingerprint.toString("hex")).toBe("73c5da0a");
+      // SIGNET provider → coin type 1: m/86'/1'/0'/0/0.
+      expect(inputDeriv![0].path).toBe("m/86'/1'/0'/0/0");
+      const outputDeriv = staged.data.outputs[0].tapBip32Derivation;
+      expect(outputDeriv).toHaveLength(1);
+      const outputScript = Buffer.from(staged.txOutputs[0].script);
+      expect(outputDeriv![0].pubkey).toEqual(outputScript.subarray(2));
+      expect(outputDeriv![0].pubkey.toString("hex")).not.toBe(DEVICE_XONLY);
+    });
+
+    it("rejects a refund whose leaf key is not this device's depositor key, before any device I/O", async () => {
+      const provider = await connected();
+
+      await expect(provider.signPsbt(refundPsbtHex({ leafKeyHex: "ab".repeat(32) }))).rejects.toMatchObject({
+        code: ERROR_CODES.INVALID_PARAMS,
+      });
+      expect(signMock.prepareSignPsbt).not.toHaveBeenCalled();
+      expect(signMock.signPreparedVaultPsbt).not.toHaveBeenCalled();
+    });
+
+    it("refuses a refund for a DIFFERENT vault while an intent is loaded — a typed error instead of the device's opaque reject", async () => {
+      const provider = await approved();
+
+      // Wrong timelock and wrong prevout each pin to the loaded intent on-device.
+      await expect(provider.signPsbt(refundPsbtHex({ csv: 144 }))).rejects.toMatchObject({
+        code: ERROR_CODES.DEVICE_CEREMONY_INVALID,
+      });
+      await expect(provider.signPsbt(refundPsbtHex({ prevHashInternal: Buffer.alloc(32, 0x77) }))).rejects.toMatchObject({
+        code: ERROR_CODES.DEVICE_CEREMONY_INVALID,
+      });
+      expect(signMock.prepareSignPsbt).not.toHaveBeenCalled();
+      expect(signMock.signPreparedVaultPsbt).not.toHaveBeenCalled();
+      // The rejection ran before any ceremony: the loaded intent is untouched.
+      await expect(provider.holdsApprovedDepositTerms(TERMS)).resolves.toBe(true);
+    });
+
+    it("signs a refund matching the loaded intent's vault", async () => {
+      const provider = await approved();
+
+      await expect(provider.signPsbt(refundPsbtHex())).resolves.toMatch(/^signed:/);
+    });
+
+    it("a no-intent refund can be re-signed — there is no loaded intent to nullify on the device", async () => {
+      const provider = await connected();
+      const hex = refundPsbtHex();
+
+      await expect(provider.signPsbt(hex)).resolves.toMatch(/^signed:/);
+      await expect(provider.signPsbt(hex)).resolves.toMatch(/^signed:/);
+      expect(signMock.signPreparedVaultPsbt).toHaveBeenCalledTimes(2);
+    });
+
+    it("a refund can be re-signed under the loaded intent too — the standalone path consumes no device mask", async () => {
+      const provider = await approved();
+      const hex = refundPsbtHex();
+
+      await expect(provider.signPsbt(hex)).resolves.toMatch(/^signed:/);
+      await expect(provider.signPsbt(hex)).resolves.toMatch(/^signed:/);
+      expect(signMock.signPreparedVaultPsbt).toHaveBeenCalledTimes(2);
+      // Refund signs never touch the intent mirror or the replay guard.
+      await expect(provider.holdsApprovedDepositTerms(TERMS)).resolves.toBe(true);
+    });
+
+    it("rejects a no-intent refund whose CSV is below the device floor of 72, before any device I/O", async () => {
+      const provider = await connected();
+
+      await expect(provider.signPsbt(refundPsbtHex({ csv: 71 }))).rejects.toMatchObject({
+        code: ERROR_CODES.INVALID_PARAMS,
+      });
+      expect(signMock.prepareSignPsbt).not.toHaveBeenCalled();
+      expect(signMock.signPreparedVaultPsbt).not.toHaveBeenCalled();
+    });
+
+    it("signPsbts refuses a batched refund before any ceremony — refunds sign standalone via signPsbt", async () => {
+      const provider = await approved();
+
+      await expect(provider.signPsbts(["aa".repeat(40), refundPsbtHex()])).rejects.toMatchObject({
+        code: ERROR_CODES.INVALID_PARAMS,
+      });
+      expect(signMock.signPreparedVaultPsbt).not.toHaveBeenCalled();
+      // The whole batch was refused at staging: the loaded intent is untouched.
+      await expect(provider.holdsApprovedDepositTerms(TERMS)).resolves.toBe(true);
+    });
+  });
+
   describe("getChangeAddress", () => {
     it("returns the P2TR address of m/86'/coin'/0'/1/0 derived from the device's account xpub", async () => {
       const p = await connected();

--- a/packages/babylon-wallet-connector/src/core/wallets/btc/ledger-vault/__tests__/provider.test.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/ledger-vault/__tests__/provider.test.ts
@@ -1385,6 +1385,8 @@ describe("LedgerVaultProvider", () => {
     const LEAF_VERSION = 0xc0;
     /** Internal-order prevout of {@link TERMS}'s Pre-PegIn — the loaded intent's vault. */
     const INTENT_TXID_INTERNAL = Buffer.from(TERMS.prepeginTxid, "hex").reverse();
+    /** A generic (non-refund) PSBT that signs under the loaded intent. */
+    const PSBT_UNDER_INTENT = "ab".repeat(40);
 
     /** Minimal positive CScriptNum push (opcode-length form, like the WASM builder emits). */
     function csvPush(value: number): Buffer {
@@ -1472,21 +1474,23 @@ describe("LedgerVaultProvider", () => {
       expect(signMock.signPreparedVaultPsbt).not.toHaveBeenCalled();
     });
 
-    it("refuses a refund for a DIFFERENT vault while an intent is loaded — a typed error instead of the device's opaque reject", async () => {
-      const provider = await approved();
+    it.each([
+      ["a mismatched refund timelock", { csv: 144 }],
+      ["a mismatched Pre-PegIn txid", { prevHashInternal: Buffer.alloc(32, 0x77) }],
+    ] as const)(
+      "refuses a refund with %s while an intent is loaded — a typed error instead of the device's opaque reject",
+      async (_label, overrides) => {
+        const provider = await approved();
 
-      // Wrong timelock and wrong prevout each pin to the loaded intent on-device.
-      await expect(provider.signPsbt(refundPsbtHex({ csv: 144 }))).rejects.toMatchObject({
-        code: ERROR_CODES.DEVICE_CEREMONY_INVALID,
-      });
-      await expect(provider.signPsbt(refundPsbtHex({ prevHashInternal: Buffer.alloc(32, 0x77) }))).rejects.toMatchObject({
-        code: ERROR_CODES.DEVICE_CEREMONY_INVALID,
-      });
-      expect(signMock.prepareSignPsbt).not.toHaveBeenCalled();
-      expect(signMock.signPreparedVaultPsbt).not.toHaveBeenCalled();
-      // The rejection ran before any ceremony: the loaded intent is untouched.
-      await expect(provider.holdsApprovedDepositTerms(TERMS)).resolves.toBe(true);
-    });
+        await expect(provider.signPsbt(refundPsbtHex(overrides))).rejects.toMatchObject({
+          code: ERROR_CODES.DEVICE_CEREMONY_INVALID,
+        });
+        expect(signMock.prepareSignPsbt).not.toHaveBeenCalled();
+        expect(signMock.signPreparedVaultPsbt).not.toHaveBeenCalled();
+        // The rejection ran before any ceremony: the loaded intent is untouched.
+        await expect(provider.holdsApprovedDepositTerms(TERMS)).resolves.toBe(true);
+      },
+    );
 
     it("signs a refund matching the loaded intent's vault", async () => {
       const provider = await approved();
@@ -1514,25 +1518,51 @@ describe("LedgerVaultProvider", () => {
       await expect(provider.holdsApprovedDepositTerms(TERMS)).resolves.toBe(true);
     });
 
-    it("rejects a no-intent refund whose CSV is below the device floor of 72, before any device I/O", async () => {
+    it("rejects a no-intent refund whose CSV is below the device floor of 72 with ZERO device I/O — not even the liveness probe", async () => {
       const provider = await connected();
+      dmkSessionMock.isSessionAlive.mockClear();
+      derivationMock.getMasterFingerprintHex.mockClear();
 
       await expect(provider.signPsbt(refundPsbtHex({ csv: 71 }))).rejects.toMatchObject({
         code: ERROR_CODES.INVALID_PARAMS,
       });
+      expect(dmkSessionMock.isSessionAlive).not.toHaveBeenCalled();
+      expect(derivationMock.getMasterFingerprintHex).not.toHaveBeenCalled();
       expect(signMock.prepareSignPsbt).not.toHaveBeenCalled();
       expect(signMock.signPreparedVaultPsbt).not.toHaveBeenCalled();
+    });
+
+    it("a device-side refund failure leaves the loaded intent and the replay guard untouched", async () => {
+      const provider = await approved();
+      // Arm the replay guard with an intent-bound PSBT so its survival is observable.
+      await provider.signPsbt(PSBT_UNDER_INTENT);
+      signMock.signPreparedVaultPsbt.mockRejectedValueOnce(new LedgerUserRefusedError(0x6985));
+
+      await expect(provider.signPsbt(refundPsbtHex())).rejects.toMatchObject({
+        code: ERROR_CODES.CONNECTION_REJECTED,
+      });
+      // The refund path never invalidates the device's vault context, so the
+      // mirror must not drop either: the intent still holds…
+      await expect(provider.holdsApprovedDepositTerms(TERMS)).resolves.toBe(true);
+      // …and the armed fingerprint still blocks its replay.
+      await expect(provider.signPsbt(PSBT_UNDER_INTENT)).rejects.toThrow(/already signed/);
     });
 
     it("signPsbts refuses a batched refund before any ceremony — refunds sign standalone via signPsbt", async () => {
       const provider = await approved();
 
-      await expect(provider.signPsbts(["aa".repeat(40), refundPsbtHex()])).rejects.toMatchObject({
-        code: ERROR_CODES.INVALID_PARAMS,
-      });
+      await expect(provider.signPsbts(["aa".repeat(40), refundPsbtHex()])).rejects.toThrow(/standalone via signPsbt/);
       expect(signMock.signPreparedVaultPsbt).not.toHaveBeenCalled();
       // The whole batch was refused at staging: the loaded intent is untouched.
       await expect(provider.holdsApprovedDepositTerms(TERMS)).resolves.toBe(true);
+    });
+
+    it("signPsbts refuses a batched refund with the refund-specific error even when NO intent is loaded", async () => {
+      const provider = await connected();
+
+      await expect(provider.signPsbts([refundPsbtHex()])).rejects.toThrow(/standalone via signPsbt/);
+      expect(signMock.prepareSignPsbt).not.toHaveBeenCalled();
+      expect(signMock.signPreparedVaultPsbt).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/babylon-wallet-connector/src/core/wallets/btc/ledger-vault/provider.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/ledger-vault/provider.ts
@@ -11,9 +11,11 @@
 import {
   approveVaultIntent,
   assertDepositTermsDeviceCompatible,
+  augmentPsbtForRefund,
   augmentPsbtForWalletPolicy,
   buildDefaultTaprootPolicy,
   buildPopPsbtHex,
+  classifyRefundPsbt,
   connectDmkSession,
   createDmkApduSender,
   createDmkRawApduSender,
@@ -50,6 +52,7 @@ import {
   type IntentVaultGroup,
   type PreparedSignPsbt,
   type RawApduSender,
+  type RefundPsbtClassification,
   type SignVaultPsbtResult,
 } from "@babylonlabs-io/ledger-vault-signer";
 
@@ -89,7 +92,18 @@ const SCHNORR_SIG_BYTES = 64;
  * consumes it; failures invalidate to IDLE (`approve_vault_intent.c`). The
  * mirror pre-empts opaque SW_BAD_STATE with an actionable error.
  */
-type DeviceIntentState = { phase: "idle" } | { phase: "derived" } | { phase: "intent-loaded"; termsKey: string };
+type DeviceIntentState =
+  | { phase: "idle" }
+  | { phase: "derived" }
+  | {
+      phase: "intent-loaded";
+      termsKey: string;
+      /** Internal-order hex of the intent's Pre-PegIn txid — under INTENT_LOADED the
+       * device pins a refund's input 0 prevout to it (`sign_psbt_validate.c:1076-1081`). */
+      prepeginTxidInternalHex: string;
+      /** The approved `htlc_refund_timelock` — the device pins a refund leaf's CSV to it (`:888-903`). */
+      htlcRefundTimelock: number;
+    };
 
 /** Batch-level gate output, shared by every element of one public sign call. */
 interface SignContext {
@@ -112,6 +126,8 @@ interface StagedPsbt {
   readonly prepared: PreparedSignPsbt;
   readonly fingerprintKey: string;
   readonly label: string;
+  /** Whether success arms the replay guard — false only for a no-intent standalone refund. */
+  readonly guardReplay: boolean;
 }
 
 /**
@@ -646,7 +662,12 @@ export class LedgerVaultProvider implements IBTCProvider {
     this.deviceState = { phase: "idle" };
     await approveVaultIntent(send, intent);
     this.assertSameConnection(generation);
-    this.deviceState = { phase: "intent-loaded", termsKey: key };
+    this.deviceState = {
+      phase: "intent-loaded",
+      termsKey: key,
+      prepeginTxidInternalHex: Buffer.from(intent.scalars.prepeginTxidInternal).toString("hex"),
+      htlcRefundTimelock: intent.scalars.htlcRefundTimelock,
+    };
     // A NEW ceremony ran: the device's signature counters and dedup masks are
     // fresh, so the same PSBT bytes are legitimately signable again. (The
     // byte-equal re-approval no-op above returns earlier and keeps both.)
@@ -672,21 +693,90 @@ export class LedgerVaultProvider implements IBTCProvider {
    * SIGN_PSBT under the loaded intent (#2219 B3). Tapscript PSBTs sign in
    * no-policy mode; all-key-path ones (Pre-PegIn, #2222) sign under the default
    * wallet policy after {@link augmentPsbtForWalletPolicy} adds the derivation
-   * fields. Never finalizes — the SDK extracts signatures and finalizes itself.
-   * Every rejection before the device loop starts leaves the mirror and the
-   * loaded intent untouched.
+   * fields. A refund — classified from the provider's OWN parse, never a
+   * caller flag (#2371) — is the one standalone sign: the device accepts it
+   * with no loaded intent (`sign_psbt_validate.c:889-903`), so only the intent
+   * requirement is waived; every other gate still runs, and
+   * {@link augmentPsbtForRefund} adds the derivation entries the device
+   * requires. Never finalizes — the SDK extracts signatures and finalizes
+   * itself. Every rejection before the device loop starts leaves the mirror
+   * and the loaded intent untouched.
    */
   signPsbt = async (psbtHex: string, options?: SignPsbtOptions): Promise<string> =>
     this.withDeviceOperation("signPsbt", () =>
       this.withSignAbort(async (controller) => {
-        const ctx = await this.gateSignContext();
-        const staged = await this.stagePsbt(psbtHex, options, "signPsbt", new Set(), ctx.depositorXOnlyHex);
+        const refund = classifyRefundPsbt(psbtHex);
+        const ctx = await this.gateSignContext(refund === undefined);
+        let stagingHex = psbtHex;
+        // A refund routes to the device's standalone sign path in EVERY vault
+        // state (`sign_psbt_validate.c:3552-3618` fall-through dispatch), and
+        // that path consumes no dedup mask or cap (`sign_custom_inputs.c`,
+        // standalone section — contrast PegIn `:183` and Payout `:400`), so
+        // re-signing one is always a fresh user-approved ceremony.
+        const guardReplay = refund === undefined;
+        if (refund !== undefined) {
+          this.assertRefundSignable(refund, ctx.depositorXOnlyHex);
+          const { masterFingerprintHex } = await this.getPolicyContext();
+          this.assertSameConnection(ctx.generation);
+          try {
+            stagingHex = augmentPsbtForRefund({
+              psbtHex,
+              depositorXOnlyHex: ctx.depositorXOnlyHex,
+              masterFingerprintHex,
+              depositorPath: this.depositorPath,
+            });
+          } catch (error) {
+            throw toStagingWalletError(error, "signPsbt rejected before device I/O");
+          }
+        }
+        const staged = await this.stagePsbt(
+          stagingHex,
+          options,
+          "signPsbt",
+          new Set(),
+          ctx.depositorXOnlyHex,
+          guardReplay,
+        );
         // Staging awaits the policy read; a reconnect during it would leave the
         // captured sender stale (signPsbts guards the same way per element).
         this.assertSameConnection(ctx.generation);
         return this.signStaged(staged, ctx, controller);
       }),
     );
+
+  /**
+   * Zero-I/O refund gates (#2371). The key check pre-empts the device's own
+   * derive-and-compare (`sign_psbt_validate.c:905-950`); the vault check
+   * pre-empts the INTENT_LOADED pins on the leaf CSV (`:893-897`) and input 0's
+   * prevout (`:1076-1081`) — both fire pre-approval on-device, but as an opaque
+   * SW_INCORRECT_DATA whose failure path would also take {@link signStaged}'s
+   * pessimistic mirror reset. Rejecting here keeps the typed error AND the
+   * loaded intent. No automatic reset — tearing down a loaded ceremony is
+   * never a silent side effect of a refund attempt.
+   */
+  private assertRefundSignable(refund: RefundPsbtClassification, depositorXOnlyHex: string): void {
+    if (refund.leafKeyHex !== depositorXOnlyHex) {
+      throw new WalletError({
+        code: ERROR_CODES.INVALID_PARAMS,
+        message: `${WALLET_PROVIDER_NAME}: the refund leaf key is not this device's depositor key — this device cannot sign this refund.`,
+        wallet: WALLET_PROVIDER_NAME,
+      });
+    }
+    const state = this.deviceState;
+    if (
+      state.phase === "intent-loaded" &&
+      (refund.inputTxidInternalHex !== state.prepeginTxidInternalHex || refund.csv !== state.htlcRefundTimelock)
+    ) {
+      throw new WalletError({
+        code: ERROR_CODES.DEVICE_CEREMONY_INVALID,
+        message:
+          `${WALLET_PROVIDER_NAME} holds an approved intent for a different vault — the device pins a ` +
+          `refund's timelock and Pre-PegIn txid to the loaded intent and would reject this one. ` +
+          `Reconnect the device (or restart that deposit's flow from derivation) and retry the refund.`,
+        wallet: WALLET_PROVIDER_NAME,
+      });
+    }
+  }
 
   /**
    * Device ceremonies run strictly sequentially, array order, fail-fast — a
@@ -709,6 +799,16 @@ export class LedgerVaultProvider implements IBTCProvider {
         const stagedKeys = new Set<string>();
         const staged: StagedPsbt[] = [];
         for (const [index, hex] of psbtsHexes.entries()) {
+          // A refund is a standalone single-PSBT ceremony — signPsbt classifies
+          // and augments it. Staged unaugmented here it would start a ceremony
+          // the device rejects (missing derivation entries). Refuse at zero I/O.
+          if (classifyRefundPsbt(hex) !== undefined) {
+            throw new WalletError({
+              code: ERROR_CODES.INVALID_PARAMS,
+              message: `signPsbts[${index}]: a refund signs standalone via signPsbt — it cannot be part of a batch ceremony.`,
+              wallet: WALLET_PROVIDER_NAME,
+            });
+          }
           const one = await this.stagePsbt(
             hex,
             options?.[index],
@@ -798,8 +898,9 @@ export class LedgerVaultProvider implements IBTCProvider {
    * the device state is gone with it (generation-guarded against a racing
    * reconnect's fresh state).
    *
-   * `requireIntent: false` is for the state-independent PoP — every other
-   * caller keeps the default.
+   * `requireIntent: false` is for the signs the device itself accepts without
+   * an intent — the state-independent PoP and the standalone refund (#2371);
+   * every other caller keeps the default.
    */
   private async gateSignContext(requireIntent = true): Promise<SignContext> {
     const { session, rawSend } = this.requireSignContext();
@@ -840,6 +941,7 @@ export class LedgerVaultProvider implements IBTCProvider {
     label: string,
     stagedKeys: ReadonlySet<string>,
     depositorXOnlyHex: string,
+    guardReplay = true,
   ): Promise<StagedPsbt> {
     // Never finalize, and never silently ignore a request to — the SDK
     // extracts signatures and finalizes itself.
@@ -925,7 +1027,7 @@ export class LedgerVaultProvider implements IBTCProvider {
         wallet: WALLET_PROVIDER_NAME,
       });
     }
-    if (this.signedFingerprints.has(fingerprintKey)) {
+    if (guardReplay && this.signedFingerprints.has(fingerprintKey)) {
       throw new WalletError({
         code: ERROR_CODES.INVALID_PARAMS,
         message:
@@ -935,7 +1037,7 @@ export class LedgerVaultProvider implements IBTCProvider {
         wallet: WALLET_PROVIDER_NAME,
       });
     }
-    return { prepared, fingerprintKey, label };
+    return { prepared, fingerprintKey, label, guardReplay };
   }
 
   /**
@@ -954,7 +1056,7 @@ export class LedgerVaultProvider implements IBTCProvider {
    * committed — and takes the pessimistic reset below.
    */
   private async signStaged(staged: StagedPsbt, ctx: SignContext, controller: AbortController): Promise<string> {
-    const { prepared, fingerprintKey, label } = staged;
+    const { prepared, fingerprintKey, label, guardReplay } = staged;
     const { session, rawSend, generation } = ctx;
     try {
       const result = await signPreparedVaultPsbt(rawSend, prepared, {
@@ -964,8 +1066,9 @@ export class LedgerVaultProvider implements IBTCProvider {
       });
       this.assertSameConnection(generation);
       // Success never consumes the intent: further (different) PSBTs sign
-      // under the same approval; this one never again.
-      this.signedFingerprints.add(fingerprintKey);
+      // under the same approval; this one never again. No-intent standalone
+      // refunds are exempt — the device holds no masks to consult there.
+      if (guardReplay) this.signedFingerprints.add(fingerprintKey);
       return result.signedPsbtHex;
     } catch (error) {
       const walletError = this.classifySignFailure(error, generation, label);

--- a/packages/babylon-wallet-connector/src/core/wallets/btc/ledger-vault/provider.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/ledger-vault/provider.ts
@@ -11,6 +11,7 @@
 import {
   approveVaultIntent,
   assertDepositTermsDeviceCompatible,
+  assertRefundPsbtSignable,
   augmentPsbtForRefund,
   augmentPsbtForWalletPolicy,
   buildDefaultTaprootPolicy,
@@ -126,8 +127,13 @@ interface StagedPsbt {
   readonly prepared: PreparedSignPsbt;
   readonly fingerprintKey: string;
   readonly label: string;
-  /** Whether success arms the replay guard — false only for a no-intent standalone refund. */
-  readonly guardReplay: boolean;
+  /**
+   * True for ANY classified refund, intent loaded or not: the device's
+   * standalone path consumes no dedup mask or cap in any vault state, and no
+   * failure on it invalidates the vault context — so the refund skips the
+   * replay guard and the pessimistic mirror reset.
+   */
+  readonly standaloneRefund: boolean;
 }
 
 /**
@@ -706,14 +712,17 @@ export class LedgerVaultProvider implements IBTCProvider {
     this.withDeviceOperation("signPsbt", () =>
       this.withSignAbort(async (controller) => {
         const refund = classifyRefundPsbt(psbtHex);
+        if (refund !== undefined) {
+          // Pure term pins first — this rejection really is zero device I/O,
+          // not even the liveness probe or a cold derivation read.
+          try {
+            assertRefundPsbtSignable(refund);
+          } catch (error) {
+            throw toStagingWalletError(error, "signPsbt rejected before any device I/O");
+          }
+        }
         const ctx = await this.gateSignContext(refund === undefined);
         let stagingHex = psbtHex;
-        // A refund routes to the device's standalone sign path in EVERY vault
-        // state (`sign_psbt_validate.c:3552-3618` fall-through dispatch), and
-        // that path consumes no dedup mask or cap (`sign_custom_inputs.c`,
-        // standalone section — contrast PegIn `:183` and Payout `:400`), so
-        // re-signing one is always a fresh user-approved ceremony.
-        const guardReplay = refund === undefined;
         if (refund !== undefined) {
           this.assertRefundSignable(refund, ctx.depositorXOnlyHex);
           const { masterFingerprintHex } = await this.getPolicyContext();
@@ -726,7 +735,9 @@ export class LedgerVaultProvider implements IBTCProvider {
               depositorPath: this.depositorPath,
             });
           } catch (error) {
-            throw toStagingWalletError(error, "signPsbt rejected before device I/O");
+            // The policy read above may have exchanged APDUs on a cold cache —
+            // "before the ceremony", not "before device I/O".
+            throw toStagingWalletError(error, "signPsbt rejected before the signing ceremony");
           }
         }
         const staged = await this.stagePsbt(
@@ -735,7 +746,12 @@ export class LedgerVaultProvider implements IBTCProvider {
           "signPsbt",
           new Set(),
           ctx.depositorXOnlyHex,
-          guardReplay,
+          // A refund routes to the device's standalone sign path in EVERY vault
+          // state (`sign_psbt_validate.c:3691` dispatch), and that path consumes
+          // no dedup mask or cap (`sign_custom_inputs.c`, standalone section —
+          // contrast PegIn `:184` and Payout `:401`), so re-signing one is
+          // always a fresh user-approved ceremony.
+          refund !== undefined,
         );
         // Staging awaits the policy read; a reconnect during it would leave the
         // captured sender stale (signPsbts guards the same way per element).
@@ -795,13 +811,12 @@ export class LedgerVaultProvider implements IBTCProvider {
             wallet: WALLET_PROVIDER_NAME,
           });
         }
-        const ctx = await this.gateSignContext();
-        const stagedKeys = new Set<string>();
-        const staged: StagedPsbt[] = [];
+        // A refund is a standalone single-PSBT ceremony — signPsbt classifies
+        // and augments it. Staged unaugmented here it would start a ceremony
+        // the device rejects (missing derivation entries). The scan is pure,
+        // so it runs BEFORE the intent gate: a no-intent caller must get this
+        // actionable refusal, not "restart the flow from derivation".
         for (const [index, hex] of psbtsHexes.entries()) {
-          // A refund is a standalone single-PSBT ceremony — signPsbt classifies
-          // and augments it. Staged unaugmented here it would start a ceremony
-          // the device rejects (missing derivation entries). Refuse at zero I/O.
           if (classifyRefundPsbt(hex) !== undefined) {
             throw new WalletError({
               code: ERROR_CODES.INVALID_PARAMS,
@@ -809,6 +824,11 @@ export class LedgerVaultProvider implements IBTCProvider {
               wallet: WALLET_PROVIDER_NAME,
             });
           }
+        }
+        const ctx = await this.gateSignContext();
+        const stagedKeys = new Set<string>();
+        const staged: StagedPsbt[] = [];
+        for (const [index, hex] of psbtsHexes.entries()) {
           const one = await this.stagePsbt(
             hex,
             options?.[index],
@@ -941,7 +961,7 @@ export class LedgerVaultProvider implements IBTCProvider {
     label: string,
     stagedKeys: ReadonlySet<string>,
     depositorXOnlyHex: string,
-    guardReplay = true,
+    standaloneRefund = false,
   ): Promise<StagedPsbt> {
     // Never finalize, and never silently ignore a request to — the SDK
     // extracts signatures and finalizes itself.
@@ -1027,7 +1047,7 @@ export class LedgerVaultProvider implements IBTCProvider {
         wallet: WALLET_PROVIDER_NAME,
       });
     }
-    if (guardReplay && this.signedFingerprints.has(fingerprintKey)) {
+    if (!standaloneRefund && this.signedFingerprints.has(fingerprintKey)) {
       throw new WalletError({
         code: ERROR_CODES.INVALID_PARAMS,
         message:
@@ -1037,7 +1057,7 @@ export class LedgerVaultProvider implements IBTCProvider {
         wallet: WALLET_PROVIDER_NAME,
       });
     }
-    return { prepared, fingerprintKey, label, guardReplay };
+    return { prepared, fingerprintKey, label, standaloneRefund };
   }
 
   /**
@@ -1056,7 +1076,7 @@ export class LedgerVaultProvider implements IBTCProvider {
    * committed — and takes the pessimistic reset below.
    */
   private async signStaged(staged: StagedPsbt, ctx: SignContext, controller: AbortController): Promise<string> {
-    const { prepared, fingerprintKey, label, guardReplay } = staged;
+    const { prepared, fingerprintKey, label, standaloneRefund } = staged;
     const { session, rawSend, generation } = ctx;
     try {
       const result = await signPreparedVaultPsbt(rawSend, prepared, {
@@ -1066,9 +1086,10 @@ export class LedgerVaultProvider implements IBTCProvider {
       });
       this.assertSameConnection(generation);
       // Success never consumes the intent: further (different) PSBTs sign
-      // under the same approval; this one never again. No-intent standalone
-      // refunds are exempt — the device holds no masks to consult there.
-      if (guardReplay) this.signedFingerprints.add(fingerprintKey);
+      // under the same approval; this one never again. Any standalone refund
+      // is exempt — the device's standalone path consumes no dedup mask or
+      // cap in any vault state (`sign_custom_inputs.c`, standalone section).
+      if (!standaloneRefund) this.signedFingerprints.add(fingerprintKey);
       return result.signedPsbtHex;
     } catch (error) {
       const walletError = this.classifySignFailure(error, generation, label);
@@ -1077,7 +1098,20 @@ export class LedgerVaultProvider implements IBTCProvider {
       // Pre-dispatch lock keeps the intent (provenance in the method doc); an
       // unproven lock is treated like any other sign failure.
       const lockedBeforeDispatch = isLedgerDeviceLockedError(error) && error.preDispatch === true;
-      if (generation === this.connectionGeneration && !isLedgerSignPsbtAbortedError(error) && !lockedBeforeDispatch) {
+      if (
+        generation === this.connectionGeneration &&
+        !isLedgerSignPsbtAbortedError(error) &&
+        !lockedBeforeDispatch &&
+        // Refunds keep the mirror: NOTHING on the device's refund path
+        // invalidates the vault context — not the validator's rejects
+        // (`sign_psbt_validate.c:798-1104` holds none of the file's six
+        // invalidate sites), not the standalone sign section, not the review
+        // screen's SW_DENY, and not the base app's PSBT-phase failures
+        // (zero vault references in `base:sign_psbt.c` and its phases).
+        // INTENT_LOADED is terminal until an explicit invalidate
+        // (`vault_context.c:44-47`). The abort branch above stays uniform.
+        !standaloneRefund
+      ) {
         // Pessimistically assume the device dropped the intent (error-path
         // invalidation is mixed in firmware — never assume survival).
         this.deviceState = { phase: "idle" };


### PR DESCRIPTION
Refund was unreachable for a Ledger depositor; both blockers were host-side — the device signs a standalone refund from any vault state (fw `ff1e1ce17`).

- New `refundPsbt.ts` in ledger-vault-signer: refund-leaf parser mirroring the firmware grammar byte-for-byte, a 1-in/1-out classifier, and `augmentPsbtForRefund` adding the two required TAP_BIP32_DERIVATION entries — input 0 keyed by the **untweaked** depositor key, output 0 by the **BIP-86 tweaked** witness program. Enforces the device's CSV floor (72) before any I/O.
- Provider: `signPsbt` classifies the refund from its own parse (never a caller flag) and waives only the intent gate; a wrong-vault guard rejects a refund not matching a loaded intent's terms with a typed error; refunds are exempt from the replay guard (the standalone path consumes no device mask); `signPsbts` refuses a batched refund.

No SDK changes — augmentation is provider-side, like `augmentPsbtForWalletPolicy`.