### PR TITLE
fix(vault): polish the Deposit Progress modal

### DIFF
--- a/services/vault/src/components/shared/layoutClasses.ts
+++ b/services/vault/src/components/shared/layoutClasses.ts
@@ -48,3 +48,6 @@ export const SUMMARY_CARD_CLASS = "w-full border-0 !py-[34px]";
  */
 export const CARD_SHELL_CLASS =
   "w-full overflow-hidden rounded-lg border border-secondary-strokeLight bg-secondary-highlight dark:bg-[#202020]";
+
+export const DETAIL_PANEL_CLASS =
+  "flex flex-col gap-2 rounded-lg border border-secondary-strokeLight bg-primary-contrast p-3";

--- a/services/vault/src/components/shared/layoutClasses.ts
+++ b/services/vault/src/components/shared/layoutClasses.ts
@@ -50,4 +50,4 @@ export const CARD_SHELL_CLASS =
   "w-full overflow-hidden rounded-lg border border-secondary-strokeLight bg-secondary-highlight dark:bg-[#202020]";
 
 export const DETAIL_PANEL_CLASS =
-  "flex flex-col gap-2 rounded-lg border border-secondary-strokeLight bg-primary-contrast p-3";
+  "flex flex-col gap-2 rounded-lg border border-secondary-strokeLight bg-background-contrast p-3";

