### PR TITLE
fix(vault): rebuild the Vaults pending-deposit row

### DIFF
--- a/services/vault/src/components/shared/ListRow.tsx
+++ b/services/vault/src/components/shared/ListRow.tsx
@@ -19,17 +19,17 @@ import { CARD_SHELL_CLASS } from "@/components/shared/layoutClasses";
  * cell and opening a gap before the trailing action button.
  *
  * The basis is the widest cell's intrinsic content — the status cell's 12px
- * dot and 108px label with their 4px gap. `min-w-0` is what lets the cell
- * shrink below that basis: the lifecycle rows are `xl:flex-nowrap`, so from
- * `xl` up the columns absorb any shortfall rather than breaking the action
- * button onto a second line.
+ * dot and 108px label with their 4px gap. The bases are the lever that fits a
+ * lifecycle row on one line: they sum (with the gaps and the action slot) to
+ * less than the row's width from `xl` up, where the rows are
+ * `xl:flex-nowrap`. Below `xl` the row wraps instead.
  */
 export const LIST_ROW_COLUMN_CLASS = "min-w-0 grow basis-[144px]";
 
 /**
  * The status cell. Same basis as a plain data column, but it takes a double
  * share of the leftover slack, matching the leading cell — the longest status
- * (`COPY.pegin.statusLabel.AWAITING_ACTIVATION_WINDOW`) wraps to two lines
+ * (`COPY.pegin.labels.AWAITING_ACTIVATION_WINDOW`) wraps to two lines
  * otherwise. Grow factors divide only the surplus, so they cost nothing once
  * the row is narrow enough that every column is shrinking instead.
  */
@@ -39,9 +39,9 @@ export const LIST_ROW_STATUS_COLUMN_CLASS = "min-w-0 grow-[2] basis-[144px]";
  * The leading cell — a 32px coin avatar beside a two-line amount / sub-line
  * block. The basis fits the amount and the sub-lines the rows produce in the
  * common case; longer interpolated sub-lines (notably
- * `COPY.vaults.statusHints.refundMaturing`) truncate rather than widen the
- * cell, since from `xl` up the row may not wrap. It takes a double share of
- * any remaining slack.
+ * `COPY.pegin.messages.refundMaturing`) truncate rather than widen the cell,
+ * because widening it would push the bases past the row's width and break the
+ * one-line fit from `xl` up. It takes a double share of any remaining slack.
  */
 export const LIST_ROW_LEADING_COLUMN_CLASS = "min-w-0 grow-[2] basis-[240px]";
 

--- a/services/vault/src/components/shared/ListRow.tsx
+++ b/services/vault/src/components/shared/ListRow.tsx
@@ -19,45 +19,31 @@ import { CARD_SHELL_CLASS } from "@/components/shared/layoutClasses";
  * cell and opening a gap before the trailing action button.
  *
  * The basis is the widest cell's intrinsic content — the status cell's 12px
- * dot, 108px label and 16px info icon with their 4px gaps. Keeping it that
- * tight matters: `flex-wrap` breaks lines on the basis and never shrinks to
- * avoid a break, so every extra pixel here raises the viewport width at which
- * the action button drops onto a second line. 120px is the floor below which
- * wrapping is preferable to squashing.
+ * dot and 108px label with their 4px gap. `min-w-0` is what lets the cell
+ * shrink below that basis: the lifecycle rows are `xl:flex-nowrap`, so from
+ * `xl` up the columns absorb any shortfall rather than breaking the action
+ * button onto a second line.
  */
-export const LIST_ROW_COLUMN_CLASS = "min-w-[120px] grow basis-[144px]";
+export const LIST_ROW_COLUMN_CLASS = "min-w-0 grow basis-[144px]";
 
 /**
- * The status cell. Same basis as a plain data column — so the viewport width at
- * which the action button wraps is unchanged — but it takes a double share of
- * the leftover slack, matching the leading cell.
- *
- * Slack was previously split 2:1:1:1 between the leading, status, provider and
- * hash cells, which left the leading cell roomy while the status label wrapped:
- * the basis above is sized for a 108px label, and the longest status is now
- * `COPY.pegin.statusLabel.AWAITING_ACTIVATION_WINDOW`. Widening the basis would
- * have fixed the wrap at every width but raised the action button's wrap
- * threshold, which the comment above deliberately keeps as low as possible.
- * Grow factors divide only the surplus, so they cost nothing at narrow widths.
+ * The status cell. Same basis as a plain data column, but it takes a double
+ * share of the leftover slack, matching the leading cell — the longest status
+ * (`COPY.pegin.statusLabel.AWAITING_ACTIVATION_WINDOW`) wraps to two lines
+ * otherwise. Grow factors divide only the surplus, so they cost nothing once
+ * the row is narrow enough that every column is shrinking instead.
  */
-export const LIST_ROW_STATUS_COLUMN_CLASS =
-  "min-w-[120px] grow-[2] basis-[144px]";
+export const LIST_ROW_STATUS_COLUMN_CLASS = "min-w-0 grow-[2] basis-[144px]";
 
 /**
- * The leading cell — a logo beside a two-line amount / sub-line block. Its
- * basis fits the longest sub-line the rows produce (the refund-maturity
- * notice from `COPY.vaults.statusHints.refundMaturing`, measured at 343px in
- * the app's 12px face) plus the 32px logo and its 8px gap, so that copy reads
- * in full rather than ellipsing. It takes a double share of any remaining
- * slack.
- *
- * That 343px is one measurement of an interpolated string — the block count,
- * the hours and the block/blocks plural all vary — so a longer combination
- * ellipses again. `copy.ts` points back here for that reason; re-measure both
- * together.
+ * The leading cell — a 32px coin avatar beside a two-line amount / sub-line
+ * block. The basis fits the amount and the sub-lines the rows produce in the
+ * common case; longer interpolated sub-lines (notably
+ * `COPY.vaults.statusHints.refundMaturing`) truncate rather than widen the
+ * cell, since from `xl` up the row may not wrap. It takes a double share of
+ * any remaining slack.
  */
