### PR TITLE
fix(ts-sdk, vault): read a deposit's protocol state at one pinned block

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,9 +27,18 @@ pnpm run build                        # Build all packages
 pnpm run lint                         # Lint all packages
 pnpm run test                         # Run all tests (vitest)
 pnpm --filter vault run dev           # Dev server for vault service
+
+# Regenerate the checked-in ts-sdk API docs. Required whenever the SDK's public
+# surface changes — a signature, a parameter, an exported type, or the JSDoc on
+# any of them.
+pnpm --filter @babylonlabs-io/ts-sdk run docs:clean
 ```
 
-Run `pnpm run lint` and `pnpm run test` in the affected service before considering work done.
+Run `pnpm run lint` and `pnpm run test` in the affected service before considering work done. If the change touched `packages/babylon-ts-sdk`'s public surface, run `docs:clean` as well and commit the regenerated `docs/api/` output.
+
+The `verify` CI job regenerates those docs and diffs them against what is committed, failing with *"Generated API docs are stale"*. It is easy to miss locally: `docs:clean` is not part of `build`, `lint` or `test`, so a change can be green on all three and still fail CI. Note also that the generator prints hundreds of pre-existing warnings about undocumented symbols — those are not the failure; only staleness is.
+
+Run the SDK's own `test` script rather than `vitest` directly when checking that package. `pnpm --filter @babylonlabs-io/ts-sdk run test` is `build && vitest run && node --test tests/wasm-facade.node.mjs`; invoking `vitest` alone skips the build and the WASM-facade pin check that CI runs.
 
 ---
 

--- a/packages/babylon-ts-sdk/docs/api/clients.md
+++ b/packages/babylon-ts-sdk/docs/api/clients.md
@@ -52,7 +52,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/operation-key-read
 ##### getCurrentOperationKeys()
 
 ```ts
-getCurrentOperationKeys(query): Promise<RawOperationKeys>;
+getCurrentOperationKeys(query, blockNumber?): Promise<RawOperationKeys>;
 ```
 
 Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/operation-key-reader.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/operation-key-reader.ts)
@@ -68,6 +68,10 @@ fallback, so an operator that never rotated yields its registration key.
 ###### query
 
 [`OperationKeyQuery`](#operationkeyquery)
+
+###### blockNumber?
+
+`bigint`
 
 ###### Returns
 
@@ -308,7 +312,7 @@ If the deployment does not expose `peginActivationDelay()`, or
 ##### getPegInConfiguration()
 
 ```ts
-getPegInConfiguration(): Promise<PegInConfiguration>;
+getPegInConfiguration(blockNumber?): Promise<PegInConfiguration>;
 ```
 
 Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/protocol-params-reader.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/protocol-params-reader.ts)
@@ -318,6 +322,17 @@ label atomically via multicall. The version is paired with the params so
 that a governance update between separate reads cannot let JS build BTC
 scripts with version N params while the contract registers the vault
 under version N+1.
+
+That guarantee holds only within this multicall. A caller that also reads
+participant keys — every fresh peg-in build does — must pass the same
+`blockNumber` here and to those reads, or the two describe different
+blocks and the pairing above buys nothing across the seam.
+
+###### Parameters
+
+###### blockNumber?
+
+`bigint`
 
 ###### Returns
 
@@ -403,7 +418,10 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/signer-set-reader.
 ##### getVaultKeepersByVersion()
 
 ```ts
-getVaultKeepersByVersion(appEntryPoint, version): Promise<AddressBTCKeyPair[]>;
+getVaultKeepersByVersion(
+   appEntryPoint, 
+   version, 
+blockNumber?): Promise<AddressBTCKeyPair[]>;
 ```
 
 Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/signer-set-reader.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/signer-set-reader.ts)
@@ -417,6 +435,10 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/signer-set-reader.
 ###### version
 
 `number`
+
+###### blockNumber?
+
+`bigint`
 
 ###### Returns
 
@@ -451,7 +473,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/signer-set-reader.
 ##### getCurrentVaultKeepersVersion()
 
 ```ts
-getCurrentVaultKeepersVersion(appEntryPoint): Promise<number>;
+getCurrentVaultKeepersVersion(appEntryPoint, blockNumber?): Promise<number>;
 ```
 
 Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/signer-set-reader.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/signer-set-reader.ts)
@@ -461,6 +483,10 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/signer-set-reader.
 ###### appEntryPoint
 
 `` `0x${string}` ``
+
+###### blockNumber?
+
+`bigint`
 
 ###### Returns
 
@@ -515,7 +541,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/signer-set-reader.
 ##### getUniversalChallengersByVersion()
 
 ```ts
-getUniversalChallengersByVersion(version): Promise<AddressBTCKeyPair[]>;
+getUniversalChallengersByVersion(version, blockNumber?): Promise<AddressBTCKeyPair[]>;
 ```
 
 Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/signer-set-reader.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/signer-set-reader.ts)
@@ -525,6 +551,10 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/signer-set-reader.
 ###### version
 
 `number`
+
+###### blockNumber?
+
+`bigint`
 
 ###### Returns
 
@@ -553,10 +583,16 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/signer-set-reader.
 ##### getLatestUniversalChallengersVersion()
 
 ```ts
-getLatestUniversalChallengersVersion(): Promise<number>;
+getLatestUniversalChallengersVersion(blockNumber?): Promise<number>;
 ```
 
 Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/signer-set-reader.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/signer-set-reader.ts)
+
+###### Parameters
+
+###### blockNumber?
+
+`bigint`
 
 ###### Returns
 
@@ -611,7 +647,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/vault-registry-rea
 ##### getVaultProviderGenesisBtcPubKey()
 
 ```ts
-getVaultProviderGenesisBtcPubKey(vpAddress): Promise<OnChainBtcPubkey>;
+getVaultProviderGenesisBtcPubKey(vpAddress, blockNumber?): Promise<OnChainBtcPubkey>;
 ```
 
 Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/vault-registry-reader.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/vault-registry-reader.ts)
@@ -643,6 +679,10 @@ the brand. Returns 64-char lowercase hex without the `0x` prefix.
 ###### vpAddress
 
 `` `0x${string}` ``
+
+###### blockNumber?
+
+`bigint`
 
 ###### Returns
 
@@ -1967,7 +2007,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://
 ##### getVaultProviderGenesisBtcPubKey()
 
 ```ts
-getVaultProviderGenesisBtcPubKey(vpAddress): Promise<OnChainBtcPubkey>;
+getVaultProviderGenesisBtcPubKey(vpAddress, blockNumber?): Promise<OnChainBtcPubkey>;
 ```
 
 Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
@@ -1987,6 +2027,10 @@ RFC-006 registry — as does every caller.
 ###### vpAddress
 
 `` `0x${string}` ``
+
+###### blockNumber?
+
+`bigint`
 
 ###### Returns
 
@@ -2521,10 +2565,20 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://
 ##### getPegInConfiguration()
 
 ```ts
-getPegInConfiguration(): Promise<PegInConfiguration>;
+getPegInConfiguration(blockNumber?): Promise<PegInConfiguration>;
 ```
 
 Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
+
+Pass `blockNumber` when the result will shape a Bitcoin lock, so this
+multicall and the participant-key reads describe the same block. Omit it
+for display-only reads, where a slightly stale value is harmless.
+
+###### Parameters
+
+###### blockNumber?
+
+`bigint`
 
 ###### Returns
 
@@ -2608,12 +2662,29 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://
 
 Interface for reading vault keepers from the ApplicationRegistry contract.
 
+The reads used to build a peg-in — here and on the sibling reader interfaces
+— take an optional `blockNumber` that pins them to one block instead of
+`latest`. Omitting it, the historical behaviour, is correct for every read
+that resolves against a vault's already-frozen epochs, because those are
+immutable once stamped. It is NOT correct for a fresh peg-in build: the
+participant keys, roster versions and protocol params that shape the Bitcoin
+lock must all describe the same block, or the lock commits to a mixture of
+chain states that never existed at once. See
+`services/deposit/validateOnChainParticipantKeys`.
+
+The `getCurrent*` roster reads are the exception and take no block. Nothing
+on the build path uses them — it resolves rosters by version instead — so
+they were left alone rather than given a pin no caller would pass.
+
 #### Methods
 
 ##### getVaultKeepersByVersion()
 
 ```ts
-getVaultKeepersByVersion(appEntryPoint, version): Promise<AddressBTCKeyPair[]>;
+getVaultKeepersByVersion(
+   appEntryPoint, 
+   version, 
+blockNumber?): Promise<AddressBTCKeyPair[]>;
 ```
 
 Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
@@ -2627,6 +2698,10 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://
 ###### version
 
 `number`
+
+###### blockNumber?
+
+`bigint`
 
 ###### Returns
 
@@ -2653,7 +2728,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://
 ##### getCurrentVaultKeepersVersion()
 
 ```ts
-getCurrentVaultKeepersVersion(appEntryPoint): Promise<number>;
+getCurrentVaultKeepersVersion(appEntryPoint, blockNumber?): Promise<number>;
 ```
 
 Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
@@ -2663,6 +2738,10 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://
 ###### appEntryPoint
 
 `` `0x${string}` ``
+
+###### blockNumber?
+
+`bigint`
 
 ###### Returns
 
@@ -2681,7 +2760,7 @@ Interface for reading universal challengers from the ProtocolParams contract.
 ##### getUniversalChallengersByVersion()
 
 ```ts
