### PR TITLE
fix(wallet-connector): require approval after wallet identity changes

### DIFF
--- a/packages/babylon-wallet-connector/src/components/WalletProvider/components/WalletDialog.tsx
+++ b/packages/babylon-wallet-connector/src/components/WalletProvider/components/WalletDialog.tsx
@@ -3,7 +3,13 @@ import { useCallback, useLayoutEffect, useRef, type ReactNode } from "react";
 
 import { useChainProviders, type Connectors } from "@/context/Chain.context";
 import { useLifeCycleHooks, type WalletLifecycleConnection } from "@/context/LifecycleHooks.context";
-import { createConfirmationReceipt, sameIdentity, WALLET_CONFIRMATION_RECEIPT_KEY } from "@/core/confirmationReceipt";
+import {
+  confirmedChains,
+  createConfirmationReceipt,
+  sameIdentity,
+  subscribeToConfirmationIdentityChanges,
+  WALLET_CONFIRMATION_RECEIPT_KEY,
+} from "@/core/confirmationReceipt";
 import type { ChainId, HashMap, IBTCProvider, IETHProvider, IWallet } from "@/core/types";
 import { useWalletConnectors } from "@/hooks/useWalletConnectors";
 import { useWalletWidgets } from "@/hooks/useWalletWidgets";
