### PR TITLE
fix(wallet-connector): resolve Storybook buffer polyfill

### DIFF
--- a/packages/babylon-wallet-connector/vite.config.ts
+++ b/packages/babylon-wallet-connector/vite.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
       include: ["src"],
       exclude: ["src/**/*.stories.tsx", "src/**/*.test.ts", "src/**/*.test.tsx", "src/__fixtures__/**"],
     }),
-    nodePolyfills(),
+    nodePolyfills({ include: ["crypto"] }),
   ],
   build: {
     outDir: "dist",


### PR DESCRIPTION
## Summary

- Limit Vite Node polyfill aliases to `crypto`.
- Avoid bare shim aliases for `buffer`, `global`, and `process` under pnpm.
- Keep the plugin global injections.

This fixes the wallet connector Storybook resolution failure for `vite-plugin-node-polyfills/shims/buffer`. It uses the same configuration as the Vault and Simple Staking builds. It also matches the failure described in [vite-plugin-node-polyfills#81](https://github.com/davidmyersdev/vite-plugin-node-polyfills/issues/81).

## Verification

- Wallet connector Storybook static build passed.
- Wallet connector package build passed.
- Storybook Playwright tests passed: 214.
- Wallet connector Vitest tests passed: 194.
- Wallet connector lint passed with no errors.