--- a/services/vault/src/components/simple/DepositProgressView/BtcConfirmationDetail.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/BtcConfirmationDetail.tsx
@@ -47,7 +47,7 @@ export function BtcConfirmationDetail({
     : "flex items-center justify-between gap-2";
 
   return (
-    <div className="mt-3 flex flex-col gap-2 rounded-lg bg-secondary-highlight p-3">
+    <div className="mt-3 flex flex-col gap-2 rounded-lg border border-secondary-strokeLight bg-primary-contrast p-3">
       <div className={rowClass}>
         <Text as="span" variant="body2" className="text-accent-secondary">
           {depthReached ? COPY.deposit.waitDetails.status : copy.estRemaining}:

--- a/services/vault/src/components/simple/DepositProgressView/BtcConfirmationDetail.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/BtcConfirmationDetail.tsx
@@ -1,6 +1,7 @@
 import { Loader, Text } from "@babylonlabs-io/core-ui";
 
 import { CopyableHash } from "@/components/shared/CopyableHash";
+import { DETAIL_PANEL_CLASS } from "@/components/shared/layoutClasses";
 import { COPY } from "@/copy";
 import { getBtcExplorerTxUrl } from "@/utils/explorer";
 
@@ -47,7 +48,7 @@ export function BtcConfirmationDetail({
     : "flex items-center justify-between gap-2";
 
   return (
-    <div className="mt-3 flex flex-col gap-2 rounded-lg border border-secondary-strokeLight bg-primary-contrast p-3">
+    <div className={`mt-3 ${DETAIL_PANEL_CLASS}`}>
       <div className={rowClass}>
         <Text as="span" variant="body2" className="text-accent-secondary">
           {depthReached ? COPY.deposit.waitDetails.status : copy.estRemaining}:

--- a/services/vault/src/components/simple/DepositProgressView/DepositCardShell.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/DepositCardShell.tsx
@@ -4,14 +4,15 @@
  * Presentational chrome shared by every state of the deposit progress flow.
  * It owns the card border, the heading + time estimate, the explanation, an
  * optional overall progress bar, the full-bleed divider, the step/group body,
- * and a footer region (primary CTA + optional fine print).
+ * and the footer's primary CTA.
  *
  * The body is intentionally a `children` slot so the same card can host either
  * state of the flow:
- *   - pre-sign  → DepositSummaryCard passes the collapsed group rows
+ *   - pre-sign  → the entry state passes the current group alone, opened on
+ *                 the Pre-PegIn step to carry the fee selector
  *   - in-flight → the live stepper passes its expanded GroupedProgress (with
  *                 per-step detail panels), a progress bar, and the
- *                 close-and-continue CTA + do-not-spend footnote
+ *                 close-and-continue CTA
  *
  * Keeping the chrome here means the user sees one consistent card from the
  * summary through completion — only the body and footer change per state.
@@ -29,8 +30,8 @@ import { DEPOSIT_VIEW_MAX_WIDTH_CLASS } from "./layout";
 
 interface DepositCardShellProps {
   /**
-   * Step/group list. Collapsed group rows in the summary state; the expanded
-   * grouped stepper (with active-step detail panels) in the live state.
+   * Step/group list: the group holding the current step — collapsed on the
+   * pre-sign entry, expanded with its detail panels once the flow runs.
    */
   children: ReactNode;
   /**
@@ -44,11 +45,6 @@ interface DepositCardShellProps {
    */
   progressBar?: ReactNode;
   /**
-   * Optional fine print rendered under the footer action — e.g. the
-   * do-not-spend warning shown while the deposit is in flight.
-   */
-  footnote?: ReactNode;
-  /**
    * The deposit's registered offchain-params version, so the header estimate
    * uses the same pinned confirmation depth the flow actually gates on.
    * Omitted pre-sign, where no version is registered yet → latest params.
@@ -60,7 +56,6 @@ export function DepositCardShell({
   children,
   footer,
   progressBar,
-  footnote,
   offchainParamsVersion,
 }: DepositCardShellProps) {
   const requiredDepth = useRequiredPrePeginDepth(offchainParamsVersion);
@@ -98,10 +93,7 @@ export function DepositCardShell({
       {/* Scrollable middle: the step list. Header + footer stay fixed. */}
       <div className="flex-1 overflow-y-auto px-6 py-6">{children}</div>
 
-      <div className="shrink-0 px-6 pb-6 pt-2">
-        {footer}
-        {footnote && <div className="mt-4">{footnote}</div>}
-      </div>
+      <div className="shrink-0 px-6 pb-6 pt-2">{footer}</div>
     </div>
   );
 }

--- a/services/vault/src/components/simple/DepositProgressView/DepositProgressView.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/DepositProgressView.tsx
@@ -355,9 +355,8 @@ export function DepositProgressView(props: DepositProgressViewProps) {
   // a current group with none of its own work done reads not-started, so
   // nothing spins or announces progress while the flow idles awaiting the
   // click. Flows entering at step 1 have nothing completed, so they render
-  // as no bar, no pill, and collapsed not-started headers — except the group
-  // owning the Pre-PegIn step, which opens to carry the fee selector on its
-  // one relevant row (see GroupBlock).
+  // as no bar and no pill — just the group owning the Pre-PegIn step, opened
+  // to carry the fee selector on its one relevant row (see GroupBlock).
   const visualStep = isComplete
     ? TOTAL_VISUAL_STEPS + 1
     : getVisualStep(currentStep);
@@ -545,14 +544,6 @@ export function DepositProgressView(props: DepositProgressViewProps) {
             )}
           </Button>
         </div>
-      }
-      footnote={
-        <Text
-          variant="body2"
-          className="text-center text-xs text-accent-secondary"
-        >
-          {COPY.deposit.progress.doNotSpendWarning}
-        </Text>
       }
     >
       <div className="flex flex-col gap-6">

--- a/services/vault/src/components/simple/DepositProgressView/EthConfirmationDetail.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/EthConfirmationDetail.tsx
@@ -39,7 +39,7 @@ export function EthConfirmationDetail({
     : "flex items-center justify-between gap-2";
 
   return (
-    <div className="mt-3 flex flex-col gap-2 rounded-lg bg-secondary-highlight p-3">
+    <div className="mt-3 flex flex-col gap-2 rounded-lg border border-secondary-strokeLight bg-primary-contrast p-3">
       <div className={rowClass}>
         <Text as="span" variant="body2" className="text-accent-secondary">
           {copy.confirmations}:

--- a/services/vault/src/components/simple/DepositProgressView/EthConfirmationDetail.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/EthConfirmationDetail.tsx
@@ -1,5 +1,6 @@
 import { Loader, Text } from "@babylonlabs-io/core-ui";
 
+import { DETAIL_PANEL_CLASS } from "@/components/shared/layoutClasses";
 import { COPY } from "@/copy";
 
 import { computeRemainingEthEstimateSeconds } from "./ethConfirmationProgress";
@@ -39,7 +40,7 @@ export function EthConfirmationDetail({
     : "flex items-center justify-between gap-2";
 
   return (
-    <div className="mt-3 flex flex-col gap-2 rounded-lg border border-secondary-strokeLight bg-primary-contrast p-3">
+    <div className={`mt-3 ${DETAIL_PANEL_CLASS}`}>
       <div className={rowClass}>
         <Text as="span" variant="body2" className="text-accent-secondary">
           {copy.confirmations}:

--- a/services/vault/src/components/simple/DepositProgressView/FeeRateSelector.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/FeeRateSelector.tsx
@@ -13,6 +13,7 @@ import { peginOutputCount } from "@babylonlabs-io/ts-sdk/tbv/core";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { IoClose } from "react-icons/io5";
 
+import { DETAIL_PANEL_CLASS } from "@/components/shared/layoutClasses";
 import { MIN_RELAY_FEE_RATE_SATS_VB } from "@/constants";
 import { useBTCWallet } from "@/context/wallet";
 import { COPY } from "@/copy";
@@ -190,7 +191,7 @@ export function FeeRateSelector({
   ];
 
   return (
-    <div className="flex flex-col gap-2 rounded-lg border border-secondary-strokeLight bg-primary-contrast p-3">
+    <div className={DETAIL_PANEL_CLASS}>
       <div className="flex items-center justify-between">
         <Text variant="body2" className="text-accent-primary">
           {FEE_SELECTOR_COPY.title}

--- a/services/vault/src/components/simple/DepositProgressView/FeeRateSelector.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/FeeRateSelector.tsx
@@ -190,7 +190,7 @@ export function FeeRateSelector({
   ];
 
   return (
-    <div className="flex flex-col gap-2 rounded-lg border border-secondary-strokeLight bg-secondary-highlight p-3">
+    <div className="flex flex-col gap-2 rounded-lg border border-secondary-strokeLight bg-primary-contrast p-3">
       <div className="flex items-center justify-between">
         <Text variant="body2" className="text-accent-primary">
           {FEE_SELECTOR_COPY.title}

--- a/services/vault/src/components/simple/DepositProgressView/GroupBlock.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/GroupBlock.tsx
@@ -2,10 +2,10 @@
  * GroupBlock
  *
  * Renders one step group with the deposit-progress design: the active group
- * expands into a filled card (header → divider → sub-steps), while a collapsed
- * (upcoming) group renders as a single header row. Shared by the single-vault
- * stepper ({@link GroupedProgress}) and each lane of the split stepper
- * ({@link SplitGroupedProgress}) so both look identical.
+ * expands into a filled card (header → divider → sub-steps), while an
+ * un-started (pre-entry) group renders as a single header row. Shared by the
+ * single-vault stepper ({@link GroupedProgress}) and each lane of the split
+ * stepper ({@link SplitGroupedProgress}) so both look identical.
  */
 
 import type { StepperItem } from "@babylonlabs-io/core-ui";
@@ -65,6 +65,8 @@ export function GroupBlock({
     group.startStep <= PRE_PEGIN_VISUAL_STEP &&
     PRE_PEGIN_VISUAL_STEP <= group.endStep;
 
+  const headerHasError = hasError && group.status === "active";
+
   if (!group.expanded && !showPreSignDetail) {
     return (
       <GroupHeader
@@ -73,6 +75,7 @@ export function GroupBlock({
         status={group.status}
         completedInGroup={group.completedInGroup}
         totalInGroup={group.totalInGroup}
+        hasError={headerHasError}
       />
     );
   }
@@ -91,6 +94,7 @@ export function GroupBlock({
           status={group.status}
           completedInGroup={group.completedInGroup}
           totalInGroup={group.totalInGroup}
+          hasError={headerHasError}
         />
         <div className="border-t border-secondary-strokeLight" />
         <div className="flex flex-col gap-2 px-2">

--- a/services/vault/src/components/simple/DepositProgressView/GroupBlock.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/GroupBlock.tsx
@@ -15,7 +15,7 @@ import { DepositFlowStep } from "@/hooks/deposit/depositFlowSteps/types";
 
 import { GroupHeader } from "./GroupHeader";
 import { StepRow, type StepRowState } from "./StepRow";
-import { getVisualStep, type StepGroupView } from "./steps";
+import { getVisualStep, groupContainsStep, type StepGroupView } from "./steps";
 
 /** The step whose transaction the pre-sign fee rate pays for. */
 const PRE_PEGIN_VISUAL_STEP = getVisualStep(
@@ -65,7 +65,7 @@ export function GroupBlock({
     group.startStep <= PRE_PEGIN_VISUAL_STEP &&
     PRE_PEGIN_VISUAL_STEP <= group.endStep;
 
-  const headerHasError = hasError && group.status === "active";
+  const headerHasError = hasError && groupContainsStep(group, currentStep);
 
   if (!group.expanded && !showPreSignDetail) {
     return (
@@ -101,12 +101,11 @@ export function GroupBlock({
           {showPreSignDetail ? (
             <>
               <StepRow
-                state="active"
+                state={headerHasError ? "error" : "active"}
                 number={PRE_PEGIN_VISUAL_STEP - group.startStep + 1}
                 ariaNumber={PRE_PEGIN_VISUAL_STEP}
                 label={steps[PRE_PEGIN_VISUAL_STEP - 1]?.label ?? ""}
                 compact={compact}
-                inCard
               />
               {preSignDetail}
             </>
@@ -133,9 +132,7 @@ export function GroupBlock({
                   label={step.label}
                   description={step.description}
                   detail={activeStepDetail}
-                  hasNext={subIndex < stepNumbers.length - 1}
                   compact={compact}
-                  inCard
                 />
               );
             })

--- a/services/vault/src/components/simple/DepositProgressView/GroupHeader.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/GroupHeader.tsx
@@ -13,17 +13,23 @@ interface GroupHeaderProps {
   status: GroupStatus;
   completedInGroup: number;
   totalInGroup: number;
+  /** True when this group's current step failed — render title + circle red. */
+  hasError?: boolean;
 }
 
 function GroupIndicator({
   status,
   number,
+  hasError,
 }: {
   status: GroupStatus;
   number: number;
+  hasError: boolean;
 }) {
   const base = "flex h-8 w-8 shrink-0 items-center justify-center rounded-full";
-  const ariaLabel = COPY.deposit.a11y.groupStatus[status];
+  const ariaLabel = hasError
+    ? COPY.deposit.a11y.groupStatus.failed
+    : COPY.deposit.a11y.groupStatus[status];
 
   if (status === "completed") {
     return (
@@ -38,13 +44,21 @@ function GroupIndicator({
 
   return (
     <div
-      className={twMerge(base, "border-2 border-accent-primary")}
+      className={twMerge(
+        base,
+        hasError
+          ? "border-2 border-error-main"
+          : "border-2 border-secondary-strokeDark",
+      )}
       aria-label={ariaLabel}
     >
       <Text
         as="span"
         variant="body2"
-        className="font-medium text-accent-primary"
+        className={twMerge(
+          "font-medium",
+          hasError ? "text-error-main" : "text-accent-primary",
+        )}
       >
         {number}
       </Text>
@@ -58,14 +72,18 @@ export function GroupHeader({
   status,
   completedInGroup,
   totalInGroup,
+  hasError = false,
 }: GroupHeaderProps) {
   return (
     <div className="flex items-center gap-3">
-      <GroupIndicator status={status} number={number} />
+      <GroupIndicator status={status} number={number} hasError={hasError} />
       <Text
         as="span"
         variant="body1"
-        className="flex-1 font-medium text-accent-primary"
+        className={twMerge(
+          "flex-1 font-medium",
+          hasError ? "text-error-main" : "text-accent-primary",
+        )}
       >
         {title}
       </Text>

--- a/services/vault/src/components/simple/DepositProgressView/GroupHeader.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/GroupHeader.tsx
@@ -1,5 +1,5 @@
 import { Text } from "@babylonlabs-io/core-ui";
-import { IoCheckmarkSharp } from "react-icons/io5";
+import { IoCheckmarkSharp, IoCloseSharp } from "react-icons/io5";
 import { twMerge } from "tailwind-merge";
 
 import { COPY } from "@/copy";
@@ -42,23 +42,29 @@ function GroupIndicator({
     );
   }
 
+  if (hasError) {
+    return (
+      <div
+        className={twMerge(base, "border-2 border-error-main")}
+        aria-label={ariaLabel}
+      >
+        <IoCloseSharp size={16} className="text-error-main" />
+      </div>
+    );
+  }
+
   return (
     <div
       className={twMerge(
         base,
-        hasError
-          ? "border-2 border-error-main"
-          : "border-2 border-secondary-strokeDark",
+        "border-2 border-accent-secondary dark:border-secondary-strokeDark",
       )}
       aria-label={ariaLabel}
     >
       <Text
         as="span"
         variant="body2"
-        className={twMerge(
-          "font-medium",
-          hasError ? "text-error-main" : "text-accent-primary",
-        )}
+        className="font-medium text-accent-primary"
       >
         {number}
       </Text>

--- a/services/vault/src/components/simple/DepositProgressView/GroupedProgress.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/GroupedProgress.tsx
@@ -2,19 +2,20 @@
  * GroupedProgress
  *
  * Renders the deposit flow steps grouped into logical sections (see STEP_GROUPS).
- * Completed groups are hidden — they fold into the "X of N steps completed" pill
- * — so only the active and upcoming groups render. The active group expands into
- * a filled card revealing its sub-steps; upcoming groups collapse to a header
- * row. Visibility is derived from `currentStep`; expansion additionally
- * requires the flow to have `started` (see buildStepGroups).
+ * Only the group holding the current step renders: finished groups fold into the
+ * "X of N steps completed" pill and later groups stay out of sight until their
+ * turn. That group expands into a filled card revealing its sub-steps — except
+ * at the pre-sign entry (`started` false), where it stays a collapsed header row
+ * unless it owns the Pre-PegIn step and carries the fee selector (see
+ * GroupBlock). Nothing renders once the flow completes: no group holds the step
+ * past the last one.
  */
 
 import type { StepperItem } from "@babylonlabs-io/core-ui";
 import type { ReactNode } from "react";
 
 import { GroupBlock } from "./GroupBlock";
-import { StepConnector } from "./StepConnector";
-import { buildStepGroups } from "./steps";
+import { buildStepGroups, groupContainsStep } from "./steps";
 
 interface GroupedProgressProps {
   steps: StepperItem[];
@@ -39,35 +40,24 @@ export function GroupedProgress({
   preSignDetail,
 }: GroupedProgressProps) {
   const groups = buildStepGroups(currentStep, started);
+  // Original 1-based group numbers are preserved (after group 1 finishes, the
+  // rendered group still reads "2") to match the design.
+  const index = groups.findIndex((group) =>
+    groupContainsStep(group, currentStep),
+  );
+  const group = groups[index];
 
-  // Completed groups are represented by the steps-completed pill, so hide their
-  // rows. Original 1-based group numbers are preserved (after group 1 finishes,
-  // the active group still reads "2") to match the design.
-  const visibleGroups = groups
-    .map((group, index) => ({ group, number: index + 1 }))
-    .filter(({ group }) => group.status !== "completed");
+  if (!group) return null;
 
   return (
-    <div className="flex flex-col">
-      {visibleGroups.map(({ group, number }, visibleIndex) => {
-        const isLastGroup = visibleIndex === visibleGroups.length - 1;
-
-        return (
-          <div key={group.startStep} className="flex flex-col">
-            <GroupBlock
-              group={group}
-              number={number}
-              steps={steps}
-              currentStep={currentStep}
-              hasError={hasError}
-              activeStepDetail={activeStepDetail}
-              preSignDetail={preSignDetail}
-            />
-
-            {!isLastGroup && <StepConnector />}
-          </div>
-        );
-      })}
-    </div>
+    <GroupBlock
+      group={group}
+      number={index + 1}
+      steps={steps}
+      currentStep={currentStep}
+      hasError={hasError}
+      activeStepDetail={activeStepDetail}
+      preSignDetail={preSignDetail}
+    />
   );
 }

--- a/services/vault/src/components/simple/DepositProgressView/ProviderWaitDetail.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/ProviderWaitDetail.tsx
@@ -1,5 +1,6 @@
 import { Loader, Text } from "@babylonlabs-io/core-ui";
 
+import { DETAIL_PANEL_CLASS } from "@/components/shared/layoutClasses";
 import { COPY } from "@/copy";
 import { DepositFlowStep } from "@/hooks/deposit/depositFlowSteps/types";
 
@@ -40,7 +41,7 @@ export function ProviderWaitDetail({
     : "flex items-center justify-between gap-2";
 
   return (
-    <div className="mt-3 flex flex-col gap-2 rounded-lg border border-secondary-strokeLight bg-primary-contrast p-3">
+    <div className={`mt-3 ${DETAIL_PANEL_CLASS}`}>
       <div className={rowClass}>
         <Text as="span" variant="body2" className="text-accent-secondary">
           {copy.status}:

--- a/services/vault/src/components/simple/DepositProgressView/ProviderWaitDetail.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/ProviderWaitDetail.tsx
@@ -40,7 +40,7 @@ export function ProviderWaitDetail({
     : "flex items-center justify-between gap-2";
 
   return (
-    <div className="mt-3 flex flex-col gap-2 rounded-lg bg-secondary-highlight p-3">
+    <div className="mt-3 flex flex-col gap-2 rounded-lg border border-secondary-strokeLight bg-primary-contrast p-3">
       <div className={rowClass}>
         <Text as="span" variant="body2" className="text-accent-secondary">
           {copy.status}:

--- a/services/vault/src/components/simple/DepositProgressView/SplitGroupedProgress.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/SplitGroupedProgress.tsx
@@ -6,8 +6,11 @@
  * each vault is on its own VP-paced timeline (WOTS submission, payout signing,
  * artifact download, activation) and can diverge by an hour or more. This
  * component renders the shared "Register deposit" group as a single trunk and
- * the remaining groups as one column per vault, reusing the same GroupBlock
- * (filled active-group card + collapsed header rows) as the single-vault stepper.
+ * the remaining groups as one column per vault, reusing the same GroupBlock as
+ * the single-vault stepper. Each region shows one group: the trunk while the
+ * shared step is still inside it, then one per lane — the group holding that
+ * vault's own step, clamped so a queued vault shows its next group and a
+ * finished one its last.
  */
 
 import type { StepperItem } from "@babylonlabs-io/core-ui";
@@ -18,11 +21,12 @@ import { COPY } from "@/copy";
 import { DepositFlowStep } from "@/hooks/deposit/depositFlowSteps/types";
 
 import { GroupBlock } from "./GroupBlock";
-import { StepConnector } from "./StepConnector";
 import {
   buildStepGroups,
   derivePerVaultStep,
   getVisualStep,
+  groupContainsStep,
+  TOTAL_VISUAL_STEPS,
   TRUNK_END_VISUAL_STEP,
 } from "./steps";
 
@@ -66,7 +70,7 @@ interface SplitGroupedProgressProps {
   preSignDetail?: ReactNode;
 }
 
-/** One group list per vault, rendered as the new filled-card / header blocks. */
+/** One vault's lane: its label plus the group holding that vault's own step. */
 function VaultColumn({
   vaultIndex,
   branchGroups,
@@ -85,6 +89,8 @@ function VaultColumn({
   hasError: boolean;
   activeStepDetail?: ReactNode;
 }) {
+  if (branchGroups.length === 0) return null;
+
   return (
     <div className="flex min-w-0 flex-1 flex-col">
       <Text
@@ -95,24 +101,19 @@ function VaultColumn({
         {COPY.deposit.progress.splitVaultColumnLabel(vaultIndex + 1)}
       </Text>
       <div className="flex flex-col">
-        {branchGroups.map(({ group, number }, idx) => {
-          const isLast = idx === branchGroups.length - 1;
-          return (
-            <div key={group.startStep} className="flex flex-col">
-              <GroupBlock
-                group={group}
-                number={number}
-                steps={steps}
-                currentStep={perVaultVisualStep}
-                hasError={hasError}
-                activeStepDetail={activeStepDetail}
-                // Columns are narrow → stack each row's sub-counter.
-                compact
-              />
-              {!isLast && <StepConnector />}
-            </div>
-          );
-        })}
+        {branchGroups.map(({ group, number }) => (
+          <GroupBlock
+            key={group.startStep}
+            group={group}
+            number={number}
+            steps={steps}
+            currentStep={perVaultVisualStep}
+            hasError={hasError}
+            activeStepDetail={activeStepDetail}
+            // Columns are narrow → stack each row's sub-counter.
+            compact
+          />
+        ))}
       </div>
     </div>
   );
@@ -130,31 +131,32 @@ export function SplitGroupedProgress({
   started = true,
   preSignDetail,
 }: SplitGroupedProgressProps) {
-  // Shared trunk groups (Register deposit). Keep original 1-based numbers, hide
-  // completed groups (they fold into the steps-completed pill).
+  // Shared trunk (Register deposit): rendered only while the shared step is
+  // still inside it. Original 1-based numbers are kept so the group reads the
+  // same as in the single-vault stepper.
   const trunkGroups = buildStepGroups(currentStep, started)
     .map((group, index) => ({ group, number: index + 1 }))
     .filter(
       ({ group }) =>
-        group.endStep <= TRUNK_END_VISUAL_STEP && group.status !== "completed",
+        group.endStep <= TRUNK_END_VISUAL_STEP &&
+        groupContainsStep(group, currentStep),
     );
+  const trunkVisible = trunkGroups.length > 0;
 
   return (
     <div className="flex flex-col">
       {trunkGroups.map(({ group, number }) => (
-        <div key={group.startStep} className="flex flex-col">
-          <GroupBlock
-            group={group}
-            number={number}
-            steps={steps}
-            currentStep={currentStep}
-            hasError={hasError}
-            // Trunk is full-width → inline detail (e.g. the pegin-fee notice).
-            activeStepDetail={renderStepDetail?.(rawStep, { stacked: false })}
-            preSignDetail={preSignDetail}
-          />
-          <StepConnector />
-        </div>
+        <GroupBlock
+          key={group.startStep}
+          group={group}
+          number={number}
+          steps={steps}
+          currentStep={currentStep}
+          hasError={hasError}
+          // Trunk is full-width → inline detail (e.g. the pegin-fee notice).
+          activeStepDetail={renderStepDetail?.(rawStep, { stacked: false })}
+          preSignDetail={preSignDetail}
+        />
       ))}
 
       <div className="flex gap-6">
@@ -171,6 +173,15 @@ export function SplitGroupedProgress({
           // panel, e.g. the confirmation-depth counter) reflects a genuinely
           // running remote process, not the action awaiting this click.
           const columnStarted = started || vaultRawStep !== rawStep;
+          // Once the trunk folds away every lane must still show a group: the
+          // flow parks queued vaults on the trunk's last step, and a finished
+          // vault sits past the last one. Status stays the lane's real step.
+          const laneGroupStep = trunkVisible
+            ? perVaultVisualStep
+            : Math.min(
+                Math.max(perVaultVisualStep, TRUNK_END_VISUAL_STEP + 1),
+                TOTAL_VISUAL_STEPS,
+              );
           const branchGroups = buildStepGroups(
             perVaultVisualStep,
             columnStarted,
@@ -179,7 +190,7 @@ export function SplitGroupedProgress({
             .filter(
               ({ group }) =>
                 group.startStep > TRUNK_END_VISUAL_STEP &&
-                group.status !== "completed",
+                groupContainsStep(group, laneGroupStep),
             );
 
           return (

--- a/services/vault/src/components/simple/DepositProgressView/SplitGroupedProgress.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/SplitGroupedProgress.tsx
@@ -159,63 +159,63 @@ export function SplitGroupedProgress({
         />
       ))}
 
-      <div className="flex gap-6">
-        {Array.from({ length: vaultCount }, (_, vaultIndex) => {
-          // Resume path supplies each column's true step; the live flow infers
-          // it from array position. `??` (not `||`) so step 0 isn't dropped.
-          const vaultRawStep =
-            perVaultSteps?.[vaultIndex] ??
-            derivePerVaultStep(rawStep, currentVaultIndex, vaultIndex);
-          const perVaultVisualStep = getVisualStep(vaultRawStep);
-          // The pre-entry gate applies only to columns mirroring the flow's
-          // own un-started step. A sibling lane on a different step is driven
-          // by its own polled state — its expansion (and any live detail
-          // panel, e.g. the confirmation-depth counter) reflects a genuinely
-          // running remote process, not the action awaiting this click.
-          const columnStarted = started || vaultRawStep !== rawStep;
-          // Once the trunk folds away every lane must still show a group: the
-          // flow parks queued vaults on the trunk's last step, and a finished
-          // vault sits past the last one. Status stays the lane's real step.
-          const laneGroupStep = trunkVisible
-            ? perVaultVisualStep
-            : Math.min(
-                Math.max(perVaultVisualStep, TRUNK_END_VISUAL_STEP + 1),
-                TOTAL_VISUAL_STEPS,
-              );
-          const branchGroups = buildStepGroups(
-            perVaultVisualStep,
-            columnStarted,
-          )
-            .map((group, index) => ({ group, number: index + 1 }))
-            .filter(
-              ({ group }) =>
-                group.startStep > TRUNK_END_VISUAL_STEP &&
-                groupContainsStep(group, laneGroupStep),
+      {!trunkVisible && (
+        <div className="flex gap-6">
+          {Array.from({ length: vaultCount }, (_, vaultIndex) => {
+            // Resume path supplies each column's true step; the live flow infers
+            // it from array position. `??` (not `||`) so step 0 isn't dropped.
+            const vaultRawStep =
+              perVaultSteps?.[vaultIndex] ??
+              derivePerVaultStep(rawStep, currentVaultIndex, vaultIndex);
+            const perVaultVisualStep = getVisualStep(vaultRawStep);
+            // The pre-entry gate applies only to columns mirroring the flow's
+            // own un-started step. A sibling lane on a different step is driven
+            // by its own polled state — its expansion (and any live detail
+            // panel, e.g. the confirmation-depth counter) reflects a genuinely
+            // running remote process, not the action awaiting this click.
+            const columnStarted = started || vaultRawStep !== rawStep;
+            // Every lane must still show a group: the flow parks queued vaults on
+            // the trunk's last step, and a finished vault sits past the last one.
+            // Status stays the lane's real step.
+            const laneGroupStep = Math.min(
+              Math.max(perVaultVisualStep, TRUNK_END_VISUAL_STEP + 1),
+              TOTAL_VISUAL_STEPS,
             );
+            const branchGroups = buildStepGroups(
+              perVaultVisualStep,
+              columnStarted,
+            )
+              .map((group, index) => ({ group, number: index + 1 }))
+              .filter(
+                ({ group }) =>
+                  group.startStep > TRUNK_END_VISUAL_STEP &&
+                  groupContainsStep(group, laneGroupStep),
+              );
 
-          return (
-            <VaultColumn
-              key={vaultIndex}
-              vaultIndex={vaultIndex}
-              branchGroups={branchGroups}
-              steps={steps}
-              perVaultVisualStep={perVaultVisualStep}
-              // Only the failing vault's own lane shows the error — gate on the
-              // active vault index, not just the visual step, since two lanes can
-              // sit on the same step while only the current vault was rejected.
-              hasError={
-                hasError &&
-                vaultIndex === currentVaultIndex &&
-                perVaultVisualStep === currentStep
-              }
-              activeStepDetail={renderStepDetail?.(vaultRawStep, {
-                stacked: true,
-                isActiveVault: vaultIndex === currentVaultIndex,
-              })}
-            />
-          );
-        })}
-      </div>
+            return (
+              <VaultColumn
+                key={vaultIndex}
+                vaultIndex={vaultIndex}
+                branchGroups={branchGroups}
+                steps={steps}
+                perVaultVisualStep={perVaultVisualStep}
+                // Only the failing vault's own lane shows the error — gate on the
+                // active vault index, not just the visual step, since two lanes can
+                // sit on the same step while only the current vault was rejected.
+                hasError={
+                  hasError &&
+                  vaultIndex === currentVaultIndex &&
+                  perVaultVisualStep === currentStep
+                }
+                activeStepDetail={renderStepDetail?.(vaultRawStep, {
+                  stacked: true,
+                  isActiveVault: vaultIndex === currentVaultIndex,
+                })}
+              />
+            );
+          })}
+        </div>
+      )}
     </div>
   );
 }

--- a/services/vault/src/components/simple/DepositProgressView/StepConnector.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/StepConnector.tsx
@@ -1,5 +1,0 @@
-export function StepConnector() {
-  return (
-    <div className="ml-[15px] h-6 w-0 border-l-2 border-solid border-secondary-strokeDark" />
-  );
-}

--- a/services/vault/src/components/simple/DepositProgressView/StepRow.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/StepRow.tsx
@@ -11,100 +11,45 @@ function StepCircle({
   state,
   number,
   ariaNumber,
-  inCard = false,
 }: {
   state: StepRowState;
   number: number;
   /** Override for screen-reader label; defaults to `number` (visual) when absent. */
   ariaNumber?: number;
-  /**
-   * Small, bare indicators (no 32px chrome) for sub-steps rendered inside the
-   * active-group card — a 16px check / spinner / ring instead of the numbered
-   * 32px circle used at the group level.
-   */
-  inCard?: boolean;
 }) {
-  // Sub-step indicators inside the active-group card: 16px, no enclosing circle.
-  if (inCard) {
-    if (state === "completed") {
-      return (
-        <IoCheckmarkSharp size={16} className="shrink-0 text-success-bright" />
-      );
-    }
-    if (state === "error") {
-      return (
-        <IoCloseSharp
-          size={16}
-          className="shrink-0 text-error-main"
-          aria-label={COPY.deposit.a11y.stepFailed(ariaNumber ?? number)}
-        />
-      );
-    }
-    if (state === "active") {
-      return (
-        <span
-          className="relative flex h-4 w-4 shrink-0 items-center justify-center"
-          aria-label={COPY.deposit.a11y.stepActive(ariaNumber ?? number)}
-        >
-          {/* Static track ring in stroke/primary; the white arc spins over it. */}
-          <span className="absolute inset-0 rounded-full border border-secondary-strokeDark" />
-          <Loader size={16} className="relative text-accent-primary" />
-        </span>
-      );
-    }
+  // Sub-step indicators inside the active-group card: 16px, no enclosing circle
+  // — a check / cross / spinner / ring instead of a numbered 32px circle.
+  if (state === "completed") {
     return (
-      <span
-        className="block h-4 w-4 shrink-0 rounded-full border border-secondary-strokeDark"
-        aria-label={COPY.deposit.a11y.stepPending(ariaNumber ?? number)}
+      <IoCheckmarkSharp size={16} className="shrink-0 text-success-bright" />
+    );
+  }
+  if (state === "error") {
+    return (
+      <IoCloseSharp
+        size={16}
+        className="shrink-0 text-error-main"
+        aria-label={COPY.deposit.a11y.stepFailed(ariaNumber ?? number)}
       />
     );
   }
-
-  const base = "flex h-8 w-8 shrink-0 items-center justify-center rounded-full";
-
-  if (state === "completed") {
-    return (
-      <div className={twMerge(base, "bg-primary-light")}>
-        <IoCheckmarkSharp size={16} className="text-accent-contrast" />
-      </div>
-    );
-  }
-
-  if (state === "error") {
-    return (
-      <div
-        className={twMerge(base, "bg-error-main")}
-        aria-label={COPY.deposit.a11y.stepFailed(ariaNumber ?? number)}
-      >
-        <IoCloseSharp size={16} className="text-accent-contrast" />
-      </div>
-    );
-  }
-
   if (state === "active") {
     return (
-      <div
-        className={twMerge(base, "border-2 border-secondary-strokeDark")}
+      <span
+        className="relative flex h-4 w-4 shrink-0 items-center justify-center"
         aria-label={COPY.deposit.a11y.stepActive(ariaNumber ?? number)}
       >
-        <Loader size={16} className="text-primary-light" />
-      </div>
+        {/* Static track ring in stroke/primary; the white arc spins over it. */}
+        <span className="absolute inset-0 rounded-full border border-accent-secondary dark:border-secondary-strokeDark" />
+        <Loader size={16} className="relative text-accent-primary" />
+      </span>
     );
   }
-
   return (
-    <div
-      className={twMerge(base, "border-2 border-secondary-strokeDark")}
+    <span
+      className="block h-4 w-4 shrink-0 rounded-full border border-accent-secondary dark:border-secondary-strokeDark"
       aria-label={COPY.deposit.a11y.stepPending(ariaNumber ?? number)}
-    >
-      <Text
-        as="span"
-        variant="body2"
-        className="font-medium text-accent-secondary"
-      >
-        {number}
-      </Text>
-    </div>
+    />
   );
 }
 
@@ -116,8 +61,6 @@ interface StepRowProps {
   description?: string;
   /** Detail panel rendered below the label; rendered only on the active step. */
   detail?: ReactNode;
-  /** True when another sub-step follows in the group (i.e. not the last). */
-  hasNext?: boolean;
   /** Override for screen-reader label; defaults to `number` (visual) when absent. */
   ariaNumber?: number;
   /**
@@ -125,12 +68,6 @@ interface StepRowProps {
    * the narrow split-deposit columns, where "label (x of n)" doesn't fit.
    */
   compact?: boolean;
-  /**
-   * When true, render without the left timeline column — just circle + label +
-   * detail, left-aligned. Used inside the active-group card in
-   * {@link GroupedProgress}.
-   */
-  inCard?: boolean;
 }
 
 export function StepRow({
@@ -139,20 +76,14 @@ export function StepRow({
   label,
   description,
   detail,
-  hasNext = false,
   ariaNumber,
   compact = false,
-  inCard = false,
 }: StepRowProps) {
   const isActive = state === "active";
   const hasDetail = isActive && Boolean(detail);
   // A detail panel makes the active row taller than the circle. When there's
   // no detail panel, align the circle and label vertically (items-center)
-  // to match the non-active step alignment. Fill the extra height from a
-  // detail panel with a connector segment so the timeline stays unbroken
-  // — but never dangle a line below the group's last step.
-  const showTrailingLine = !inCard && hasDetail && hasNext;
-
+  // to match the non-active step alignment.
   return (
     <div
       className={twMerge(
@@ -160,21 +91,7 @@ export function StepRow({
         hasDetail ? "items-start" : "items-center",
       )}
     >
-      {inCard ? (
-        <StepCircle
-          state={state}
-          number={number}
-          ariaNumber={ariaNumber}
-          inCard
-        />
-      ) : (
-        <div className="flex w-8 flex-col items-center self-stretch">
-          <StepCircle state={state} number={number} ariaNumber={ariaNumber} />
-          {showTrailingLine && (
-            <div className="w-0 flex-1 border-l-2 border-secondary-strokeDark" />
-          )}
-        </div>
-      )}
+      <StepCircle state={state} number={number} ariaNumber={ariaNumber} />
       <div className="flex flex-1 flex-col">
         <div
           className={

--- a/services/vault/src/components/simple/DepositProgressView/StepRow.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/StepRow.tsx
@@ -84,7 +84,7 @@ function StepCircle({
   if (state === "active") {
     return (
       <div
-        className={twMerge(base, "border-2 border-primary-light")}
+        className={twMerge(base, "border-2 border-secondary-strokeDark")}
         aria-label={COPY.deposit.a11y.stepActive(ariaNumber ?? number)}
       >
         <Loader size={16} className="text-primary-light" />
@@ -189,9 +189,11 @@ export function StepRow({
             as="span"
             variant="body2"
             className={
-              isActive
-                ? "font-medium text-accent-primary"
-                : "text-accent-secondary"
+              state === "error"
+                ? "font-medium text-error-main"
+                : isActive
+                  ? "font-medium text-accent-primary"
+                  : "text-accent-secondary"
             }
           >
             {label}

--- a/services/vault/src/components/simple/DepositProgressView/__tests__/DepositCardShell.test.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/__tests__/DepositCardShell.test.tsx
@@ -94,7 +94,7 @@ describe("DepositCardShell", () => {
     expect(screen.getByTestId("footer")).toBeTruthy();
   });
 
-  it("omits the progress bar and footnote when not provided (summary state)", () => {
+  it("omits the progress bar when not provided (summary state)", () => {
     render(
       <DepositCardShell footer={<button type="button">cta</button>}>
         <div>body</div>
@@ -102,21 +102,18 @@ describe("DepositCardShell", () => {
     );
 
     expect(screen.queryByTestId("progress-bar")).toBeNull();
-    expect(screen.queryByTestId("footnote")).toBeNull();
   });
 
-  it("renders the progress bar and footnote when provided (in-flight state)", () => {
+  it("renders the progress bar when provided (in-flight state)", () => {
     render(
       <DepositCardShell
         footer={<button type="button">cta</button>}
         progressBar={<div data-testid="progress-bar" />}
-        footnote={<div data-testid="footnote" />}
       >
         <div>body</div>
       </DepositCardShell>,
     );
 
     expect(screen.getByTestId("progress-bar")).toBeTruthy();
-    expect(screen.getByTestId("footnote")).toBeTruthy();
   });
 });

--- a/services/vault/src/components/simple/DepositProgressView/__tests__/DepositProgressView.test.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/__tests__/DepositProgressView.test.tsx
@@ -58,7 +58,7 @@ const baseProps = {
 
 describe("DepositProgressView", () => {
   describe("grouped sections", () => {
-    it("always renders the four group headers", () => {
+    it("renders only the group holding the current step", () => {
       render(
         <DepositProgressView
           {...baseProps}
@@ -70,14 +70,14 @@ describe("DepositProgressView", () => {
         screen.getByText(COPY.deposit.groups.registerDeposit),
       ).toBeInTheDocument();
       expect(
-        screen.getByText(COPY.deposit.groups.signWots),
-      ).toBeInTheDocument();
+        screen.queryByText(COPY.deposit.groups.signWots),
+      ).not.toBeInTheDocument();
       expect(
-        screen.getByText(COPY.deposit.groups.signPayout),
-      ).toBeInTheDocument();
+        screen.queryByText(COPY.deposit.groups.signPayout),
+      ).not.toBeInTheDocument();
       expect(
-        screen.getByText(COPY.deposit.groups.activateVault),
-      ).toBeInTheDocument();
+        screen.queryByText(COPY.deposit.groups.activateVault),
+      ).not.toBeInTheDocument();
     });
 
     it("expands only the section containing the current step", () => {
@@ -220,8 +220,8 @@ describe("DepositProgressView", () => {
 
     it("keeps the step-1 entry fully collapsed with no progress affordances", () => {
       // DepositSignContent's entry state: nothing is completed, so the
-      // pre-entry render must look exactly as it always has — four collapsed
-      // group headers, no bar, no pill, no expanded sub-steps.
+      // pre-entry render shows the current group's collapsed header alone —
+      // no bar, no pill, no expanded sub-steps.
       render(
         <DepositProgressView
           {...baseProps}
@@ -240,11 +240,11 @@ describe("DepositProgressView", () => {
       expect(screen.queryByRole("progressbar")).not.toBeInTheDocument();
       expect(screen.queryByText(/steps completed/)).not.toBeInTheDocument();
 
-      // All four groups read not-started — including the first, whose flow
-      // position is "current" but whose work has not begun.
+      // The one rendered group reads not-started — its flow position is
+      // "current" but its work has not begun.
       expect(
         screen.getAllByLabelText(COPY.deposit.a11y.groupStatus.upcoming),
-      ).toHaveLength(4);
+      ).toHaveLength(1);
     });
 
     it("renders the fee selector under the Pre-PegIn step inside the Register deposit card", () => {

--- a/services/vault/src/components/simple/DepositProgressView/__tests__/GroupedProgress.test.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/__tests__/GroupedProgress.test.tsx
@@ -9,19 +9,23 @@ import { buildStepItems } from "../steps";
 const steps = buildStepItems(null);
 
 describe("GroupedProgress", () => {
-  it("renders all four group headers before any group completes", () => {
+  it("renders only the group holding the current step", () => {
     render(<GroupedProgress steps={steps} currentStep={1} />);
 
     expect(
       screen.getByText(COPY.deposit.groups.registerDeposit),
     ).toBeInTheDocument();
-    expect(screen.getByText(COPY.deposit.groups.signWots)).toBeInTheDocument();
+
+    // Every later group is hidden until its own turn.
     expect(
-      screen.getByText(COPY.deposit.groups.signPayout),
-    ).toBeInTheDocument();
+      screen.queryByText(COPY.deposit.groups.signWots),
+    ).not.toBeInTheDocument();
     expect(
-      screen.getByText(COPY.deposit.groups.activateVault),
-    ).toBeInTheDocument();
+      screen.queryByText(COPY.deposit.groups.signPayout),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(COPY.deposit.groups.activateVault),
+    ).not.toBeInTheDocument();
   });
 
   it("expands only the active group and hides other groups' sub-steps", () => {
@@ -38,9 +42,12 @@ describe("GroupedProgress", () => {
       screen.queryByText(COPY.deposit.steps.generateSecret),
     ).not.toBeInTheDocument();
 
-    // An upcoming group's sub-step (Sign payouts) stays collapsed.
+    // An upcoming group is not rendered at all — neither header nor sub-step.
     expect(
       screen.queryByText(COPY.deposit.steps.signPayouts),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(COPY.deposit.groups.signPayout),
     ).not.toBeInTheDocument();
   });
 
@@ -58,19 +65,21 @@ describe("GroupedProgress", () => {
     ).toBeInTheDocument();
   });
 
-  it("renders completed sub-steps without a step number inside the active group", () => {
+  it("renders the active group's sub-steps by state, not by number", () => {
     // Step 11 -> "Sign payout" group (9-12) active; steps 9-10 are already done.
     render(<GroupedProgress steps={steps} currentStep={11} />);
 
-    // Completed sub-step label is shown...
+    // Completed sub-step label is shown as a checkmark row, not a numbered one.
     expect(
       screen.getByText(COPY.deposit.steps.authenticateSession),
     ).toBeInTheDocument();
-    // ...but rendered as a checkmark row, not the numbered pending row "1".
     expect(screen.queryByText("1")).not.toBeInTheDocument();
 
-    // The remaining pending sub-step carries its per-group number (4 within the group).
-    expect(screen.getByText("4")).toBeInTheDocument();
+    // The remaining sub-step reads pending; only the group circle is numbered.
+    expect(
+      screen.getByLabelText(COPY.deposit.a11y.stepPending(12)),
+    ).toBeInTheDocument();
+    expect(screen.getByText("3")).toBeInTheDocument();
   });
 
   it("mounts the active-step detail panel inside the active step", () => {
@@ -103,6 +112,53 @@ describe("GroupedProgress", () => {
     ).not.toBeInTheDocument();
   });
 
+  describe("pre-sign entry (started=false)", () => {
+    it("renders the Pre-PegIn group with its fee selector", () => {
+      render(
+        <GroupedProgress
+          steps={steps}
+          currentStep={1}
+          started={false}
+          preSignDetail={<div data-testid="pre-sign-detail" />}
+        />,
+      );
+
+      expect(
+        screen.getByText(COPY.deposit.groups.registerDeposit),
+      ).toBeInTheDocument();
+      expect(screen.getByTestId("pre-sign-detail")).toBeInTheDocument();
+      expect(
+        screen.queryByText(COPY.deposit.groups.signWots),
+      ).not.toBeInTheDocument();
+    });
+
+    it("renders the current group's header when re-entering un-started mid-flow", () => {
+      // WOTS re-offer: no group is `active` (nothing has started), so the
+      // rendered group is the one holding the current step — and the finished
+      // Register-deposit group must not come back with it.
+      render(<GroupedProgress steps={steps} currentStep={7} started={false} />);
+
+      expect(
+        screen.getByText(COPY.deposit.groups.signWots),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByText(COPY.deposit.groups.registerDeposit),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it("marks the group title as failed when the current step errors", () => {
+    render(<GroupedProgress steps={steps} currentStep={8} hasError />);
+
+    expect(screen.getByText(COPY.deposit.groups.signWots).className).toContain(
+      "text-error-main",
+    );
+    // The failed sub-step label turns red too.
+    expect(
+      screen.getByText(COPY.deposit.steps.awaitPayoutTransactions).className,
+    ).toContain("text-error-main");
+  });
+
   describe("accessibility", () => {
     it("labels the active sub-step for screen readers with the global step number", () => {
       // Step 8 -> "Set up claim" group active; screen reader gets global step 8,
@@ -124,20 +180,20 @@ describe("GroupedProgress", () => {
       ).toBeInTheDocument();
     });
 
-    it("exposes visible groups' status to screen readers (completed groups are hidden)", () => {
+    it("exposes only the rendered group's status to screen readers", () => {
       render(<GroupedProgress steps={steps} currentStep={8} />);
 
       // Register deposit is done and therefore hidden — no completed indicator.
       expect(
         screen.queryByLabelText(COPY.deposit.a11y.groupStatus.completed),
       ).not.toBeInTheDocument();
-      // Set up claim is active; Sign payout and Activate vault are upcoming.
+      // Set up claim is the only group left in the tree, and it is active.
       expect(
         screen.getByLabelText(COPY.deposit.a11y.groupStatus.active),
       ).toBeInTheDocument();
       expect(
-        screen.getAllByLabelText(COPY.deposit.a11y.groupStatus.upcoming),
-      ).toHaveLength(2);
+        screen.queryByLabelText(COPY.deposit.a11y.groupStatus.upcoming),
+      ).not.toBeInTheDocument();
     });
   });
 });

--- a/services/vault/src/components/simple/DepositProgressView/__tests__/GroupedProgress.test.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/__tests__/GroupedProgress.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, within } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
 import { COPY } from "@/copy";
@@ -147,16 +147,37 @@ describe("GroupedProgress", () => {
     });
   });
 
-  it("marks the group title as failed when the current step errors", () => {
+  it("marks the group and its failing sub-step as failed when the current step errors", () => {
     render(<GroupedProgress steps={steps} currentStep={8} hasError />);
 
-    expect(screen.getByText(COPY.deposit.groups.signWots).className).toContain(
-      "text-error-main",
+    const failed = screen.getAllByLabelText(
+      COPY.deposit.a11y.groupStatus.failed,
     );
-    // The failed sub-step label turns red too.
+    expect(failed).toHaveLength(1);
+
+    const header = failed[0].parentElement as HTMLElement;
     expect(
-      screen.getByText(COPY.deposit.steps.awaitPayoutTransactions).className,
-    ).toContain("text-error-main");
+      within(header).getByText(COPY.deposit.groups.signWots),
+    ).toBeInTheDocument();
+
+    for (const status of ["active", "completed", "upcoming"] as const) {
+      expect(
+        screen.queryByLabelText(COPY.deposit.a11y.groupStatus[status]),
+      ).not.toBeInTheDocument();
+    }
+
+    // The failing sub-step announces itself too.
+    expect(
+      screen.getByLabelText(COPY.deposit.a11y.stepFailed(8)),
+    ).toBeInTheDocument();
+  });
+
+  it("swaps the group number for the close glyph on a failed header", () => {
+    render(<GroupedProgress steps={steps} currentStep={8} hasError />);
+
+    const circle = screen.getByLabelText(COPY.deposit.a11y.groupStatus.failed);
+    expect(within(circle).queryByText("2")).not.toBeInTheDocument();
+    expect(circle.querySelector("svg")).toBeInTheDocument();
   });
 
   describe("accessibility", () => {

--- a/services/vault/src/components/simple/DepositProgressView/__tests__/SplitGroupedProgress.test.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/__tests__/SplitGroupedProgress.test.tsx
@@ -46,7 +46,7 @@ describe("SplitGroupedProgress", () => {
     expect(trunkHeaders).toHaveLength(1);
   });
 
-  it("renders each post-trunk group once per vault column", () => {
+  it("renders each lane's own current group once per vault column", () => {
     render(
       <SplitGroupedProgress
         steps={steps}
@@ -57,11 +57,108 @@ describe("SplitGroupedProgress", () => {
       />,
     );
 
+    // Both lanes sit on the WOTS step → one card each, and nothing later.
     expect(screen.getAllByText(COPY.deposit.groups.signWots)).toHaveLength(2);
-    expect(screen.getAllByText(COPY.deposit.groups.signPayout)).toHaveLength(2);
-    expect(screen.getAllByText(COPY.deposit.groups.activateVault)).toHaveLength(
-      2,
+    expect(
+      screen.queryByText(COPY.deposit.groups.signPayout),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(COPY.deposit.groups.activateVault),
+    ).not.toBeInTheDocument();
+  });
+
+  it("keeps a queued vault visible once the trunk folds away", () => {
+    // The flow parks every lane on AWAIT_BTC_CONFIRMATION, then advances only
+    // the vault it is processing. The queued lane is still on the trunk's last
+    // step, but the trunk has folded into the pill — its column must show its
+    // next group rather than vanish.
+    render(
+      <SplitGroupedProgress
+        steps={steps}
+        currentStep={getVisualStep(DepositFlowStep.SUBMIT_WOTS_KEYS)}
+        vaultCount={2}
+        currentVaultIndex={0}
+        rawStep={DepositFlowStep.SUBMIT_WOTS_KEYS}
+        perVaultSteps={[
+          DepositFlowStep.SUBMIT_WOTS_KEYS,
+          DepositFlowStep.AWAIT_BTC_CONFIRMATION,
+        ]}
+      />,
     );
+
+    expect(
+      screen.getByText(COPY.deposit.progress.splitVaultColumnLabel(2)),
+    ).toBeInTheDocument();
+    // Both lanes show the "Set up claim" group: the active one expanded, the
+    // queued one as a not-started header with nothing done inside it.
+    expect(screen.getAllByText(COPY.deposit.groups.signWots)).toHaveLength(2);
+    expect(
+      screen.getByLabelText(COPY.deposit.a11y.groupStatus.upcoming),
+    ).toBeInTheDocument();
+  });
+
+  it("keeps a finished vault visible while a sibling still runs", () => {
+    render(
+      <SplitGroupedProgress
+        steps={steps}
+        currentStep={getVisualStep(DepositFlowStep.SIGN_PAYOUTS)}
+        vaultCount={2}
+        currentVaultIndex={1}
+        rawStep={DepositFlowStep.SIGN_PAYOUTS}
+        perVaultSteps={[
+          DepositFlowStep.COMPLETED,
+          DepositFlowStep.SIGN_PAYOUTS,
+        ]}
+      />,
+    );
+
+    // The finished lane keeps its last group, marked completed.
+    expect(
+      screen.getByText(COPY.deposit.groups.activateVault),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByLabelText(COPY.deposit.a11y.groupStatus.completed),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(COPY.deposit.progress.splitVaultColumnLabel(1)),
+    ).toBeInTheDocument();
+  });
+
+  it("renders no vault columns while the shared trunk is still running", () => {
+    render(
+      <SplitGroupedProgress
+        steps={steps}
+        currentStep={getVisualStep(DepositFlowStep.SIGN_PEGIN_BTC)}
+        vaultCount={2}
+        currentVaultIndex={null}
+        rawStep={DepositFlowStep.SIGN_PEGIN_BTC}
+      />,
+    );
+
+    // Every lane is still on the shared Register-deposit group, so the columns
+    // (labels included) stay out of the tree until the lanes diverge.
+    expect(
+      screen.queryByText(COPY.deposit.progress.splitVaultColumnLabel(1)),
+    ).not.toBeInTheDocument();
+  });
+
+  it("keeps the trunk's Pre-PegIn fee selector on the un-started entry", () => {
+    render(
+      <SplitGroupedProgress
+        steps={steps}
+        currentStep={getVisualStep(DepositFlowStep.DERIVE_VAULT_SECRET)}
+        vaultCount={2}
+        currentVaultIndex={null}
+        rawStep={DepositFlowStep.DERIVE_VAULT_SECRET}
+        started={false}
+        preSignDetail={<div data-testid="pre-sign-detail" />}
+      />,
+    );
+
+    expect(screen.getAllByTestId("pre-sign-detail")).toHaveLength(1);
+    expect(
+      screen.getByText(COPY.deposit.groups.registerDeposit),
+    ).toBeInTheDocument();
   });
 
   it("expands each column at its own active step when the vaults diverge", () => {

--- a/services/vault/src/components/simple/DepositProgressView/__tests__/SplitGroupedProgress.test.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/__tests__/SplitGroupedProgress.test.tsx
@@ -142,6 +142,32 @@ describe("SplitGroupedProgress", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("holds the columns back while the trunk runs, even for a lane past the end", () => {
+    render(
+      <SplitGroupedProgress
+        steps={steps}
+        currentStep={getVisualStep(DepositFlowStep.SIGN_PEGIN_BTC)}
+        vaultCount={2}
+        currentVaultIndex={null}
+        rawStep={DepositFlowStep.SIGN_PEGIN_BTC}
+        perVaultSteps={[
+          DepositFlowStep.COMPLETED,
+          DepositFlowStep.SIGN_PEGIN_BTC,
+        ]}
+      />,
+    );
+
+    expect(
+      screen.getByText(COPY.deposit.groups.registerDeposit),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(COPY.deposit.progress.splitVaultColumnLabel(1)),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(COPY.deposit.groups.activateVault),
+    ).not.toBeInTheDocument();
+  });
+
   it("keeps the trunk's Pre-PegIn fee selector on the un-started entry", () => {
     render(
       <SplitGroupedProgress

--- a/services/vault/src/components/simple/DepositProgressView/__tests__/StepRow.test.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/__tests__/StepRow.test.tsx
@@ -26,3 +26,21 @@ describe("StepRow — sub-counter layout", () => {
     expect(wrapper?.className).not.toContain("flex-col");
   });
 });
+
+describe("StepRow — failed step", () => {
+  it("renders the label in the error colour when the step failed", () => {
+    render(<StepRow state="error" number={1} label="Submit WOTS key" />);
+
+    const label = screen.getByText("Submit WOTS key");
+    expect(label.className).toContain("text-error-main");
+    expect(label.className).not.toContain("text-accent-secondary");
+  });
+
+  it("keeps the label muted while the step is still pending", () => {
+    render(<StepRow state="pending" number={1} label="Submit WOTS key" />);
+
+    expect(screen.getByText("Submit WOTS key").className).toContain(
+      "text-accent-secondary",
+    );
+  });
+});

--- a/services/vault/src/components/simple/DepositProgressView/__tests__/StepRow.test.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/__tests__/StepRow.test.tsx
@@ -1,6 +1,8 @@
 import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
+import { COPY } from "@/copy";
+
 import { StepRow } from "../StepRow";
 
 describe("StepRow — sub-counter layout", () => {
@@ -28,12 +30,22 @@ describe("StepRow — sub-counter layout", () => {
 });
 
 describe("StepRow — failed step", () => {
-  it("renders the label in the error colour when the step failed", () => {
-    render(<StepRow state="error" number={1} label="Submit WOTS key" />);
+  it("announces the failure to screen readers, not by colour alone", () => {
+    render(
+      <StepRow
+        state="error"
+        number={1}
+        ariaNumber={8}
+        label="Submit WOTS key"
+      />,
+    );
 
-    const label = screen.getByText("Submit WOTS key");
-    expect(label.className).toContain("text-error-main");
-    expect(label.className).not.toContain("text-accent-secondary");
+    expect(
+      screen.getByLabelText(COPY.deposit.a11y.stepFailed(8)),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByLabelText(COPY.deposit.a11y.stepActive(8)),
+    ).not.toBeInTheDocument();
   });
 
   it("keeps the label muted while the step is still pending", () => {

--- a/services/vault/src/components/simple/DepositProgressView/steps.ts
+++ b/services/vault/src/components/simple/DepositProgressView/steps.ts
@@ -98,8 +98,8 @@ export const TOTAL_VISUAL_STEPS = buildStepItems(null).length;
 /**
  * Logical groupings of the deposit flow. Each group covers a contiguous,
  * inclusive range of 1-based visual step numbers (the same numbering produced
- * by {@link getVisualStep}). The grouped progress UI expands only the group
- * containing the current step and collapses the rest.
+ * by {@link getVisualStep}). The grouped progress UI renders only the group
+ * containing the current step and hides the rest.
  */
 export interface StepGroup {
   title: string;
@@ -124,6 +124,14 @@ export const STEP_GROUPS: StepGroup[] = [
  * in the multi-vault stepper.
  */
 export const TRUNK_END_VISUAL_STEP = 6;
+
+/** True when the group's inclusive step range covers `currentStep`. */
+export function groupContainsStep(
+  group: StepGroup,
+  currentStep: number,
+): boolean {
+  return currentStep >= group.startStep && currentStep <= group.endStep;
+}
 
 /**
  * Returns the per-vault current step for a single vault in a split deposit.

--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -397,6 +397,7 @@ export const COPY = {
         completed: "Completed",
         active: "In progress",
         upcoming: "Not started",
+        failed: "Failed",
       },
     },
     progress: {
@@ -412,8 +413,6 @@ export const COPY = {
       stepsCompleted: (completed: number, total: number) =>
         `${completed} of ${total} steps completed`,
       defaultSuccessMessage: PRE_PEGIN_BROADCAST_CONFIRMATION_MESSAGE,
-      doNotSpendWarning:
-        "Do not spend the BTC used for this deposit until the transactions are confirmed.",
       splitVaultColumnLabel: (vaultNumber: number) => `BTCVault ${vaultNumber}`,
       buttons: {
         closeContinueLater: "Close & continue later",


### PR DESCRIPTION
## Summary

Polish pass on the Deposit Progress modal: the numbered step circles get a neutral stroke, the footer caption goes away, detail panels sit on their own surface, only the group the flow is actually in stays on screen, and a failed step now reads red end to end.

## Changes

**1. Step-number circles use the stroke token, not the text colour**

`GroupHeader`'s `GroupIndicator` drew its ring in `accent-primary`, which the vault re-points to `#ffffff` in dark mode; `StepRow`'s active 32px circle drew its ring in `primary-light`, the `#387085` teal. Neither is a stroke colour. Both now use `border-secondary-strokeDark`.

The issue notes there is no `#5A5A5A` token — there is: core-ui's dark `secondary.strokeDark` is exactly `#5A5A5A`. Only the light value is re-pointed in the vault (`services/vault/src/globals.css`, to `#cccccc`), so no new token was needed.

**2. Footer caption removed**

`DepositCardShell` loses its `footnote` prop, its rendering and the copy string behind it (`COPY.deposit.progress.doNotSpendWarning`).

The issue quotes the caption as "To ensure a seamless deposit…", but the string shipped in this modal is "Do not spend the BTC used for this deposit until the transactions are confirmed." — same element, different wording. The similarly named `COPY.deposit.refundSuccess.doNotSpendWarning(symbol)` is untouched; `RefundSuccessContent` still uses it.

**3. Detail panels get their own surface**

`BtcConfirmationDetail`, `EthConfirmationDetail`, `ProviderWaitDetail` and `FeeRateSelector` all painted `bg-secondary-highlight` — the exact fill of the `GroupBlock` card that encloses them, so every panel read flat. They now share `rounded-lg border border-secondary-strokeLight bg-primary-contrast p-3`: `#F5F7F2` on the card's `#F9F9F9` in light (separation comes mostly from the `#dddddd` border there), `#191919` on `#252525` in dark. Copy inside the panels is unchanged.

Background token chosen from the existing palette; the Figma page was not reachable, so this is pending a design check.

**4. Only the current group renders**

The stepper previously hid completed groups (they fold into the "X of N steps completed" pill, which stays) and rendered every later group as a collapsed header row. Now only the group holding the current step renders — in `GroupedProgress` and in each lane of `SplitGroupedProgress`.

Split lanes need one extra rule, because the flow parks every vault on `AWAIT_BTC_CONFIRMATION` and then advances only the vault it is processing (`useDepositFlow.ts`). A queued lane therefore sits on the trunk's last step after the trunk has already folded into the pill, and taking the rule literally would erase that vault's whole column. Once the trunk is no longer rendered, each lane's group lookup is clamped into the branch range: a queued vault shows its next group as a not-started header, a finished vault keeps its last group marked complete. Group status and sub-step state still come from the lane's real step, so nothing is misreported. While the trunk is on screen the columns stay hidden — every lane is in the state the trunk card already shows.

The rule is "the group whose inclusive step range covers the current step" (new `groupContainsStep` in `steps.ts`), not "the group whose status is active". The two differ on the pre-sign entry: with `started` false `buildStepGroups` deliberately marks the current group `upcoming`, so an active-only rule would render nothing at all on a WOTS re-offer, and a rule keyed on the Pre-PegIn step would resurrect the finished Register-deposit group. The range rule handles the fee-selector entry, the mid-flow re-offer and completion (nothing renders) with one predicate.

With a single block on screen, `StepConnector` is unreachable and is deleted.

**5. A failed step reads red**

Only the 16px close icon was red before. Now `StepRow` renders an errored step's label in `font-medium text-error-main`, and `GroupHeader` takes a `hasError` prop that turns the group title and the numbered circle red. `GroupBlock` passes `hasError && group.status === "active"`, so an un-started group never inherits a failure.

Colour alone is not an accessible failure signal, so the group indicator also swaps its `aria-label` from "In progress" to a new `COPY.deposit.a11y.groupStatus.failed`. The per-step labels are unchanged.

Worth a design decision before merge: `error-main` is `#D32F2F`, which measures 4.73:1 against the light group card `#F9F9F9` (passes) but 3.08:1 against the dark `#252525` — below the 4.5:1 WCAG AA floor for 14px text. The palette has no compliant red (`error-light` `#EF5350` reaches only 4.40:1 on dark), so this uses the token the design asked for rather than inventing one.

## Tests

- `GroupedProgress.test.tsx` — upcoming groups are no longer rendered, the current one is; pre-sign entry still opens the Pre-PegIn group with its fee selector; the un-started mid-flow re-offer renders its own group and not the finished one; error styling on the group title and sub-step label.
- `SplitGroupedProgress.test.tsx` — each lane renders only its own current group; a queued vault stays visible once the trunk folds away; a finished vault stays visible while a sibling runs; no columns while the shared trunk runs; the trunk keeps the single fee selector on the un-started entry.
- `StepRow.test.tsx` — errored label colour, pending label stays muted.
- `DepositCardShell.test.tsx` / `DepositProgressView.test.tsx` — footnote assertions removed, group-header expectations updated.

211 tests pass across `DepositProgressView`, `DepositSignContent` and `ResumeDepositContent`; lint and `tsc --noEmit` are clean.

Closes #2344