-getUniversalChallengersByVersion(version): Promise<AddressBTCKeyPair[]>;
+getUniversalChallengersByVersion(version, blockNumber?): Promise<AddressBTCKeyPair[]>;
 ```
 
 Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
@@ -2691,6 +2770,10 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://
 ###### version
 
 `number`
+
+###### blockNumber?
+
+`bigint`
 
 ###### Returns
 
@@ -2711,10 +2794,16 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://
 ##### getLatestUniversalChallengersVersion()
 
 ```ts
-getLatestUniversalChallengersVersion(): Promise<number>;
+getLatestUniversalChallengersVersion(blockNumber?): Promise<number>;
 ```
 
 Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
+
+###### Parameters
+
+###### blockNumber?
+
+`bigint`
 
 ###### Returns
 
@@ -2871,7 +2960,7 @@ builds a lock no counterparty agrees with.
 ##### getCurrentOperationKeys()
 
 ```ts
-getCurrentOperationKeys(query): Promise<RawOperationKeys>;
+getCurrentOperationKeys(query, blockNumber?): Promise<RawOperationKeys>;
 ```
 
 Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
@@ -2887,6 +2976,10 @@ fallback, so an operator that never rotated yields its registration key.
 ###### query
 
 [`OperationKeyQuery`](#operationkeyquery)
+
+###### blockNumber?
+
+`bigint`
 
 ###### Returns
 

--- a/packages/babylon-ts-sdk/docs/api/services.md
+++ b/packages/babylon-ts-sdk/docs/api/services.md
@@ -1731,6 +1731,32 @@ immediately before the throw.
 
 `void`
 
+##### blockNumber
+
+```ts
+blockNumber: bigint;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnChainParticipantKeys.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnChainParticipantKeys.ts)
+
+Block to resolve every read against, so the roster versions, the roster
+members and their operation keys all describe one chain state.
+
+This function reads in three dependent rounds — versions, then the members
+at those versions, then those members' operation keys — because each round
+needs the previous round's output. Left unpinned, each round lands on
+whatever `latest` happens to be, and a rotation between rounds yields a key
+set that no single block ever held. The Bitcoin lock built from it would
+commit to that mixture, and no counterparty would agree with it.
+
+Required rather than optional, and deliberately so. This function exists
+only for the fresh-deposit path, where an unpinned read is never correct —
+an optional pin would be a silent fallback to `latest`-per-round on a path
+that builds a Bitcoin lock. Callers must pass the same block to
+`ProtocolParamsReader.getPegInConfiguration`; the reader interfaces keep
+their pin optional because their other callers resolve against a vault's
+already-frozen epochs, where pinning is meaningless.
+
 ***
 
 ### ValidatedOnChainParticipantKeys
@@ -4056,6 +4082,13 @@ Resolve every participant's *current* operation key.
 Use for a peg-in being built now. Issues no epoch read, so it never touches
 the extended `getBtcVaultProtocolInfo` ABI.
 
+`blockNumber` pins the resolution to one block, and is required. Pass the
+same block the rosters in `query` were read at: the roster supplies each
+participant's address and genesis key, and this call resolves what that
+participant has rotated to. Reading the two at different blocks can pair a
+roster member with a key from a different chain state, so there is no
+correct unpinned call and no default worth having.
+
 #### Parameters
 
 ##### params