@@ -103,6 +109,10 @@ async function createConfirmationSnapshot(
       try {
         if (!provider) throw new Error(`${WALLET_PROVIDER_MISSING_ERROR_MESSAGE}: ${chain}`);
 
+        if (provider.isIdentityCurrent?.() === false) {
+          throw new Error(WALLET_CHANGED_ERROR_MESSAGE);
+        }
+
         let network: string | number | undefined;
         if (chain === "ETH" || chain === "BTC") {
           // Fixed-network providers report their operational network here. They
@@ -128,6 +138,10 @@ async function createConfirmationSnapshot(
           !sameIdentity(address, candidate.connection.account.address) ||
           !sameIdentity(publicKeyHex, candidate.connection.account.publicKeyHex)
         ) {
+          throw new Error(WALLET_CHANGED_ERROR_MESSAGE);
+        }
+
+        if (provider.isIdentityCurrent?.() === false) {
           throw new Error(WALLET_CHANGED_ERROR_MESSAGE);
         }
 
@@ -204,7 +218,7 @@ export function WalletDialog({
   closeButtonClassName,
   actionsClassName,
 }: WalletDialogProps) {
-  const { visible, screen, confirmed, requiredChainIds, close, confirm, displayChains, displayError } =
+  const { visible, screen, confirmed, requiredChainIds, close, confirm, unconfirm, displayChains, displayError } =
     useWidgetState();
   const { acceptTermsOfService, onConfirm } = useLifeCycleHooks();
   const connectors = useChainProviders();
@@ -214,20 +228,26 @@ export function WalletDialog({
   const connectorsRef = useRef(connectors);
   const attemptGenerationRef = useRef(0);
   const activeAttemptRef = useRef<number | null>(null);
+  const activeIdentitySubscriptionRef = useRef<(() => void) | null>(null);
   const mountedRef = useRef(false);
   const visibleRef = useRef(visible);
+  const confirmedRef = useRef(confirmed);
   const confirmationInputsRef = useRef({ persistent, requiredChainIds: [...requiredChainIds], storage });
 
   const invalidateAttempt = useCallback(() => {
+    const stopWatchingIdentity = activeIdentitySubscriptionRef.current;
+    activeIdentitySubscriptionRef.current = null;
     attemptGenerationRef.current += 1;
     activeAttemptRef.current = null;
+    stopWatchingIdentity?.();
   }, []);
 
   useLayoutEffect(() => {
     connectorsRef.current = connectors;
-    if (visibleRef.current && !visible) invalidateAttempt();
+    if ((visibleRef.current && !visible) || (!confirmedRef.current && confirmed)) invalidateAttempt();
     visibleRef.current = visible;
-  }, [connectors, invalidateAttempt, visible]);
+    confirmedRef.current = confirmed;
+  }, [confirmed, connectors, invalidateAttempt, visible]);
 
   useLayoutEffect(() => {
     mountedRef.current = true;
@@ -269,9 +289,35 @@ export function WalletDialog({
       attemptGenerationRef.current === generation &&
       mountedRef.current &&
       visibleRef.current;
+    let stopWatchingIdentity = () => {};
+    let confirmationHandoffPending = false;
 
     try {
       if (!confirmed) {
+        const initialConnectors = connectorsRef.current;
+        const initialReceipt = createConfirmationReceipt(collectConnections(initialConnectors), initialConnectors);
+        const unsubscribeIdentity = subscribeToConfirmationIdentityChanges(
+          initialReceipt,
+          confirmedChains(initialReceipt),
+          initialConnectors,
+          () => {
+            invalidateAttempt();
+            storage.delete(WALLET_CONFIRMATION_RECEIPT_KEY);
+            unconfirm?.();
+          },
+        );
+        let watchingIdentity = true;
+        stopWatchingIdentity = () => {
+          if (!watchingIdentity) return;
+          watchingIdentity = false;
+          unsubscribeIdentity();
+        };
+        if (!isCurrentAttempt()) {
+          stopWatchingIdentity();
+          return;
+        }
+        activeIdentitySubscriptionRef.current = stopWatchingIdentity;
+
         const confirmationSnapshot = await createConfirmationSnapshot(
           () => connectorsRef.current,
           requiredChainIds,
@@ -324,9 +370,13 @@ export function WalletDialog({
         if (persistent) {
           storage.set(WALLET_CONFIRMATION_RECEIPT_KEY, confirmationSnapshot.receipt);
         }
+
+        if (!isCurrentAttempt()) return;
+        confirm?.(confirmationSnapshot.receipt);
+        if (!isCurrentAttempt()) return;
+        confirmationHandoffPending = Boolean(confirm);
       }
 
-      confirm?.();
       if (!isCurrentAttempt()) return;
       close?.();
     } catch (error) {
@@ -343,8 +393,14 @@ export function WalletDialog({
         onCancel: displayChains,
       });
     } finally {
-      if (attemptGenerationRef.current === generation && activeAttemptRef.current === generation) {
-        activeAttemptRef.current = null;
+      if (!confirmationHandoffPending) {
+        stopWatchingIdentity();
+        if (activeIdentitySubscriptionRef.current === stopWatchingIdentity) {
+          activeIdentitySubscriptionRef.current = null;
+        }
+        if (attemptGenerationRef.current === generation && activeAttemptRef.current === generation) {
+          activeAttemptRef.current = null;
+        }
       }
     }
   }, [
@@ -354,11 +410,13 @@ export function WalletDialog({
     confirmed,
     displayChains,
     displayError,
+    invalidateAttempt,
     onConfirm,
     onError,
     persistent,
     requiredChainIds,
     storage,
+    unconfirm,
   ]);
 
   const onBack = screen.type === "WALLETS" ? displayChains : undefined;

--- a/packages/babylon-wallet-connector/src/components/WalletProvider/components/__tests__/WalletDialog.test.tsx
+++ b/packages/babylon-wallet-connector/src/components/WalletProvider/components/__tests__/WalletDialog.test.tsx
@@ -1,4 +1,5 @@
 import { act, render, screen, waitFor } from "@testing-library/react";
+import { useState } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { TermsOfServiceParams } from "@/context/LifecycleHooks.context";
@@ -88,6 +89,45 @@ function bbnWallet(id: string, account: { address: string; publicKeyHex: string 
     getPublicKeyHex: vi.fn().mockResolvedValue(account.publicKeyHex),
   } as unknown as IWallet["provider"];
   return connectedWallet;
+}
+
+function eventWallet(
+  id: string,
+  cachedAccount: { address: string; publicKeyHex: string },
+  liveAccount = cachedAccount,
+  tracksCachedIdentity = false,
+) {
+  const handlers = new Map<string, Set<(...args: unknown[]) => void>>();
+  let currentAccount = liveAccount;
+  let identityCurrent = true;
+  const provider = {
+    getAddress: vi.fn(async () => currentAccount.address),
+    getPublicKeyHex: vi.fn(async () => currentAccount.publicKeyHex),
+    getChainId: vi.fn().mockResolvedValue(11155111),
+    getNetwork: vi.fn().mockResolvedValue("signet"),
+    isIdentityCurrent: vi.fn(() => identityCurrent),
+    on: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+      const eventHandlers = handlers.get(event) ?? new Set();
+      eventHandlers.add(handler);
+      handlers.set(event, eventHandlers);
+    }),
+    off: vi.fn((event: string, handler: (...args: unknown[]) => void) => {
+      handlers.get(event)?.delete(handler);
+    }),
+    changeAccount(account: { address: string; publicKeyHex: string }) {
+      currentAccount = account;
+    },
+    emit(event: string, ...args: unknown[]) {
+      if (tracksCachedIdentity && (event === "accountsChanged" || event === "networkChanged")) {
+        identityCurrent = false;
+      }
+      handlers.get(event)?.forEach((handler) => handler(...args));
+    },
+  };
+  const connectedWallet = wallet(id, cachedAccount);
+  connectedWallet.provider = provider as unknown as IWallet["provider"];
+
+  return { connectedWallet, provider };
 }
 
 let store: Map<string, string>;
@@ -232,10 +272,12 @@ describe("confirming the dialog", () => {
       screen.getByText("confirm").click();
     });
 
-    expect(JSON.parse(store.get(WALLET_CONFIRMATION_RECEIPT_KEY)!)).toMatchObject({
+    const receipt = store.get(WALLET_CONFIRMATION_RECEIPT_KEY)!;
+    expect(JSON.parse(receipt)).toMatchObject({
       version: 2,
       entries: [{ chain: "ETH", walletId: "metamask", network: "11155111" }],
     });
+    expect(confirm).toHaveBeenCalledWith(receipt);
   });
 
   it("stores no receipt when sessions are not persisted", async () => {
@@ -246,7 +288,10 @@ describe("confirming the dialog", () => {
     });
 
     expect(store.has(WALLET_CONFIRMATION_RECEIPT_KEY)).toBe(false);
-    expect(confirm).toHaveBeenCalled();
+    expect(JSON.parse(confirm.mock.calls[0][0])).toMatchObject({
+      version: 2,
+      entries: [{ chain: "ETH", walletId: "metamask", network: "11155111" }],
+    });
   });
 
   it("skips the terms hook when the session is already confirmed", async () => {
@@ -530,6 +575,169 @@ describe("confirming the dialog", () => {
     expect(confirm).not.toHaveBeenCalled();
     expect(close).not.toHaveBeenCalled();
     expect(store.has(WALLET_CONFIRMATION_RECEIPT_KEY)).toBe(false);
+  });
+
+  it("rejects a stale adapter cache after an earlier identity event", async () => {
+    const { connectedWallet: btc, provider } = eventWallet("unisat", BTC_ACCOUNT, BTC_ACCOUNT, true);
+    provider.emit("accountsChanged", ["bc1psomeoneelse"]);
+    harness.connectors = {
+      ETH: null,
+      BTC: { config: { network: "signet" }, connectedWallet: btc, disconnect: vi.fn() },
+      BBN: null,
+    };
+    setup({ requiredChainIds: ["BTC"] });
+
+    await act(async () => {
+      screen.getByText("confirm").click();
+    });
+
+    expect(acceptTermsOfService).not.toHaveBeenCalled();
+    expect(onConfirm).not.toHaveBeenCalled();
+    expect(confirm).not.toHaveBeenCalled();
+  });
+
+  it("does not expose a confirmed render when identity changes during the session handoff", async () => {
+    const confirmedRenders: boolean[] = [];
+    const { connectedWallet: btc, provider } = eventWallet("unisat", BTC_ACCOUNT);
+    harness.connectors = {
+      ETH: null,
+      BTC: { config: { network: "signet" }, connectedWallet: btc, disconnect: vi.fn() },
+      BBN: null,
+    };
+
+    function HandoffHarness() {
+      const [dialogState, setDialogState] = useState({ confirmed: false, visible: true });
+      confirmedRenders.push(dialogState.confirmed);
+      harness.widgetState = {
+        visible: dialogState.visible,
+        screen: { type: "CHAINS" },
+        confirmed: dialogState.confirmed,
+        requiredChainIds: ["BTC"],
+        close: () => setDialogState((state) => ({ ...state, visible: false })),
+        confirm: () => {
+          setDialogState((state) => ({ ...state, confirmed: true }));
+          provider.emit("disconnect");
+        },
+        unconfirm: () => setDialogState((state) => ({ ...state, confirmed: false })),
+        displayChains: vi.fn(),
+        displayError: vi.fn(),
+      };
+
+      return <WalletDialog persistent storage={storage} config={[]} />;
+    }
+
+    render(<HandoffHarness />);
+    await act(async () => {
+      screen.getByText("confirm").click();
+    });
+
+    expect(confirmedRenders).not.toContain(true);
+    expect(store.has(WALLET_CONFIRMATION_RECEIPT_KEY)).toBe(false);
+  });
+
+  it("stops an active attempt when the provider emits an identity change", async () => {
+    const pending = deferred();
+    const { connectedWallet, provider } = eventWallet("metamask", ETH_ACCOUNT);
+    acceptTermsOfService.mockReturnValue(pending.promise);
+    harness.connectors = {
+      ...harness.connectors,
+      ETH: { config: { chainId: 11155111 }, connectedWallet, disconnect: disconnectEth },
+    };
+    setup();
+
+    act(() => {
+      screen.getByText("confirm").click();
+    });
+    await waitFor(() => expect(acceptTermsOfService).toHaveBeenCalledTimes(1));
+
+    act(() => {
+      provider.emit("accountsChanged", ["0xnewaccount"]);
+    });
+    await act(async () => pending.resolve());
+
+    expect(onConfirm).not.toHaveBeenCalled();
+    expect(confirm).not.toHaveBeenCalled();
+  });
+
+  it("stops when an optional wallet emits an identity change during confirmation", async () => {
+    const pending = deferred();
+    const eth = ethWallet("metamask", ETH_ACCOUNT);
+    const { connectedWallet: btc, provider: btcProvider } = eventWallet("unisat", BTC_ACCOUNT);
+    acceptTermsOfService.mockReturnValue(pending.promise);
+    harness.connectors = {
+      ETH: { config: { chainId: 11155111 }, connectedWallet: eth, disconnect: disconnectEth },
+      BTC: { config: { network: "signet" }, connectedWallet: btc, disconnect: vi.fn() },
+      BBN: null,
+    };
+    setup({ requiredChainIds: ["ETH"] });
+
+    act(() => {
+      screen.getByText("confirm").click();
+    });
+    await waitFor(() => expect(acceptTermsOfService).toHaveBeenCalledTimes(1));
+
+    act(() => {
+      btcProvider.emit("accountsChanged", ["bc1psomeoneelse"]);
+    });
+    await act(async () => pending.resolve());
+
+    expect(onConfirm).not.toHaveBeenCalled();
+    expect(confirm).not.toHaveBeenCalled();
+  });
+
+  it("stops an active attempt when required chains change", async () => {
+    const pending = deferred();
+    acceptTermsOfService.mockReturnValue(pending.promise);
+    const view = setup({ requiredChainIds: ["ETH"] });
+
+    act(() => {
+      screen.getByText("confirm").click();
+    });
+    await waitFor(() => expect(acceptTermsOfService).toHaveBeenCalledTimes(1));
+
+    harness.widgetState = { ...harness.widgetState, requiredChainIds: ["ETH", "BTC"] };
+    view.rerender(<WalletDialog persistent storage={storage} config={[]} />);
+    await act(async () => pending.resolve());
+
+    expect(onConfirm).not.toHaveBeenCalled();
+    expect(confirm).not.toHaveBeenCalled();
+  });
+
+  it("removes an old requirement listener before a new attempt starts", async () => {
+    const oldHook = deferred();
+    const newHook = deferred();
+    const { connectedWallet: eth, provider: ethProvider } = eventWallet("metamask", ETH_ACCOUNT);
+    const btc = btcWallet("unisat", BTC_ACCOUNT);
+    acceptTermsOfService.mockReturnValueOnce(oldHook.promise).mockReturnValueOnce(newHook.promise);
+    harness.connectors = {
+      ETH: { config: { chainId: 11155111 }, connectedWallet: eth, disconnect: disconnectEth },
+      BTC: { config: { network: "signet" }, connectedWallet: btc, disconnect: vi.fn() },
+      BBN: null,
+    };
+    const view = setup({ requiredChainIds: ["ETH"] });
+
+    act(() => {
+      screen.getByText("confirm").click();
+    });
+    await waitFor(() => expect(acceptTermsOfService).toHaveBeenCalledTimes(1));
+
+    harness.connectors = { ...harness.connectors, ETH: null };
+    harness.widgetState = { ...harness.widgetState, requiredChainIds: ["BTC"] };
+    view.rerender(<WalletDialog persistent storage={storage} config={[]} />);
+    act(() => {
+      screen.getByText("confirm").click();
+    });
+    await waitFor(() => expect(acceptTermsOfService).toHaveBeenCalledTimes(2));
+
+    act(() => {
+      ethProvider.emit("accountsChanged", ["0xoldattemptchange"]);
+    });
+    await act(async () => newHook.resolve());
+
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+    expect(confirm).toHaveBeenCalledTimes(1);
+
+    await act(async () => oldHook.resolve());
   });
 
   it("runs one confirmation when the user submits twice", async () => {

--- a/packages/babylon-wallet-connector/src/constants/walletEvents.ts
+++ b/packages/babylon-wallet-connector/src/constants/walletEvents.ts
@@ -15,8 +15,33 @@ export function isAccountChangeEvent(eventName: string): eventName is AccountCha
   return ACCOUNT_CHANGE_EVENTS.includes(eventName as AccountChangeEvent);
 }
 
+export const NETWORK_CHANGE_EVENT = "networkChanged" as const;
+
 /** Event name for disconnect */
 export const DISCONNECT_EVENT = "disconnect" as const;
+
+export function trackProviderIdentityChanges(
+  provider: { on?: (event: string, callback: () => void) => void },
+  callback: () => void,
+): boolean {
+  if (typeof provider.on !== "function") return false;
+
+  try {
+    provider.on("accountsChanged", callback);
+  } catch {
+    return false;
+  }
+
+  [NETWORK_CHANGE_EVENT, DISCONNECT_EVENT].forEach((event) => {
+    try {
+      provider.on?.(event, callback);
+    } catch {
+      // Some wallet providers reject event names that they do not support.
+    }
+  });
+
+  return true;
+}
 
 /**
  * Window event dispatched when the wallet-selection modal opens.

--- a/packages/babylon-wallet-connector/src/context/State.context.tsx
+++ b/packages/babylon-wallet-connector/src/context/State.context.tsx
@@ -1,4 +1,4 @@
-import { type PropsWithChildren, createContext, useEffect, useMemo, useRef, useState } from "react";
+import { type PropsWithChildren, createContext, useEffect, useInsertionEffect, useMemo, useRef, useState } from "react";
 
 import { WALLET_MODAL_OPEN_EVENT } from "@/constants/walletEvents";
 import { WALLET_CONFIRMATION_RECEIPT_KEY } from "@/core/confirmationReceipt";
@@ -17,6 +17,8 @@ export type Screens =
 
 export interface State {
   confirmed: boolean;
+  /** The wallet identity that the user approved for this live session. */
+  confirmationReceipt?: string;
   visible: boolean;
   screen: Screens;
   selectedWallets: Record<string, IWallet | undefined>;
@@ -46,9 +48,9 @@ export interface Actions {
   }) => void;
   selectWallet?: (chain: string, wallet: IWallet) => void;
   removeWallet?: (chain: string) => void;
-  confirm?: () => void;
+  confirm?: (receipt: string) => void;
   /** Withdraws the confirmation without disconnecting anything. */
-  unconfirm?: () => void;
+  unconfirm?: (keepReceipt?: boolean) => void;
   reset?: () => void;
 }
 
@@ -89,22 +91,31 @@ export function StateProvider({ children, chains, requiredChainIds, storage }: P
     chains: chains.reduce((acc, chain) => ({ ...acc, [chain.id]: chain }), {}),
     requiredChainIds: [...requiredChainIds],
   }));
-  const stateRef = useRef(state);
-  stateRef.current = state;
-
-  // A change to the requirement set is not itself a consent change. Hosts that
-  // derive requirements per route narrow and widen this list as the user
-  // navigates, and tearing the confirmation down here would sign them out on
-  // routine navigation. Whether the stored approval still covers the new set is
-  // decided in `useWalletConnectors`, which can see the live connections.
+  const requirementsExpanded = requiredChainIds.some((chainId) => !state.requiredChainIds.includes(chainId));
+  const renderedState = useMemo(
+    () => ({
+      ...state,
+      confirmed: requirementsExpanded ? false : state.confirmed,
+      requiredChainIds: [...requiredChainIds],
+    }),
+    [requiredChainIds, requirementsExpanded, state],
+  );
+  const requiredChainIdsRef = useRef(requiredChainIds);
+  useInsertionEffect(() => {
+    requiredChainIdsRef.current = requiredChainIds;
+  }, [requiredChainIds]);
+  // Expose new requirements as unconfirmed during render. This prevents a
+  // child from observing one approved commit before live validation starts.
   useEffect(() => {
     setState((state) => {
       const newChains = chains.reduce((acc, chain) => ({ ...acc, [chain.id]: chain }), {});
       const validChainIds = new Set(chains.map((chain) => chain.id));
       const filteredWallets = filterWalletsByValidChains(state.selectedWallets, validChainIds);
+      const requirementsExpanded = requiredChainIds.some((chainId) => !state.requiredChainIds.includes(chainId));
 
       return {
         ...state,
+        confirmed: requirementsExpanded ? false : state.confirmed,
         chains: newChains,
         selectedWallets: filteredWallets,
         requiredChainIds: [...requiredChainIds],
@@ -158,7 +169,8 @@ export function StateProvider({ children, chains, requiredChainIds, storage }: P
       },
 
       removeWallet: (chain: string) => {
-        if (stateRef.current.requiredChainIds.includes(chain)) {
+        const required = requiredChainIdsRef.current.includes(chain);
+        if (required) {
           storage?.delete(WALLET_CONFIRMATION_RECEIPT_KEY);
         }
         setState((state) => ({
@@ -166,17 +178,22 @@ export function StateProvider({ children, chains, requiredChainIds, storage }: P
           // Losing an optional chain must not tear down a confirmed session.
           // Losing a required one does invalidate the confirmation, so
           // reconnecting cannot silently restore it.
-          confirmed: state.requiredChainIds.includes(chain) ? false : state.confirmed,
+          confirmed: required ? false : state.confirmed,
+          confirmationReceipt: required ? undefined : state.confirmationReceipt,
           selectedWallets: { ...state.selectedWallets, [chain]: undefined },
         }));
       },
 
-      confirm: () => {
-        setState((state) => ({ ...state, confirmed: true }));
+      confirm: (confirmationReceipt: string) => {
+        setState((state) => ({ ...state, confirmed: true, confirmationReceipt }));
       },
 
-      unconfirm: () => {
-        setState((state) => (state.confirmed ? { ...state, confirmed: false } : state));
+      unconfirm: (keepReceipt = false) => {
+        setState((state) => ({
+          ...state,
+          confirmed: false,
+          confirmationReceipt: keepReceipt ? state.confirmationReceipt : undefined,
+        }));
       },
     }),
     [storage],
@@ -184,10 +201,10 @@ export function StateProvider({ children, chains, requiredChainIds, storage }: P
 
   const context = useMemo(
     () => ({
-      ...state,
+      ...renderedState,
       ...actions,
     }),
-    [state, actions],
+    [renderedState, actions],
   );
 
   return <StateContext.Provider value={context}>{children}</StateContext.Provider>;

--- a/packages/babylon-wallet-connector/src/context/__tests__/Chain.context.requiredChains.test.tsx
+++ b/packages/babylon-wallet-connector/src/context/__tests__/Chain.context.requiredChains.test.tsx
@@ -1,8 +1,9 @@
-import { renderHook, waitFor } from "@testing-library/react";
-import { type PropsWithChildren } from "react";
+import { act, render, renderHook, waitFor } from "@testing-library/react";
+import { type PropsWithChildren, useLayoutEffect } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { ChainProvider, type ChainConfigArr, type ChainMetadataMap } from "@/context/Chain.context";
+import { StateProvider } from "@/context/State.context";
 import type { ChainId, HashMap } from "@/core/types";
 import { useWidgetState } from "@/hooks/useWidgetState";
 
@@ -89,5 +90,88 @@ describe("required chains", () => {
     // BBN has no metadata here, so no connector exists for it — but a chain the
     // host requires must not quietly drop out of the requirement set.
     expect(result.current.requiredChainIds).toContain("BBN");
+  });
+
+  it("exposes a widened requirement as unconfirmed on its first render", () => {
+    const snapshots: Array<{ confirmed: boolean; hostRequiredChainIds: readonly string[] }> = [];
+    let confirm: ((receipt: string) => void) | undefined;
+    const Probe = ({ hostRequiredChainIds }: { hostRequiredChainIds: readonly string[] }) => {
+      const state = useWidgetState();
+      confirm = state.confirm;
+      snapshots.push({ confirmed: state.confirmed, hostRequiredChainIds });
+      return null;
+    };
+    const initialRequiredChainIds = ["ETH"];
+    const widenedRequiredChainIds = ["BTC", "ETH"];
+    const view = render(
+      <StateProvider chains={[]} requiredChainIds={initialRequiredChainIds} storage={storage}>
+        <Probe hostRequiredChainIds={initialRequiredChainIds} />
+      </StateProvider>,
+    );
+    act(() => confirm?.("approved receipt"));
+    const firstWidenedRender = snapshots.length;
+
+    view.rerender(
+      <StateProvider chains={[]} requiredChainIds={widenedRequiredChainIds} storage={storage}>
+        <Probe hostRequiredChainIds={widenedRequiredChainIds} />
+      </StateProvider>,
+    );
+
+    expect(
+      snapshots.slice(firstWidenedRender).some(({ confirmed, hostRequiredChainIds }) =>
+        hostRequiredChainIds.includes("BTC") && confirmed,
+      ),
+    ).toBe(false);
+  });
+
+  it("uses committed requirements in an old wallet-removal callback", () => {
+    let state = {} as ReturnType<typeof useWidgetState>;
+    const Probe = () => {
+      state = useWidgetState();
+      return null;
+    };
+    const view = render(
+      <StateProvider chains={[]} requiredChainIds={["BTC", "ETH"]} storage={storage}>
+        <Probe />
+      </StateProvider>,
+    );
+    act(() => state.confirm?.("approved receipt"));
+    const oldRemoveWallet = state.removeWallet;
+
+    view.rerender(
+      <StateProvider chains={[]} requiredChainIds={["ETH"]} storage={storage}>
+        <Probe />
+      </StateProvider>,
+    );
+    act(() => oldRemoveWallet?.("BTC"));
+
+    expect(state.confirmed).toBe(true);
+    expect(state.confirmationReceipt).toBe("approved receipt");
+  });
+
+  it("uses narrowed requirements before child layout effects run", () => {
+    let state = {} as ReturnType<typeof useWidgetState>;
+    const Probe = ({ removeBtc }: { removeBtc: boolean }) => {
+      state = useWidgetState();
+      useLayoutEffect(() => {
+        if (removeBtc) state.removeWallet?.("BTC");
+      }, [removeBtc]);
+      return null;
+    };
+    const view = render(
+      <StateProvider chains={[]} requiredChainIds={["BTC", "ETH"]} storage={storage}>
+        <Probe removeBtc={false} />
+      </StateProvider>,
+    );
+    act(() => state.confirm?.("approved receipt"));
+
+    view.rerender(
+      <StateProvider chains={[]} requiredChainIds={["ETH"]} storage={storage}>
+        <Probe removeBtc />
+      </StateProvider>,
+    );
+
+    expect(state.confirmed).toBe(true);
+    expect(state.confirmationReceipt).toBe("approved receipt");
   });
 });

--- a/packages/babylon-wallet-connector/src/core/__tests__/confirmationReceipt.test.ts
+++ b/packages/babylon-wallet-connector/src/core/__tests__/confirmationReceipt.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import type { Connectors } from "@/context/Chain.context";
 import {
   createConfirmationReceipt,
+  isLiveConfirmationReceiptValid,
   isValidConfirmationReceipt,
   type ConfirmationConnection,
 } from "@/core/confirmationReceipt";
@@ -127,5 +128,74 @@ describe("isValidConfirmationReceipt", () => {
     const disconnected = connectors({ ethWallet: wallet("metamask", ETH_ACCOUNT) });
 
     expect(isValidConfirmationReceipt(receipt, ["BTC", "ETH"], disconnected)).toBe(false);
+  });
+});
+
+describe("isLiveConfirmationReceiptValid", () => {
+  function liveWallet(
+    id: string,
+    approved: Account,
+    current: { account: Account; network: string | number; identityCurrent?: boolean },
+  ): IWallet {
+    return {
+      ...wallet(id, approved),
+      provider: {
+        connectWallet: async () => {},
+        getAddress: async () => current.account.address,
+        getPublicKeyHex: async () => current.account.publicKeyHex,
+        getNetwork: async () => current.network,
+        getChainId: async () => current.network,
+        isIdentityCurrent: () => current.identityCurrent !== false,
+      },
+    } as IWallet;
+  }
+
+  it("rejects a live account change that the connector cache has not received", async () => {
+    const current = { account: BTC_ACCOUNT, network: "signet" };
+    const btcWallet = liveWallet("unisat", BTC_ACCOUNT, current);
+    const live = connectors({ btcWallet });
+    const receipt = createConfirmationReceipt([connection("BTC", "unisat", BTC_ACCOUNT)], live);
+
+    current.account = { address: "bc1psomeoneelse", publicKeyHex: `02${"c".repeat(64)}` };
+
+    await expect(isLiveConfirmationReceiptValid(receipt, ["BTC"], live)).resolves.toBe(false);
+  });
+
+  it("rejects an adapter cache invalidated by a provider event", async () => {
+    const current = { account: BTC_ACCOUNT, network: "signet", identityCurrent: true };
+    const btcWallet = liveWallet("unisat", BTC_ACCOUNT, current);
+    const live = connectors({ btcWallet });
+    const receipt = createConfirmationReceipt([connection("BTC", "unisat", BTC_ACCOUNT)], live);
+
+    current.identityCurrent = false;
+
+    await expect(isLiveConfirmationReceiptValid(receipt, ["BTC"], live)).resolves.toBe(false);
+  });
+
+  it("rejects a live network change", async () => {
+    const current = { account: ETH_ACCOUNT, network: 11155111 };
+    const ethWallet = liveWallet("metamask", ETH_ACCOUNT, current);
+    const live = connectors({ ethWallet });
+    const receipt = createConfirmationReceipt([connection("ETH", "metamask", ETH_ACCOUNT)], live);
+
+    current.network = 1;
+
+    await expect(isLiveConfirmationReceiptValid(receipt, ["ETH"], live)).resolves.toBe(false);
+  });
+
+  it("ignores a changed optional wallet", async () => {
+    const btc = { account: BTC_ACCOUNT, network: "signet" };
+    const eth = { account: ETH_ACCOUNT, network: 11155111 };
+    const btcWallet = liveWallet("unisat", BTC_ACCOUNT, btc);
+    const ethWallet = liveWallet("metamask", ETH_ACCOUNT, eth);
+    const live = connectors({ btcWallet, ethWallet });
+    const receipt = createConfirmationReceipt(
+      [connection("BTC", "unisat", BTC_ACCOUNT), connection("ETH", "metamask", ETH_ACCOUNT)],
+      live,
+    );
+
+    btc.account = { address: "bc1psomeoneelse", publicKeyHex: `02${"c".repeat(64)}` };
+
+    await expect(isLiveConfirmationReceiptValid(receipt, ["ETH"], live)).resolves.toBe(true);
   });
 });

--- a/packages/babylon-wallet-connector/src/core/confirmationReceipt.ts
+++ b/packages/babylon-wallet-connector/src/core/confirmationReceipt.ts
@@ -1,5 +1,6 @@
+import { DISCONNECT_EVENT, NETWORK_CHANGE_EVENT } from "@/constants/walletEvents";
 import type { Connectors } from "@/context/Chain.context";
-import type { Account, ChainId, IWallet } from "@/core/types";
+import type { Account, ChainId, IBTCProvider, IETHProvider, IProvider, IWallet } from "@/core/types";
 
 export const WALLET_CONFIRMATION_RECEIPT_KEY = "__babylon-wallet-confirmation-v1__";
 
@@ -23,6 +24,17 @@ interface ConfirmationReceipt {
   version: typeof RECEIPT_VERSION;
   entries: ConfirmationReceiptEntry[];
 }
+
+const IDENTITY_CHANGE_EVENTS: Record<ChainId, readonly string[]> = {
+  BTC: ["accountsChanged", NETWORK_CHANGE_EVENT, DISCONNECT_EVENT],
+  BBN: ["accountChanged"],
+  ETH: ["accountsChanged", "chainChanged"],
+};
+
+type IdentityEventProvider = IProvider & {
+  on?: (event: string, handler: (...args: unknown[]) => void) => void;
+  off?: (event: string, handler: (...args: unknown[]) => void) => void;
+};
 
 function connectorFor(connectors: Connectors, chain: ChainId) {
   return connectors[chain];
@@ -62,6 +74,25 @@ function isReceiptEntry(value: unknown): value is ConfirmationReceiptEntry {
     typeof entry.publicKeyHex === "string" &&
     typeof entry.network === "string"
   );
+}
+
+function parseConfirmationReceipt(serialized: string | undefined): ConfirmationReceipt | undefined {
+  if (!serialized) return;
+
+  try {
+    const receipt = JSON.parse(serialized) as Partial<ConfirmationReceipt>;
+    if (
+      receipt?.version !== RECEIPT_VERSION ||
+      !Array.isArray(receipt.entries) ||
+      !receipt.entries.every(isReceiptEntry)
+    ) {
+      return;
+    }
+
+    return receipt as ConfirmationReceipt;
+  } catch {
+    return;
+  }
 }
 
 /**
@@ -106,28 +137,8 @@ export function isValidConfirmationReceipt(
   requiredChainIds: readonly string[],
   connectors: Connectors,
 ): boolean {
-  if (!serialized) return false;
-
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(serialized) as unknown;
-  } catch {
-    return false;
-  }
-
-  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return false;
-
-  const receipt = parsed as Partial<ConfirmationReceipt>;
-
-  if (
-    receipt.version !== RECEIPT_VERSION ||
-    !Array.isArray(receipt.entries) ||
-    !receipt.entries.every(isReceiptEntry)
-  ) {
-    return false;
-  }
-
-  const entries = receipt.entries;
+  const entries = parseConfirmationReceipt(serialized)?.entries;
+  if (!entries) return false;
 
   // An empty requirement set is satisfied by any receipt, but never by none:
   // the caller still has to have an approval on file.
@@ -149,16 +160,130 @@ export function isValidConfirmationReceipt(
   });
 }
 
+export function isConfirmationReceiptCovered(
+  serialized: string | undefined,
+  requiredChainIds: readonly string[],
+  connectors: Connectors,
+): boolean {
+  const entries = parseConfirmationReceipt(serialized)?.entries;
+  if (!entries) return false;
+
+  return requiredChainIds.every((chainId) => {
+    const chain = chainId as ChainId;
+    const wallet = connectorFor(connectors, chain)?.connectedWallet;
+    const entry = entries.find((candidate) => candidate.chain === chain);
+
+    return Boolean(
+      wallet && entry && entry.walletId === wallet.id && entry.network === networkIdentity(connectors, chain),
+    );
+  });
+}
+
+/** Checks the current provider values instead of the connector's cached account. */
+export async function isLiveConfirmationReceiptValid(
+  serialized: string | undefined,
+  requiredChainIds: readonly string[],
+  connectors: Connectors,
+): Promise<boolean> {
+  const entries = parseConfirmationReceipt(serialized)?.entries;
+  if (!entries) return false;
+
+  const matches = await Promise.all(
+    requiredChainIds.map(async (chainId) => {
+      const chain = chainId as ChainId;
+      const connector = connectorFor(connectors, chain);
+      const wallet = connector?.connectedWallet;
+      const provider = wallet?.provider;
+      const entry = entries.find((candidate) => candidate.chain === chain);
+      if (!wallet || !provider || !entry || entry.walletId !== wallet.id) return false;
+
+      try {
+        if (provider.isIdentityCurrent?.() === false) return false;
+        const [address, publicKeyHex, network] = await Promise.all([
+          provider.getAddress(),
+          provider.getPublicKeyHex(),
+          chain === "ETH"
+            ? (provider as IETHProvider).getChainId()
+            : chain === "BTC"
+              ? (provider as IBTCProvider).getNetwork()
+              : networkIdentity(connectors, chain),
+        ]);
+        if (provider.isIdentityCurrent?.() === false) return false;
+
+        return (
+          sameIdentity(entry.address, address) &&
+          sameIdentity(entry.publicKeyHex, publicKeyHex) &&
+          entry.network === String(network)
+        );
+      } catch {
+        return false;
+      }
+    }),
+  );
+
+  return matches.every(Boolean);
+}
+
+export function subscribeToConfirmationIdentityChanges(
+  serialized: string,
+  requiredChainIds: readonly string[],
+  connectors: Connectors,
+  onChange: (chain: ChainId) => void,
+): () => void {
+  const entries = parseConfirmationReceipt(serialized)?.entries;
+  if (!entries) return () => {};
+
+  const subscriptions: Array<{
+    event: string;
+    handler: (...args: unknown[]) => void;
+    provider: IdentityEventProvider;
+  }> = [];
+
+  requiredChainIds.forEach((chainId) => {
+    const chain = chainId as ChainId;
+    const provider = connectors[chain]?.connectedWallet?.provider as IdentityEventProvider | null | undefined;
+    if (!provider?.on) return;
+
+    IDENTITY_CHANGE_EVENTS[chain]?.forEach((event) => {
+      const handler = (...args: unknown[]) => {
+        const accounts = args[0];
+        const approved = entries.find((entry) => entry.chain === chain);
+        if (
+          chain === "ETH" &&
+          event === "accountsChanged" &&
+          Array.isArray(accounts) &&
+          accounts.length === 1 &&
+          typeof accounts[0] === "string" &&
+          approved &&
+          sameIdentity(approved.address, accounts[0])
+        ) {
+          return;
+        }
+
+        onChange(chain);
+      };
+
+      try {
+        provider.on?.(event, handler);
+        subscriptions.push({ event, handler, provider });
+      } catch {
+        // Some wallet adapters reject event names they do not support.
+      }
+    });
+  });
+
+  return () => {
+    subscriptions.forEach(({ event, handler, provider }) => {
+      try {
+        provider.off?.(event, handler);
+      } catch {
+        // The provider can disconnect before the listener is removed.
+      }
+    });
+  };
+}
+
 /** Chains the stored approval names, whether or not they are required now. */
 export function confirmedChains(serialized: string | undefined): ChainId[] {
-  if (!serialized) return [];
-
-  try {
-    const parsed = JSON.parse(serialized) as Partial<ConfirmationReceipt>;
-    if (parsed?.version !== RECEIPT_VERSION || !Array.isArray(parsed.entries)) return [];
-
-    return parsed.entries.filter(isReceiptEntry).map((entry) => entry.chain);
-  } catch {
-    return [];
-  }
+  return parseConfirmationReceipt(serialized)?.entries.map((entry) => entry.chain) ?? [];
 }

--- a/packages/babylon-wallet-connector/src/core/types.ts
+++ b/packages/babylon-wallet-connector/src/core/types.ts
@@ -198,6 +198,7 @@ export interface IProvider {
   connectWallet: (onProgress?: ProgressReporter) => Promise<void>;
   getAddress: () => Promise<string>;
   getPublicKeyHex: () => Promise<string>;
+  isIdentityCurrent?: () => boolean;
 }
 
 export interface IWallet<P extends IProvider = IProvider> {

--- a/packages/babylon-wallet-connector/src/core/wallets/bbn/__tests__/provider.identity.test.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/bbn/__tests__/provider.identity.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { BBNConfig, IBBNProvider } from "@/core/types";
+import { KeplrProvider } from "@/core/wallets/bbn/keplr/provider";
+import { LeapProvider } from "@/core/wallets/bbn/leap/provider";
+import { OKXBabylonProvider } from "@/core/wallets/bbn/okx/provider";
+
+const config = {
+  chainId: "bbn-test-5",
+  rpc: "https://rpc.example.com",
+  chainData: {},
+} as BBNConfig;
+
+describe.each([
+  ["Keplr", (wallet: unknown) => new KeplrProvider(wallet as ConstructorParameters<typeof KeplrProvider>[0], config)],
+  ["Leap", (wallet: unknown) => new LeapProvider(wallet, config)],
+  ["OKX", (wallet: unknown) => new OKXBabylonProvider({ keplr: wallet }, config)],
+])("%s Babylon provider identity", (_name, createProvider) => {
+  it("reads the current key instead of the connection cache", async () => {
+    let key = { bech32Address: "bbn1old", pubKey: Uint8Array.from([1, 2, 3]) };
+    const wallet = {
+      enable: vi.fn(async () => {}),
+      getKey: vi.fn(async () => key),
+    };
+    const provider = createProvider(wallet) as IBBNProvider;
+
+    await provider.connectWallet();
+    key = { bech32Address: "bbn1new", pubKey: Uint8Array.from([4, 5, 6]) };
+
+    await expect(provider.getAddress()).resolves.toBe("bbn1new");
+    await expect(provider.getPublicKeyHex()).resolves.toBe("040506");
+  });
+});

--- a/packages/babylon-wallet-connector/src/core/wallets/bbn/keplr/provider.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/bbn/keplr/provider.ts
@@ -83,8 +83,11 @@ export class KeplrProvider implements IBBNProvider {
         }
       }
     }
-    const key = await this.keplr.getKey(this.chainId);
+    this.walletInfo = await this.getLiveWalletInfo();
+  }
 
+  private async getLiveWalletInfo(): Promise<WalletInfo> {
+    const key = await this.keplr!.getKey(this.chainId!);
     if (!key)
       throw new WalletError({
         code: ERROR_CODES.WALLET_INITIALIZATION_FAILED,
@@ -95,7 +98,7 @@ export class KeplrProvider implements IBBNProvider {
     const { bech32Address, pubKey } = key;
 
     if (bech32Address && pubKey) {
-      this.walletInfo = {
+      return {
         publicKeyHex: Buffer.from(key.pubKey).toString("hex"),
         address: bech32Address,
       };
@@ -115,7 +118,7 @@ export class KeplrProvider implements IBBNProvider {
         message: "Wallet not connected",
         wallet: WALLET_PROVIDER_NAME,
       });
-    return this.walletInfo.address;
+    return (await this.getLiveWalletInfo()).address;
   }
 
   async getPublicKeyHex(): Promise<string> {
@@ -125,7 +128,7 @@ export class KeplrProvider implements IBBNProvider {
         message: "Wallet not connected",
         wallet: WALLET_PROVIDER_NAME,
       });
-    return this.walletInfo.publicKeyHex;
+    return (await this.getLiveWalletInfo()).publicKeyHex;
   }
 
   async getWalletProviderName(): Promise<string> {

--- a/packages/babylon-wallet-connector/src/core/wallets/bbn/leap/provider.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/bbn/leap/provider.ts
@@ -88,8 +88,11 @@ export class LeapProvider implements IBBNProvider {
         }
       }
     }
-    const key = await this.wallet.getKey(this.chainId);
+    this.walletInfo = await this.getLiveWalletInfo();
+  }
 
+  private async getLiveWalletInfo(): Promise<WalletInfo> {
+    const key = await this.wallet.getKey(this.chainId!);
     if (!key)
       throw new WalletError({
         code: ERROR_CODES.FAILED_TO_GET_KEY,
@@ -100,7 +103,7 @@ export class LeapProvider implements IBBNProvider {
     const { bech32Address, pubKey } = key;
 
     if (bech32Address && pubKey) {
-      this.walletInfo = {
+      return {
         publicKeyHex: Buffer.from(key.pubKey).toString("hex"),
         address: bech32Address,
       };
@@ -120,7 +123,7 @@ export class LeapProvider implements IBBNProvider {
         message: "Wallet not connected",
         wallet: WALLET_PROVIDER_NAME,
       });
-    return this.walletInfo.address;
+    return (await this.getLiveWalletInfo()).address;
   }
 
   async getPublicKeyHex(): Promise<string> {
@@ -130,7 +133,7 @@ export class LeapProvider implements IBBNProvider {
         message: "Wallet not connected",
         wallet: WALLET_PROVIDER_NAME,
       });
-    return this.walletInfo.publicKeyHex;
+    return (await this.getLiveWalletInfo()).publicKeyHex;
   }
 
   async getWalletProviderName(): Promise<string> {

--- a/packages/babylon-wallet-connector/src/core/wallets/bbn/okx/provider.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/bbn/okx/provider.ts
@@ -3,8 +3,8 @@ import { Buffer } from "buffer";
 
 import { isAccountChangeEvent } from "@/constants/walletEvents";
 import { BBNConfig, IBBNProvider, WalletInfo } from "@/core/types";
-import { ERROR_CODES, WalletError } from "@/error";
 import logo from "@/core/wallets/icons/okx.svg";
+import { ERROR_CODES, WalletError } from "@/error";
 
 export const WALLET_PROVIDER_NAME = "OKX";
 
@@ -88,8 +88,11 @@ export class OKXBabylonProvider implements IBBNProvider {
         }
       }
     }
-    const key = await this.wallet.keplr.getKey(this.chainId);
+    this.walletInfo = await this.getLiveWalletInfo();
+  }
 
+  private async getLiveWalletInfo(): Promise<WalletInfo> {
+    const key = await this.wallet.keplr.getKey(this.chainId!);
     if (!key)
       throw new WalletError({
         code: ERROR_CODES.FAILED_TO_GET_KEY,
@@ -100,7 +103,7 @@ export class OKXBabylonProvider implements IBBNProvider {
     const { bech32Address, pubKey } = key;
 
     if (bech32Address && pubKey) {
-      this.walletInfo = {
+      return {
         publicKeyHex: Buffer.from(key.pubKey).toString("hex"),
         address: bech32Address,
       };
@@ -120,7 +123,7 @@ export class OKXBabylonProvider implements IBBNProvider {
         message: "Wallet not connected",
         wallet: WALLET_PROVIDER_NAME,
       });
-    return this.walletInfo.address;
+    return (await this.getLiveWalletInfo()).address;
   }
 
   async getPublicKeyHex(): Promise<string> {
@@ -130,7 +133,7 @@ export class OKXBabylonProvider implements IBBNProvider {
         message: "Wallet not connected",
         wallet: WALLET_PROVIDER_NAME,
       });
-    return this.walletInfo.publicKeyHex;
+    return (await this.getLiveWalletInfo()).publicKeyHex;
   }
 
   async getWalletProviderName(): Promise<string> {

--- a/packages/babylon-wallet-connector/src/core/wallets/btc/appkit/__tests__/provider.network.test.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/appkit/__tests__/provider.network.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { BTCConfig } from "@/core/types";
+import { Network } from "@/core/types";
+
+import { APPKIT_BTC_CONNECTED_EVENT } from "../constants";
+import { getCaipNetworkForNetwork } from "../network";
+import { AppKitBTCProvider } from "../provider";
+import { __resetSharedBtcAppKitConfigForTests, setSharedBtcAppKitConfig } from "../sharedConfig";
+
+interface NetworkState {
+  caipNetwork?: {
+    chainNamespace: string;
+    caipNetworkId: string;
+  };
+}
+
+afterEach(() => {
+  __resetSharedBtcAppKitConfigForTests();
+});
+
+describe("AppKitBTCProvider network events", () => {
+  it("emits only after the active BTC network changes", async () => {
+    const connectionEvents = new EventTarget();
+    const unsubscribeNetwork = vi.fn();
+    let networkListener: ((state: NetworkState) => void) | undefined;
+    const modal = {
+      disconnect: vi.fn().mockResolvedValue(undefined),
+      subscribeNetwork: vi.fn((listener: (state: NetworkState) => void) => {
+        networkListener = listener;
+        return unsubscribeNetwork;
+      }),
+    };
+    setSharedBtcAppKitConfig({
+      modal: modal as never,
+      adapter: {} as never,
+      network: "signet",
+      connectionEvents,
+    });
+    const provider = new AppKitBTCProvider({ network: Network.SIGNET } as BTCConfig);
+    const onNetworkChanged = vi.fn();
+    provider.on("networkChanged", onNetworkChanged);
+
+    const connection = provider.connectWallet();
+    connectionEvents.dispatchEvent(
+      new CustomEvent(APPKIT_BTC_CONNECTED_EVENT, {
+        detail: { address: "bc1pdepositor", publicKey: `02${"a".repeat(64)}` },
+      }),
+    );
+    await connection;
+
+    networkListener?.({ caipNetwork: { chainNamespace: "eip155", caipNetworkId: "eip155:1" } });
+    const signetId = getCaipNetworkForNetwork("signet").caipNetworkId;
+    const mainnetId = getCaipNetworkForNetwork("mainnet").caipNetworkId;
+    networkListener?.({ caipNetwork: { chainNamespace: "bip122", caipNetworkId: signetId } });
+    expect(onNetworkChanged).not.toHaveBeenCalled();
+
+    networkListener?.({ caipNetwork: { chainNamespace: "bip122", caipNetworkId: mainnetId } });
+    expect(onNetworkChanged).toHaveBeenCalledWith(mainnetId);
+
+    await provider.disconnect();
+    expect(unsubscribeNetwork).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/babylon-wallet-connector/src/core/wallets/btc/appkit/provider.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/appkit/provider.ts
@@ -1,6 +1,7 @@
 import type { BitcoinAdapter } from "@reown/appkit-adapter-bitcoin";
 import { Psbt } from "bitcoinjs-lib";
 
+import { NETWORK_CHANGE_EVENT } from "@/constants/walletEvents";
 import type { BTCConfig, IBTCProvider, InscriptionIdentifier, SignPsbtOptions } from "@/core/types";
 import { Network } from "@/core/types";
 import { resolveUseTweakedSigner } from "@/core/utils/psbtOptionsMapper";
@@ -10,7 +11,7 @@ import { ERROR_CODES, WalletError, isUserRejectionMessage } from "@/error";
 
 import { APPKIT_BTC_CONNECTED_EVENT } from "./constants";
 import icon from "./icon.svg";
-import { resolveLiveNetwork } from "./network";
+import { getCaipNetworkForNetwork, resolveLiveNetwork } from "./network";
 import { getSharedBtcAppKitConfig, hasSharedBtcAppKitConfig } from "./sharedConfig";
 
 const APPKIT_PROVIDER_NAME = "AppKit";
@@ -58,6 +59,8 @@ export class AppKitBTCProvider implements IBTCProvider {
   private eventHandlers: Map<string, Set<(...args: unknown[]) => void>> = new Map();
   private listeningForChanges = false;
   private boundHandleAccountChange: ((event: Event) => void) | null = null;
+  private unsubscribeNetwork: (() => void) | null = null;
+  private lastBtcNetworkId?: string;
   /**
    * The {@link EventTarget} we currently have a persistent listener on.
    * Captured at registration time so we always remove the listener from
@@ -104,7 +107,7 @@ export class AppKitBTCProvider implements IBTCProvider {
     if (this.listeningForChanges) return;
     if (!hasSharedBtcAppKitConfig()) return;
 
-    const { connectionEvents } = getSharedBtcAppKitConfig();
+    const { connectionEvents, modal } = getSharedBtcAppKitConfig();
 
     this.boundHandleAccountChange = (event: Event) => {
       const detail = (event as BtcConnectedEvent).detail;
@@ -129,6 +132,17 @@ export class AppKitBTCProvider implements IBTCProvider {
 
     connectionEvents.addEventListener(APPKIT_BTC_CONNECTED_EVENT, this.boundHandleAccountChange);
     this.boundConnectionEventsTarget = connectionEvents;
+    const configuredNetwork = this.config.network === Network.MAINNET ? "mainnet" : "signet";
+    this.lastBtcNetworkId = getCaipNetworkForNetwork(configuredNetwork).caipNetworkId;
+    this.unsubscribeNetwork = modal.subscribeNetwork(({ caipNetwork }) => {
+      if (caipNetwork?.chainNamespace !== "bip122") return;
+
+      const networkId = caipNetwork.caipNetworkId;
+      if (networkId === this.lastBtcNetworkId) return;
+
+      this.lastBtcNetworkId = networkId;
+      this.emit(NETWORK_CHANGE_EVENT, networkId);
+    });
     this.listeningForChanges = true;
   }
 
@@ -143,6 +157,9 @@ export class AppKitBTCProvider implements IBTCProvider {
     );
     this.boundHandleAccountChange = null;
     this.boundConnectionEventsTarget = null;
+    this.unsubscribeNetwork?.();
+    this.unsubscribeNetwork = null;
+    this.lastBtcNetworkId = undefined;
     this.listeningForChanges = false;
   }
 

--- a/packages/babylon-wallet-connector/src/core/wallets/btc/okx/provider.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/okx/provider.ts
@@ -1,10 +1,16 @@
-import { isAccountChangeEvent, DISCONNECT_EVENT, removeProviderListener } from "@/constants/walletEvents";
+import {
+  DISCONNECT_EVENT,
+  NETWORK_CHANGE_EVENT,
+  isAccountChangeEvent,
+  removeProviderListener,
+  trackProviderIdentityChanges,
+} from "@/constants/walletEvents";
 import type { BTCConfig, InscriptionIdentifier, SignPsbtOptions, WalletInfo } from "@/core/types";
 import { IBTCProvider, Network } from "@/core/types";
 import { mapSignInputsToToSignInputs } from "@/core/utils/psbtOptionsMapper";
 import { withTimeout } from "@/core/utils/withTimeout";
-import { ERROR_CODES, WalletError, isUserRejectionMessage } from "@/error";
 import logo from "@/core/wallets/icons/okx.svg";
+import { ERROR_CODES, WalletError, isUserRejectionMessage } from "@/error";
 
 import { MIN_OKX_VERSION, checkOKXVersion } from "./version";
 
@@ -25,6 +31,10 @@ export class OKXProvider implements IBTCProvider {
   private wallet: any;
   private walletInfo: WalletInfo | undefined;
   private config: BTCConfig;
+  private identityVersion = 0;
+  private walletInfoIdentityVersion = -1;
+  private tracksIdentityChanges = false;
+  private identityEventsTracked = false;
 
   constructor(wallet: any, config: BTCConfig) {
     this.config = config;
@@ -57,6 +67,8 @@ export class OKXProvider implements IBTCProvider {
     // Fail fast on an out-of-date OKX here, not at deposit time.
     await this.ensureSupportedVersion();
 
+    this.trackIdentityChanges();
+    const identityVersion = this.identityVersion;
     let result;
     try {
       result = await this.provider.connect();
@@ -83,6 +95,7 @@ export class OKXProvider implements IBTCProvider {
         publicKeyHex: compressedPublicKey,
         address,
       };
+      this.walletInfoIdentityVersion = identityVersion;
     } else {
       throw new WalletError({
         code: ERROR_CODES.CONNECTION_FAILED,
@@ -90,6 +103,17 @@ export class OKXProvider implements IBTCProvider {
         wallet: WALLET_PROVIDER_NAME,
       });
     }
+  };
+
+  isIdentityCurrent = (): boolean =>
+    this.identityEventsTracked && this.walletInfoIdentityVersion === this.identityVersion;
+
+  private trackIdentityChanges = (): void => {
+    if (this.tracksIdentityChanges) return;
+    this.identityEventsTracked = trackProviderIdentityChanges(this.provider, () => {
+      this.identityVersion += 1;
+    });
+    this.tracksIdentityChanges = this.identityEventsTracked;
   };
 
   private timeoutError = (operation: string): WalletError =>
@@ -313,6 +337,10 @@ export class OKXProvider implements IBTCProvider {
       return this.provider.on("accountsChanged", callBack);
     }
 
+    if (eventName === NETWORK_CHANGE_EVENT) {
+      return this.provider.on(NETWORK_CHANGE_EVENT, callBack);
+    }
+
     if (eventName === DISCONNECT_EVENT) {
       return this.provider.on(DISCONNECT_EVENT, callBack);
     }
@@ -329,6 +357,10 @@ export class OKXProvider implements IBTCProvider {
     // OKX uses "accountsChanged" for account change events
     if (isAccountChangeEvent(eventName)) {
       return removeProviderListener(this.provider, "accountsChanged", callBack);
+    }
+
+    if (eventName === NETWORK_CHANGE_EVENT) {
+      return removeProviderListener(this.provider, NETWORK_CHANGE_EVENT, callBack);
     }
 
     if (eventName === DISCONNECT_EVENT) {

--- a/packages/babylon-wallet-connector/src/core/wallets/btc/onekey/provider.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/onekey/provider.ts
@@ -1,4 +1,10 @@
-import { isAccountChangeEvent, DISCONNECT_EVENT, removeProviderListener } from "@/constants/walletEvents";
+import {
+  DISCONNECT_EVENT,
+  NETWORK_CHANGE_EVENT,
+  isAccountChangeEvent,
+  removeProviderListener,
+  trackProviderIdentityChanges,
+} from "@/constants/walletEvents";
 import type { BTCConfig, IBTCProvider, InscriptionIdentifier, SignPsbtOptions, WalletInfo } from "@/core/types";
 import { Network } from "@/core/types";
 import { mapSignInputsToToSignInputs } from "@/core/utils/psbtOptionsMapper";
@@ -34,6 +40,10 @@ export class OneKeyProvider implements IBTCProvider {
   private versionChecked = false;
   private walletInfo: WalletInfo | undefined;
   private config: BTCConfig;
+  private identityVersion = 0;
+  private walletInfoIdentityVersion = -1;
+  private tracksIdentityChanges = false;
+  private identityEventsTracked = false;
 
   constructor(wallet: any, config: BTCConfig) {
     this.config = config;
@@ -63,9 +73,7 @@ export class OneKeyProvider implements IBTCProvider {
 
   connectWallet = async (): Promise<void> => {
     try {
-      await withTimeout(this.provider.connectWallet(), ONEKEY_PROMPT_TIMEOUT_MS, () =>
-        this.timeoutError("connecting"),
-      );
+      await withTimeout(this.provider.connectWallet(), ONEKEY_PROMPT_TIMEOUT_MS, () => this.timeoutError("connecting"));
     } catch (error) {
       if (error instanceof WalletError) throw error;
 
@@ -98,6 +106,8 @@ export class OneKeyProvider implements IBTCProvider {
     // prompt in the connect UI rather than failing later mid-deposit.
     await this.ensureSupportedVersion();
 
+    this.trackIdentityChanges();
+    const identityVersion = this.identityVersion;
     const address = await withTimeout<string>(this.provider.getAddress(), ONEKEY_RPC_TIMEOUT_MS, () =>
       this.timeoutError("reading the address"),
     );
@@ -110,6 +120,7 @@ export class OneKeyProvider implements IBTCProvider {
         publicKeyHex,
         address,
       };
+      this.walletInfoIdentityVersion = identityVersion;
     } else {
       throw new WalletError({
         code: ERROR_CODES.CONNECTION_FAILED,
@@ -117,6 +128,17 @@ export class OneKeyProvider implements IBTCProvider {
         wallet: WALLET_PROVIDER_NAME,
       });
     }
+  };
+
+  isIdentityCurrent = (): boolean =>
+    this.identityEventsTracked && this.walletInfoIdentityVersion === this.identityVersion;
+
+  private trackIdentityChanges = (): void => {
+    if (this.tracksIdentityChanges) return;
+    this.identityEventsTracked = trackProviderIdentityChanges(this.provider, () => {
+      this.identityVersion += 1;
+    });
+    this.tracksIdentityChanges = this.identityEventsTracked;
   };
 
   // Reads the OneKey app/extension version from `$onekey.$walletInfo.version`.
@@ -379,6 +401,10 @@ export class OneKeyProvider implements IBTCProvider {
       return this.provider.on("accountsChanged", callBack);
     }
 
+    if (eventName === NETWORK_CHANGE_EVENT) {
+      return this.provider.on(NETWORK_CHANGE_EVENT, callBack);
+    }
+
     if (eventName === DISCONNECT_EVENT) {
       return this.provider.on(DISCONNECT_EVENT, callBack);
     }
@@ -395,6 +421,10 @@ export class OneKeyProvider implements IBTCProvider {
     // OneKey uses "accountsChanged" for account change events
     if (isAccountChangeEvent(eventName)) {
       return removeProviderListener(this.provider, "accountsChanged", callBack);
+    }
+
+    if (eventName === NETWORK_CHANGE_EVENT) {
+      return removeProviderListener(this.provider, NETWORK_CHANGE_EVENT, callBack);
     }
 
     if (eventName === DISCONNECT_EVENT) {
@@ -449,14 +479,10 @@ export class OneKeyProvider implements IBTCProvider {
       // imported, and watch-only accounts reject before the approval dialog with
       // methodNotSupported. Surface the typed capability error so callers branch
       // on it deterministically instead of the raw "Method not supported." string.
-      if (
-        (error as { code?: number } | undefined)?.code ===
-        ONEKEY_METHOD_NOT_SUPPORTED_CODE
-      ) {
+      if ((error as { code?: number } | undefined)?.code === ONEKEY_METHOD_NOT_SUPPORTED_CODE) {
         throw new WalletError({
           code: ERROR_CODES.WALLET_METHOD_NOT_SUPPORTED,
-          message:
-            "This OneKey account does not support deriveContextHash. Connect a OneKey app (HD) wallet account.",
+          message: "This OneKey account does not support deriveContextHash. Connect a OneKey app (HD) wallet account.",
           wallet: WALLET_PROVIDER_NAME,
         });
       }

--- a/packages/babylon-wallet-connector/src/core/wallets/btc/unisat/provider.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/unisat/provider.ts
@@ -1,7 +1,20 @@
 import { Psbt, address as btcAddress, networks } from "bitcoinjs-lib";
 
-import { isAccountChangeEvent, DISCONNECT_EVENT, removeProviderListener } from "@/constants/walletEvents";
-import type { BTCConfig, IBTCProvider, InscriptionIdentifier, ProgressReporter, SignPsbtOptions, WalletInfo } from "@/core/types";
+import {
+  DISCONNECT_EVENT,
+  NETWORK_CHANGE_EVENT,
+  isAccountChangeEvent,
+  removeProviderListener,
+  trackProviderIdentityChanges,
+} from "@/constants/walletEvents";
+import type {
+  BTCConfig,
+  IBTCProvider,
+  InscriptionIdentifier,
+  ProgressReporter,
+  SignPsbtOptions,
+  WalletInfo,
+} from "@/core/types";
 import { Network } from "@/core/types";
 import { initBTCCurve } from "@/core/utils/initBTCCurve";
 import { resolveUseTweakedSigner } from "@/core/utils/psbtOptionsMapper";
@@ -67,6 +80,10 @@ export class UnisatProvider implements IBTCProvider {
   private provider: any;
   private walletInfo: WalletInfo | undefined;
   private config: BTCConfig;
+  private identityVersion = 0;
+  private walletInfoIdentityVersion = -1;
+  private tracksIdentityChanges = false;
+  private identityEventsTracked = false;
 
   constructor(wallet: any, config: BTCConfig) {
     this.config = config;
@@ -134,8 +151,13 @@ export class UnisatProvider implements IBTCProvider {
       "Finalizing connection",
       didSwitchChain ? "Approve the connection request in your Unisat extension" : undefined,
     );
-    const accounts: string[] = await withTimeout(this.provider.requestAccounts(), UNISAT_PROMPT_TIMEOUT_MS, () =>
+    await withTimeout(this.provider.requestAccounts(), UNISAT_PROMPT_TIMEOUT_MS, () =>
       this.timeoutError("requesting accounts"),
+    );
+    this.trackIdentityChanges();
+    const identityVersion = this.identityVersion;
+    const accounts: string[] = await withTimeout(this.provider.getAccounts(), UNISAT_RPC_TIMEOUT_MS, () =>
+      this.timeoutError("reading accounts"),
     );
     const address = accounts[0];
     const publicKeyHex: string = await withTimeout(this.provider.getPublicKey(), UNISAT_RPC_TIMEOUT_MS, () =>
@@ -147,6 +169,7 @@ export class UnisatProvider implements IBTCProvider {
         publicKeyHex,
         address,
       };
+      this.walletInfoIdentityVersion = identityVersion;
     } else {
       throw new WalletError({
         code: ERROR_CODES.CONNECTION_FAILED,
@@ -154,6 +177,17 @@ export class UnisatProvider implements IBTCProvider {
         wallet: WALLET_PROVIDER_NAME,
       });
     }
+  };
+
+  isIdentityCurrent = (): boolean =>
+    this.identityEventsTracked && this.walletInfoIdentityVersion === this.identityVersion;
+
+  private trackIdentityChanges = (): void => {
+    if (this.tracksIdentityChanges) return;
+    this.identityEventsTracked = trackProviderIdentityChanges(this.provider, () => {
+      this.identityVersion += 1;
+    });
+    this.tracksIdentityChanges = this.identityEventsTracked;
   };
 
   private ensureSupportedVersion = async (): Promise<void> => {
@@ -585,6 +619,10 @@ export class UnisatProvider implements IBTCProvider {
       return this.provider.on("accountsChanged", callBack);
     }
 
+    if (eventName === NETWORK_CHANGE_EVENT) {
+      return this.provider.on(NETWORK_CHANGE_EVENT, callBack);
+    }
+
     if (eventName === DISCONNECT_EVENT) {
       return this.provider.on(DISCONNECT_EVENT, callBack);
     }
@@ -601,6 +639,10 @@ export class UnisatProvider implements IBTCProvider {
     // Unisat uses "accountsChanged" for account change events
     if (isAccountChangeEvent(eventName)) {
       return removeProviderListener(this.provider, "accountsChanged", callBack);
+    }
+
+    if (eventName === NETWORK_CHANGE_EVENT) {
+      return removeProviderListener(this.provider, NETWORK_CHANGE_EVENT, callBack);
     }
 
     if (eventName === DISCONNECT_EVENT) {

--- a/packages/babylon-wallet-connector/src/core/wallets/btc/utila/__tests__/provider.identity.test.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/utila/__tests__/provider.identity.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it, vi } from "vitest";
+
+import type { IBTCProvider } from "@/core/types";
+
+import { UtilaProvider } from "../provider";
+
+describe("UtilaProvider identity cache", () => {
+  it("marks cached identity stale until a successful refresh", async () => {
+    const handlers = new Map<string, () => void>();
+    let address = "bc1pold";
+    let publicKeyHex = `02${"a".repeat(64)}`;
+    const wallet = {
+      connectWallet: vi.fn(async () => {}),
+      getAddress: vi.fn(async () => address),
+      getPublicKeyHex: vi.fn(async () => publicKeyHex),
+      on: vi.fn((event: string, callback: () => void) => handlers.set(event, callback)),
+    } as unknown as IBTCProvider;
+    const provider = new UtilaProvider({ bitcoin: wallet });
+
+    await provider.connectWallet();
+    expect(provider.isIdentityCurrent()).toBe(true);
+
+    handlers.get("accountsChanged")?.();
+    expect(provider.isIdentityCurrent()).toBe(false);
+    expect(await provider.getAddress()).toBe("bc1pold");
+
+    address = "bc1pnew";
+    publicKeyHex = `02${"b".repeat(64)}`;
+    await provider.connectWallet();
+    expect(provider.isIdentityCurrent()).toBe(true);
+    expect(await provider.getAddress()).toBe("bc1pnew");
+
+    handlers.get("networkChanged")?.();
+    expect(provider.isIdentityCurrent()).toBe(false);
+
+    await provider.connectWallet();
+    handlers.get("disconnect")?.();
+    expect(provider.isIdentityCurrent()).toBe(false);
+  });
+
+  it("does not mark an identity read current after an event interrupts it", async () => {
+    const handlers = new Map<string, () => void>();
+    let resolveAddress!: (address: string) => void;
+    let markAddressStarted!: () => void;
+    const address = new Promise<string>((resolve) => {
+      resolveAddress = resolve;
+    });
+    const addressStarted = new Promise<void>((resolve) => {
+      markAddressStarted = resolve;
+    });
+    const wallet = {
+      connectWallet: vi.fn(async () => {}),
+      getAddress: vi.fn(() => {
+        markAddressStarted();
+        return address;
+      }),
+      getPublicKeyHex: vi.fn(async () => `02${"a".repeat(64)}`),
+      on: vi.fn((event: string, callback: () => void) => handlers.set(event, callback)),
+    } as unknown as IBTCProvider;
+    const provider = new UtilaProvider({ bitcoin: wallet });
+
+    const connecting = provider.connectWallet();
+    await addressStarted;
+    handlers.get("accountsChanged")?.();
+    resolveAddress("bc1pstale");
+    await connecting;
+
+    expect(provider.isIdentityCurrent()).toBe(false);
+  });
+
+  it("allows optional identity events to be unsupported", async () => {
+    let onAccountsChanged = () => {};
+    const wallet = {
+      connectWallet: vi.fn(async () => {}),
+      getAddress: vi.fn(async () => "bc1pcurrent"),
+      getPublicKeyHex: vi.fn(async () => `02${"a".repeat(64)}`),
+      on: vi.fn((event: string, callback: () => void) => {
+        if (event !== "accountsChanged") throw new Error("Unsupported event");
+        onAccountsChanged = callback;
+      }),
+    } as unknown as IBTCProvider;
+    const provider = new UtilaProvider({ bitcoin: wallet });
+
+    await provider.connectWallet();
+    expect(provider.isIdentityCurrent()).toBe(true);
+
+    onAccountsChanged();
+    expect(provider.isIdentityCurrent()).toBe(false);
+  });
+
+  it("retries required event tracking and keeps supported optional events", async () => {
+    let accountAttempts = 0;
+    let onNetworkChanged = () => {};
+    const wallet = {
+      connectWallet: vi.fn(async () => {}),
+      getAddress: vi.fn(async () => "bc1pcurrent"),
+      getPublicKeyHex: vi.fn(async () => `02${"a".repeat(64)}`),
+      on: vi.fn((event: string, callback: () => void) => {
+        if (event === "accountsChanged") {
+          accountAttempts += 1;
+          if (accountAttempts === 1) throw new Error("Temporary error");
+        }
+        if (event === "networkChanged") onNetworkChanged = callback;
+        if (event === "disconnect") throw new Error("Unsupported event");
+      }),
+    } as unknown as IBTCProvider;
+    const provider = new UtilaProvider({ bitcoin: wallet });
+
+    await provider.connectWallet();
+    expect(provider.isIdentityCurrent()).toBe(false);
+
+    await provider.connectWallet();
+    expect(provider.isIdentityCurrent()).toBe(true);
+
+    onNetworkChanged();
+    expect(provider.isIdentityCurrent()).toBe(false);
+  });
+});

--- a/packages/babylon-wallet-connector/src/core/wallets/btc/utila/provider.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/utila/provider.ts
@@ -1,4 +1,10 @@
-import { isAccountChangeEvent, DISCONNECT_EVENT, removeProviderListener } from "@/constants/walletEvents";
+import {
+  DISCONNECT_EVENT,
+  NETWORK_CHANGE_EVENT,
+  isAccountChangeEvent,
+  removeProviderListener,
+  trackProviderIdentityChanges,
+} from "@/constants/walletEvents";
 import type { IBTCProvider, InscriptionIdentifier, SignPsbtOptions, WalletInfo } from "@/core/types";
 import { Network } from "@/core/types";
 import { withTimeout } from "@/core/utils/withTimeout";
@@ -31,6 +37,10 @@ const UTILA_PROMPT_TIMEOUT_MS = 60_000;
 export class UtilaProvider implements IBTCProvider {
   private provider: IBTCProvider;
   private walletInfo: WalletInfo | undefined;
+  private identityVersion = 0;
+  private walletInfoIdentityVersion = -1;
+  private tracksIdentityChanges = false;
+  private identityEventsTracked = false;
 
   constructor(wallet?: { bitcoin?: IBTCProvider }) {
     // The injected object may be absent if the extension isn't installed.
@@ -70,9 +80,7 @@ export class UtilaProvider implements IBTCProvider {
 
   connectWallet = async (): Promise<void> => {
     try {
-      await withTimeout(this.provider.connectWallet(), UTILA_PROMPT_TIMEOUT_MS, () =>
-        this.timeoutError("connecting"),
-      );
+      await withTimeout(this.provider.connectWallet(), UTILA_PROMPT_TIMEOUT_MS, () => this.timeoutError("connecting"));
     } catch (error) {
       if (error instanceof WalletError) throw error;
       if (isUserRejectionMessage((error as Error | undefined)?.message)) {
@@ -89,6 +97,8 @@ export class UtilaProvider implements IBTCProvider {
       });
     }
 
+    this.trackIdentityChanges();
+    const identityVersion = this.identityVersion;
     const address = await withTimeout<string>(this.provider.getAddress(), UTILA_RPC_TIMEOUT_MS, () =>
       this.timeoutError("reading the address"),
     );
@@ -101,6 +111,7 @@ export class UtilaProvider implements IBTCProvider {
         publicKeyHex,
         address,
       };
+      this.walletInfoIdentityVersion = identityVersion;
     } else {
       throw new WalletError({
         code: ERROR_CODES.CONNECTION_FAILED,
@@ -108,6 +119,17 @@ export class UtilaProvider implements IBTCProvider {
         wallet: WALLET_PROVIDER_NAME,
       });
     }
+  };
+
+  isIdentityCurrent = (): boolean =>
+    this.identityEventsTracked && this.walletInfoIdentityVersion === this.identityVersion;
+
+  private trackIdentityChanges = (): void => {
+    if (this.tracksIdentityChanges) return;
+    this.identityEventsTracked = trackProviderIdentityChanges(this.provider, () => {
+      this.identityVersion += 1;
+    });
+    this.tracksIdentityChanges = this.identityEventsTracked;
   };
 
   getAddress = async (): Promise<string> => {
@@ -238,6 +260,9 @@ export class UtilaProvider implements IBTCProvider {
     if (isAccountChangeEvent(eventName)) {
       return this.provider.on("accountsChanged", callBack);
     }
+    if (eventName === NETWORK_CHANGE_EVENT) {
+      return this.provider.on(NETWORK_CHANGE_EVENT, callBack);
+    }
     if (eventName === DISCONNECT_EVENT) {
       return this.provider.on(DISCONNECT_EVENT, callBack);
     }
@@ -252,6 +277,9 @@ export class UtilaProvider implements IBTCProvider {
       });
     if (isAccountChangeEvent(eventName)) {
       return removeProviderListener(this.provider, "accountsChanged", callBack);
+    }
+    if (eventName === NETWORK_CHANGE_EVENT) {
+      return removeProviderListener(this.provider, NETWORK_CHANGE_EVENT, callBack);
     }
     if (eventName === DISCONNECT_EVENT) {
       return removeProviderListener(this.provider, DISCONNECT_EVENT, callBack);

--- a/packages/babylon-wallet-connector/src/hooks/__tests__/useWalletConnectors.requirementChurn.test.tsx
+++ b/packages/babylon-wallet-connector/src/hooks/__tests__/useWalletConnectors.requirementChurn.test.tsx
@@ -1,4 +1,5 @@
-import { act, renderHook } from "@testing-library/react";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { useLayoutEffect } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { createConfirmationReceipt, WALLET_CONFIRMATION_RECEIPT_KEY } from "@/core/confirmationReceipt";
@@ -16,27 +17,90 @@ vi.mock("@/context/LifecycleHooks.context", () => ({ useLifeCycleHooks: () => ({
 
 const BTC_ACCOUNT: Account = { address: "bc1pdepositor", publicKeyHex: `02${"a".repeat(64)}` };
 const BBN_ACCOUNT: Account = { address: "bbn1depositor", publicKeyHex: `03${"b".repeat(64)}` };
+const ETH_ACCOUNT: Account = { address: "0xDepositor", publicKeyHex: "" };
 
-function wallet(id: string, account: Account): IWallet {
-  return { id, name: id, account } as IWallet;
+type EventHandler = (...args: unknown[]) => void;
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+
+  return { promise, resolve };
+}
+
+function liveProvider(account: Account, network: string | number) {
+  let currentAccount = account;
+  let currentNetwork = network;
+  const handlers = new Map<string, Set<EventHandler>>();
+
+  return {
+    connectWallet: vi.fn(async () => {}),
+    getAddress: vi.fn(async () => currentAccount.address),
+    getPublicKeyHex: vi.fn(async () => currentAccount.publicKeyHex),
+    getNetwork: vi.fn(async () => currentNetwork),
+    getChainId: vi.fn(async () => currentNetwork),
+    on: vi.fn((event: string, handler: EventHandler) => {
+      const eventHandlers = handlers.get(event) ?? new Set<EventHandler>();
+      eventHandlers.add(handler);
+      handlers.set(event, eventHandlers);
+    }),
+    off: vi.fn((event: string, handler: EventHandler) => {
+      handlers.get(event)?.delete(handler);
+    }),
+    changeAccount(next: Account) {
+      currentAccount = next;
+    },
+    changeNetwork(next: string | number) {
+      currentNetwork = next;
+    },
+    emit(event: string, ...args: unknown[]) {
+      handlers.get(event)?.forEach((handler) => handler(...args));
+    },
+  };
+}
+
+function wallet(id: string, account: Account, provider: ReturnType<typeof liveProvider>): IWallet {
+  return { id, name: id, icon: "", docs: "", installed: true, account, provider, label: "" };
 }
 
 let store: Map<string, string>;
 let storage: HashMap;
 let confirm: ReturnType<typeof vi.fn>;
 let unconfirm: ReturnType<typeof vi.fn>;
+let approvedReceipt: string;
+let btcProvider: ReturnType<typeof liveProvider>;
+let bbnProvider: ReturnType<typeof liveProvider>;
+let ethProvider: ReturnType<typeof liveProvider>;
 
 function liveConnectors() {
   return {
-    BTC: { id: "BTC", config: { network: "signet" }, connectedWallet: wallet("unisat", BTC_ACCOUNT), on: () => () => {} },
-    BBN: { id: "BBN", config: { chainId: "bbn-test" }, connectedWallet: wallet("keplr", BBN_ACCOUNT), on: () => () => {} },
-    ETH: null,
+    BTC: {
+      id: "BTC",
+      config: { network: "signet" },
+      connectedWallet: wallet("unisat", BTC_ACCOUNT, btcProvider),
+      on: () => () => {},
+    },
+    BBN: {
+      id: "BBN",
+      config: { chainId: "bbn-test" },
+      connectedWallet: wallet("keplr", BBN_ACCOUNT, bbnProvider),
+      on: () => () => {},
+    },
+    ETH: {
+      id: "ETH",
+      config: { chainId: 11155111 },
+      connectedWallet: wallet("metamask", ETH_ACCOUNT, ethProvider),
+      on: () => () => {},
+    },
   };
 }
 
-function render(requiredChainIds: string[], confirmed: boolean) {
+function setWidgetState(requiredChainIds: string[], confirmed: boolean) {
   harness.widgetState = {
     confirmed,
+    confirmationReceipt: confirmed ? approvedReceipt : undefined,
     visible: false,
     requiredChainIds,
     selectWallet: vi.fn(),
@@ -47,8 +111,12 @@ function render(requiredChainIds: string[], confirmed: boolean) {
     confirm,
     unconfirm,
   };
+}
 
-  return renderHook(() => useWalletConnectors({ persistent: true, accountStorage: storage }));
+function render(requiredChainIds: string[], confirmed: boolean, persistent = true) {
+  setWidgetState(requiredChainIds, confirmed);
+
+  return renderHook(() => useWalletConnectors({ persistent, accountStorage: storage }));
 }
 
 beforeEach(() => {
@@ -61,104 +129,382 @@ beforeEach(() => {
   } as unknown as HashMap;
   confirm = vi.fn();
   unconfirm = vi.fn();
+  btcProvider = liveProvider(BTC_ACCOUNT, "signet");
+  bbnProvider = liveProvider(BBN_ACCOUNT, "bbn-test");
+  ethProvider = liveProvider(ETH_ACCOUNT, 11155111);
   harness.connectors = liveConnectors();
   // Both chains connected and previously approved together, as after pressing
   // Connect on a route that requires both.
   store.set("BTC", "unisat");
   store.set("BBN", "keplr");
-  store.set(
-    WALLET_CONFIRMATION_RECEIPT_KEY,
-    createConfirmationReceipt(
-      [
-        { chain: "BTC", wallet: wallet("unisat", BTC_ACCOUNT), account: BTC_ACCOUNT },
-        { chain: "BBN", wallet: wallet("keplr", BBN_ACCOUNT), account: BBN_ACCOUNT },
-      ],
-      harness.connectors as never,
-    ),
+  approvedReceipt = createConfirmationReceipt(
+    [
+      { chain: "BTC", wallet: wallet("unisat", BTC_ACCOUNT, btcProvider), account: BTC_ACCOUNT },
+      { chain: "BBN", wallet: wallet("keplr", BBN_ACCOUNT, bbnProvider), account: BBN_ACCOUNT },
+      { chain: "ETH", wallet: wallet("metamask", ETH_ACCOUNT, ethProvider), account: ETH_ACCOUNT },
+    ],
+    harness.connectors as never,
   );
+  store.set(WALLET_CONFIRMATION_RECEIPT_KEY, approvedReceipt);
 });
 
 // simple-staking derives requiredChains from the route: ["BTC","BBN"] on the
 // main routes, ["BBN"] under /baby. Navigating between them must not touch the
 // session.
 describe("requirements that change with the route", () => {
-  it("keeps the confirmation when the required set narrows", () => {
+  it("keeps the confirmation when the required set narrows", async () => {
     const { rerender } = render(["BTC", "BBN"], true);
-    act(() => rerender());
+    await waitFor(() => expect(btcProvider.getAddress).toHaveBeenCalled());
 
-    render(["BBN"], true);
-    act(() => rerender());
-
-    expect(unconfirm).not.toHaveBeenCalled();
-    expect(store.has(WALLET_CONFIRMATION_RECEIPT_KEY)).toBe(true);
-  });
-
-  it("keeps the confirmation when the required set widens back to an approved chain", () => {
-    render(["BBN"], true);
-    render(["BTC", "BBN"], true);
+    setWidgetState(["BBN"], true);
+    rerender();
+    await waitFor(() => expect(bbnProvider.getAddress).toHaveBeenCalledTimes(2));
 
     expect(unconfirm).not.toHaveBeenCalled();
     expect(store.has(WALLET_CONFIRMATION_RECEIPT_KEY)).toBe(true);
   });
 
-  it("restores the confirmation on a cold start under the narrowed requirements", () => {
+  it("restores an unchanged approval after the required set widens", async () => {
+    const { rerender } = render(["BBN"], true);
+    await waitFor(() => expect(bbnProvider.getAddress).toHaveBeenCalled());
+
+    setWidgetState(["BTC", "BBN"], true);
+    rerender();
+    await waitFor(() => expect(btcProvider.getAddress).toHaveBeenCalled());
+
+    expect(unconfirm).toHaveBeenCalledWith(true);
+    harness.widgetState = { ...harness.widgetState, confirmed: false, confirmationReceipt: approvedReceipt };
+    rerender();
+    await waitFor(() => expect(confirm).toHaveBeenCalledWith(approvedReceipt));
+    expect(store.has(WALLET_CONFIRMATION_RECEIPT_KEY)).toBe(true);
+  });
+
+  it("restores the confirmation on a cold start under the narrowed requirements", async () => {
     render(["BBN"], false);
 
-    expect(confirm).toHaveBeenCalled();
+    await waitFor(() => expect(confirm).toHaveBeenCalledWith(approvedReceipt));
   });
 
-  it("restores the confirmation on a cold start under the widened requirements", () => {
+  it("restores the confirmation on a cold start under the widened requirements", async () => {
     render(["BTC", "BBN"], false);
 
-    expect(confirm).toHaveBeenCalled();
+    await waitFor(() => expect(confirm).toHaveBeenCalledWith(approvedReceipt));
+  });
+
+  it("waits for a required wallet to reconnect before it checks stored approval", async () => {
+    harness.connectors = {
+      ...liveConnectors(),
+      BTC: { id: "BTC", config: { network: "signet" }, connectedWallet: null, on: () => () => {} },
+    };
+    const { rerender } = render(["BTC"], false);
+    await act(async () => {});
+
+    expect(confirm).not.toHaveBeenCalled();
+    expect(store.has(WALLET_CONFIRMATION_RECEIPT_KEY)).toBe(true);
+
+    harness.connectors = liveConnectors();
+    rerender();
+
+    await waitFor(() => expect(confirm).toHaveBeenCalledWith(approvedReceipt));
+  });
+
+  it("keeps an optional event dirty while cold restore waits for a required wallet", async () => {
+    const connectors = liveConnectors();
+    harness.connectors = {
+      ...connectors,
+      ETH: { id: "ETH", config: { chainId: 11155111 }, connectedWallet: null, on: () => () => {} },
+    };
+    const { rerender } = render(["ETH"], false);
+    await waitFor(() => expect(btcProvider.on).toHaveBeenCalledWith("accountsChanged", expect.any(Function)));
+
+    act(() => {
+      btcProvider.emit("accountsChanged", ["bc1psomeoneelse"]);
+    });
+    harness.connectors = liveConnectors();
+    rerender();
+    await waitFor(() => expect(confirm).toHaveBeenCalledWith(approvedReceipt));
+
+    setWidgetState(["ETH"], true);
+    rerender();
+    setWidgetState(["BTC", "ETH"], true);
+    rerender();
+
+    expect(unconfirm).toHaveBeenCalledWith();
+  });
+
+  it("does not restore after an identity event during live validation", async () => {
+    const addressRead = deferred<string>();
+    btcProvider.getAddress.mockReturnValueOnce(addressRead.promise);
+    render(["BTC"], false);
+    await waitFor(() => expect(btcProvider.on).toHaveBeenCalledWith("accountsChanged", expect.any(Function)));
+
+    act(() => {
+      btcProvider.emit("accountsChanged", ["bc1psomeoneelse"]);
+    });
+    await act(async () => addressRead.resolve(BTC_ACCOUNT.address));
+
+    expect(confirm).not.toHaveBeenCalled();
+    expect(store.has(WALLET_CONFIRMATION_RECEIPT_KEY)).toBe(false);
+  });
+
+  it("does not restore after the dialog opens during live validation", async () => {
+    const addressRead = deferred<string>();
+    btcProvider.getAddress.mockReturnValueOnce(addressRead.promise);
+    const { rerender } = render(["BTC"], false);
+    await waitFor(() => expect(btcProvider.getAddress).toHaveBeenCalled());
+
+    harness.widgetState = { ...harness.widgetState, visible: true };
+    rerender();
+    await act(async () => addressRead.resolve(BTC_ACCOUNT.address));
+
+    expect(confirm).not.toHaveBeenCalled();
   });
 });
 
 describe("an approval that stops covering the requirements", () => {
-  it("withdraws the confirmation when a chain the user never approved becomes required", () => {
-    harness.connectors = {
-      ...liveConnectors(),
-      ETH: {
-        id: "ETH",
-        config: { chainId: 11155111 },
-        connectedWallet: wallet("metamask", { address: "0xlate", publicKeyHex: `04${"c".repeat(64)}` }),
-        on: () => () => {},
-      },
-    };
-    store.set("ETH", "metamask");
+  it("withdraws the confirmation when a chain the user never approved becomes required", async () => {
+    const addressRead = deferred<string>();
+    btcProvider.getAddress.mockReturnValueOnce(addressRead.promise);
+    approvedReceipt = createConfirmationReceipt(
+      [
+        { chain: "BTC", wallet: wallet("unisat", BTC_ACCOUNT, btcProvider), account: BTC_ACCOUNT },
+        { chain: "BBN", wallet: wallet("keplr", BBN_ACCOUNT, bbnProvider), account: BBN_ACCOUNT },
+      ],
+      harness.connectors as never,
+    );
+    store.set(WALLET_CONFIRMATION_RECEIPT_KEY, approvedReceipt);
 
     render(["BTC", "BBN", "ETH"], true);
 
     expect(unconfirm).toHaveBeenCalled();
+    await act(async () => addressRead.resolve(BTC_ACCOUNT.address));
   });
 
-  it("withdraws the confirmation when a required account changes underneath it", () => {
+  it("withdraws before a changed optional account is read after it becomes required", async () => {
+    const changedAccount = { address: "bc1psomeoneelse", publicKeyHex: `02${"d".repeat(64)}` };
+    const addressRead = deferred<string>();
+    store.delete(WALLET_CONFIRMATION_RECEIPT_KEY);
+    const { rerender } = render(["ETH"], true, false);
+    await waitFor(() => expect(ethProvider.getAddress).toHaveBeenCalled());
+
+    btcProvider.changeAccount(changedAccount);
+    btcProvider.getAddress.mockReturnValueOnce(addressRead.promise);
+    setWidgetState(["BTC", "ETH"], true);
+    rerender();
+
+    expect(unconfirm).toHaveBeenCalledWith(true);
+    await act(async () => addressRead.resolve(changedAccount.address));
+    expect(unconfirm).toHaveBeenCalledWith();
+  });
+
+  it("does not restore an optional account after its change event precedes adapter refresh", async () => {
+    store.delete(WALLET_CONFIRMATION_RECEIPT_KEY);
+    const { rerender } = render(["ETH"], true, false);
+    await waitFor(() => expect(btcProvider.on).toHaveBeenCalledWith("accountsChanged", expect.any(Function)));
+
+    act(() => {
+      btcProvider.emit("accountsChanged", ["bc1psomeoneelse"]);
+    });
+    expect(unconfirm).not.toHaveBeenCalled();
+
+    setWidgetState(["BTC", "ETH"], true);
+    rerender();
+
+    expect(unconfirm).toHaveBeenCalledWith();
+  });
+
+  it.each([true, false])("withdraws after a live required account change when persistent is %s", async (persistent) => {
+    if (!persistent) store.delete(WALLET_CONFIRMATION_RECEIPT_KEY);
+    render(["BTC"], true, persistent);
+    await waitFor(() => expect(btcProvider.on).toHaveBeenCalledWith("accountsChanged", expect.any(Function)));
+
+    act(() => {
+      btcProvider.emit("accountsChanged", ["bc1psomeoneelse"]);
+      btcProvider.emit("accountsChanged", [BTC_ACCOUNT.address]);
+    });
+
+    await waitFor(() => expect(unconfirm).toHaveBeenCalled());
+    expect(store.has(WALLET_CONFIRMATION_RECEIPT_KEY)).toBe(false);
+  });
+
+  it("withdraws after a live required key change", async () => {
+    store.delete(WALLET_CONFIRMATION_RECEIPT_KEY);
+    render(["BTC"], true, false);
+    await waitFor(() => expect(btcProvider.on).toHaveBeenCalledWith("accountsChanged", expect.any(Function)));
+
+    act(() => {
+      btcProvider.changeAccount({ address: BTC_ACCOUNT.address, publicKeyHex: `02${"d".repeat(64)}` });
+      btcProvider.emit("accountsChanged", [BTC_ACCOUNT.address]);
+    });
+
+    await waitFor(() => expect(unconfirm).toHaveBeenCalled());
+  });
+
+  it("ignores AppKit's repeated ETH account and rejects a changed account", async () => {
+    store.delete(WALLET_CONFIRMATION_RECEIPT_KEY);
+    render(["ETH"], true, false);
+    await waitFor(() => expect(ethProvider.on).toHaveBeenCalledWith("accountsChanged", expect.any(Function)));
+
+    act(() => {
+      ethProvider.emit("accountsChanged", [ETH_ACCOUNT.address.toLowerCase()]);
+    });
+    await act(async () => {});
+
+    expect(unconfirm).not.toHaveBeenCalled();
+
+    act(() => {
+      ethProvider.emit("accountsChanged", ["0xsomeoneelse"]);
+    });
+    await waitFor(() => expect(unconfirm).toHaveBeenCalled());
+  });
+
+  it("withdraws after a live required network change", async () => {
+    store.delete(WALLET_CONFIRMATION_RECEIPT_KEY);
+    render(["ETH"], true, false);
+    await waitFor(() => expect(ethProvider.on).toHaveBeenCalledWith("chainChanged", expect.any(Function)));
+
+    act(() => {
+      ethProvider.emit("chainChanged", "0x1");
+    });
+
+    await waitFor(() => expect(unconfirm).toHaveBeenCalled());
+  });
+
+  it("withdraws after a live required BTC network change", async () => {
+    store.delete(WALLET_CONFIRMATION_RECEIPT_KEY);
+    render(["BTC"], true, false);
+    await waitFor(() => expect(btcProvider.on).toHaveBeenCalledWith("networkChanged", expect.any(Function)));
+
+    act(() => {
+      btcProvider.emit("networkChanged", "mainnet");
+    });
+
+    await waitFor(() => expect(unconfirm).toHaveBeenCalled());
+  });
+
+  it("withdraws after the required wallet changes", async () => {
+    const { rerender } = render(["BTC"], true, false);
+    await waitFor(() => expect(btcProvider.getAddress).toHaveBeenCalled());
+
     harness.connectors = {
       ...liveConnectors(),
-      BBN: {
-        id: "BBN",
-        config: { chainId: "bbn-test" },
-        connectedWallet: wallet("keplr", { address: "bbn1someoneelse", publicKeyHex: `03${"d".repeat(64)}` }),
+      BTC: {
+        id: "BTC",
+        config: { network: "signet" },
+        connectedWallet: wallet("okx", BTC_ACCOUNT, btcProvider),
         on: () => () => {},
       },
     };
+    rerender();
 
-    render(["BTC", "BBN"], true);
-
-    expect(unconfirm).toHaveBeenCalled();
+    await waitFor(() => expect(unconfirm).toHaveBeenCalled());
   });
 
-  it("does not withdraw a confirmation that was never persisted", () => {
+  it("keeps the confirmation after an optional wallet changes", async () => {
     store.delete(WALLET_CONFIRMATION_RECEIPT_KEY);
+    render(["ETH"], true, false);
+    await waitFor(() => expect(ethProvider.getAddress).toHaveBeenCalled());
 
-    render(["BTC", "BBN"], true);
+    act(() => {
+      btcProvider.changeAccount({ address: "bc1psomeoneelse", publicKeyHex: `02${"d".repeat(64)}` });
+      btcProvider.emit("accountsChanged", ["bc1psomeoneelse"]);
+    });
+    await act(async () => {});
 
     expect(unconfirm).not.toHaveBeenCalled();
+  });
+
+  it("ends the confirmation after a required provider disconnects", async () => {
+    render(["BTC"], true);
+    await waitFor(() => expect(btcProvider.getAddress).toHaveBeenCalled());
+
+    act(() => {
+      btcProvider.emit("disconnect");
+    });
+
+    expect(unconfirm).toHaveBeenCalled();
+    expect(store.has(WALLET_CONFIRMATION_RECEIPT_KEY)).toBe(false);
+  });
+
+  it("removes a listener when a required wallet becomes optional", async () => {
+    const { rerender } = render(["BTC", "ETH"], true);
+    await waitFor(() => expect(btcProvider.on).toHaveBeenCalledWith("accountsChanged", expect.any(Function)));
+
+    setWidgetState(["ETH"], true);
+    rerender();
+    await waitFor(() => expect(btcProvider.off).toHaveBeenCalledWith("accountsChanged", expect.any(Function)));
+
+    act(() => {
+      btcProvider.emit("accountsChanged", ["bc1psomeoneelse"]);
+    });
+    await act(async () => {});
+
+    expect(unconfirm).not.toHaveBeenCalled();
+    expect(store.get(WALLET_CONFIRMATION_RECEIPT_KEY)).toBe(approvedReceipt);
+  });
+
+  it("uses narrowed requirements for a disconnect fired during the same commit", async () => {
+    const disconnectHandlers = new Set<(wallet: IWallet) => void>();
+    const connectors = liveConnectors();
+    const btcConnector = connectors.BTC;
+    let disconnectInLayout = false;
+    harness.connectors = {
+      ...connectors,
+      BTC: {
+        ...btcConnector,
+        on: (event: string, handler: (wallet: IWallet) => void) => {
+          if (event === "disconnect") disconnectHandlers.add(handler);
+          return () => disconnectHandlers.delete(handler);
+        },
+      },
+    };
+    setWidgetState(["BTC", "ETH"], true);
+    const { rerender } = renderHook(() => {
+      useWalletConnectors({ persistent: true, accountStorage: storage });
+      useLayoutEffect(() => {
+        if (!disconnectInLayout) return;
+        [...disconnectHandlers].forEach((handler) => handler(btcConnector.connectedWallet));
+      });
+    });
+    await waitFor(() => expect(btcProvider.getAddress).toHaveBeenCalled());
+
+    setWidgetState(["ETH"], true);
+    disconnectInLayout = true;
+    rerender();
+
+    expect(unconfirm).not.toHaveBeenCalled();
+    expect(store.get(WALLET_CONFIRMATION_RECEIPT_KEY)).toBe(approvedReceipt);
+  });
+
+  it("does not restore approval after a required disconnect interrupts validation", async () => {
+    const addressRead = deferred<string>();
+    const disconnectHandlers = new Set<(wallet: IWallet) => void>();
+    const btcConnector = liveConnectors().BTC;
+    btcProvider.getAddress.mockReturnValueOnce(addressRead.promise);
+    harness.connectors = {
+      ...liveConnectors(),
+      BTC: {
+        ...btcConnector,
+        on: (event: string, handler: (wallet: IWallet) => void) => {
+          if (event === "disconnect") disconnectHandlers.add(handler);
+          return () => disconnectHandlers.delete(handler);
+        },
+      },
+    };
+    render(["BTC"], true);
+    await waitFor(() => expect(btcProvider.getAddress).toHaveBeenCalled());
+
+    act(() => {
+      disconnectHandlers.forEach((handler) => handler(btcConnector.connectedWallet));
+    });
+    await act(async () => addressRead.resolve(BTC_ACCOUNT.address));
+
+    expect(store.has(WALLET_CONFIRMATION_RECEIPT_KEY)).toBe(false);
   });
 });
 
 describe("the approval's lifetime", () => {
-  it("re-stamps the stored approval while the session stays confirmed, so it expires with the session", () => {
+  it("re-stamps the stored approval while the session stays confirmed, so it expires with the session", async () => {
     const stamps: string[] = [];
     storage.set = (k: string, v: string) => {
       stamps.push(k);
@@ -167,6 +513,6 @@ describe("the approval's lifetime", () => {
 
     render(["BTC", "BBN"], true);
 
-    expect(stamps).toContain(WALLET_CONFIRMATION_RECEIPT_KEY);
+    await waitFor(() => expect(stamps).toContain(WALLET_CONFIRMATION_RECEIPT_KEY));
   });
 });

--- a/packages/babylon-wallet-connector/src/hooks/useWalletConnectors.tsx
+++ b/packages/babylon-wallet-connector/src/hooks/useWalletConnectors.tsx
@@ -1,9 +1,16 @@
-import { useCallback, useEffect } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef } from "react";
 
 import { useChainProviders } from "@/context/Chain.context";
 import { useLifeCycleHooks } from "@/context/LifecycleHooks.context";
-import { isValidConfirmationReceipt, WALLET_CONFIRMATION_RECEIPT_KEY } from "@/core/confirmationReceipt";
-import { HashMap, IChain, IETHProvider, IWallet } from "@/core/types";
+import {
+  confirmedChains,
+  isConfirmationReceiptCovered,
+  isLiveConfirmationReceiptValid,
+  isValidConfirmationReceipt,
+  subscribeToConfirmationIdentityChanges,
+  WALLET_CONFIRMATION_RECEIPT_KEY,
+} from "@/core/confirmationReceipt";
+import { ChainId, HashMap, IChain, IETHProvider, IWallet } from "@/core/types";
 import { validateAddress, validateAddressWithPK } from "@/core/utils/wallet";
 import { resolveFirstPartyIcon } from "@/core/wallets/firstPartyIcons";
 import { ERROR_CODES, WalletError } from "@/error";
@@ -57,6 +64,7 @@ export function useWalletConnectors({ persistent, accountStorage, onError }: Pro
   const connectors = useChainProviders();
   const {
     confirmed,
+    confirmationReceipt,
     visible,
     selectWallet,
     removeWallet,
@@ -65,9 +73,18 @@ export function useWalletConnectors({ persistent, accountStorage, onError }: Pro
     displayError,
     confirm,
     unconfirm,
-    requiredChainIds,
+    requiredChainIds = [],
   } = useWidgetState();
   const { verifyBTCAddress } = useLifeCycleHooks();
+  const validationGenerationRef = useRef(0);
+  const previousRequiredChainIdsRef = useRef(requiredChainIds);
+  const confirmationCandidate = confirmationReceipt ??
+    (persistent && !visible ? accountStorage.get(WALLET_CONFIRMATION_RECEIPT_KEY) : undefined);
+  const confirmationCandidateRef = useRef<string>();
+  const dirtyOptionalChainsRef = useRef<Set<ChainId>>(new Set());
+  const requiredConnectorsReady = requiredChainIds.every(
+    (chainId) => connectors[chainId as ChainId]?.connectedWallet,
+  );
 
   // Connecting event
   useEffect(() => {
@@ -211,7 +228,7 @@ export function useWalletConnectors({ persistent, accountStorage, onError }: Pro
   ]);
 
   // Disconnect Event
-  useEffect(() => {
+  useLayoutEffect(() => {
     const connectorArr = Object.values(connectors);
 
     const unsubscribeArr = connectorArr.filter(Boolean).map((connector) =>
@@ -221,6 +238,7 @@ export function useWalletConnectors({ persistent, accountStorage, onError }: Pro
           // of, so the receipt must not survive to auto-confirm a later
           // reconnect. An optional chain leaving is not a consent change.
           if (requiredChainIds.includes(connector.id)) {
+            validationGenerationRef.current += 1;
             accountStorage.delete(WALLET_CONFIRMATION_RECEIPT_KEY);
           }
           removeWallet?.(connector.id);
@@ -276,67 +294,117 @@ export function useWalletConnectors({ persistent, accountStorage, onError }: Pro
     return () => unsubscribeArr.forEach((unsubscribe) => unsubscribe());
   }, [onError, displayChains, displayError, connectors]);
 
-  // Keeps the confirmation in step with the stored approval.
-  //
-  // One effect rather than a one-way "eligible for restore" latch: a host may
-  // narrow and widen its requirements as the user navigates, and a latch cannot
-  // re-open once it has closed, so the session could never recover. The stored
-  // receipt is the authority in both directions - it grants the confirmation
-  // when it covers the required chains, and withdraws it when it stops doing so.
-  useEffect(() => {
-    if (!persistent || visible) return;
+  const validateConfirmation = useCallback(async () => {
+    const generation = ++validationGenerationRef.current;
+    if (!confirmationCandidate) return;
 
-    const requiredConnectors = requiredChainIds
-      .map((chainId) => connectors[chainId as keyof typeof connectors])
-      .filter((connector): connector is NonNullable<typeof connector> => Boolean(connector));
-    const allRequiredConnectorsAvailable = requiredConnectors.length === requiredChainIds.length;
-    const allConnected = requiredConnectors.every((connector) => connector.connectedWallet !== null);
-    const hasStorage = requiredConnectors.every((connector) => accountStorage.has(connector.id));
+    if (!confirmationReceipt && !requiredConnectorsReady) return;
 
-    const stored = accountStorage.get(WALLET_CONFIRMATION_RECEIPT_KEY);
-    const covered =
-      allRequiredConnectorsAvailable &&
-      allConnected &&
-      hasStorage &&
-      isValidConfirmationReceipt(stored, requiredChainIds, connectors);
+    const covered = await isLiveConfirmationReceiptValid(confirmationCandidate, requiredChainIds, connectors);
+    if (generation !== validationGenerationRef.current) return;
 
-    if (covered && !confirmed) {
-      confirm?.();
+    if (!covered) {
+      accountStorage.delete(WALLET_CONFIRMATION_RECEIPT_KEY);
+      unconfirm?.();
+      return;
+    }
+
+    if (!confirmed && !visible) {
+      confirm?.(confirmationCandidate);
       displayChains?.();
       return;
     }
 
-    // The approval no longer covers what is being asked for - a chain the user
-    // never approved, or an account/wallet/network that has changed underneath
-    // it. Withdraw the confirmation so the host stops treating the session as
-    // signed in, and let the user confirm again explicitly.
-    if (!covered && confirmed && stored !== undefined) {
-      unconfirm?.();
+    // Keep the stored receipt alive with its confirmed session.
+    if (persistent && confirmed) {
+      accountStorage.set(WALLET_CONFIRMATION_RECEIPT_KEY, confirmationCandidate);
     }
   }, [
-    persistent,
-    connectors,
-    requiredChainIds,
-    confirm,
-    unconfirm,
-    displayChains,
     accountStorage,
-    visible,
+    confirmationCandidate,
+    confirmationReceipt,
     confirmed,
+    confirm,
+    connectors,
+    displayChains,
+    persistent,
+    requiredChainIds,
+    requiredConnectorsReady,
+    unconfirm,
+    visible,
   ]);
 
-  // The approval slides with the session it belongs to. Chain entries are
-  // re-stamped on every connect, including auto-reconnect, so without this the
-  // receipt would be the only entry that expires and any reload an hour after
-  // the single confirm would be a hard sign-out.
   useEffect(() => {
-    if (!persistent || !confirmed) return;
+    void validateConfirmation();
+  }, [validateConfirmation]);
 
-    const stored = accountStorage.get(WALLET_CONFIRMATION_RECEIPT_KEY);
-    if (stored && isValidConfirmationReceipt(stored, requiredChainIds, connectors)) {
-      accountStorage.set(WALLET_CONFIRMATION_RECEIPT_KEY, stored);
+  useLayoutEffect(() => {
+    const previousCandidate = confirmationCandidateRef.current;
+    if (!confirmationCandidate || (previousCandidate && previousCandidate !== confirmationCandidate)) {
+      dirtyOptionalChainsRef.current.clear();
     }
-  }, [persistent, confirmed, connectors, requiredChainIds, accountStorage]);
+    confirmationCandidateRef.current = confirmationCandidate;
+  }, [confirmationCandidate]);
+
+  useLayoutEffect(() => {
+    validationGenerationRef.current += 1;
+    const newlyRequiredChainIds = requiredChainIds.filter(
+      (chainId) => !previousRequiredChainIdsRef.current.includes(chainId),
+    );
+    previousRequiredChainIdsRef.current = requiredChainIds;
+    if (!confirmationCandidate) return;
+
+    const stopWatchingIdentity = subscribeToConfirmationIdentityChanges(
+      confirmationCandidate,
+      confirmedChains(confirmationCandidate),
+      connectors,
+      (chain) => {
+        if (!requiredChainIds.includes(chain)) {
+          dirtyOptionalChainsRef.current.add(chain);
+          return;
+        }
+
+        validationGenerationRef.current += 1;
+        accountStorage.delete(WALLET_CONFIRMATION_RECEIPT_KEY);
+        unconfirm?.();
+      },
+    );
+    if (!confirmationReceipt && !requiredConnectorsReady) return stopWatchingIdentity;
+
+    if (
+      !isConfirmationReceiptCovered(confirmationCandidate, requiredChainIds, connectors) ||
+      newlyRequiredChainIds.some((chainId) => dirtyOptionalChainsRef.current.has(chainId as ChainId)) ||
+      (confirmationReceipt &&
+        newlyRequiredChainIds.length > 0 &&
+        !isValidConfirmationReceipt(confirmationCandidate, newlyRequiredChainIds, connectors))
+    ) {
+      stopWatchingIdentity();
+      accountStorage.delete(WALLET_CONFIRMATION_RECEIPT_KEY);
+      unconfirm?.();
+      return;
+    }
+
+    if (confirmationReceipt && newlyRequiredChainIds.length > 0) {
+      unconfirm?.(true);
+    }
+
+    return stopWatchingIdentity;
+  }, [
+    accountStorage,
+    confirmationCandidate,
+    confirmationReceipt,
+    connectors,
+    requiredChainIds,
+    requiredConnectorsReady,
+    unconfirm,
+  ]);
+
+  useEffect(
+    () => () => {
+      validationGenerationRef.current += 1;
+    },
+    [],
+  );
 
   const connect = useCallback(
     async (chain: IChain, wallet: IWallet) => {

--- a/packages/babylon-wallet-connector/src/providers/BTCWalletProvider.tsx
+++ b/packages/babylon-wallet-connector/src/providers/BTCWalletProvider.tsx
@@ -284,21 +284,35 @@ export const BTCWalletProvider = ({ children, callbacks }: BTCWalletProviderProp
       disconnect();
     };
 
-    // Add listeners if provider supports events
-    // Different wallets use different event names
+    const registeredAccountEvents: (typeof ACCOUNT_CHANGE_EVENTS)[number][] = [];
+    let disconnectRegistered = false;
+
     if (typeof btcWalletProvider.on === "function") {
       ACCOUNT_CHANGE_EVENTS.forEach((event) => {
-        btcWalletProvider.on(event, onAccountsChanged);
+        try {
+          btcWalletProvider.on(event, onAccountsChanged);
+          registeredAccountEvents.push(event);
+        } catch {
+          // Some wallet providers reject event names that they do not support.
+        }
       });
-      btcWalletProvider.on(DISCONNECT_EVENT, onDisconnect);
+
+      try {
+        btcWalletProvider.on(DISCONNECT_EVENT, onDisconnect);
+        disconnectRegistered = true;
+      } catch {
+        // Some wallet providers reject event names that they do not support.
+      }
     }
 
     return () => {
       if (typeof btcWalletProvider.off === "function") {
-        ACCOUNT_CHANGE_EVENTS.forEach((event) => {
+        registeredAccountEvents.forEach((event) => {
           btcWalletProvider.off(event, onAccountsChanged);
         });
-        btcWalletProvider.off(DISCONNECT_EVENT, onDisconnect);
+        if (disconnectRegistered) {
+          btcWalletProvider.off(DISCONNECT_EVENT, onDisconnect);
+        }
       }
     };
   }, [btcWalletProvider, address, callbacks, disconnect]);
@@ -627,4 +641,3 @@ export const BTCWalletProvider = ({ children, callbacks }: BTCWalletProviderProp
 };
 
 export const useBTCWallet = () => useContext(BTCWalletContext);
-

--- a/packages/babylon-wallet-connector/src/providers/__tests__/BTCWalletProvider.lock.test.tsx
+++ b/packages/babylon-wallet-connector/src/providers/__tests__/BTCWalletProvider.lock.test.tsx
@@ -13,6 +13,8 @@ interface FakeBtcProvider {
   getPublicKeyHex: () => Promise<string>;
   connectWallet: () => Promise<void>;
   getAccounts?: () => Promise<string[]>;
+  on?: (event: string, callback: () => void) => void;
+  off?: (event: string, callback: () => void) => void;
 }
 
 const harness = vi.hoisted(() => ({
@@ -137,6 +139,37 @@ describe("BTCWalletProvider — silent lock engine", () => {
     // A wallet without getAccounts is feature-detected out: it is never probed.
     expect(getAccounts).not.toHaveBeenCalled();
     expect(result.current.locked).toBe(false);
+  });
+
+  it("keeps supported listeners when other event names are unsupported", async () => {
+    let liveAddress = ADDR;
+    const listeners = new Set<() => void>();
+    const on = vi.fn((event: string, callback: () => void) => {
+      if (event !== "accountsChanged") throw new Error("Unsupported event");
+      listeners.add(callback);
+    });
+    const off = vi.fn((event: string, callback: () => void) => {
+      if (event !== "accountsChanged") throw new Error("Unexpected cleanup");
+      listeners.delete(callback);
+    });
+    connectWith(makeProvider({ getAddress: async () => liveAddress, on, off }));
+
+    const { result, unmount } = renderHook(() => useBTCWallet(), { wrapper });
+
+    await waitFor(() => expect(result.current.connected).toBe(true));
+    expect(on).toHaveBeenCalledWith("accountChanged", expect.any(Function));
+    expect(on).toHaveBeenCalledWith("accountsChanged", expect.any(Function));
+    expect(on).toHaveBeenCalledWith("disconnect", expect.any(Function));
+    expect(listeners.size).toBe(1);
+
+    liveAddress = OTHER_ADDR;
+    act(() => listeners.forEach((listener) => listener()));
+    await waitFor(() => expect(result.current.address).toBe(OTHER_ADDR));
+
+    unmount();
+
+    expect(listeners.size).toBe(0);
+    expect(off.mock.calls.every(([event]) => event === "accountsChanged")).toBe(true);
   });
 
   it("clears the lock after a successful reconnect", async () => {


### PR DESCRIPTION
## Summary

- Store the approved wallet identity in memory for each session.
- Check live account, key, wallet, network, and disconnect data.
- Require new approval when a required wallet identity changes.
- Recheck approval when required chains change.
- Keep approval when only an optional wallet changes.
- Guard confirmation and restore flows against stale provider data and event races.

## Validation

- pnpm nx run @babylonlabs-io/wallet-connector:test --skip-nx-cache - 254 tests pass
- pnpm nx run @babylonlabs-io/wallet-connector:build --skip-nx-cache - passes
- pnpm nx run @babylonlabs-io/wallet-connector:lint --skip-nx-cache - 0 errors

Closes #2351