-export const LIST_ROW_LEADING_COLUMN_CLASS =
-  "min-w-[120px] grow-[2] basis-[384px]";
+export const LIST_ROW_LEADING_COLUMN_CLASS = "min-w-0 grow-[2] basis-[240px]";
 
 /**
  * Trailing action cell. Every lifecycle and activity row routes its action
@@ -96,7 +82,8 @@ export const LIST_ROW_MIN_HEIGHT_CLASS = "min-h-[78px]";
 /**
  * Bordered row card shared by the vault, activity and loan lists. `className`
  * carries per-surface layout — the vault lifecycle rows pass
- * `LIST_ROW_MIN_HEIGHT_CLASS`; the single-line lists pass nothing.
+ * `LIST_ROW_MIN_HEIGHT_CLASS` and `xl:flex-nowrap`; the single-line lists pass
+ * nothing and keep the wrapping default.
  */
 export function ListRowCard({
   children,

--- a/services/vault/src/components/simple/DepositProgressView/__tests__/btcConfirmationProgress.test.ts
+++ b/services/vault/src/components/simple/DepositProgressView/__tests__/btcConfirmationProgress.test.ts
@@ -4,6 +4,7 @@ import {
   computeConfirmations,
   computeRemainingEstimateMinutes,
   computeTotalEstimateMinutes,
+  pendingActivationEstimateMinutes,
 } from "../btcConfirmationProgress";
 
 describe("computeConfirmations", () => {
@@ -62,5 +63,20 @@ describe("computeTotalEstimateMinutes", () => {
   it("scales with the on-chain confirmation depth", () => {
     expect(computeTotalEstimateMinutes(2)).toBe(30);
     expect(computeTotalEstimateMinutes(12)).toBe(130);
+  });
+});
+
+describe("pendingActivationEstimateMinutes", () => {
+  it("estimates the full total when no poll result has landed yet", () => {
+    expect(pendingActivationEstimateMinutes(null, 6)).toBe(70);
+  });
+
+  it("deducts ten minutes for each confirmation already accrued", () => {
+    expect(pendingActivationEstimateMinutes(4, 6)).toBe(30);
+  });
+
+  it("floors at the pipeline overhead at and past the required depth", () => {
+    expect(pendingActivationEstimateMinutes(6, 6)).toBe(10);
+    expect(pendingActivationEstimateMinutes(8, 6)).toBe(10);
   });
 });

--- a/services/vault/src/components/simple/DepositProgressView/__tests__/btcConfirmationProgress.test.ts
+++ b/services/vault/src/components/simple/DepositProgressView/__tests__/btcConfirmationProgress.test.ts
@@ -67,8 +67,8 @@ describe("computeTotalEstimateMinutes", () => {
 });
 
 describe("pendingActivationEstimateMinutes", () => {
-  it("estimates the full total when no poll result has landed yet", () => {
-    expect(pendingActivationEstimateMinutes(null, 6)).toBe(70);
+  it("has no estimate when no poll result has landed yet", () => {
+    expect(pendingActivationEstimateMinutes(null, 6)).toBeNull();
   });
 
   it("deducts ten minutes for each confirmation already accrued", () => {

--- a/services/vault/src/components/simple/DepositProgressView/btcConfirmationProgress.ts
+++ b/services/vault/src/components/simple/DepositProgressView/btcConfirmationProgress.ts
@@ -57,15 +57,16 @@ export function computeTotalEstimateMinutes(requiredDepth: number): number {
  * Estimated minutes until the deposit activates, for the /vaults pending row.
  * Same model as {@link computeTotalEstimateMinutes}, less the depth already
  * confirmed: it floors at the pipeline overhead once the required depth is
- * met, and never goes negative. `null` confirmations (no poll result yet) is
- * treated as zero.
+ * met, and never goes negative. `null` confirmations (no poll result yet)
+ * returns `null` — there is no estimate until the first poll lands.
  */
 export function pendingActivationEstimateMinutes(
   confirmations: number | null,
   requiredDepth: number,
-): number {
+): number | null {
+  if (confirmations === null) return null;
   return (
-    (computeRemainingEstimateMinutes(confirmations ?? 0, requiredDepth) ?? 0) +
+    (computeRemainingEstimateMinutes(confirmations, requiredDepth) ?? 0) +
     DEPOSIT_PIPELINE_OVERHEAD_MINS
   );
 }

--- a/services/vault/src/components/simple/DepositProgressView/btcConfirmationProgress.ts
+++ b/services/vault/src/components/simple/DepositProgressView/btcConfirmationProgress.ts
@@ -52,3 +52,20 @@ export function computeRemainingEstimateMinutes(
 export function computeTotalEstimateMinutes(requiredDepth: number): number {
   return requiredDepth * BTC_BLOCK_TIME_MINS + DEPOSIT_PIPELINE_OVERHEAD_MINS;
 }
+
+/**
+ * Estimated minutes until the deposit activates, for the /vaults pending row.
+ * Same model as {@link computeTotalEstimateMinutes}, less the depth already
+ * confirmed: it floors at the pipeline overhead once the required depth is
+ * met, and never goes negative. `null` confirmations (no poll result yet) is
+ * treated as zero.
+ */
+export function pendingActivationEstimateMinutes(
+  confirmations: number | null,
+  requiredDepth: number,
+): number {
+  return (
+    (computeRemainingEstimateMinutes(confirmations ?? 0, requiredDepth) ?? 0) +
+    DEPOSIT_PIPELINE_OVERHEAD_MINS
+  );
+}

--- a/services/vault/src/components/vaults/VaultsActiveSection.tsx
+++ b/services/vault/src/components/vaults/VaultsActiveSection.tsx
@@ -9,7 +9,7 @@
  * optimistic (`isActivating`) rows never reach an action flow.
  */
 
-import { Heading, Loader } from "@babylonlabs-io/core-ui";
+import { Avatar, Heading, Loader } from "@babylonlabs-io/core-ui";
 import type { ReactNode } from "react";
 
 import { ApplicationLogo } from "@/components/ApplicationLogo";
@@ -22,6 +22,7 @@ import {
   LIST_ROW_MIN_HEIGHT_CLASS,
   ListRowCard,
 } from "@/components/shared/ListRow";
+import { getNetworkConfigBTC } from "@/config";
 import { COPY } from "@/copy";
 import type { CollateralVaultEntry } from "@/types/collateral";
 import { getBtcExplorerTxUrl } from "@/utils/explorer";
@@ -48,6 +49,7 @@ function ActiveVaultRow({
   // Peg-in first: once a vault is active the peg-in tx is the canonical
   // on-Bitcoin one (pending/inactive rows prefer the opposite).
   const hash = vault.peginTxHash ?? vault.prePeginTxHash;
+  const btcConfig = getNetworkConfigBTC();
 
   return (
     // This row's data-testid is a real-wallet E2E hook
@@ -56,16 +58,17 @@ function ActiveVaultRow({
     // which is what the withdraw flow selects on.
     <ListRowCard
       testId={`vault-row-${vault.vaultId}`}
-      className={LIST_ROW_MIN_HEIGHT_CLASS}
+      className={`${LIST_ROW_MIN_HEIGHT_CLASS} xl:flex-nowrap`}
     >
       {/* Amount + liquidation ordinal */}
       <div
         className={`flex items-center gap-2 ${LIST_ROW_LEADING_COLUMN_CLASS}`}
       >
-        <ApplicationLogo
-          logoUrl={vault.providerIconUrl ?? null}
-          name={vault.providerName}
-          size="small"
+        <Avatar
+          size="medium"
+          url={btcConfig.icon}
+          alt={btcConfig.coinSymbol}
+          className="shrink-0"
         />
         <span className="min-w-0 truncate">
           <span className="text-base leading-6 tracking-[0.15px] text-accent-primary">

--- a/services/vault/src/components/vaults/VaultsEmptyState.tsx
+++ b/services/vault/src/components/vaults/VaultsEmptyState.tsx
@@ -35,7 +35,7 @@ interface VaultsEmptyStateProps {
 /** The section-placement surface: same bordered fill as the summary card and
  *  the lifecycle rows, at the empty state's larger 16px radius. */
 const SECTION_CARD_CLASS =
-  "w-full rounded-2xl border border-secondary-strokeLight bg-secondary-highlight dark:bg-[#202020]";
+  "w-full rounded-2xl border border-secondary-strokeLight bg-secondary-highlight p-6 dark:bg-[#202020]";
 
 export function VaultsEmptyState({
   isConnected,

--- a/services/vault/src/components/vaults/VaultsLifecycleSections.tsx
+++ b/services/vault/src/components/vaults/VaultsLifecycleSections.tsx
@@ -59,6 +59,7 @@ import { useReclaimVaultChainData } from "@/hooks/useReclaimVaultChainData";
 import {
   canPerformAction,
   getPeginDisplayStep,
+  hasActionableStep,
   PeginAction,
   type PeginState,
 } from "@/models/peginStateMachine";
@@ -156,22 +157,31 @@ function PendingRow({
       : null;
   const fillPercent = step !== null ? getStepFillPercent(step) : null;
 
-  const activationEstimate =
-    peginState?.displayVariant !== "pending" ||
-    result?.requiredPrePeginDepth === undefined
-      ? null
-      : COPY.vaults.pendingActivationEstimate(
-          formatDurationShort(
-            pendingActivationEstimateMinutes(
-              result.prePeginConfirmations,
-              result.requiredPrePeginDepth,
-            ),
-          ),
-        );
-
   const actionStatus: ReturnType<typeof getActionStatus> = result
     ? getActionStatus(result)
     : { type: "noAction" };
+
+  const estimateMinutes =
+    peginState?.displayVariant === "pending" &&
+    !hasActionableStep(peginState, result?.depositorBtcPubkey) &&
+    result?.requiredPrePeginDepth !== undefined
+      ? pendingActivationEstimateMinutes(
+          result.prePeginConfirmations,
+          result.requiredPrePeginDepth,
+        )
+      : null;
+  const activationEstimate =
+    estimateMinutes === null
+      ? null
+      : COPY.vaults.pendingActivationEstimate(
+          formatDurationShort(estimateMinutes),
+        );
+  const subLine =
+    peginState?.inlineSubtext ||
+    activationEstimate ||
+    (peginState?.displayVariant === "pending" ? peginState.message : "") ||
+    "";
+
   const routeAction = (action: PeginAction) => {
     if (action === PeginAction.SIGN_AND_BROADCAST_TO_BITCOIN) {
       onBroadcast(activity.id);
@@ -214,11 +224,14 @@ function PendingRow({
           <span className="truncate text-base leading-6 tracking-[0.15px] text-accent-primary">
             {activity.collateral.amount} {activity.collateral.symbol}
           </span>
-          <span className="truncate text-xs leading-[1.66] tracking-[0.4px] text-accent-secondary">
+          <span
+            title={subLine}
+            className="truncate text-xs leading-[1.66] tracking-[0.4px] text-accent-secondary"
+          >
             {/* Subtext wins when a state sets one: it is state-specific (e.g.
                 an activation-window countdown) and therefore sharper than the
                 block-depth estimate, which only models the common wait. */}
-            {peginState?.inlineSubtext ?? activationEstimate ?? ""}
+            {subLine}
           </span>
         </div>
       </div>
@@ -233,6 +246,12 @@ function PendingRow({
             <span className="text-sm leading-[1.43] tracking-[0.17px] text-accent-primary">
               {peginState.displayLabel}
             </span>
+            {peginState.displayVariant !== "pending" && peginState.message && (
+              <Hint
+                tooltip={peginState.message}
+                icon={<InfoIcon size={16} className="text-accent-secondary" />}
+              />
+            )}
           </span>
         ) : (
           <Loader size={16} />
@@ -384,7 +403,10 @@ function InactiveRow({
           <span className="truncate text-base leading-6 tracking-[0.15px] text-accent-primary">
             {activity.collateral.amount} {activity.collateral.symbol}
           </span>
-          <span className="truncate text-xs leading-[1.66] tracking-[0.4px] text-accent-secondary">
+          <span
+            title={peginState?.inlineSubtext}
+            className="truncate text-xs leading-[1.66] tracking-[0.4px] text-accent-secondary"
+          >
             {peginState?.inlineSubtext ?? ""}
           </span>
         </div>

--- a/services/vault/src/components/vaults/VaultsLifecycleSections.tsx
+++ b/services/vault/src/components/vaults/VaultsLifecycleSections.tsx
@@ -15,7 +15,13 @@
  * is instantiated once.
  */
 
-import { Heading, Hint, InfoIcon, Loader } from "@babylonlabs-io/core-ui";
+import {
+  Avatar,
+  Heading,
+  Hint,
+  InfoIcon,
+  Loader,
+} from "@babylonlabs-io/core-ui";
 import { useCallback, useMemo, useState, type ReactNode } from "react";
 import type { Address, Hex } from "viem";
 
@@ -36,14 +42,12 @@ import {
   PRIMARY_ROW_BUTTON_CLASS,
 } from "@/components/shared/buttonClasses";
 import { ProgressBar } from "@/components/simple/DepositProgressView/ProgressBar";
+import { pendingActivationEstimateMinutes } from "@/components/simple/DepositProgressView/btcConfirmationProgress";
 import { DEPOSIT_VIEW_MAX_WIDTH_CLASS } from "@/components/simple/DepositProgressView/layout";
-import {
-  getStepFillPercent,
-  getVisualStep,
-  TOTAL_VISUAL_STEPS,
-} from "@/components/simple/DepositProgressView/steps";
+import { getStepFillPercent } from "@/components/simple/DepositProgressView/steps";
 import { PendingDepositModals } from "@/components/simple/PendingDepositModals";
 import { PostDepositContinuationContent } from "@/components/simple/PostDepositContinuationContent";
+import { getNetworkConfigBTC } from "@/config";
 import { ProtocolParamsProvider } from "@/context/ProtocolParamsContext";
 import { useDepositPollingResult } from "@/context/deposit/PeginPollingContext";
 import { COPY } from "@/copy";
@@ -64,7 +68,7 @@ import type { VaultProvider } from "@/types/vaultProvider";
 import { truncateHash } from "@/utils/addressUtils";
 import { getBatchSiblings } from "@/utils/batchedPegin";
 import { getBtcExplorerTxUrl } from "@/utils/explorer";
-import { formatSats } from "@/utils/formatting";
+import { formatDurationShort, formatSats } from "@/utils/formatting";
 
 /** Step-progress bar fill — the pending amber, matching the status dot. */
 const PROGRESS_FILL_COLOR = "rgb(var(--risk-amber))";
@@ -152,6 +156,19 @@ function PendingRow({
       : null;
   const fillPercent = step !== null ? getStepFillPercent(step) : null;
 
+  const activationEstimate =
+    peginState?.displayVariant !== "pending" ||
+    result?.requiredPrePeginDepth === undefined
+      ? null
+      : COPY.vaults.pendingActivationEstimate(
+          formatDurationShort(
+            pendingActivationEstimateMinutes(
+              result.prePeginConfirmations,
+              result.requiredPrePeginDepth,
+            ),
+          ),
+        );
+
   const actionStatus: ReturnType<typeof getActionStatus> = result
     ? getActionStatus(result)
     : { type: "noAction" };
@@ -181,34 +198,27 @@ function PendingRow({
     // element. The harness scopes a --txid resume to one row through it.
     <div
       data-testid="pending-deposit-row"
-      className={`${LIST_ROW_MIN_HEIGHT_CLASS} flex w-full flex-wrap items-center gap-x-4 gap-y-3 rounded-lg border border-secondary-strokeLight p-4`}
+      className={`${LIST_ROW_MIN_HEIGHT_CLASS} flex w-full flex-wrap items-center gap-x-4 gap-y-3 rounded-lg border border-secondary-strokeLight p-4 xl:flex-nowrap`}
     >
-      {/* Amount + step position */}
+      {/* Amount + activation estimate */}
       <div
         className={`flex items-center gap-2 ${LIST_ROW_LEADING_COLUMN_CLASS}`}
       >
-        <ApplicationLogo
-          logoUrl={provider?.iconUrl ?? null}
-          name={providerName}
-          size="small"
+        <Avatar
+          size="medium"
+          url={getNetworkConfigBTC().icon}
+          alt={activity.collateral.symbol}
+          className="shrink-0"
         />
         <div className="flex min-w-0 flex-col">
           <span className="truncate text-base leading-6 tracking-[0.15px] text-accent-primary">
             {activity.collateral.amount} {activity.collateral.symbol}
           </span>
           <span className="truncate text-xs leading-[1.66] tracking-[0.4px] text-accent-secondary">
-            {/* Subtext wins when a state sets one: it is state-specific
-                (e.g. an activation-window countdown) and therefore more
-                informative than the generic step position. States that set it
-                and still have a step are exactly the ones that need it. */}
-            {peginState?.inlineSubtext
-              ? peginState.inlineSubtext
-              : step !== null
-                ? COPY.deposit.progress.stepPrefix(
-                    getVisualStep(step),
-                    TOTAL_VISUAL_STEPS,
-                  )
-                : ""}
+            {/* Subtext wins when a state sets one: it is state-specific (e.g.
+                an activation-window countdown) and therefore sharper than the
+                block-depth estimate, which only models the common wait. */}
+            {peginState?.inlineSubtext ?? activationEstimate ?? ""}
           </span>
         </div>
       </div>
@@ -223,12 +233,6 @@ function PendingRow({
             <span className="text-sm leading-[1.43] tracking-[0.17px] text-accent-primary">
               {peginState.displayLabel}
             </span>
-            {peginState.message && (
-              <Hint
-                tooltip={peginState.message}
-                icon={<InfoIcon size={16} className="text-accent-secondary" />}
-              />
-            )}
           </span>
         ) : (
           <Loader size={16} />
@@ -365,15 +369,16 @@ function InactiveRow({
   const hash = activity.prePeginTxHash ?? activity.peginTxHash;
 
   return (
-    <ListRowCard className={LIST_ROW_MIN_HEIGHT_CLASS}>
+    <ListRowCard className={`${LIST_ROW_MIN_HEIGHT_CLASS} xl:flex-nowrap`}>
       {/* Amount + refund maturity */}
       <div
         className={`flex items-center gap-2 ${LIST_ROW_LEADING_COLUMN_CLASS}`}
       >
-        <ApplicationLogo
-          logoUrl={provider?.iconUrl ?? null}
-          name={providerName}
-          size="small"
+        <Avatar
+          size="medium"
+          url={getNetworkConfigBTC().icon}
+          alt={activity.collateral.symbol}
+          className="shrink-0"
         />
         <div className="flex min-w-0 flex-col">
           <span className="truncate text-base leading-6 tracking-[0.15px] text-accent-primary">

--- a/services/vault/src/components/vaults/VaultsSummaryCard.tsx
+++ b/services/vault/src/components/vaults/VaultsSummaryCard.tsx
@@ -84,7 +84,6 @@ export function VaultsSummaryCard({
           <HeartIcon color={healthFactorColor} className="size-6" />
         </span>
       ),
-      caption: COPY.vaults.summary.healthFactorCaption,
     },
   ];
 

--- a/services/vault/src/components/vaults/__tests__/VaultsLifecycleSections.test.tsx
+++ b/services/vault/src/components/vaults/__tests__/VaultsLifecycleSections.test.tsx
@@ -1,0 +1,254 @@
+import { render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import type { Hex } from "viem";
+import { describe, expect, it, vi } from "vitest";
+
+import { VaultsLifecycleSections } from "@/components/vaults/VaultsLifecycleSections";
+import { COPY } from "@/copy";
+import type { usePendingDeposits } from "@/hooks/usePendingDeposits";
+import {
+  ContractStatus,
+  PEGIN_DISPLAY_LABELS,
+  PeginAction,
+  type PeginState,
+} from "@/models/peginStateMachine";
+import type { VaultActivity } from "@/types/activity";
+import type { DepositPollingResult } from "@/types/peginPolling";
+import { formatDurationShort } from "@/utils/formatting";
+
+const mockUseDepositPollingResult = vi.hoisted(() =>
+  vi.fn<(depositId: string) => DepositPollingResult | undefined>(
+    () => undefined,
+  ),
+);
+
+vi.mock("@babylonlabs-io/core-ui", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@babylonlabs-io/core-ui")>()),
+  Hint: ({ tooltip, children }: { tooltip?: string; children?: ReactNode }) => (
+    <span data-testid="row-hint">
+      {tooltip}
+      {children}
+    </span>
+  ),
+}));
+
+vi.mock("@babylonlabs-io/wallet-connector", () => ({
+  Network: { MAINNET: "mainnet", SIGNET: "signet" },
+  useChainConnector: () => undefined,
+}));
+
+vi.mock("@/context/deposit/PeginPollingContext", () => ({
+  useDepositPollingResult: mockUseDepositPollingResult,
+}));
+
+vi.mock("@/context/ProtocolParamsContext", () => ({
+  ProtocolParamsProvider: ({ children }: { children?: ReactNode }) => (
+    <>{children}</>
+  ),
+}));
+
+vi.mock("@/hooks/deposit/useRefundRowAction", () => ({
+  useRefundRowAction: () => ({ available: false, blockedTooltip: null }),
+}));
+
+vi.mock("@/hooks/deposit/useReclaimRowAction", () => ({
+  useReclaimRowAction: () => ({
+    available: false,
+    reclaiming: false,
+    blockedTooltip: null,
+    reclaimableSats: null,
+  }),
+}));
+
+vi.mock("@/hooks/useReclaimStatus", () => ({
+  useReclaimStatus: () => ({ statusByDepositId: new Map() }),
+}));
+
+vi.mock("@/hooks/useReclaimVaultChainData", () => ({
+  useReclaimVaultChainData: () => new Map(),
+}));
+
+vi.mock("@/components/simple/PendingDepositModals", () => ({
+  PendingDepositModals: () => null,
+}));
+
+vi.mock("@/components/simple/PostDepositContinuationContent", () => ({
+  PostDepositContinuationContent: () => null,
+}));
+
+const ACTIVITY_ID = "0xdeposit" as Hex;
+
+const ACTIVITY: VaultActivity = {
+  id: ACTIVITY_ID,
+  collateral: { amount: "0.1", symbol: "BTC" },
+  providers: [{ id: "0xprovider" }],
+  prePeginTxHash: "0xprepegin" as Hex,
+  contractStatus: ContractStatus.PENDING,
+  displayLabel: PEGIN_DISPLAY_LABELS.PENDING,
+  depositorBtcPubkey: "ab".repeat(32),
+  unsignedPrePeginTx: "0xdeadbeef",
+  depositorWotsPkHash: "0xwotshash",
+};
+
+const PROCESSING_STATE: PeginState = {
+  contractStatus: ContractStatus.PENDING,
+  displayLabel: PEGIN_DISPLAY_LABELS.PROCESSING,
+  displayVariant: "pending",
+  availableActions: [PeginAction.NONE],
+  message: COPY.pegin.messages.payoutSignaturesSubmitted,
+};
+
+const FAILED_STATE: PeginState = {
+  contractStatus: ContractStatus.PENDING,
+  displayLabel: PEGIN_DISPLAY_LABELS.FAILED,
+  displayVariant: "warning",
+  availableActions: [PeginAction.NONE],
+  message: "Vault provider rejected the deposit terms.",
+};
+
+const BROADCAST_STATE: PeginState = {
+  contractStatus: ContractStatus.PENDING,
+  displayLabel: PEGIN_DISPLAY_LABELS.PENDING,
+  displayVariant: "pending",
+  availableActions: [PeginAction.SIGN_AND_BROADCAST_TO_BITCOIN],
+  message: COPY.pegin.messages.broadcastMayHaveFailed,
+};
+
+function pollingResult(
+  peginState: PeginState,
+  overrides: Partial<DepositPollingResult> = {},
+): DepositPollingResult {
+  return {
+    depositId: ACTIVITY_ID,
+    loading: false,
+    error: null,
+    peginState,
+    isOwnedByCurrentWallet: true,
+    depositorBtcPubkey: ACTIVITY.depositorBtcPubkey,
+    prePeginConfirmations: 0,
+    requiredPrePeginDepth: 6,
+    ...overrides,
+  };
+}
+
+function renderPendingRow(result: DepositPollingResult) {
+  mockUseDepositPollingResult.mockReturnValue(result);
+  const deposits = {
+    pendingActivities: [ACTIVITY],
+    expiredActivities: [],
+    reclaimableCandidates: [],
+    allActivities: [ACTIVITY],
+    vaultProviders: [],
+    btcAddress: "tb1depositor",
+    btcConnected: true,
+    ethAddress: "0x1111111111111111111111111111111111111111",
+    hasPendingDeposits: true,
+    hasExpiredDeposits: false,
+    isLoading: false,
+    error: null,
+    refetchActivities: vi.fn(),
+    broadcastModal: {
+      broadcastingActivity: null,
+      broadcastingBatchIds: [],
+      isOpen: false,
+      successOpen: false,
+      successAmount: "",
+      handleBroadcastClick: vi.fn(),
+      handleClose: vi.fn(),
+      handleSuccess: vi.fn(),
+      handleSuccessClose: vi.fn(),
+    },
+    refundModal: {
+      refundingActivity: null,
+      handleRefundClick: vi.fn(),
+      handleClose: vi.fn(),
+      handleSuccess: vi.fn(),
+    },
+    reclaimModal: {
+      reclaimingActivity: null,
+      inFlightVaultIds: new Set<string>(),
+      handleReclaimClick: vi.fn(),
+      handleClose: vi.fn(),
+      handleBroadcast: vi.fn(),
+      handleSuccess: vi.fn(),
+    },
+    emergencyWithdrawModal: {
+      withdrawing: null,
+      handleWithdrawClick: vi.fn(),
+      handleClose: vi.fn(),
+      handleSuccess: vi.fn(),
+    },
+    demo: null,
+  } satisfies ReturnType<typeof usePendingDeposits>;
+
+  return render(<VaultsLifecycleSections deposits={deposits} />);
+}
+
+const estimateText = (minutes: number) =>
+  COPY.vaults.pendingActivationEstimate(formatDurationShort(minutes));
+
+const ANY_ESTIMATE = new RegExp(
+  COPY.vaults
+    .pendingActivationEstimate("")
+    .replace(/[.*+?^${}()|[\]\\]/g, "\\$&"),
+);
+
+describe("VaultsLifecycleSections pending row", () => {
+  it("keeps the failure reason in a hint on a FAILED row", () => {
+    renderPendingRow(pollingResult(FAILED_STATE));
+
+    const message = FAILED_STATE.message as string;
+    expect(screen.getByTestId("row-hint")).toHaveTextContent(message);
+    expect(screen.getAllByText(message)).toHaveLength(1);
+  });
+
+  it("shows no hint beside the pending chip", () => {
+    renderPendingRow(pollingResult(PROCESSING_STATE));
+
+    expect(screen.queryByTestId("row-hint")).not.toBeInTheDocument();
+  });
+
+  it("estimates the wait while the deposit is machine-paced", () => {
+    renderPendingRow(pollingResult(PROCESSING_STATE));
+
+    expect(screen.getByText(estimateText(70))).toBeInTheDocument();
+  });
+
+  it("shows no estimate while the deposit waits on the user", () => {
+    renderPendingRow(pollingResult(BROADCAST_STATE));
+
+    expect(
+      screen.getByTestId("pending-deposit-resume-cta"),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(ANY_ESTIMATE)).not.toBeInTheDocument();
+  });
+
+  it("keeps the state message in the sub-line on a user-paced row", () => {
+    renderPendingRow(pollingResult(BROADCAST_STATE));
+
+    expect(
+      screen.getByText(COPY.pegin.messages.broadcastMayHaveFailed),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(ANY_ESTIMATE)).not.toBeInTheDocument();
+  });
+
+  it("shows no estimate on a user-paced row owned by another wallet", () => {
+    renderPendingRow(
+      pollingResult(BROADCAST_STATE, { isOwnedByCurrentWallet: false }),
+    );
+
+    expect(
+      screen.queryByTestId("pending-deposit-resume-cta"),
+    ).not.toBeInTheDocument();
+    expect(screen.getByTestId("row-hint")).toBeInTheDocument();
+    expect(screen.queryByText(ANY_ESTIMATE)).not.toBeInTheDocument();
+  });
+
+  it("shows no estimate before the first confirmation poll lands", () => {
+    renderPendingRow(
+      pollingResult(PROCESSING_STATE, { prePeginConfirmations: null }),
+    );
+
+    expect(screen.queryByText(ANY_ESTIMATE)).not.toBeInTheDocument();
+  });
+});

--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -179,8 +179,9 @@ export const COPY = {
       // recoverable. Lead with that before explaining what happened.
       activationIncomplete:
         "Your BTC is not lost. The peg-in was completed on Bitcoin, but the BTCVault was never activated. Click 'Withdraw' and the vault provider will send your BTC to your payout address.",
-      // Always-visible one-liner under the amount (the message above is
-      // tooltip-only); same reassuring tone.
+      // Always-visible one-liner under the amount; same reassuring tone. The
+      // full sentence above is tooltip-only, and the /vaults pending row no
+      // longer renders that tooltip.
       activationIncompleteSubtext:
         "Your BTC is not lost — withdraw to receive it back.",
       // Activation floor. Blocks lead because they are the fact the contract
@@ -193,8 +194,9 @@ export const COPY = {
       activationWindowTooltip:
         "Activation opens a short time after verification. This is a protocol requirement.",
       // Compact form for the always-visible slot under the amount. The full
-      // sentence stays in `message` (the info-icon tooltip); this is what a
-      // depositor sees without interacting, so it must survive `truncate`.
+      // sentence stays in `message`, which the /vaults pending row no longer
+      // surfaces, so this is the only form a depositor sees there and it must
+      // survive `truncate`.
       activationWindowSubtext: (blocks: number, minutes: number) =>
         `Opens in ${blocks} ${blocks === 1 ? "block" : "blocks"} (~${minutes} min)`,
       activationWindowSubtextUnknown: "Waiting for the activation window",
@@ -220,9 +222,9 @@ export const COPY = {
         "Refund transaction has been broadcast to Bitcoin. Waiting for on-chain confirmation...",
       refundComplete:
         "Your refund has been confirmed on Bitcoin. The locked BTC has returned to your wallet.",
-      // Longest sub-line the lifecycle rows render, so it sizes
-      // LIST_ROW_LEADING_COLUMN_CLASS's basis (components/shared/ListRow.tsx).
-      // Lengthening it here ellipses that cell unless the basis moves too.
+      // Longest sub-line the lifecycle rows render. It exceeds
+      // LIST_ROW_LEADING_COLUMN_CLASS's basis (components/shared/ListRow.tsx),
+      // so that cell truncates it rather than widening.
       refundMaturing: (blocks: number, hours: number) =>
         `Your refund will be claimable in ~${blocks} Bitcoin ${blocks === 1 ? "block" : "blocks"} (~${hours}h).`,
       refundMaturingUnknown: "Checking when your refund will be claimable...",
@@ -399,10 +401,6 @@ export const COPY = {
       },
       stepsCompleted: (completed: number, total: number) =>
         `${completed} of ${total} steps completed`,
-      // Inline prefix for the pending-deposit card's active-step label
-      // (e.g. "Step 6 of 15"). Sits before the bolded step label.
-      stepPrefix: (current: number, total: number) =>
-        `Step ${current} of ${total}`,
       defaultSuccessMessage: PRE_PEGIN_BROADCAST_CONFIRMATION_MESSAGE,
       doNotSpendWarning:
         "Do not spend the BTC used for this deposit until the transactions are confirmed.",
@@ -1910,6 +1908,10 @@ export const COPY = {
       disconnected: connectToView("BTCVaults"),
       depositAction: "Deposit",
     },
+    // Sub-line under a pending row's amount: the machine-paced wait left
+    // before the deposit activates.
+    pendingActivationEstimate: (duration: string) =>
+      `Activates in ~${duration}`,
     loadError:
       "We couldn't load your BTCVaults. Check your connection and try again.",
     partialLoadError: {
@@ -1920,8 +1922,6 @@ export const COPY = {
       totalCollateralLabel: "Total Collateral Value",
       activeVaultsLabel: "Active Vaults",
       healthFactorLabel: "Health Factor",
-      healthFactorCaption:
-        "When the ratio falls below 1.0, liquidation may occur.",
       vaultCount: (count: number) =>
         count === 1 ? "1 Vault" : `${count} Vaults`,
       // e.g. "Order: 0.6 → 0.2 → 0.4 sBTC" — liquidation order, seized-first


### PR DESCRIPTION
## Summary

Rebuilds the `/vaults` pending-deposit row to match Figma (node `10247-49814`) and clears the surrounding layout defects on the page. The pending row is now a single line at `xl` and up: coin avatar, amount over an activation estimate, status dot with its progress bar, provider, hash, and the action button flush right.

## Changes

**Pending row is one line.** The lifecycle rows wrapped because their container was `flex-wrap` while the shared `LIST_ROW_*` bases (384 + 144×3 + 168 = 984px, plus four 16px gaps = 1048px) exceeded the card's content box. The pending, active and inactive rows are now `flex-wrap xl:flex-nowrap`; the data columns swap `min-w-[120px]` for `min-w-0` so they can shrink, and the leading column's basis drops from 384px to 240px. `LIST_ROW_ACTION_SLOT_CLASS` stays the fixed, non-shrinking slot, so the columns still line up across Pending / Active / Inactive.

**Activation estimate replaces the step counter.** The sub-line under the amount was `inlineSubtext ?? "Step N of 15"`. It is now `inlineSubtext` when a state sets one (the Figma "Activate within 25h 17m" case), otherwise a machine-paced estimate derived from the polling result: `pendingActivationEstimateMinutes(prePeginConfirmations, requiredPrePeginDepth)` in `btcConfirmationProgress.ts`, rendered as "Activates in ~1.5 h". The estimate is withheld while `requiredPrePeginDepth` is undefined, so a loading protocol-params read never produces a guessed number, and withheld on any non-`pending` display variant — a "Failed" or "Expired" row reaches this section too, and a countdown under those labels would contradict the status beside it. `COPY.deposit.progress.stepPrefix` had no other caller and is deleted.

**sBTC coin icon in the leading cell.** The leading cell showed the vault provider's logo — the same logo the provider column already carries one cell over, so a row rendered it twice. It is now the network's Bitcoin icon (`getNetworkConfigBTC().icon`) on core-ui's 32px `Avatar`. Applied to the pending, inactive and active-vault rows for consistency with Figma; the provider column keeps its `ApplicationLogo`.

**Pending status info icon removed.** The `Hint` + `InfoIcon` beside the pending status label is gone per the design. `peginState.message` is untouched — the inactive row and other surfaces still use it.

**Health-factor caption removed** from the `/vaults` summary card, and `COPY.vaults.summary.healthFactorCaption` with it. The tooltip, value and heart stay. The Loans summary keeps its own `COPY.loans.healthFactorCaption`.

**Empty state padding.** The section placement wrapped `EmptyState` in a bordered card with no padding of its own, so the illustration sat flush against the border. `SECTION_CARD_CLASS` now carries `p-6`; `EmptyState` renders unpadded with `withCard={false}`, so there is no double padding.

The Total Collateral Value card already sets no tooltip on `main` — nothing to remove there.

## Consequences

- Long leading sub-lines now truncate instead of forcing a wrap. The longest is `COPY.pegin.messages.refundMaturing` on an inactive row; the `truncate` class was already on those spans. The comments in `ListRow.tsx` and `copy.ts` that documented the old 384px / no-truncation trade-off are rewritten to describe this.
- The row's bases now total 904px (240 + 144×3 + 168 + four 16px gaps), down from 1048px. With the 242px sidebar, the `mx-10` page gutter and the card's 16px padding, a 1280px viewport gives the card 926px of content — so from `xl` the row holds one line without shrinking any column. Below that the rows wrap exactly as they do today. The basis reduction alone already unwraps the row at the widths where the bug was reported: at a 1364px viewport the card has 1010px of content against the old 1048px requirement.
- A `pending`-variant row that is waiting on the depositor rather than on Bitcoin (WOTS submission, payout signing, "Ready to activate") still shows the estimate. It is a machine-paced lower bound on the remaining wait, not a promise of unattended completion.
- The Activity and Active Loans rows keep `flex-wrap` and are unaffected by the basis changes — they use `LIST_ROW_ACTION_SLOT_CLASS` and `ListRowMetric`, neither of which changed.

## Testing

- `pnpm exec eslint` on every changed file — clean.
- `NODE_OPTIONS=--max-old-space-size=8192 pnpm exec tsc --noEmit -p tsconfig.lib.json` — clean.
- `pnpm exec vitest run --maxWorkers=2 src/components` — 91 files, 862 tests passing. That covers `src/components/vaults`, `btcConfirmationProgress.test.ts`, `steps.test.ts`, `ActivityRowV3.test.tsx`, `ActivityList.test.tsx`, `ActiveLoansList.test.tsx`, `VaultsPage.test.tsx` and `src/components/shared`.
- New unit test covers `pendingActivationEstimateMinutes` for null confirmations, a partial depth, and at/over depth where it floors at the pipeline overhead.

Closes #2341