@@ -4067,6 +4100,10 @@ the extended `getBtcVaultProtocolInfo` ABI.
 ###### query
 
 [`OperationKeyQuery`](clients.md#operationkeyquery)
+
+###### blockNumber
+
+`bigint`
 
 #### Returns
 

--- a/packages/babylon-ts-sdk/src/tbv/core/clients/eth/operation-key-reader.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/eth/operation-key-reader.ts
@@ -103,10 +103,12 @@ export class ViemOperationKeyReader implements OperationKeyReader {
     keeperCount: number,
     challengerCount: number,
     label: string,
+    blockNumber?: bigint,
   ) {
     const results = (await this.publicClient.multicall({
       contracts: calls,
       allowFailure: false,
+      blockNumber,
     })) as readonly T[];
 
     assertMulticallLength(
@@ -120,6 +122,7 @@ export class ViemOperationKeyReader implements OperationKeyReader {
 
   async getCurrentOperationKeys(
     query: OperationKeyQuery,
+    blockNumber?: bigint,
   ): Promise<RawOperationKeys> {
     const calls: Call[] = [
       {
@@ -147,6 +150,7 @@ export class ViemOperationKeyReader implements OperationKeyReader {
       query.vaultKeepers.length,
       query.universalChallengers.length,
       "getCurrentOperationKeys",
+      blockNumber,
     );
   }
 

--- a/packages/babylon-ts-sdk/src/tbv/core/clients/eth/protocol-params-reader.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/eth/protocol-params-reader.ts
@@ -214,9 +214,17 @@ export class ViemProtocolParamsReader implements ProtocolParamsReader {
    * that a governance update between separate reads cannot let JS build BTC
    * scripts with version N params while the contract registers the vault
    * under version N+1.
+   *
+   * That guarantee holds only within this multicall. A caller that also reads
+   * participant keys — every fresh peg-in build does — must pass the same
+   * `blockNumber` here and to those reads, or the two describe different
+   * blocks and the pairing above buys nothing across the seam.
    */
-  async getPegInConfiguration(): Promise<PegInConfiguration> {
+  async getPegInConfiguration(
+    blockNumber?: bigint,
+  ): Promise<PegInConfiguration> {
     const results = await this.publicClient.multicall({
+      blockNumber,
       contracts: [
         {
           address: this.contractAddress,

--- a/packages/babylon-ts-sdk/src/tbv/core/clients/eth/signer-set-reader.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/eth/signer-set-reader.ts
@@ -43,12 +43,14 @@ export class ViemVaultKeeperReader implements VaultKeeperReader {
   async getVaultKeepersByVersion(
     appEntryPoint: Address,
     version: number,
+    blockNumber?: bigint,
   ): Promise<AddressBTCKeyPair[]> {
     const result = (await this.publicClient.readContract({
       address: this.contractAddress,
       abi: ApplicationRegistryABI,
       functionName: "getVaultKeepersByVersion",
       args: [appEntryPoint, version],
+      blockNumber,
     })) as readonly { ethAddress: Address; btcPubKey: Hex }[];
 
     return mapKeyPairs(result);
@@ -69,12 +71,14 @@ export class ViemVaultKeeperReader implements VaultKeeperReader {
 
   async getCurrentVaultKeepersVersion(
     appEntryPoint: Address,
+    blockNumber?: bigint,
   ): Promise<number> {
     const result = (await this.publicClient.readContract({
       address: this.contractAddress,
       abi: ApplicationRegistryABI,
       functionName: "getCurrentVaultKeepersVersion",
       args: [appEntryPoint],
+      blockNumber,
     })) as number;
 
     return result;
@@ -98,12 +102,14 @@ export class ViemUniversalChallengerReader implements UniversalChallengerReader 
 
   async getUniversalChallengersByVersion(
     version: number,
+    blockNumber?: bigint,
   ): Promise<AddressBTCKeyPair[]> {
     const result = (await this.publicClient.readContract({
       address: this.contractAddress,
       abi: ProtocolParamsABI,
       functionName: "getUniversalChallengersByVersion",
       args: [version],
+      blockNumber,
     })) as readonly { ethAddress: Address; btcPubKey: Hex }[];
 
     return mapKeyPairs(result);
@@ -119,11 +125,14 @@ export class ViemUniversalChallengerReader implements UniversalChallengerReader 
     return mapKeyPairs(result);
   }
 
-  async getLatestUniversalChallengersVersion(): Promise<number> {
+  async getLatestUniversalChallengersVersion(
+    blockNumber?: bigint,
+  ): Promise<number> {
     const result = (await this.publicClient.readContract({
       address: this.contractAddress,
       abi: ProtocolParamsABI,
       functionName: "latestUniversalChallengersVersion",
+      blockNumber,
     })) as number;
 
     return result;

--- a/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts
@@ -126,6 +126,7 @@ export interface VaultRegistryReader {
    */
   getVaultProviderGenesisBtcPubKey(
     vpAddress: Address,
+    blockNumber?: bigint,
   ): Promise<OnChainBtcPubkey>;
   /** Read the protocol pegin fee (in wei) for a given vault provider. */
   getPegInFee(vaultProvider: Address): Promise<bigint>;
@@ -268,7 +269,12 @@ export interface ProtocolParamsReader {
   getLatestOffchainParams(): Promise<VersionedOffchainParams>;
   getLatestOffchainParamsVersion(): Promise<number>;
   getTimelockPeginByVersion(version: number): Promise<number>;
-  getPegInConfiguration(): Promise<PegInConfiguration>;
+  /**
+   * Pass `blockNumber` when the result will shape a Bitcoin lock, so this
+   * multicall and the participant-key reads describe the same block. Omit it
+   * for display-only reads, where a slightly stale value is harmless.
+   */
+  getPegInConfiguration(blockNumber?: bigint): Promise<PegInConfiguration>;
   /**
    * Observation window enforced between a vault's final ACK and its
    * activation, in ETH blocks measured from `verifiedAt`. `0` disables it.
@@ -300,23 +306,44 @@ export interface AddressBTCKeyPair {
   btcPubKey: Hex;
 }
 
-/** Interface for reading vault keepers from the ApplicationRegistry contract. */
+/**
+ * Interface for reading vault keepers from the ApplicationRegistry contract.
+ *
+ * The reads used to build a peg-in — here and on the sibling reader interfaces
+ * — take an optional `blockNumber` that pins them to one block instead of
+ * `latest`. Omitting it, the historical behaviour, is correct for every read
+ * that resolves against a vault's already-frozen epochs, because those are
+ * immutable once stamped. It is NOT correct for a fresh peg-in build: the
+ * participant keys, roster versions and protocol params that shape the Bitcoin
+ * lock must all describe the same block, or the lock commits to a mixture of
+ * chain states that never existed at once. See
+ * `services/deposit/validateOnChainParticipantKeys`.
+ *
+ * The `getCurrent*` roster reads are the exception and take no block. Nothing
+ * on the build path uses them — it resolves rosters by version instead — so
+ * they were left alone rather than given a pin no caller would pass.
+ */
 export interface VaultKeeperReader {
   getVaultKeepersByVersion(
     appEntryPoint: Address,
     version: number,
+    blockNumber?: bigint,
   ): Promise<AddressBTCKeyPair[]>;
   getCurrentVaultKeepers(appEntryPoint: Address): Promise<AddressBTCKeyPair[]>;
-  getCurrentVaultKeepersVersion(appEntryPoint: Address): Promise<number>;
+  getCurrentVaultKeepersVersion(
+    appEntryPoint: Address,
+    blockNumber?: bigint,
+  ): Promise<number>;
 }
 
 /** Interface for reading universal challengers from the ProtocolParams contract. */
 export interface UniversalChallengerReader {
   getUniversalChallengersByVersion(
     version: number,
+    blockNumber?: bigint,
   ): Promise<AddressBTCKeyPair[]>;
   getCurrentUniversalChallengers(): Promise<AddressBTCKeyPair[]>;
-  getLatestUniversalChallengersVersion(): Promise<number>;
+  getLatestUniversalChallengersVersion(blockNumber?: bigint): Promise<number>;
 }
 
 // ============================================================================
@@ -387,7 +414,10 @@ export interface OperationKeyReader {
    * each registry's `getCurrentOperationBtcKey` resolves its own genesis
    * fallback, so an operator that never rotated yields its registration key.
    */
-  getCurrentOperationKeys(query: OperationKeyQuery): Promise<RawOperationKeys>;
+  getCurrentOperationKeys(
+    query: OperationKeyQuery,
+    blockNumber?: bigint,
+  ): Promise<RawOperationKeys>;
   /**
    * Resolve every participant's operation key bonded at a vault's frozen
    * epochs. Used for every existing-vault path (resume, payout, refund).

--- a/packages/babylon-ts-sdk/src/tbv/core/clients/eth/vault-registry-reader.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/eth/vault-registry-reader.ts
@@ -194,12 +194,14 @@ export class ViemVaultRegistryReader implements VaultRegistryReader {
    */
   async getVaultProviderGenesisBtcPubKey(
     vpAddress: Address,
+    blockNumber?: bigint,
   ): Promise<OnChainBtcPubkey> {
     const result = (await this.publicClient.readContract({
       address: this.contractAddress,
       abi: BTCVaultRegistryABI,
       functionName: "getOperationBtcKeyAtEpoch",
       args: [vpAddress, VP_GENESIS_KEY_EPOCH],
+      blockNumber,
     })) as Hex;
     return assertOnChainBtcPubkey(
       result,

--- a/packages/babylon-ts-sdk/src/tbv/core/services/deposit/__tests__/validateOnChainParticipantKeys.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/deposit/__tests__/validateOnChainParticipantKeys.test.ts
@@ -48,6 +48,9 @@ const VP_ETH_ADDRESS = "0xVP" as Address;
 const KEEPERS_VERSION = 7;
 const CHALLENGERS_VERSION = 11;
 
+/** Every read must resolve against the caller's block; there is no unpinned path. */
+const TEST_BLOCK = 9_000_001n;
+
 function pair(btcPubKey: string): AddressBTCKeyPair {
   // The registry always returns roster keys 0x-prefixed; the bare constants in
   // this file are for readability only.
@@ -126,6 +129,55 @@ describe("validateOnChainParticipantKeys", () => {
     vi.clearAllMocks();
   });
 
+  it("resolves every read against the caller's block when one is given", async () => {
+    const readers = buildReaders();
+    const operationKeyReader: OperationKeyReader = {
+      ...readers.operationKeyReader,
+      getCurrentOperationKeys: vi.fn(async (query: OperationKeyQuery) => ({
+        vaultProvider: query.vaultProviderGenesisBtcPubkey,
+        vaultKeepers: query.vaultKeepers.map((k) => k.btcPubKey),
+        universalChallengers: query.universalChallengers.map(
+          (c) => c.btcPubKey,
+        ),
+      })),
+    };
+    const blockNumber = 4_242_042n;
+
+    await validateOnChainParticipantKeys({
+      ...readers,
+      operationKeyReader,
+      vaultProviderEthAddress: VP_ETH_ADDRESS,
+      applicationEntryPoint: APP_ENTRY_POINT,
+      expectedVaultProviderBtcPubkey: VP_KEY,
+      expectedVaultKeeperBtcPubkeys: [KEEPER_1, KEEPER_2],
+      expectedUniversalChallengerBtcPubkeys: [CHALLENGER_1, CHALLENGER_2],
+      blockNumber,
+    });
+
+    // The three rounds are dependent — versions, then members at those
+    // versions, then those members' operation keys — so an unpinned read in any
+    // one of them reopens the window this parameter exists to close.
+    expect(
+      readers.vaultRegistryReader.getVaultProviderGenesisBtcPubKey,
+    ).toHaveBeenCalledWith(VP_ETH_ADDRESS, blockNumber);
+    expect(
+      readers.vaultKeeperReader.getCurrentVaultKeepersVersion,
+    ).toHaveBeenCalledWith(APP_ENTRY_POINT, blockNumber);
+    expect(
+      readers.universalChallengerReader.getLatestUniversalChallengersVersion,
+    ).toHaveBeenCalledWith(blockNumber);
+    expect(
+      readers.vaultKeeperReader.getVaultKeepersByVersion,
+    ).toHaveBeenCalledWith(APP_ENTRY_POINT, KEEPERS_VERSION, blockNumber);
+    expect(
+      readers.universalChallengerReader.getUniversalChallengersByVersion,
+    ).toHaveBeenCalledWith(CHALLENGERS_VERSION, blockNumber);
+    expect(operationKeyReader.getCurrentOperationKeys).toHaveBeenCalledWith(
+      expect.anything(),
+      blockNumber,
+    );
+  });
+
   it("returns canonical lowercase sorted sets and the on-chain versions on the happy path", async () => {
     const readers = buildReaders();
 
@@ -136,6 +188,7 @@ describe("validateOnChainParticipantKeys", () => {
       expectedVaultProviderBtcPubkey: VP_KEY,
       expectedVaultKeeperBtcPubkeys: [KEEPER_1, KEEPER_2],
       expectedUniversalChallengerBtcPubkeys: [CHALLENGER_1, CHALLENGER_2],
+      blockNumber: TEST_BLOCK,
     });
 
     expect(result.vaultProviderBtcPubkeyXOnly).toBe(VP_KEY);
@@ -161,6 +214,7 @@ describe("validateOnChainParticipantKeys", () => {
         expectedVaultProviderBtcPubkey: VP_KEY,
         expectedVaultKeeperBtcPubkeys: [KEEPER_1, KEEPER_2],
         expectedUniversalChallengerBtcPubkeys: [CHALLENGER_1, CHALLENGER_2],
+        blockNumber: TEST_BLOCK,
       }),
     ).rejects.toThrow(/Vault provider BTC pubkey/);
   });
@@ -182,6 +236,7 @@ describe("validateOnChainParticipantKeys", () => {
         expectedVaultProviderBtcPubkey: VP_KEY,
         expectedVaultKeeperBtcPubkeys: [KEEPER_1, KEEPER_2],
         expectedUniversalChallengerBtcPubkeys: [CHALLENGER_1, CHALLENGER_2],
+        blockNumber: TEST_BLOCK,
       }),
     ).rejects.toThrow("has no registered BTC pubkey on-chain");
   });
@@ -199,6 +254,7 @@ describe("validateOnChainParticipantKeys", () => {
         expectedVaultProviderBtcPubkey: VP_KEY,
         expectedVaultKeeperBtcPubkeys: [KEEPER_1, KEEPER_2],
         expectedUniversalChallengerBtcPubkeys: [CHALLENGER_1, CHALLENGER_2],
+        blockNumber: TEST_BLOCK,
       }),
     ).rejects.toThrow(/keeper.*does not match/i);
   });
@@ -214,6 +270,7 @@ describe("validateOnChainParticipantKeys", () => {
         expectedVaultProviderBtcPubkey: VP_KEY,
         expectedVaultKeeperBtcPubkeys: [KEEPER_1, KEEPER_2],
         expectedUniversalChallengerBtcPubkeys: [CHALLENGER_1, CHALLENGER_2],
+        blockNumber: TEST_BLOCK,
       }),
     ).rejects.toThrow(/keeper.*does not match/i);
   });
@@ -231,6 +288,7 @@ describe("validateOnChainParticipantKeys", () => {
         expectedVaultProviderBtcPubkey: VP_KEY,
         expectedVaultKeeperBtcPubkeys: [KEEPER_1, KEEPER_2],
         expectedUniversalChallengerBtcPubkeys: [CHALLENGER_1, CHALLENGER_2],
+        blockNumber: TEST_BLOCK,
       }),
     ).rejects.toThrow(/challenger.*does not match/i);
   });
@@ -245,6 +303,7 @@ describe("validateOnChainParticipantKeys", () => {
       expectedVaultProviderBtcPubkey: VP_KEY_COMPRESSED,
       expectedVaultKeeperBtcPubkeys: [KEEPER_1, KEEPER_2],
       expectedUniversalChallengerBtcPubkeys: [CHALLENGER_1, CHALLENGER_2],
+      blockNumber: TEST_BLOCK,
     });
 
     expect(result.vaultProviderBtcPubkeyXOnly).toBe(VP_KEY);
@@ -263,6 +322,7 @@ describe("validateOnChainParticipantKeys", () => {
       expectedVaultProviderBtcPubkey: VP_KEY,
       expectedVaultKeeperBtcPubkeys: [KEEPER_2, KEEPER_3, KEEPER_1],
       expectedUniversalChallengerBtcPubkeys: [CHALLENGER_1, CHALLENGER_2],
+      blockNumber: TEST_BLOCK,
     });
 
     expect(result.vaultKeeperBtcPubkeysSorted).toEqual([
@@ -286,6 +346,7 @@ describe("validateOnChainParticipantKeys", () => {
       expectedVaultProviderBtcPubkey: VP_KEY_UPPERCASE,
       expectedVaultKeeperBtcPubkeys: [KEEPER_1, KEEPER_2],
       expectedUniversalChallengerBtcPubkeys: [CHALLENGER_1, CHALLENGER_2],
+      blockNumber: TEST_BLOCK,
     });
 
     expect(result.vaultProviderBtcPubkeyXOnly).toBe(VP_KEY);
@@ -358,6 +419,7 @@ describe("validateOnChainParticipantKeys with operation-key resolution", () => {
       expectedVaultProviderBtcPubkey: REGISTRATION.vp,
       expectedVaultKeeperBtcPubkeys: REGISTRATION.keepers,
       expectedUniversalChallengerBtcPubkeys: REGISTRATION.challengers,
+      blockNumber: TEST_BLOCK,
     });
 
     expect(result.vaultProviderBtcPubkeyXOnly).toBe(OPERATION.vp);
@@ -381,6 +443,7 @@ describe("validateOnChainParticipantKeys with operation-key resolution", () => {
         expectedVaultKeeperBtcPubkeys: REGISTRATION.keepers,
         expectedUniversalChallengerBtcPubkeys: REGISTRATION.challengers,
         onIndexerServingOperationKeys,
+        blockNumber: TEST_BLOCK,
       }),
     ).resolves.toBeDefined();
 
@@ -398,6 +461,7 @@ describe("validateOnChainParticipantKeys with operation-key resolution", () => {
         expectedVaultKeeperBtcPubkeys: OPERATION.keepers,
         expectedUniversalChallengerBtcPubkeys: OPERATION.challengers,
         onIndexerServingOperationKeys,
+        blockNumber: TEST_BLOCK,
       }),
     ).resolves.toBeDefined();
 
@@ -416,6 +480,7 @@ describe("validateOnChainParticipantKeys with operation-key resolution", () => {
         expectedVaultProviderBtcPubkey: REGISTRATION.vp,
         expectedVaultKeeperBtcPubkeys: REGISTRATION.keepers,
         expectedUniversalChallengerBtcPubkeys: OPERATION.challengers,
+        blockNumber: TEST_BLOCK,
       }),
     ).rejects.toThrow(/internally inconsistent/i);
   });
@@ -433,6 +498,7 @@ describe("validateOnChainParticipantKeys with operation-key resolution", () => {
         expectedVaultKeeperBtcPubkeys: REGISTRATION.keepers,
         expectedUniversalChallengerBtcPubkeys: OPERATION.challengers,
         onIndexerHintsInconsistent,
+        blockNumber: TEST_BLOCK,
       }),
     ).rejects.toThrow(/internally inconsistent/i);
 
@@ -451,6 +517,7 @@ describe("validateOnChainParticipantKeys with operation-key resolution", () => {
         expectedVaultProviderBtcPubkey: KEYS.outsider,
         expectedVaultKeeperBtcPubkeys: REGISTRATION.keepers,
         expectedUniversalChallengerBtcPubkeys: REGISTRATION.challengers,
+        blockNumber: TEST_BLOCK,
       }),
     ).rejects.toThrow(/Vault provider BTC pubkey/);
   });

--- a/packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnChainParticipantKeys.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/deposit/validateOnChainParticipantKeys.ts
@@ -45,6 +45,26 @@ export interface ValidateOnChainParticipantKeysParams {
    * immediately before the throw.
    */
   onIndexerHintsInconsistent?: (message: string) => void;
+  /**
+   * Block to resolve every read against, so the roster versions, the roster
+   * members and their operation keys all describe one chain state.
+   *
+   * This function reads in three dependent rounds — versions, then the members
+   * at those versions, then those members' operation keys — because each round
+   * needs the previous round's output. Left unpinned, each round lands on
+   * whatever `latest` happens to be, and a rotation between rounds yields a key
+   * set that no single block ever held. The Bitcoin lock built from it would
+   * commit to that mixture, and no counterparty would agree with it.
+   *
+   * Required rather than optional, and deliberately so. This function exists
+   * only for the fresh-deposit path, where an unpinned read is never correct —
+   * an optional pin would be a silent fallback to `latest`-per-round on a path
+   * that builds a Bitcoin lock. Callers must pass the same block to
+   * `ProtocolParamsReader.getPegInConfiguration`; the reader interfaces keep
+   * their pin optional because their other callers resolve against a vault's
+   * already-frozen epochs, where pinning is meaningless.
+   */
+  blockNumber: bigint;
 }
 
 export interface ValidatedOnChainParticipantKeys {
@@ -88,6 +108,7 @@ export async function validateOnChainParticipantKeys(
     operationKeyReader,
     onIndexerServingOperationKeys,
     onIndexerHintsInconsistent,
+    blockNumber,
   } = params;
 
   const [
@@ -97,18 +118,24 @@ export async function validateOnChainParticipantKeys(
   ] = await Promise.all([
     vaultRegistryReader.getVaultProviderGenesisBtcPubKey(
       vaultProviderEthAddress,
+      blockNumber,
     ),
-    vaultKeeperReader.getCurrentVaultKeepersVersion(applicationEntryPoint),
-    universalChallengerReader.getLatestUniversalChallengersVersion(),
+    vaultKeeperReader.getCurrentVaultKeepersVersion(
+      applicationEntryPoint,
+      blockNumber,
+    ),
+    universalChallengerReader.getLatestUniversalChallengersVersion(blockNumber),
   ]);
 
   const [onChainKeepers, onChainChallengers] = await Promise.all([
     vaultKeeperReader.getVaultKeepersByVersion(
       applicationEntryPoint,
       expectedAppVaultKeepersVersion,
+      blockNumber,
     ),
     universalChallengerReader.getUniversalChallengersByVersion(
       expectedUniversalChallengersVersion,
+      blockNumber,
     ),
   ]);
 
@@ -135,6 +162,7 @@ export async function validateOnChainParticipantKeys(
         vaultKeepers: onChainKeepers,
         universalChallengers: onChainChallengers,
       },
+      blockNumber,
     });
 
   const operationKeys = {

--- a/packages/babylon-ts-sdk/src/tbv/core/services/participants/__tests__/resolveParticipantKeys.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/participants/__tests__/resolveParticipantKeys.test.ts
@@ -15,6 +15,9 @@ import {
   epochsAt,
 } from "./fixtures/rotation";
 
+/** Current-key resolution is always pinned; there is no unpinned path. */
+const TEST_BLOCK = 9_000_001n;
+
 describe("resolveParticipantKeysAtEpochs", () => {
   it("resolves every participant to its genesis key at epoch 0", async () => {
     // The proof that epoch-aware resolution is a no-op before anyone rotates:
@@ -191,6 +194,7 @@ describe("resolveCurrentParticipantKeys", () => {
     const current = await resolveCurrentParticipantKeys({
       operationKeyReader: currentReader,
       query: buildQuery(),
+      blockNumber: TEST_BLOCK,
     });
 
     const atLatest = await resolveParticipantKeysAtEpochs({
@@ -233,6 +237,7 @@ describe("resolveCurrentParticipantKeys", () => {
       resolveCurrentParticipantKeys({
         operationKeyReader: shortReader,
         query: buildQuery(),
+        blockNumber: TEST_BLOCK,
       }),
     ).rejects.toThrow(/for a roster of/i);
   });

--- a/packages/babylon-ts-sdk/src/tbv/core/services/participants/resolveParticipantKeys.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/services/participants/resolveParticipantKeys.ts
@@ -150,13 +150,22 @@ function finalize(
  *
  * Use for a peg-in being built now. Issues no epoch read, so it never touches
  * the extended `getBtcVaultProtocolInfo` ABI.
+ *
+ * `blockNumber` pins the resolution to one block, and is required. Pass the
+ * same block the rosters in `query` were read at: the roster supplies each
+ * participant's address and genesis key, and this call resolves what that
+ * participant has rotated to. Reading the two at different blocks can pair a
+ * roster member with a key from a different chain state, so there is no
+ * correct unpinned call and no default worth having.
  */
 export async function resolveCurrentParticipantKeys(params: {
   operationKeyReader: OperationKeyReader;
   query: OperationKeyQuery;
+  blockNumber: bigint;
 }): Promise<ParticipantKeySet> {
   const raw = await params.operationKeyReader.getCurrentOperationKeys(
     params.query,
+    params.blockNumber,
   );
   return finalize(params.query, raw, { mode: "current" });
 }

--- a/services/vault/src/clients/eth-contract/__tests__/pinnedReadBlock.test.ts
+++ b/services/vault/src/clients/eth-contract/__tests__/pinnedReadBlock.test.ts
@@ -1,0 +1,35 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const getBlockNumber = vi.hoisted(() => vi.fn());
+
+vi.mock("../client", () => ({
+  ethClient: { getPublicClient: () => ({ getBlockNumber }) },
+}));
+
+import { resolvePinnedReadBlock } from "../pinnedReadBlock";
+
+describe("resolvePinnedReadBlock", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("steps back from the head so a replica one block behind can still serve the read", async () => {
+    getBlockNumber.mockResolvedValue(1_000_000n);
+
+    await expect(resolvePinnedReadBlock()).resolves.toBe(999_998n);
+  });
+
+  it("steps back to block zero at exactly the lag height", async () => {
+    // The boundary: block zero is a legal anchor, so this must step back
+    // rather than fall through to the short-chain branch.
+    getBlockNumber.mockResolvedValue(2n);
+
+    await expect(resolvePinnedReadBlock()).resolves.toBe(0n);
+  });
+
+  it("returns the head itself on a chain too short to step back", async () => {
+    getBlockNumber.mockResolvedValue(1n);
+
+    await expect(resolvePinnedReadBlock()).resolves.toBe(1n);
+  });
+});

--- a/services/vault/src/clients/eth-contract/pinnedReadBlock.ts
+++ b/services/vault/src/clients/eth-contract/pinnedReadBlock.ts
@@ -1,0 +1,52 @@
+/**
+ * Anchor block for the protocol-state reads a peg-in is built against.
+ *
+ * A Pre-PegIn commits to participant operation keys, roster versions and
+ * offchain params. Those are read in several dependent rounds, and if each
+ * round resolves against whatever `latest` happens to be, a rotation landing
+ * between rounds produces a key set no single block ever held. The Bitcoin
+ * lock built from it commits to that mixture and no counterparty agrees with
+ * it. Pinning every round to one block is what removes that window.
+ *
+ * @module clients/eth-contract/pinnedReadBlock
+ */
+
+import { ethClient } from "./client";
+
+/**
+ * Blocks to step back from the head when choosing the anchor.
+ *
+ * The head itself is a poor anchor. `eth_blockNumber` and the pinned reads are
+ * separate requests, and behind a load-balanced RPC endpoint they can land on
+ * different nodes; one that has not yet seen the head rejects a read pinned to
+ * it. Stepping back absorbs that skew. The same lag hazard is noted for the
+ * activation floor in `utils/activationFloor.ts`.
+ *
+ * Two blocks, not more: the lag is pure cost at the other end. Everything read
+ * here is compared against the chain again when the registration is included,
+ * so a staler anchor only widens the window in which one of these values can
+ * move and invalidate the build. Two absorbs ordinary replica skew without
+ * meaningfully widening that window.
+ *
+ * Freshness is explicitly not the goal. What the build needs is that its reads
+ * agree with each other, not that they are the newest available.
+ */
+const PINNED_READ_LAG_BLOCKS = 2n;
+
+/**
+ * Resolve the block every protocol-state read for one deposit build must pin
+ * to.
+ *
+ * Call once per build and thread the result through every read that shapes the
+ * Bitcoin lock — the participant-key resolution and the peg-in configuration
+ * alike. Two reads pinned to different blocks are no better than two unpinned
+ * reads.
+ *
+ * On a chain too short to step back (local test nodes near genesis) this
+ * returns the head itself rather than underflowing. At exactly the lag height
+ * the step back still lands on block zero, which is a valid anchor.
+ */
+export async function resolvePinnedReadBlock(): Promise<bigint> {
+  const head = await ethClient.getPublicClient().getBlockNumber();
+  return head >= PINNED_READ_LAG_BLOCKS ? head - PINNED_READ_LAG_BLOCKS : head;
+}

--- a/services/vault/src/hooks/deposit/__tests__/useDepositFlow.test.tsx
+++ b/services/vault/src/hooks/deposit/__tests__/useDepositFlow.test.tsx
@@ -35,6 +35,68 @@ vi.mock("@/utils/rpc", async (importOriginal) => ({
   getVpProxyUrl: (address: string) => `https://proxy.test/rpc/${address}`,
 }));
 
+// Two protocol-parameter snapshots, hoisted so the mocks below and the
+// assertions further down share one source of truth.
+//
+// They hold deliberately DIFFERENT values. `peginConfig` is what the pinned
+// chain read returns and is the only thing the Bitcoin lock may be built from;
+// `cachedConfig` is what the React Query context holds and stands in for a
+// stale cache. Backing both mocks with one object would make every downstream
+// assertion blind to which source a value came from — and that blindness is
+// exactly how a build value sourced from the cache can ship green.
+const chainMocks = vi.hoisted(() => {
+  const peginConfig = {
+    // Non-default on purpose: a literal version in useDepositFlow would
+    // fail the preparePeginTransaction assertion.
+    activeVaultCoreVersion: 3,
+    timelockPegin: 111,
+    timelockRefund: 222,
+    offchainParams: {
+      babeInstancesToFinalize: 2,
+      councilQuorum: 1,
+      securityCouncilKeys: ["0xcouncil1"],
+      feeRate: 10n,
+      timelockAssert: 111n,
+      minPeginFeeRate: 3n,
+      minPrepeginDepth: 6,
+    },
+    offchainParamsVersion: 7,
+  };
+  // Every field the lock commits to differs, so an assertion on any of them
+  // discriminates between the two sources. The two version labels deliberately
+  // match: `assertBuildConfigMatchesForm` compares only those, so making them
+  // differ would abort the flow before the build and these tests would assert
+  // nothing.
+  //
+  // That combination — same version, different values — is a chain state the
+  // protocol cannot actually produce, since a versioned struct means one
+  // version is one parameter set. It is a fixture built to isolate *which
+  // object a value was read from*, not a scenario. Real drift moves the version
+  // too and is caught by the guard; this catches the wiring mistake underneath.
+  const cachedConfig = {
+    ...peginConfig,
+    timelockPegin: 999,
+    timelockRefund: 888,
+    offchainParams: {
+      ...peginConfig.offchainParams,
+      timelockAssert: 999n,
+      feeRate: 77n,
+      minPeginFeeRate: 88n,
+    },
+  };
+  return {
+    peginConfig,
+    cachedConfig,
+    /** Block the flow pins its protocol-state reads to. */
+    pinnedBlock: 4_242_042n,
+    getPegInConfiguration: vi.fn(async () => peginConfig),
+  };
+});
+
+vi.mock("@/clients/eth-contract/pinnedReadBlock", () => ({
+  resolvePinnedReadBlock: vi.fn(async () => chainMocks.pinnedBlock),
+}));
+
 vi.mock("@/clients/eth-contract/sdk-readers", () => ({
   getVaultRegistryReader: vi.fn(() => ({
     getVaultProviderGenesisBtcPubKey: vi.fn(async () => "ab".repeat(32)),
@@ -42,6 +104,9 @@ vi.mock("@/clients/eth-contract/sdk-readers", () => ({
   getVaultKeeperReader: vi.fn(async () => ({})),
   getUniversalChallengerReader: vi.fn(async () => ({})),
   getOperationKeyReader: vi.fn(async () => ({})),
+  getProtocolParamsReader: vi.fn(async () => ({
+    getPegInConfiguration: chainMocks.getPegInConfiguration,
+  })),
 }));
 
 vi.mock("@babylonlabs-io/wallet-connector", () => ({
@@ -407,20 +472,12 @@ async function setupDefaultMocks() {
   } as any);
 
   vi.mocked(useProtocolParamsContext).mockReturnValue({
-    config: {
-      // Non-default on purpose: a literal version in useDepositFlow would
-      // fail the preparePeginTransaction assertion.
-      activeVaultCoreVersion: 3,
-      offchainParams: {
-        babeInstancesToFinalize: 2,
-        councilQuorum: 1,
-        securityCouncilKeys: ["0xcouncil1"],
-        feeRate: 10n,
-      },
-      offchainParamsVersion: 7,
-    },
-    timelockPegin: 100,
-    timelockRefund: 50,
+    // Deliberately the stale snapshot. The flow must build from the pinned
+    // chain read instead, so any build value that matches these numbers came
+    // from the wrong source.
+    config: chainMocks.cachedConfig,
+    timelockPegin: chainMocks.cachedConfig.timelockPegin,
+    timelockRefund: chainMocks.cachedConfig.timelockRefund,
     getOffchainParamsByVersion: vi.fn(() => ({
       timelockAssert: 100n,
       securityCouncilKeys: ["0xcouncil1"],
@@ -871,6 +928,107 @@ describe("useDepositFlow", () => {
           buildUniversalChallengersVersion: 5,
         }),
       );
+    });
+
+    it("reads the peg-in config and the participant keys at the same pinned block", async () => {
+      const { validateOnChainParticipantKeys } = vi.mocked(
+        await import("@babylonlabs-io/ts-sdk/tbv/core"),
+      );
+
+      const { result } = renderHook(() => useDepositFlow(MOCK_PARAMS));
+
+      await executeDepositFlow(result);
+
+      await waitFor(() => {
+        expect(validateOnChainParticipantKeys).toHaveBeenCalled();
+      });
+
+      // Both halves of the build snapshot must name the same block. Pinning
+      // only one of them is no better than pinning neither: the lock would
+      // still commit to params from one chain state and keys from another.
+      expect(chainMocks.getPegInConfiguration).toHaveBeenCalledWith(
+        chainMocks.pinnedBlock,
+      );
+      expect(validateOnChainParticipantKeys).toHaveBeenCalledWith(
+        expect.objectContaining({ blockNumber: chainMocks.pinnedBlock }),
+      );
+
+      // Resolved once for the whole build. Resolving per read would hand each
+      // one a different block and reinstate exactly the skew being closed —
+      // and because the mock returns a constant, nothing else here would
+      // notice.
+      const { resolvePinnedReadBlock } = vi.mocked(
+        await import("@/clients/eth-contract/pinnedReadBlock"),
+      );
+      expect(resolvePinnedReadBlock).toHaveBeenCalledTimes(1);
+    });
+
+    it("builds from the pinned snapshot, not the cached one, for every parameter the lock commits to", async () => {
+      const { preparePeginTransaction } = vi.mocked(
+        await import("@/services/vault/vaultTransactionService"),
+      );
+
+      const { result } = renderHook(() => useDepositFlow(MOCK_PARAMS));
+
+      await executeDepositFlow(result);
+
+      await waitFor(() => {
+        expect(preparePeginTransaction).toHaveBeenCalled();
+      });
+
+      // The cached snapshot holds a different number for every field asserted
+      // here, so a build value sourced from the context instead of the chain
+      // fails rather than passing silently. `timelockPegin` is `timelockAssert`
+      // narrowed to a number, so the two must agree with each other as well.
+      //
+      // `vaultCoreVersion` is deliberately absent: the two snapshots must share
+      // it or the drift guard aborts before the build, so an assertion on it
+      // would pass whichever source was read and would only look like coverage.
+      expect(preparePeginTransaction).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.objectContaining({
+          timelockPegin: chainMocks.peginConfig.timelockPegin,
+          timelockRefund: chainMocks.peginConfig.timelockRefund,
+          timelockAssert: Number(
+            chainMocks.peginConfig.offchainParams.timelockAssert,
+          ),
+          protocolFeeRate: chainMocks.peginConfig.offchainParams.feeRate,
+          minPeginFeeRate:
+            chainMocks.peginConfig.offchainParams.minPeginFeeRate,
+        }),
+      );
+    });
+
+    it("aborts before building when the pinned config disagrees with the one the form used", async () => {
+      const { useProtocolParamsContext } = vi.mocked(
+        await import("@/context/ProtocolParamsContext"),
+      );
+      const { preparePeginTransaction } = vi.mocked(
+        await import("@/services/vault/vaultTransactionService"),
+      );
+      const previous = vi.mocked(useProtocolParamsContext)();
+
+      // The page gated and sized against an older core version than the chain
+      // now reports. The form's own "update the app" check reads the cached
+      // value and cannot see this.
+      vi.mocked(useProtocolParamsContext).mockReturnValue({
+        ...previous,
+        config: { ...chainMocks.cachedConfig, activeVaultCoreVersion: 2 },
+      } as ReturnType<typeof useProtocolParamsContext>);
+
+      const { result } = renderHook(() => useDepositFlow(MOCK_PARAMS));
+
+      await executeDepositFlow(result);
+
+      await waitFor(() => {
+        expect(result.current.error?.title).toBe(
+          COPY.deposit.errors.versionMismatch.title,
+        );
+      });
+      // Nothing signed, nothing broadcast — restarting costs the depositor
+      // nothing at this point, which is why the guard sits here.
+      expect(preparePeginTransaction).not.toHaveBeenCalled();
     });
 
     it("aborts before any side effects when validateOnChainParticipantKeys rejects", async () => {

--- a/services/vault/src/hooks/deposit/useDepositFlow.ts
+++ b/services/vault/src/hooks/deposit/useDepositFlow.ts
@@ -38,8 +38,10 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { v4 as uuidv4 } from "uuid";
 import type { Address, Hex } from "viem";
 
+import { resolvePinnedReadBlock } from "@/clients/eth-contract/pinnedReadBlock";
 import {
   getOperationKeyReader,
+  getProtocolParamsReader,
   getUniversalChallengerReader,
   getVaultKeeperReader,
   getVaultRegistryReader,
@@ -61,6 +63,7 @@ import {
 } from "@/infrastructure/telemetryEvents";
 import { LocalStorageStatus } from "@/models/peginStateMachine";
 import { validateMultiVaultDepositInputs } from "@/services/deposit/validations";
+import { assertBuildConfigMatchesForm } from "@/services/vault/buildConfigConsistency";
 import {
   waitForEthRegistrationDepth,
   type RegistrationDepthProgress,
@@ -407,8 +410,18 @@ export function useDepositFlow(
   const queryClient = useQueryClient();
   const gate = useProtocolGateState();
   const { findProvider } = useVaultProviders(selectedApplication);
-  const { config, timelockPegin, timelockRefund, minDeposit, maxDeposit } =
-    useProtocolParamsContext();
+  // Nothing the Pre-PegIn commits to comes from this context. Those values are
+  // re-read inside `executeDeposit`, pinned to one block: the cached copy is
+  // refreshed on nothing and is additionally frozen at the render that started
+  // the flow. In particular the peg-in and refund timelocks live on the same
+  // cached object and go straight into the PegIn output and the HTLC refund
+  // leaf, so they must come from the pinned read like everything else.
+  //
+  // `config` is still taken, for one purpose: it is the snapshot this page
+  // gated and sized against, and the build asserts the pinned read agrees with
+  // it before building. Being frozen at the starting render is correct there —
+  // it is precisely the value the form validated the amount against.
+  const { config, minDeposit, maxDeposit } = useProtocolParamsContext();
 
   // ============================================================================
   // Main Execution Function
@@ -622,11 +635,35 @@ export function useDepositFlow(
           vaultKeeperReader,
           universalChallengerReader,
           operationKeyReader,
+          protocolParamsReader,
         ] = await Promise.all([
           getVaultKeeperReader(),
           getUniversalChallengerReader(),
           getOperationKeyReader(),
+          getProtocolParamsReader(),
         ]);
+
+        // Everything the Pre-PegIn commits to is read against this one block:
+        // the participant keys below and the peg-in configuration beside them.
+        // Unpinned, these are several successive `latest` observations, and the
+        // params in particular would otherwise come from the React Query cache
+        // that backs the UI — a snapshot taken when the modal opened and never
+        // refreshed, so potentially minutes old and closed over at render.
+        // Building a Bitcoin lock from a mixture of chain states is exactly the
+        // failure the post-registration guards further down exist to catch, and
+        // they can only catch it if the baseline they compare against was
+        // internally consistent to begin with.
+        const pinnedBlock = await resolvePinnedReadBlock();
+        const buildConfig =
+          await protocolParamsReader.getPegInConfiguration(pinnedBlock);
+
+        // The page gated the "update the app" check and sized the amount
+        // against the cached snapshot; the lock is about to be built from this
+        // pinned one. If a governance change landed in between they are
+        // different parameter sets, and the amount the depositor approved was
+        // validated against the wrong one. Stop here, where restarting is free.
+        assertBuildConfigMatchesForm(buildConfig, config);
+
         const validatedKeys = await validateOnChainParticipantKeys({
           vaultRegistryReader: getVaultRegistryReader(),
           vaultKeeperReader,
@@ -637,6 +674,7 @@ export function useDepositFlow(
           expectedVaultProviderBtcPubkey: vaultProviderBtcPubkey,
           expectedVaultKeeperBtcPubkeys: vaultKeeperBtcPubkeys,
           expectedUniversalChallengerBtcPubkeys: universalChallengerBtcPubkeys,
+          blockNumber: pinnedBlock,
           onIndexerServingOperationKeys: (message) => logger.info(message),
           onIndexerHintsInconsistent: (message) =>
             logger.error(new Error(message), {
@@ -668,10 +706,10 @@ export function useDepositFlow(
             // the post-registration verifyRegisteredVaultVersions call
             // asserts the stamp matches this build-time value before the
             // BTC broadcast.
-            vaultCoreVersion: config.activeVaultCoreVersion,
+            vaultCoreVersion: buildConfig.activeVaultCoreVersion,
             pegInAmounts: vaultAmounts,
-            protocolFeeRate: config.offchainParams.feeRate,
-            minPeginFeeRate: config.offchainParams.minPeginFeeRate,
+            protocolFeeRate: buildConfig.offchainParams.feeRate,
+            minPeginFeeRate: buildConfig.offchainParams.minPeginFeeRate,
             mempoolFeeRate,
             changeAddress: prePeginChangeAddress,
             vaultProviderBtcPubkey: validatedKeys.vaultProviderBtcPubkeyXOnly,
@@ -679,11 +717,13 @@ export function useDepositFlow(
             vaultKeeperBtcPubkeys: validatedKeys.vaultKeeperBtcPubkeysSorted,
             universalChallengerBtcPubkeys:
               validatedKeys.universalChallengerBtcPubkeysSorted,
-            timelockPegin,
-            timelockAssert: Number(config.offchainParams.timelockAssert),
-            timelockRefund,
-            councilQuorum: config.offchainParams.councilQuorum,
-            councilSize: config.offchainParams.securityCouncilKeys.length,
+            // `timelockPegin` is `Number(timelockAssert)` — the same contract
+            // field the line below reads. Both must come off the same snapshot.
+            timelockPegin: buildConfig.timelockPegin,
+            timelockAssert: Number(buildConfig.offchainParams.timelockAssert),
+            timelockRefund: buildConfig.timelockRefund,
+            councilQuorum: buildConfig.offchainParams.councilQuorum,
+            councilSize: buildConfig.offchainParams.securityCouncilKeys.length,
             availableUTXOs: spendableUTXOs,
           },
         );
@@ -841,12 +881,12 @@ export function useDepositFlow(
             // compare against, since both could drift to the same new value
             // while the BTC scripts stayed pinned to the construction-time
             // version.
-            buildOffchainParamsVersion: config.offchainParamsVersion,
+            buildOffchainParamsVersion: buildConfig.offchainParamsVersion,
             buildAppVaultKeepersVersion:
               validatedKeys.expectedAppVaultKeepersVersion,
             buildUniversalChallengersVersion:
               validatedKeys.expectedUniversalChallengersVersion,
-            buildVaultCoreVersion: config.activeVaultCoreVersion,
+            buildVaultCoreVersion: buildConfig.activeVaultCoreVersion,
             // RFC-006: pin the keys the scripts were actually built with, so a
             // rotation landing before a later resume can't be broadcast over.
             buildParticipantOperationKeys: {
@@ -915,12 +955,12 @@ export function useDepositFlow(
           await verifyRegisteredVaultVersions({
             vaultRegistryReader: getVaultRegistryReader(),
             vaultIds: batchRegistration.vaults.map((v) => v.vaultId as Hex),
-            expectedOffchainParamsVersion: config.offchainParamsVersion,
+            expectedOffchainParamsVersion: buildConfig.offchainParamsVersion,
             expectedAppVaultKeepersVersion:
               validatedKeys.expectedAppVaultKeepersVersion,
             expectedUniversalChallengersVersion:
               validatedKeys.expectedUniversalChallengersVersion,
-            expectedVaultCoreVersion: config.activeVaultCoreVersion,
+            expectedVaultCoreVersion: buildConfig.activeVaultCoreVersion,
           });
         } catch (err) {
           // Only a confirmed mismatch removes pending entries — transient RPC
@@ -1106,7 +1146,7 @@ export function useDepositFlow(
         // values here at broadcast time.
         setBtcConfirmationDetail({
           prePeginTxid: prePeginBroadcastTxid,
-          requiredDepth: config.offchainParams.minPrepeginDepth,
+          requiredDepth: buildConfig.offchainParams.minPrepeginDepth,
           depositIds: broadcastedResults.map((r) => r.vaultId),
         });
         setIsWaiting(true);
@@ -1624,8 +1664,6 @@ export function useDepositFlow(
       vaultProviderBtcPubkey,
       vaultKeeperBtcPubkeys,
       universalChallengerBtcPubkeys,
-      timelockPegin,
-      timelockRefund,
       config,
       minDeposit,
       maxDeposit,

--- a/services/vault/src/services/vault/__tests__/buildConfigConsistency.test.ts
+++ b/services/vault/src/services/vault/__tests__/buildConfigConsistency.test.ts
@@ -1,0 +1,54 @@
+import type { PegInConfiguration } from "@babylonlabs-io/ts-sdk/tbv/core";
+import { describe, expect, it } from "vitest";
+
+import {
+  BuildConfigDriftError,
+  assertBuildConfigMatchesForm,
+  isBuildConfigDriftError,
+} from "../buildConfigConsistency";
+
+function config(
+  offchainParamsVersion: number,
+  activeVaultCoreVersion: number,
+): PegInConfiguration {
+  return {
+    offchainParamsVersion,
+    activeVaultCoreVersion,
+  } as PegInConfiguration;
+}
+
+describe("assertBuildConfigMatchesForm", () => {
+  it("passes when both version axes agree", () => {
+    expect(() =>
+      assertBuildConfigMatchesForm(config(7, 3), config(7, 3)),
+    ).not.toThrow();
+  });
+
+  it("throws when the offchain params version moved under the form", () => {
+    expect(() =>
+      assertBuildConfigMatchesForm(config(8, 3), config(7, 3)),
+    ).toThrow(BuildConfigDriftError);
+  });
+
+  it("throws when the vault core version moved under the form", () => {
+    // The case the form's own "update the app" gate cannot see, because it
+    // checks the cached version and nothing re-checks it before the build.
+    expect(() =>
+      assertBuildConfigMatchesForm(config(7, 4), config(7, 3)),
+    ).toThrow(BuildConfigDriftError);
+  });
+
+  it("names both parameter sets so the drift is diagnosable from the message", () => {
+    expect(() =>
+      assertBuildConfigMatchesForm(config(8, 4), config(7, 3)),
+    ).toThrow(/v7 \/ vaultCore v3.*v8 \/ vaultCore v4/s);
+  });
+
+  it("is recognised across a module boundary by name, not only by instance", () => {
+    const structural = new Error("drift");
+    structural.name = "BuildConfigDriftError";
+
+    expect(isBuildConfigDriftError(structural)).toBe(true);
+    expect(isBuildConfigDriftError(new Error("something else"))).toBe(false);
+  });
+});

--- a/services/vault/src/services/vault/buildConfigConsistency.ts
+++ b/services/vault/src/services/vault/buildConfigConsistency.ts
@@ -1,0 +1,110 @@
+/**
+ * Guard that the parameters the deposit form validated against are the same
+ * parameters the Bitcoin lock is about to be built from.
+ *
+ * The form reads the peg-in configuration from the React Query context — a
+ * cached snapshot with a five minute `staleTime` that nothing invalidates. The
+ * build re-reads it from chain, pinned to a block. Those two are normally the
+ * same, and before the build was pinned they could not diverge at all, because
+ * both halves read one object.
+ *
+ * They can diverge now. A governance change landing between the cache being
+ * filled and the deposit being built leaves the form having gated and sized
+ * against one parameter set while the lock commits to another. Two consequences
+ * are already reachable today:
+ *
+ * - The form's "update the app" gate compares the *cached* vault core version
+ *   against what this bundle's WASM can construct. Nothing re-checks it on the
+ *   fresh-deposit path — `assertVaultCoreVersionSupported` is wired into the
+ *   resume, payout and refund paths only — so a version bump inside the window
+ *   lets the build reach the WASM with a version it cannot construct, and the
+ *   depositor gets a raw facade error after completing a signing ceremony
+ *   rather than the actionable message that exists for exactly this case.
+ * - The Max button reserves fees from the cached rates while the build funds
+ *   from the pinned ones, so a rate rise inside the window can leave the
+ *   deposit short and fail in UTXO selection after the amount is committed.
+ *
+ * Both are fail-closed — nothing is signed, broadcast or paid — so this guard
+ * is about turning a confusing failure into a clear one, not about protecting
+ * funds. It runs before the build for that reason: at this point restarting
+ * costs the depositor nothing, unlike the post-registration drift guards, where
+ * a restart means a stranded vault and a spent fee.
+ *
+ * @module services/vault/buildConfigConsistency
+ */
+
+import type { PegInConfiguration } from "@babylonlabs-io/ts-sdk/tbv/core";
+
+/**
+ * The cached configuration the form used and the pinned configuration the build
+ * would use describe different protocol parameter sets.
+ */
+export class BuildConfigDriftError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "BuildConfigDriftError";
+  }
+}
+
+// `instanceof` alone fails across module boundaries (duplicate copies, test
+// mocks). Fall back to the name field, as the SDK's drift guards do.
+export function isBuildConfigDriftError(
+  err: unknown,
+): err is BuildConfigDriftError {
+  return (
+    err instanceof BuildConfigDriftError ||
+    (err instanceof Error && err.name === "BuildConfigDriftError")
+  );
+}
+
+/**
+ * Throw when the form's cached configuration and the build's pinned
+ * configuration disagree on either version axis.
+ *
+ * Only the two version fields are compared, and deliberately so. They are the
+ * identifiers the protocol itself uses to say "these parameters changed": every
+ * field of the `offchainParams` struct moves under `offchainParamsVersion`, and
+ * the transaction shape moves under `activeVaultCoreVersion`. Comparing the
+ * individual values instead would be both redundant and more brittle, since a
+ * value can be re-published unchanged under a new version.
+ *
+ * What that does NOT cover: `PegInConfiguration` is composed from two contract
+ * reads, and the `getTBVProtocolParams` half — `minimumPegInAmount`,
+ * `maxPegInAmount`, `pegInAckTimeout`, `pegInActivationTimeout`,
+ * `maxHtlcOutputCount`, `expiredPegInGraceBlocks` — carries no version label at
+ * all, so a change there moves no field this guard reads. The deposit amount is
+ * gated against the cached `minimumPegInAmount` / `maxPegInAmount` before this
+ * runs, so a bound tightened inside the cache window is not caught here and the
+ * registration reverts on-chain instead.
+ *
+ * That axis is deliberately out of scope. It is a pre-existing gap that pinning
+ * the build neither opened nor widened — before, the form and the build both
+ * read the cached bounds and the same registration reverted in the same place.
+ * This guard exists to close the divergence that pinning *did* introduce, which
+ * is between the two snapshots, not between a snapshot and the chain. Closing
+ * the unversioned axis properly means re-validating the chosen amounts against
+ * the pinned bounds, which belongs with the recovery work rather than here.
+ *
+ * @param buildConfig - Read from chain, pinned to the build's block.
+ * @param formConfig - The cached snapshot the form gated and sized against.
+ * @throws {BuildConfigDriftError} when the two disagree.
+ */
+export function assertBuildConfigMatchesForm(
+  buildConfig: PegInConfiguration,
+  formConfig: PegInConfiguration,
+): void {
+  if (
+    buildConfig.offchainParamsVersion === formConfig.offchainParamsVersion &&
+    buildConfig.activeVaultCoreVersion === formConfig.activeVaultCoreVersion
+  ) {
+    return;
+  }
+
+  throw new BuildConfigDriftError(
+    `Protocol parameters changed while preparing this deposit: the form used ` +
+      `offchainParams v${formConfig.offchainParamsVersion} / vaultCore ` +
+      `v${formConfig.activeVaultCoreVersion}, the chain now reports ` +
+      `offchainParams v${buildConfig.offchainParamsVersion} / vaultCore ` +
+      `v${buildConfig.activeVaultCoreVersion}.`,
+  );
+}

--- a/services/vault/src/utils/errors/depositErrors.ts
+++ b/services/vault/src/utils/errors/depositErrors.ts
@@ -51,6 +51,7 @@ import { JsonRpcError } from "@babylonlabs-io/ts-sdk/tbv/core/clients";
 import { type ReactNode } from "react";
 
 import { COPY } from "@/copy";
+import { isBuildConfigDriftError } from "@/services/vault/buildConfigConsistency";
 
 import { isDepositorWalletMismatchError } from "./depositorWalletMismatch";
 import {
@@ -165,6 +166,15 @@ export function mapDepositError(err: unknown): DepositErrorContent {
 
   // 3. Protocol-parameter version mismatch (registered vault drifted).
   if (isRegisteredVaultVersionMismatchError(err)) {
+    return ERRORS.versionMismatch;
+  }
+
+  // 3a. The same drift caught earlier: the cached snapshot the form gated and
+  // sized against no longer matches the pinned read the build would use.
+  // Shares the copy above because the depositor's situation is identical —
+  // parameters moved mid-deposit, start again — and here it is strictly
+  // cheaper, since nothing has been signed, broadcast or paid.
+  if (isBuildConfigDriftError(err)) {
     return ERRORS.versionMismatch;
   }
 


### PR DESCRIPTION
## What this changes

A deposit builds a Bitcoin lock out of values read from Ethereum: the operators' current BTC keys, which operators are in the rosters, and the timing and fee parameters. Until now those values were read in four separate places, at four separate moments. This change reads them all at one block instead.

## Why

Nothing guaranteed those four reads described the same moment in time. Worse, one of them — the peg-in configuration — did not come from a fresh read at all. It came from the React Query cache that backs the UI, which has a five minute `staleTime`, no refetch interval, and is never invalidated anywhere in the app. On top of that, `executeDeposit` closed over that value at the render that started the flow, so it could be older still.

If an operator rotates a key, or a roster or parameter version is bumped, between any two of those reads, we build a lock out of a mixture of chain states that never existed together. No counterparty agrees with a lock like that, and the deposit cannot complete.

We do already check for this after the Ethereum registration lands, and those checks run before any Bitcoin is broadcast, so a depositor's BTC was never at risk. But those checks compare what got registered against "what we built with" — and if the baseline we built with was itself stitched together from several different blocks, the comparison is weaker than it looks.

This is also groundwork. The contracts are adding a fingerprint argument that commits to exactly these values ([vault-contracts-aave-v4#555](https://github.com/babylonlabs-io/vault-contracts-aave-v4/pull/555)). Computing that fingerprint from reads that span different blocks would produce a hash the contract accepts while our scripts are stale — reintroducing this same bug in a form that fails silently. So this has to be right before that lands. It is worth doing on its own merits regardless.

## Approaches considered

**1. Pin every read to one block (chosen).** Read the block height once at the start of a deposit, then resolve every protocol-state read against that specific block.

**2. Thread a block through the participant-key reads only, and leave the cached config alone.** Smaller diff. Rejected because it leaves the worst input untouched: the config is the one value that can be minutes old, and it is half of what the lock commits to. Fixing the fresher half and not the stale half does not give a consistent snapshot.

**3. Accept the skew and rely on the post-registration checks.** Rejected. Those checks catch the problem after we have already paid the peg-in fee and stranded a vault, and they can only be as trustworthy as the baseline they compare against.

## Two smaller decisions inside the chosen approach

**The pin is optional on the low-level readers and required on the two functions that build a deposit.** Twenty-three files touch these readers, but most are resume, refund and reclaim paths resolving against a vault's already-frozen epochs. Those values are immutable once stamped, so pinning them means nothing, and forcing every one of those call sites to pass a block would be noise. So the readers take an optional `blockNumber`.

The two functions that exist *only* for the fresh-deposit path — `validateOnChainParticipantKeys` and `resolveCurrentParticipantKeys` — take a required one. Each has exactly one production caller, and for them there is no correct unpinned call. An optional pin there would be a silent fallback to `latest`-per-round on the path that builds a Bitcoin lock, enforced by nothing but a doc comment. Required means a future caller that forgets it fails to compile.

**We pin two blocks behind the head, not the head itself.** Reading the block height and reading the contracts are separate requests, and behind a load-balanced RPC endpoint they can land on different nodes. A node that has not yet seen the head will reject a read pinned to it. This repo has already hit that class of problem — there is a note about a lagging `getBlockNumber` in `utils/activationFloor.ts`. Freshness is not what this read needs; internal consistency is, and a two block lag buys that cheaply.

## What is in the diff

- Six reader methods take an optional `blockNumber`: the VP genesis key, the two roster versions, the two roster member lists, and the current operation keys. Plus `getPegInConfiguration`.
- `validateOnChainParticipantKeys` now threads one block through all three of its rounds. It reads in three dependent rounds — versions, then the members at those versions, then those members' operation keys — because each round needs the previous round's output. An unpinned read in any one of them reopens the window.
- New `resolvePinnedReadBlock()` in the vault app: reads the head once and steps back two blocks, down to and including block zero, returning the head itself only on a chain too short to step back at all.
- `useDepositFlow` resolves that block, re-reads the peg-in configuration from chain against it, and every value the lock commits to now comes from that snapshot. That includes the peg-in and refund timelocks, which are read off the same configuration object and go into the PegIn output and the HTLC refund leaf.
- Nothing the lock commits to is read from the cached context any more. `config` is still taken from it for one purpose only — see the guard below — and being frozen at the starting render is correct there, because that is precisely the snapshot the form validated the amount against.
- New `assertBuildConfigMatchesForm()` runs before the build and stops the deposit if the pinned read and the cached snapshot disagree on either version axis. It reuses the existing "protocol parameters changed — please restart the deposit" copy.

## Tests

- The config read and the participant-key validation receive **the same** block. Pinning one and not the other is no better than pinning neither.
- A deposit aborts before building when the cached and pinned configurations disagree, and surfaces the "protocol parameters changed" message rather than a raw error. Verified by mutation: removing the guard fails this test.
- The drift guard itself: passes when both version axes agree, throws on either one moving, names both parameter sets in the message, and is recognised by name across a module boundary.
- Every read inside `validateOnChainParticipantKeys` resolves against the caller's block — all three rounds, individually asserted.
- The builder receives the **pinned** parameters, not the cached ones. The two mocked configurations deliberately hold different numbers for every field the lock commits to, so a value sourced from the wrong place fails the assertion instead of passing silently. Verified by mutation: reverting one field to the cached value fails this test with `expected 111, got 999`.
- `resolvePinnedReadBlock`: applies the lag, steps back to block zero at exactly the lag height, and returns the head on a chain too short to step back.

Full suites pass: 1812 SDK tests, 3706 vault tests, lint and typecheck clean in both.

Unrelated but worth knowing: the `useDepositFlow` suite went from 207s to 4s. The old run was hanging on a real RPC call the mocks did not cover.

## What is not in this PR

This is the first of four PRs from [#2383](https://github.com/babylonlabs-io/babylon-toolkit/issues/2383). It does not add the fingerprint, and it does not touch the contract call at all, so it is safe to merge and deploy at any time against the contract that is live today.

The remaining three: the fingerprint encoder, the recovery path for drift errors, and the ABI change itself. Note the recovery PR is about giving these errors a retry affordance in the modal — this PR only *detects* the drift and asks the depositor to start again, which is cheap here because nothing has been spent. Only the ABI change has to wait for the contract upgrade.

## Review notes

The post-registration guards (`verifyRegisteredVaultVersions` and `verifyRegisteredParticipantKeys`) are deliberately left in place. They are cheap, and once the fingerprint lands they become the thing that catches a bug in our own snapshot logic.

**On the form/build split.** The deposit form still gates and sizes against the cached configuration while the build uses the pinned one, so the two can disagree if a governance change lands inside a cache window. Before this change both read the same object and could not diverge, so this PR opens that gap — which is why it also closes it, with the guard described above rather than leaving it for a later PR.

Two things that made the guard worth including here rather than deferring. The form's "update the app" check reads the *cached* core version, and nothing re-checks it on the fresh-deposit path — `assertVaultCoreVersionSupported` is wired into the resume, payout and refund paths only — so without the guard a version bump inside the window reaches the WASM and surfaces as a raw facade error after the depositor has completed a signing ceremony. And a restart at this point costs nothing, because nothing has been signed, broadcast or paid; that is what separates this from the post-registration drift guards, where a restart means a stranded vault and a spent fee.

The guard compares only the two version fields, not every value. Those are the identifiers the protocol itself moves when parameters change, so comparing individual values would be both redundant and more brittle.

One axis it deliberately does not cover: `PegInConfiguration` is assembled from two contract reads, and the `getTBVProtocolParams` half — including `minimumPegInAmount` and `maxPegInAmount` — carries no version label, so a change there moves no field the guard reads. A bound tightened inside the cache window is therefore not caught here; the registration reverts on-chain instead. That is a pre-existing gap this change neither opened nor widened — before, the form and the build both read the cached bounds and the same registration reverted in the same place. Closing it properly means re-validating the chosen amounts against the pinned bounds, which belongs with the recovery work. The guard's docstring says so rather than implying coverage it lacks.

Part of [#2383](https://github.com/babylonlabs-io/babylon-toolkit/issues/2383).
