### PR TITLE
fix(e2e): raise the peg-in step-machine budget to 3.5h

### DIFF
--- a/services/vault/e2e/real/timing.ts
+++ b/services/vault/e2e/real/timing.ts
@@ -64,8 +64,16 @@ export const SPLIT_ALLOCATION_TIMEOUT_MS = 30_000;
  * dwells with no UI transition), Pre-PegIn inclusion (~10 min/block), the WOTS-key gate (~20 min),
  * and the payout gate (~3 min) — so a real peg-in runs 30 min–2 hr. Budgeted generously; the action
  * imposes NO short per-step timeout, which is what lets those dwells pass without a special case.
+ *
+ * Raised from 2.5 h after a testnet run exhausted it while the deposit was still healthy. The gate
+ * that overran was Pre-PegIn inclusion: signet targets 10 min/block but, unlike mainnet, does not
+ * hold that average, and the run took 2 h 13 min to collect 10 of the 11 blocks it needed — roughly
+ * 13 min/block. Only ~30% slower than the estimate above, and that was enough, because the budget
+ * covers the whole machine rather than allowing per-gate: time spent in the early steps is time the
+ * confirmation wait no longer has. 3.5 h absorbs that without masking a real hang, since a genuinely
+ * failing transaction aborts on PEGIN_TX_FAILURE_RETRY_LIMIT long before this deadline.
  */
-export const PEGIN_STEP_MACHINE_BUDGET_MS = 2.5 * 60 * 60 * 1_000;
+export const PEGIN_STEP_MACHINE_BUDGET_MS = 3.5 * 60 * 60 * 1_000;
 /** How often to poll the progress UI (advance the step log, handle the Activate/Skip dapp gates). */
 export const PEGIN_POLL_INTERVAL_MS = 3_000;
 /**


### PR DESCRIPTION
## What this changes

The real-wallet E2E gives a peg-in run 2.5 hours to get from the deposit form to an activated vault. This raises that to 3.5 hours.

## Why

A real testnet run hit the limit while the deposit was completely healthy, so the harness reported a failure that was not one.

The run took 2 h 33 m and stopped at "Set up claim", waiting for the Pre-PegIn to reach the required confirmation depth. The Bitcoin side was fine — the transaction had confirmed and was accumulating blocks normally. It simply needed 11 blocks and had 10 when the budget expired. One block short.

The assumption that broke is in the budget's own comment: `Pre-PegIn inclusion (~10 min/block)`. Signet *targets* ten minutes but, unlike mainnet, has no difficulty adjustment holding it there, and blocks arrive in clumps. This run averaged about 13 minutes per block. Only ~30% slower than assumed, and that was enough.

It was enough because the budget covers the **whole** step machine with no per-gate allowance. Time spent in the early signing steps is time the confirmation wait no longer has, so a slow patch anywhere eats the margin everywhere.

Resuming the same deposit afterwards completed normally in 1 h 15 m, which confirms nothing was actually wrong with it.

## Approaches considered

**1. Raise the overall budget (chosen).** One constant, no new logic.

**2. Give each on-chain gate its own allowance.** More precise, and it would stop a slow early step from starving the confirmation wait. Rejected as too much machinery for the evidence we have: it means teaching the harness which step maps to which gate, which is exactly the per-step coupling the current design deliberately avoids. The comment on the budget is explicit that the action "imposes NO short per-step timeout, which is what lets those dwells pass without a special case."

**3. Extend the deadline while blocks are still arriving.** The most correct option — it distinguishes "waiting on a slow chain" from "hung", which a fixed budget cannot. Rejected for now because it needs block-height polling inside the step machine, and one data point is not enough to justify that. Worth revisiting if this recurs.

**4. Leave it and re-run on failure.** Rejected. The failure looks identical to a real one, so every occurrence costs someone an investigation to reach "the chain was slow".

## Why 3.5 hours

It absorbs the observed overrun with room to spare, and it does not weaken the harness's ability to catch a genuine problem. A transaction that actually fails aborts on `PEGIN_TX_FAILURE_RETRY_LIMIT` after three retries, long before this deadline is reached — the budget is the backstop for *dwelling*, not for failing.

## What is in the diff

One constant, and the reasoning recorded alongside it so the next person changing it knows what evidence it rests on.

`RESUME_ACTIONABLE_TIMEOUT_MS` is derived from the same constant, so the resume action's wait-for-vault-provider window widens with it. That is wanted: it is the same class of wait.

## How this was verified

The change came out of an actual run rather than a hypothetical. The failing run and the successful resume are both reproducible against testnet with the real-wallet CLI, and the resume drove the deposit through to an activated vault — the on-chain vault count rose by one, which is the harness's own success assertion.

## Known, not fixed here

The budget comment lists the on-chain gates a run waits on: the Ethereum finality gate, Pre-PegIn inclusion, the WOTS-key gate and the payout gate. That list is now incomplete — it predates the activation delay added in [vault-contracts-aave-v4#534](https://github.com/babylonlabs-io/vault-contracts-aave-v4/pull/534), which holds activation until `verifiedAt + peginActivationDelay`. On testnet that parameter is 50 blocks, roughly 10 minutes per run, and it is unaccounted for in the estimate the budget was sized against.

Left out to keep this change to one thing. It is a comment-only fix and can follow.
