### PR TITLE
feat(ts-sdk): peg-in config fingerprint encoder

### DIFF
--- a/packages/babylon-ts-sdk/docs/api/README.md
+++ b/packages/babylon-ts-sdk/docs/api/README.md
@@ -33,6 +33,7 @@
 - [clients](clients.md)
 - [deposit-terms](deposit-terms.md)
 - [managers](managers.md)
+- [pegin-fingerprint](pegin-fingerprint.md)
 - [primitives](primitives.md)
 - [services](services.md)
 - [utils](utils.md)

--- a/packages/babylon-ts-sdk/docs/api/pegin-fingerprint.md
+++ b/packages/babylon-ts-sdk/docs/api/pegin-fingerprint.md
@@ -1,0 +1,273 @@
+[@babylonlabs-io/ts-sdk](README.md) / pegin-fingerprint
+
+# pegin-fingerprint
+
+Peg-in configuration fingerprint: the `keccak256(abi.encode(...))` commitment
+over the protocol state a Pre-PegIn transaction was built against, sent with
+the peg-in registration so the registry can reject a request whose protocol
+state moved between the build and inclusion.
+
+Reproduces `PeginLogic._peginFingerprint` from the vault contracts exactly;
+see [computePeginFingerprint](#computepeginfingerprint) for the encoding rules that matter.
+
+## Classes
+
+### PeginFingerprintInputError
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/pegin-fingerprint/peginFingerprint.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/pegin-fingerprint/peginFingerprint.ts)
+
+An input field is missing, malformed, or outside the width the contract declares for it.
+
+#### Extends
+
+- `Error`
+
+#### Constructors
+
+##### Constructor
+
+```ts
+new PeginFingerprintInputError(message): PeginFingerprintInputError;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/pegin-fingerprint/peginFingerprint.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/pegin-fingerprint/peginFingerprint.ts)
+
+###### Parameters
+
+###### message
+
+`string`
+
+###### Returns
+
+[`PeginFingerprintInputError`](#peginfingerprintinputerror)
+
+###### Overrides
+
+```ts
+Error.constructor
+```
+
+## Interfaces
+
+### PeginFingerprintInput
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/pegin-fingerprint/peginFingerprint.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/pegin-fingerprint/peginFingerprint.ts)
+
+Protocol state a Pre-PegIn transaction commits to, one field per encoded
+word.
+
+Declared in encoding order so the interface reads as the specification does.
+Reordering these fields does not change the output — the encoder names each
+one explicitly — but keeping them aligned makes a divergence from the
+contract visible on sight.
+
+#### Properties
+
+##### chainId
+
+```ts
+chainId: bigint;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/pegin-fingerprint/peginFingerprint.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/pegin-fingerprint/peginFingerprint.ts)
+
+`block.chainid` of the chain the registry is deployed on.
+
+##### registryAddress
+
+```ts
+registryAddress: `0x${string}`;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/pegin-fingerprint/peginFingerprint.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/pegin-fingerprint/peginFingerprint.ts)
+
+The `BTCVaultRegistry` address, which the contract encodes as
+`address(this)`. EIP-55 checksum casing is irrelevant to the encoded word
+and is not required here; see [encodePeginFingerprintPreimage](#encodepeginfingerprintpreimage).
+
+##### vaultProviderBtcKey
+
+```ts
+vaultProviderBtcKey: `0x${string}`;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/pegin-fingerprint/peginFingerprint.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/pegin-fingerprint/peginFingerprint.ts)
+
+The vault provider's RESOLVED operation-BTC key, 32 bytes, `0x`-prefixed.
+
+The resolved key, not an epoch counter: the VP epoch is one registry-wide
+counter that ANY provider's key or payout append bumps, so committing to it
+would let any registered provider invalidate every in-flight Pre-PegIn
+protocol-wide. Only the chosen provider's key reaches the HTLC leaf, so
+that is what is committed.
+
+Note the SDK resolves this key as an x-only pubkey WITHOUT a `0x` prefix
+(`OnChainBtcPubkey`); callers add the prefix.
+
+##### appKeeperKeyEpoch
+
+```ts
+appKeeperKeyEpoch: bigint;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/pegin-fingerprint/peginFingerprint.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/pegin-fingerprint/peginFingerprint.ts)
+
+Vault-keeper operation-key epoch for this application (`uint64`).
+
+##### ucKeyEpoch
+
+```ts
+ucKeyEpoch: bigint;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/pegin-fingerprint/peginFingerprint.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/pegin-fingerprint/peginFingerprint.ts)
+
+Universal-challenger operation-key epoch (`uint64`).
+
+##### appVaultKeepersVersion
+
+```ts
+appVaultKeepersVersion: number;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/pegin-fingerprint/peginFingerprint.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/pegin-fingerprint/peginFingerprint.ts)
+
+Roster version selecting which vault keepers are in the leaf (`uint16`).
+
+##### universalChallengersVersion
+
+```ts
+universalChallengersVersion: number;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/pegin-fingerprint/peginFingerprint.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/pegin-fingerprint/peginFingerprint.ts)
+
+Roster version selecting which universal challengers are in the leaf (`uint16`).
+
+##### offchainParamsVersion
+
+```ts
+offchainParamsVersion: number;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/pegin-fingerprint/peginFingerprint.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/pegin-fingerprint/peginFingerprint.ts)
+
+Off-chain params version: `tRefund` and `minPeginFeeRate` (`uint16`).
+
+##### vaultCoreVersion
+
+```ts
+vaultCoreVersion: number;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/pegin-fingerprint/peginFingerprint.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/pegin-fingerprint/peginFingerprint.ts)
+
+Vault core (tx-graph) version: the PegIn output count (`uint16`).
+
+## Functions
+
+### encodePeginFingerprintPreimage()
+
+```ts
+function encodePeginFingerprintPreimage(input): `0x${string}`;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/pegin-fingerprint/peginFingerprint.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/pegin-fingerprint/peginFingerprint.ts)
+
+The `abi.encode` preimage the contract hashes — ten 32-byte words, 320 bytes.
+
+Exposed alongside [computePeginFingerprint](#computepeginfingerprint) because a fingerprint
+mismatch is otherwise two opaque hashes: comparing preimages word by word
+localises the disagreement to a field. The contract's vector file ships the
+same preimage next to each hash for exactly that reason.
+
+Three fields are held to a tighter bound than the contract's own width — a
+zero `chainId`, a zero `registryAddress`, and a `vaultCoreVersion` below 1 —
+because for each of them a zero is unreachable on-chain and so can only mean
+a read that failed or was mis-decoded. No chain has id 0, no registry lives
+at the zero address, and
+`activeVaultCoreVersion()` is documented `uint16 >= 1` with a setter that
+rejects 0. Encoding any of them would produce a well-formed fingerprint that
+cannot ever match, turning a local mistake into an opaque on-chain revert.
+
+The three roster and params versions are NOT tightened: 0 is a legitimate
+value on those axes.
+
+#### Parameters
+
+##### input
+
+[`PeginFingerprintInput`](#peginfingerprintinput)
+
+#### Returns
+
+`` `0x${string}` ``
+
+#### Throws
+
+If any field is missing, malformed, or
+  outside the accepted range, naming the field and what was expected.
+
+***
+
+### computePeginFingerprint()
+
+```ts
+function computePeginFingerprint(input): `0x${string}`;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/pegin-fingerprint/peginFingerprint.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/pegin-fingerprint/peginFingerprint.ts)
+
+The fingerprint to send as `expectedFingerprint` on a peg-in registration.
+
+Must equal what the registry recomputes at inclusion, byte for byte — the
+comparison is exact equality, never "no older than", because resolving at a
+superseded epoch would bond a new vault to a retired key.
+
+#### Parameters
+
+##### input
+
+[`PeginFingerprintInput`](#peginfingerprintinput)
+
+#### Returns
+
+`` `0x${string}` ``
+
+#### Throws
+
+If any field is outside the width the
+  contract declares for it.
+
+## Variables
+
+### PEGIN\_FINGERPRINT\_DOMAIN\_PREIMAGE
+
+```ts
+const PEGIN_FINGERPRINT_DOMAIN_PREIMAGE: "TBV.PeginFingerprint.v1" = "TBV.PeginFingerprint.v1";
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/pegin-fingerprint/peginFingerprint.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/pegin-fingerprint/peginFingerprint.ts)
+
+Domain-separation string hashed into every fingerprint, so the commitment
+cannot be replayed as a different one. Matches the contract's
+`PEGIN_FINGERPRINT_DOMAIN` preimage.
+
+***
+
+### PEGIN\_FINGERPRINT\_DOMAIN
+
+```ts
+const PEGIN_FINGERPRINT_DOMAIN: Hex;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/pegin-fingerprint/peginFingerprint.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/pegin-fingerprint/peginFingerprint.ts)
+
+`keccak256("TBV.PeginFingerprint.v1")`, the first word of the encoded
+preimage.
+
+Derived from [PEGIN\_FINGERPRINT\_DOMAIN\_PREIMAGE](#pegin_fingerprint_domain_preimage) rather than pasted as
+a hex literal, so the string that defines it stays visible. The golden test
+pins the derived value against the constant the contract's vector file
+publishes, so a change to either side is still caught.

--- a/packages/babylon-ts-sdk/src/tbv/core/index.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/index.ts
@@ -11,6 +11,8 @@
  * - WOTS: Winternitz one-time signature utilities
  * - Vault Secrets: HKDF-Expand pipeline producing hashlock / auth-anchor /
  *   wots-seed from a spec-opaque 32-byte root.
+ * - Peg-in Fingerprint: the commitment over the protocol state a Pre-PegIn was
+ *   built against, which the registry re-checks when the request is included.
  * - Recovery: reconstruction of a Pre-PegIn whose Ethereum registration was
  *   lost to a reorg, from the wallet and the transaction alone.
  *
@@ -25,6 +27,7 @@ export * from "./contracts";
 export * from "./wots";
 export * from "./services";
 export * from "./vault-secrets";
+export * from "./pegin-fingerprint";
 export * from "./deposit-terms";
 export * from "./recovery";
 // Keep the lenient utility on the core barrel. The ETH subpath has the strict parser.

--- a/packages/babylon-ts-sdk/src/tbv/core/pegin-fingerprint/__tests__/peginFingerprint.golden.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/pegin-fingerprint/__tests__/peginFingerprint.golden.test.ts
@@ -1,0 +1,211 @@
+/**
+ * Golden vectors for the peg-in configuration fingerprint, pinning this
+ * encoder byte-for-byte against the vault contracts.
+ *
+ * ## What is being pinned, and how it could silently diverge
+ *
+ * The contract computes `keccak256(abi.encode(...))` over ten static fields.
+ * Under `abi.encode` every static field becomes one left-padded 32-byte word,
+ * so the declared integer WIDTH never reaches the output — encoding the tuple
+ * with all-`uint256` slots produces a byte-identical hash. What does change the
+ * bytes is the field ORDER, the field COUNT, and static-vs-dynamic type class.
+ * A transposition of two same-width fields is therefore invisible to type
+ * checking, invisible to a review that only reads the types, and invisible to
+ * any fixture whose fields share a value. It surfaces only here.
+ *
+ * That is why the vectors below give every numeric field of every vector a
+ * different non-zero value. The contract repository enforces the rule on its
+ * side with `test_peginFingerprintVectors_fieldsAreDistinctAndNonZero`; the
+ * fixture is consumed verbatim so the rule carries over rather than being
+ * restated.
+ *
+ * ## Oracle and provenance
+ *
+ * Source of truth: `_peginFingerprint` in `src/protocol/lib/PeginLogic.sol` of
+ * `babylonlabs-io/vault-contracts-aave-v4`, introduced by
+ * https://github.com/babylonlabs-io/vault-contracts-aave-v4/pull/555.
+ *
+ * `vectors/pegin_fingerprint_vectors.json` is that repository's
+ * `test/data/pegin_fingerprint_vectors.json`, vendored verbatim at commit
+ * `ec62ac62da7a590408ccdcd0a6339a2fa36126b0`. Not transcribed, not reformatted
+ * — byte-identity is what makes a re-vendor a diff, and what keeps this file
+ * and the Rust `depositor-cli` pinned to one artifact rather than two copies of
+ * one. Confirm it with:
+ *
+ * ```
+ * gh api "repos/babylonlabs-io/vault-contracts-aave-v4/contents/test/data/pegin_fingerprint_vectors.json?ref=ec62ac62da7a590408ccdcd0a6339a2fa36126b0" \
+ *   --jq '.content' | base64 -d \
+ *   | diff - src/tbv/core/pegin-fingerprint/__tests__/vectors/pegin_fingerprint_vectors.json
+ * ```
+ *
+ * Each vector was also recomputed independently with Foundry, which shares no
+ * code with either this encoder or the Solidity library that produced the file:
+ *
+ * ```
+ * cast abi-encode 'f(bytes32,uint256,address,bytes32,uint64,uint64,uint16,uint16,uint16,uint16)' \
+ *   0x7a76c7af21338f0474e4755a879f9ae8b6351b37d1a2e79e88e1ae95f20ea24b \
+ *   1 0x5FbDB2315678afecb367f032d93F642f64180aa3 \
+ *   0x79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798 \
+ *   3 5 7 11 13 17 | cast keccak
+ * # 0xe18d2cbf355cd69b44df7797eac6ad8c2dc522d328b63d20faa4f0be432cd73c
+ * ```
+ *
+ * ## Failure modes this test is designed to catch
+ *
+ * If the contract's field order, field count or domain string changes, the
+ * vector file changes with it and these assertions fail — which is the signal
+ * to re-vendor and re-check, not to edit the expectations. If this encoder
+ * drifts instead, the `encoded` assertion fails before the hash assertion and
+ * names the diverging word.
+ */
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  PEGIN_FINGERPRINT_ABI_PARAMETERS,
+  PEGIN_FINGERPRINT_DOMAIN,
+  PEGIN_FINGERPRINT_DOMAIN_PREIMAGE,
+  computePeginFingerprint,
+  encodePeginFingerprintPreimage,
+} from "../peginFingerprint";
+
+import type { Address, Hex } from "viem";
+
+/** The vendored file's shape, after the bigint-preserving parse below. */
+interface FingerprintVector {
+  name: string;
+  chainId: bigint;
+  registry: Address;
+  vaultProviderBtcKey: Hex;
+  appKeeperKeyEpoch: bigint;
+  ucKeyEpoch: bigint;
+  appVaultKeepersVersion: bigint;
+  universalChallengersVersion: bigint;
+  offchainParamsVersion: bigint;
+  vaultCoreVersion: bigint;
+  encoded: Hex;
+  fingerprint: Hex;
+}
+
+interface VectorFile {
+  domain: Hex;
+  domainPreimage: string;
+  /** The canonical tuple, as `keccak256(abi.encode(<type> <name>, ...))`. */
+  encoding: string;
+  vectors: FingerprintVector[];
+}
+
+const VECTORS_PATH = fileURLToPath(
+  new URL("./vectors/pegin_fingerprint_vectors.json", import.meta.url),
+);
+
+/**
+ * Parse with every JSON number taken from its SOURCE TEXT rather than from the
+ * double `JSON.parse` would produce.
+ *
+ * This is load-bearing, not a stylistic choice. The `maximum_field_values`
+ * vector carries `18446744073709551615` (`uint64` max), which is past
+ * `Number.MAX_SAFE_INTEGER`: a plain `JSON.parse` — or a static
+ * `import vectors from "./…json"`, which is the same thing — rounds it to
+ * 18446744073709552000, i.e. exactly 2^64, and the encoder then rejects it as
+ * out of range. Do not "simplify" this back to an import.
+ */
+const vectorFile = JSON.parse(
+  readFileSync(VECTORS_PATH, "utf8"),
+  (_key, value: unknown, context?: { source?: string }) =>
+    typeof value === "number" && context?.source !== undefined
+      ? BigInt(context.source)
+      : value,
+) as VectorFile;
+
+// Without source-text access the reviver silently returns the rounded double
+// and the failure surfaces as "appKeeperKeyEpoch must fit Solidity uint64",
+// which reads as a bug in the encoder rather than a gap in the runtime. Name
+// the real cause instead. (The repo pins Node 24; this guards a stray runtime.)
+if (typeof vectorFile.vectors[0]?.chainId !== "bigint") {
+  throw new Error(
+    "This runtime's JSON.parse does not expose reviver source text, so the " +
+      "uint64 vectors cannot be read exactly. Node 22.x or newer is required.",
+  );
+}
+
+describe("peg-in fingerprint golden vectors (vault-contracts-aave-v4 PR #555)", () => {
+  it("derives the domain the contract's vector file publishes", () => {
+    expect(PEGIN_FINGERPRINT_DOMAIN_PREIMAGE).toBe(vectorFile.domainPreimage);
+    expect(PEGIN_FINGERPRINT_DOMAIN).toBe(vectorFile.domain);
+  });
+
+  it("encodes the tuple the contract's vector file declares", () => {
+    // The vectors alone cannot catch a WIDTH change upstream: abi.encode pads
+    // every static field to 32 bytes, so widening (say) vaultCoreVersion to
+    // uint32 leaves all four vectors' bytes identical while our uint16 bound
+    // starts rejecting values the contract accepts. This compares the declared
+    // tuple itself, and doubles as an order check that owes nothing to the
+    // sample values.
+    const rendered = PEGIN_FINGERPRINT_ABI_PARAMETERS.map(
+      (parameter) => `${parameter.type} ${parameter.name}`,
+    ).join(", ");
+    expect(`keccak256(abi.encode(${rendered}))`).toBe(vectorFile.encoding);
+  });
+
+  it("vendored the four vectors the contract repository ships", () => {
+    expect(vectorFile.vectors.map((vector) => vector.name)).toEqual([
+      "small_distinct_primes",
+      "rotated_epochs_on_sepolia",
+      "widths_above_uint8_and_uint32",
+      "maximum_field_values",
+    ]);
+  });
+
+  it("gives every numeric field of every vector a distinct non-zero value", () => {
+    // The file's own `fieldRule` says why: equal values let a wrong field order
+    // produce the correct fingerprint. The contract repository enforces this
+    // with test_peginFingerprintVectors_fieldsAreDistinctAndNonZero; we vendor
+    // the data, not that test, so a re-vendor could otherwise quietly downgrade
+    // every assertion below to "the encoder agrees with itself".
+    for (const vector of vectorFile.vectors) {
+      const numbers = [
+        vector.chainId,
+        vector.appKeeperKeyEpoch,
+        vector.ucKeyEpoch,
+        vector.appVaultKeepersVersion,
+        vector.universalChallengersVersion,
+        vector.offchainParamsVersion,
+        vector.vaultCoreVersion,
+      ];
+      expect(numbers.filter((value) => value === 0n)).toEqual([]);
+      expect(new Set(numbers).size).toBe(numbers.length);
+    }
+  });
+
+  for (const vector of vectorFile.vectors) {
+    // The four version fields are uint16, so narrowing them is exact; the two
+    // epochs and the chain id stay bigint, as they do everywhere else.
+    const input = {
+      chainId: vector.chainId,
+      registryAddress: vector.registry,
+      vaultProviderBtcKey: vector.vaultProviderBtcKey,
+      appKeeperKeyEpoch: vector.appKeeperKeyEpoch,
+      ucKeyEpoch: vector.ucKeyEpoch,
+      appVaultKeepersVersion: Number(vector.appVaultKeepersVersion),
+      universalChallengersVersion: Number(vector.universalChallengersVersion),
+      offchainParamsVersion: Number(vector.offchainParamsVersion),
+      vaultCoreVersion: Number(vector.vaultCoreVersion),
+    };
+
+    describe(vector.name, () => {
+      // Asserted before the hash: a wrong field shows up as a diff at a known
+      // word offset, where the hash only says "wrong".
+      it("encodes the abi.encode preimage the contract encodes", () => {
+        expect(encodePeginFingerprintPreimage(input)).toBe(vector.encoded);
+      });
+
+      it("hashes to the fingerprint the contract computes", () => {
+        expect(computePeginFingerprint(input)).toBe(vector.fingerprint);
+      });
+    });
+  }
+});

--- a/packages/babylon-ts-sdk/src/tbv/core/pegin-fingerprint/__tests__/peginFingerprint.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/pegin-fingerprint/__tests__/peginFingerprint.test.ts
@@ -1,0 +1,283 @@
+/**
+ * Behaviour of the fingerprint encoder that the golden vectors cannot reach:
+ * that every field reaches the output, that out-of-range inputs are rejected by
+ * name, and that a non-checksummed address still encodes.
+ *
+ * Note what is NOT tested here. Field ORDER is pinned by the golden vectors and
+ * only by them — a test that swaps two inputs and asserts the hash moves passes
+ * just as happily against an encoder that transposes those same two fields
+ * internally. What the cases below do catch is a field that never reaches the
+ * encoding at all: dropped from the tuple, aliased to a neighbour, or shadowed
+ * by a constant. That failure is silent against a hand-written expectation and
+ * would otherwise surface only if a vector happened to vary that one field.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import {
+  PEGIN_FINGERPRINT_DOMAIN,
+  PeginFingerprintInputError,
+  computePeginFingerprint,
+  encodePeginFingerprintPreimage,
+  type PeginFingerprintInput,
+} from "../peginFingerprint";
+
+/**
+ * Every field a different non-zero value, for the same reason the contract's
+ * vectors are built that way: with equal values a transposition of two
+ * same-width fields produces the identical encoding and cannot be detected.
+ */
+const BASE: PeginFingerprintInput = {
+  chainId: 11155111n,
+  registryAddress: "0x8464135c8F25Da09e49BC8782676a84730C318bC",
+  vaultProviderBtcKey:
+    "0xc6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5",
+  appKeeperKeyEpoch: 19n,
+  ucKeyEpoch: 23n,
+  appVaultKeepersVersion: 29,
+  universalChallengersVersion: 31,
+  offchainParamsVersion: 37,
+  vaultCoreVersion: 41,
+};
+
+describe("computePeginFingerprint", () => {
+  it("produces 32 bytes", () => {
+    expect(computePeginFingerprint(BASE)).toMatch(/^0x[0-9a-f]{64}$/);
+  });
+
+  it("encodes ten 32-byte words, one per field", () => {
+    // 0x + 10 words * 64 hex digits. A field added or dropped changes this.
+    expect(encodePeginFingerprintPreimage(BASE)).toHaveLength(2 + 10 * 64);
+  });
+
+  it("starts the preimage with the domain word", () => {
+    expect(encodePeginFingerprintPreimage(BASE).slice(0, 66)).toBe(
+      PEGIN_FINGERPRINT_DOMAIN,
+    );
+  });
+
+  // The domain constant and its preimage string are pinned in the golden test,
+  // against the contract's own vector file, rather than against literals
+  // transcribed here a second time.
+});
+
+/**
+ * One altered field per case. Each altered value differs from every other value
+ * in {@link BASE}, so a field aliased onto a neighbour still moves the hash and
+ * is not mistaken for a pass.
+ *
+ * Typed as a `Record` keyed by the input's own fields, so adding a field to
+ * {@link PeginFingerprintInput} without adding a case here is a COMPILE error.
+ * A runtime test comparing this list against `Object.keys(BASE)` would assert
+ * nothing about `src/` and would miss an optional field entirely.
+ */
+const SINGLE_FIELD_CHANGES: Record<
+  keyof PeginFingerprintInput,
+  PeginFingerprintInput
+> = {
+  chainId: { ...BASE, chainId: 43n },
+  registryAddress: {
+    ...BASE,
+    registryAddress: "0x5FbDB2315678afecb367f032d93F642f64180aa3",
+  },
+  vaultProviderBtcKey: {
+    ...BASE,
+    vaultProviderBtcKey:
+      "0x79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+  },
+  appKeeperKeyEpoch: { ...BASE, appKeeperKeyEpoch: 47n },
+  ucKeyEpoch: { ...BASE, ucKeyEpoch: 53n },
+  appVaultKeepersVersion: { ...BASE, appVaultKeepersVersion: 59 },
+  universalChallengersVersion: { ...BASE, universalChallengersVersion: 61 },
+  offchainParamsVersion: { ...BASE, offchainParamsVersion: 67 },
+  vaultCoreVersion: { ...BASE, vaultCoreVersion: 71 },
+};
+
+describe("computePeginFingerprint field coverage", () => {
+  const baseline = computePeginFingerprint(BASE);
+
+  for (const [field, changed] of Object.entries(SINGLE_FIELD_CHANGES)) {
+    it(`changes when only ${field} changes`, () => {
+      expect(computePeginFingerprint(changed)).not.toBe(baseline);
+    });
+  }
+});
+
+describe("computePeginFingerprint address handling", () => {
+  it("encodes a mixed-case address whose EIP-55 checksum does not verify", () => {
+    // The contract's own `maximum_field_values` vector uses such an address.
+    // viem rejects it by default, so the encoder must normalise case itself.
+    expect(() =>
+      encodePeginFingerprintPreimage({
+        ...BASE,
+        registryAddress: "0xfFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF",
+      }),
+    ).not.toThrow();
+  });
+
+  it("ignores address casing, which the encoded word does not carry", () => {
+    const checksummed = computePeginFingerprint(BASE);
+    const lowercased = computePeginFingerprint({
+      ...BASE,
+      registryAddress:
+        BASE.registryAddress.toLowerCase() as PeginFingerprintInput["registryAddress"],
+    });
+    expect(lowercased).toBe(checksummed);
+  });
+
+  it("rejects an address that is not 20 bytes", () => {
+    expect(() =>
+      encodePeginFingerprintPreimage({
+        ...BASE,
+        registryAddress: "0x1234",
+      }),
+    ).toThrow(PeginFingerprintInputError);
+  });
+
+  it("rejects the zero address, the shape of an unresolved read", () => {
+    expect(() =>
+      encodePeginFingerprintPreimage({
+        ...BASE,
+        registryAddress: "0x0000000000000000000000000000000000000000",
+      }),
+    ).toThrow(/registryAddress must not be the zero address/);
+  });
+
+  it("lowercases the key so the preimage stays comparable to the contract's", () => {
+    // viem echoes hex casing into its output, so an upper-case key would give a
+    // correct fingerprint beside a preimage that no longer compares equal.
+    const upper = {
+      ...BASE,
+      vaultProviderBtcKey:
+        `0x${BASE.vaultProviderBtcKey.slice(2).toUpperCase()}` as PeginFingerprintInput["vaultProviderBtcKey"],
+    };
+    expect(encodePeginFingerprintPreimage(upper)).toBe(
+      encodePeginFingerprintPreimage(BASE),
+    );
+  });
+});
+
+describe("encodePeginFingerprintPreimage input validation", () => {
+  it("rejects a uint16 version above 65535", () => {
+    expect(() =>
+      encodePeginFingerprintPreimage({ ...BASE, vaultCoreVersion: 65_536 }),
+    ).toThrow(/vaultCoreVersion must be an integer fitting Solidity uint16/);
+  });
+
+  it("rejects a negative uint16 version", () => {
+    expect(() =>
+      encodePeginFingerprintPreimage({
+        ...BASE,
+        universalChallengersVersion: -1,
+      }),
+    ).toThrow(/universalChallengersVersion must be an integer/);
+  });
+
+  it("rejects a non-integer uint16 version", () => {
+    expect(() =>
+      encodePeginFingerprintPreimage({ ...BASE, offchainParamsVersion: 1.5 }),
+    ).toThrow(/offchainParamsVersion must be an integer/);
+  });
+
+  it("accepts the uint64 maximum epoch", () => {
+    expect(() =>
+      encodePeginFingerprintPreimage({
+        ...BASE,
+        appKeeperKeyEpoch: 2n ** 64n - 1n,
+      }),
+    ).not.toThrow();
+  });
+
+  it("rejects an epoch at 2^64", () => {
+    expect(() =>
+      encodePeginFingerprintPreimage({ ...BASE, ucKeyEpoch: 2n ** 64n }),
+    ).toThrow(/ucKeyEpoch must fit Solidity uint64/);
+  });
+
+  it("rejects a negative epoch", () => {
+    expect(() =>
+      encodePeginFingerprintPreimage({ ...BASE, appKeeperKeyEpoch: -1n }),
+    ).toThrow(/appKeeperKeyEpoch must fit Solidity uint64/);
+  });
+
+  it("rejects a chain id above uint256", () => {
+    expect(() =>
+      encodePeginFingerprintPreimage({ ...BASE, chainId: 2n ** 256n }),
+    ).toThrow(/chainId must fit Solidity uint256/);
+  });
+
+  it("rejects a vault provider key that is not 32 bytes", () => {
+    expect(() =>
+      encodePeginFingerprintPreimage({
+        ...BASE,
+        vaultProviderBtcKey: "0xdead",
+      }),
+    ).toThrow(/vaultProviderBtcKey must be 32 bytes/);
+  });
+
+  it("rejects a vault provider key with no 0x prefix", () => {
+    // The SDK resolves operation keys as un-prefixed x-only hex, so this is the
+    // mistake a call site is most likely to make.
+    expect(() =>
+      encodePeginFingerprintPreimage({
+        ...BASE,
+        vaultProviderBtcKey:
+          "c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5" as PeginFingerprintInput["vaultProviderBtcKey"],
+      }),
+    ).toThrow(PeginFingerprintInputError);
+  });
+
+  it("rejects chain id 0, the shape of an unresolved read", () => {
+    expect(() =>
+      encodePeginFingerprintPreimage({ ...BASE, chainId: 0n }),
+    ).toThrow(/chainId must not be 0/);
+  });
+
+  it("rejects vaultCoreVersion 0, which no live contract reports", () => {
+    // activeVaultCoreVersion() is uint16 >= 1 and its setter rejects 0, so a 0
+    // reaching here is a mis-decoded read. The rest of the SDK fails closed on
+    // it (assertValidVaultCoreVersion); encoding it would instead produce a
+    // fingerprint that can never match, failing on-chain rather than here.
+    expect(() =>
+      encodePeginFingerprintPreimage({ ...BASE, vaultCoreVersion: 0 }),
+    ).toThrow(PeginFingerprintInputError);
+  });
+
+  it("still accepts version 0 on the axes where the contract allows it", () => {
+    expect(() =>
+      encodePeginFingerprintPreimage({
+        ...BASE,
+        appVaultKeepersVersion: 0,
+        universalChallengersVersion: 0,
+        offchainParamsVersion: 0,
+      }),
+    ).not.toThrow();
+  });
+});
+
+/**
+ * TypeScript does not reach a JS consumer, an object built from a partial
+ * snapshot, or an unawaited read. A purely relational range check treats all of
+ * these as in-range, and viem then either throws something unrecognisable or —
+ * for `"7"` and `true` — encodes them as 7 and 1, producing a well-formed
+ * fingerprint from a value nobody supplied.
+ */
+describe("encodePeginFingerprintPreimage rejects non-bigint numeric fields", () => {
+  for (const [label, value] of [
+    ["undefined", undefined],
+    ["null", null],
+    ["NaN", Number.NaN],
+    ["a numeric string", "7"],
+    ["a boolean", true],
+    ["a plain number", 19],
+  ] as const) {
+    it(`rejects ${label} as appKeeperKeyEpoch`, () => {
+      expect(() =>
+        encodePeginFingerprintPreimage({
+          ...BASE,
+          appKeeperKeyEpoch: value as unknown as bigint,
+        }),
+      ).toThrow(PeginFingerprintInputError);
+    });
+  }
+});

--- a/packages/babylon-ts-sdk/src/tbv/core/pegin-fingerprint/__tests__/vectors/pegin_fingerprint_vectors.json
+++ b/packages/babylon-ts-sdk/src/tbv/core/pegin-fingerprint/__tests__/vectors/pegin_fingerprint_vectors.json
@@ -1,0 +1,67 @@
+{
+  "description": "Golden vectors for the peg-in fingerprint that BTCVaultRegistry.submitPeginRequest recomputes. Off-chain builders (web, depositor-cli) must reproduce `fingerprint` from the listed fields. `encoded` is the abi.encode preimage; compare against it first to locate a field-order or width bug.",
+  "source": "src/protocol/lib/PeginLogic.sol:_peginFingerprint",
+  "domainPreimage": "TBV.PeginFingerprint.v1",
+  "domain": "0x7a76c7af21338f0474e4755a879f9ae8b6351b37d1a2e79e88e1ae95f20ea24b",
+  "encoding": "keccak256(abi.encode(bytes32 domain, uint256 chainId, address registry, bytes32 vaultProviderBtcKey, uint64 appKeeperKeyEpoch, uint64 ucKeyEpoch, uint16 appVaultKeepersVersion, uint16 universalChallengersVersion, uint16 offchainParamsVersion, uint16 vaultCoreVersion))",
+  "regenerate": "cast abi-encode 'f(bytes32,uint256,address,bytes32,uint64,uint64,uint16,uint16,uint16,uint16)' <domain> <chainId> <registry> <vaultProviderBtcKey> <appKeeperKeyEpoch> <ucKeyEpoch> <appVaultKeepersVersion> <universalChallengersVersion> <offchainParamsVersion> <vaultCoreVersion> | cast keccak",
+  "fieldRule": "Every numeric field of every vector holds a different non-zero value. Equal values would let a wrong field order produce the correct fingerprint. test_peginFingerprintVectors_fieldsAreDistinctAndNonZero enforces this.",
+  "vectors": [
+    {
+      "name": "small_distinct_primes",
+      "chainId": 1,
+      "registry": "0x5FbDB2315678afecb367f032d93F642f64180aa3",
+      "vaultProviderBtcKey": "0x79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798",
+      "appKeeperKeyEpoch": 3,
+      "ucKeyEpoch": 5,
+      "appVaultKeepersVersion": 7,
+      "universalChallengersVersion": 11,
+      "offchainParamsVersion": 13,
+      "vaultCoreVersion": 17,
+      "encoded": "0x7a76c7af21338f0474e4755a879f9ae8b6351b37d1a2e79e88e1ae95f20ea24b00000000000000000000000000000000000000000000000000000000000000010000000000000000000000005fbdb2315678afecb367f032d93f642f64180aa379be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798000000000000000000000000000000000000000000000000000000000000000300000000000000000000000000000000000000000000000000000000000000050000000000000000000000000000000000000000000000000000000000000007000000000000000000000000000000000000000000000000000000000000000b000000000000000000000000000000000000000000000000000000000000000d0000000000000000000000000000000000000000000000000000000000000011",
+      "fingerprint": "0xe18d2cbf355cd69b44df7797eac6ad8c2dc522d328b63d20faa4f0be432cd73c"
+    },
+    {
+      "name": "rotated_epochs_on_sepolia",
+      "chainId": 11155111,
+      "registry": "0x8464135c8F25Da09e49BC8782676a84730C318bC",
+      "vaultProviderBtcKey": "0xc6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5",
+      "appKeeperKeyEpoch": 19,
+      "ucKeyEpoch": 23,
+      "appVaultKeepersVersion": 29,
+      "universalChallengersVersion": 31,
+      "offchainParamsVersion": 37,
+      "vaultCoreVersion": 41,
+      "encoded": "0x7a76c7af21338f0474e4755a879f9ae8b6351b37d1a2e79e88e1ae95f20ea24b0000000000000000000000000000000000000000000000000000000000aa36a70000000000000000000000008464135c8f25da09e49bc8782676a84730c318bcc6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee500000000000000000000000000000000000000000000000000000000000000130000000000000000000000000000000000000000000000000000000000000017000000000000000000000000000000000000000000000000000000000000001d000000000000000000000000000000000000000000000000000000000000001f00000000000000000000000000000000000000000000000000000000000000250000000000000000000000000000000000000000000000000000000000000029",
+      "fingerprint": "0x3234b02ce971a79f7994bcd08858a5c8a785f42546bfcbe6eb4f3468d2fe3c07"
+    },
+    {
+      "name": "widths_above_uint8_and_uint32",
+      "chainId": 84532,
+      "registry": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
+      "vaultProviderBtcKey": "0x2f8bde4d1a07209355b4a7250a5c5128e88b84bddc619ab7cba8d569b240efe4",
+      "appKeeperKeyEpoch": 4294967297,
+      "ucKeyEpoch": 8589934593,
+      "appVaultKeepersVersion": 257,
+      "universalChallengersVersion": 513,
+      "offchainParamsVersion": 1025,
+      "vaultCoreVersion": 2049,
+      "encoded": "0x7a76c7af21338f0474e4755a879f9ae8b6351b37d1a2e79e88e1ae95f20ea24b0000000000000000000000000000000000000000000000000000000000014a34000000000000000000000000a0b86991c6218b36c1d19d4a2e9eb0ce3606eb482f8bde4d1a07209355b4a7250a5c5128e88b84bddc619ab7cba8d569b240efe4000000000000000000000000000000000000000000000000000000010000000100000000000000000000000000000000000000000000000000000002000000010000000000000000000000000000000000000000000000000000000000000101000000000000000000000000000000000000000000000000000000000000020100000000000000000000000000000000000000000000000000000000000004010000000000000000000000000000000000000000000000000000000000000801",
+      "fingerprint": "0xcbd797c43df8acb1d6ff2879bd679333fc53f07fc782389389ff4dfb5561e0e0"
+    },
+    {
+      "name": "maximum_field_values",
+      "chainId": 1337,
+      "registry": "0xfFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF",
+      "vaultProviderBtcKey": "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      "appKeeperKeyEpoch": 18446744073709551615,
+      "ucKeyEpoch": 18446744073709551614,
+      "appVaultKeepersVersion": 65535,
+      "universalChallengersVersion": 65534,
+      "offchainParamsVersion": 65533,
+      "vaultCoreVersion": 65532,
+      "encoded": "0x7a76c7af21338f0474e4755a879f9ae8b6351b37d1a2e79e88e1ae95f20ea24b0000000000000000000000000000000000000000000000000000000000000539000000000000000000000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff000000000000000000000000000000000000000000000000ffffffffffffffff000000000000000000000000000000000000000000000000fffffffffffffffe000000000000000000000000000000000000000000000000000000000000ffff000000000000000000000000000000000000000000000000000000000000fffe000000000000000000000000000000000000000000000000000000000000fffd000000000000000000000000000000000000000000000000000000000000fffc",
+      "fingerprint": "0x6d1d1ca224b5b1c19edc950f1376f3982fb0ea0d6f390b934f2a85a250017245"
+    }
+  ]
+}

--- a/packages/babylon-ts-sdk/src/tbv/core/pegin-fingerprint/index.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/pegin-fingerprint/index.ts
@@ -1,0 +1,21 @@
+/**
+ * Peg-in configuration fingerprint: the `keccak256(abi.encode(...))` commitment
+ * over the protocol state a Pre-PegIn transaction was built against, sent with
+ * the peg-in registration so the registry can reject a request whose protocol
+ * state moved between the build and inclusion.
+ *
+ * Reproduces `PeginLogic._peginFingerprint` from the vault contracts exactly;
+ * see {@link computePeginFingerprint} for the encoding rules that matter.
+ *
+ * @module pegin-fingerprint
+ */
+
+export {
+  PEGIN_FINGERPRINT_DOMAIN,
+  PEGIN_FINGERPRINT_DOMAIN_PREIMAGE,
+  PeginFingerprintInputError,
+  computePeginFingerprint,
+  encodePeginFingerprintPreimage,
+} from "./peginFingerprint";
+
+export type { PeginFingerprintInput } from "./peginFingerprint";

--- a/packages/babylon-ts-sdk/src/tbv/core/pegin-fingerprint/peginFingerprint.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/pegin-fingerprint/peginFingerprint.ts
@@ -1,0 +1,334 @@
+/**
+ * Canonical peg-in configuration fingerprint: the commitment a depositor sends
+ * with a peg-in registration so the registry can prove, at inclusion, that the
+ * protocol state it is about to bond the vault to is the state the Bitcoin lock
+ * was actually built from.
+ *
+ * ## Why it exists
+ *
+ * Seven values are resolved live when a peg-in request is included, and every
+ * one of them changes the bytes a depositor must have built: the vault
+ * provider's operation-BTC key, the vault-keeper and universal-challenger key
+ * epochs, the two roster versions (which members are in the HTLC all-party leaf
+ * at all), the off-chain params version (`tRefund` in the refund leaf,
+ * `minPeginFeeRate` in the output value) and the vault core version (the PegIn
+ * output count, so the P2A anchor term in the value). A rotation, roster change
+ * or version bump landing between the depositor's build and inclusion would
+ * bond the vault to bytes the funded HTLC does not commit to. The registry
+ * recomputes this fingerprint and reverts with `PeginFingerprintChanged` rather
+ * than accepting such a request.
+ *
+ * ## Reproducing the contract exactly
+ *
+ * The encoding is `abi.encode`, never `abi.encodePacked` — the two produce
+ * completely different bytes. Under `abi.encode` every field here is static and
+ * occupies one left-padded 32-byte word, so the declared integer *width* never
+ * reaches the output: encoding the tuple with all-`uint256` slots yields a
+ * byte-identical hash. Only the field ORDER, the field COUNT, and whether a
+ * type is static or dynamic can change the result. The widths in
+ * {@link PeginFingerprintInput} therefore document the contract's own
+ * declarations and bound the accepted inputs; they are not what makes the bytes
+ * come out right.
+ *
+ * Mirrors `_peginFingerprint` in `src/protocol/lib/PeginLogic.sol` of
+ * `babylonlabs-io/vault-contracts-aave-v4`. Pinned byte-for-byte against that
+ * repository's committed vectors — see
+ * `__tests__/peginFingerprint.golden.test.ts`.
+ *
+ * @module pegin-fingerprint/peginFingerprint
+ */
+
+import {
+  encodeAbiParameters,
+  isAddress,
+  keccak256,
+  toHex,
+  zeroAddress,
+  type Address,
+  type Hex,
+} from "viem";
+
+/**
+ * Domain-separation string hashed into every fingerprint, so the commitment
+ * cannot be replayed as a different one. Matches the contract's
+ * `PEGIN_FINGERPRINT_DOMAIN` preimage.
+ */
+export const PEGIN_FINGERPRINT_DOMAIN_PREIMAGE = "TBV.PeginFingerprint.v1";
+
+/**
+ * `keccak256("TBV.PeginFingerprint.v1")`, the first word of the encoded
+ * preimage.
+ *
+ * Derived from {@link PEGIN_FINGERPRINT_DOMAIN_PREIMAGE} rather than pasted as
+ * a hex literal, so the string that defines it stays visible. The golden test
+ * pins the derived value against the constant the contract's vector file
+ * publishes, so a change to either side is still caught.
+ */
+export const PEGIN_FINGERPRINT_DOMAIN: Hex = keccak256(
+  toHex(PEGIN_FINGERPRINT_DOMAIN_PREIMAGE),
+);
+
+/** Inclusive upper bound of Solidity `uint16`, the width of all four versions. */
+const UINT16_MAX = 65_535;
+/** Inclusive upper bound of Solidity `uint64`, the width of both key epochs. */
+const UINT64_MAX = 2n ** 64n - 1n;
+/** Inclusive upper bound of Solidity `uint256`, the width of `block.chainid`. */
+const UINT256_MAX = 2n ** 256n - 1n;
+/** A `bytes32` value as viem accepts it: `0x` followed by 64 hex digits. */
+const BYTES32_PATTERN = /^0x[0-9a-fA-F]{64}$/;
+/**
+ * Lowest `vaultCoreVersion` any live contract reports: the setter on
+ * `ProtocolParams` rejects 0, so a 0 can only be a mis-decoded read.
+ *
+ * Mirrors the bound `assertValidVaultCoreVersion` applies in
+ * `primitives/vaultCoreVersion.ts`; the two must move together. That function
+ * is not called here because it throws a bare `Error`, which would put a second
+ * error type into a module whose whole validation surface is
+ * {@link PeginFingerprintInputError}.
+ */
+const VAULT_CORE_VERSION_MIN = 1;
+
+/**
+ * Protocol state a Pre-PegIn transaction commits to, one field per encoded
+ * word.
+ *
+ * Declared in encoding order so the interface reads as the specification does.
+ * Reordering these fields does not change the output — the encoder names each
+ * one explicitly — but keeping them aligned makes a divergence from the
+ * contract visible on sight.
+ */
+export interface PeginFingerprintInput {
+  /** `block.chainid` of the chain the registry is deployed on. */
+  chainId: bigint;
+  /**
+   * The `BTCVaultRegistry` address, which the contract encodes as
+   * `address(this)`. EIP-55 checksum casing is irrelevant to the encoded word
+   * and is not required here; see {@link encodePeginFingerprintPreimage}.
+   */
+  registryAddress: Address;
+  /**
+   * The vault provider's RESOLVED operation-BTC key, 32 bytes, `0x`-prefixed.
+   *
+   * The resolved key, not an epoch counter: the VP epoch is one registry-wide
+   * counter that ANY provider's key or payout append bumps, so committing to it
+   * would let any registered provider invalidate every in-flight Pre-PegIn
+   * protocol-wide. Only the chosen provider's key reaches the HTLC leaf, so
+   * that is what is committed.
+   *
+   * Note the SDK resolves this key as an x-only pubkey WITHOUT a `0x` prefix
+   * (`OnChainBtcPubkey`); callers add the prefix.
+   */
+  vaultProviderBtcKey: Hex;
+  /** Vault-keeper operation-key epoch for this application (`uint64`). */
+  appKeeperKeyEpoch: bigint;
+  /** Universal-challenger operation-key epoch (`uint64`). */
+  ucKeyEpoch: bigint;
+  /** Roster version selecting which vault keepers are in the leaf (`uint16`). */
+  appVaultKeepersVersion: number;
+  /** Roster version selecting which universal challengers are in the leaf (`uint16`). */
+  universalChallengersVersion: number;
+  /** Off-chain params version: `tRefund` and `minPeginFeeRate` (`uint16`). */
+  offchainParamsVersion: number;
+  /** Vault core (tx-graph) version: the PegIn output count (`uint16`). */
+  vaultCoreVersion: number;
+}
+
+/** An input field is missing, malformed, or outside the width the contract declares for it. */
+export class PeginFingerprintInputError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "PeginFingerprintInputError";
+  }
+}
+
+/**
+ * The type is checked before the range, and deliberately so.
+ *
+ * A purely relational guard (`value < 0n || value > max`) is not a guard at
+ * all for a non-bigint: every comparison against `undefined`, `null` and `NaN`
+ * evaluates `false`, so all three slip through, and `"7"` and `true` slip
+ * through AND then encode — as 7 and as 1 — producing a well-formed
+ * fingerprint from a value nobody supplied. TypeScript does not close this;
+ * a JS consumer, a snapshot object missing a key, or an unawaited read all
+ * reach here.
+ */
+function assertUnsignedRange(
+  field: string,
+  value: bigint,
+  max: bigint,
+  solidityType: string,
+): void {
+  if (typeof value !== "bigint") {
+    throw new PeginFingerprintInputError(
+      `${field} must be a bigint (Solidity ${solidityType}), got ${typeof value}`,
+    );
+  }
+  if (value < 0n || value > max) {
+    throw new PeginFingerprintInputError(
+      `${field} must fit Solidity ${solidityType} (0..${max}), got ${value}`,
+    );
+  }
+}
+
+function assertUint16(field: string, value: number): void {
+  if (!Number.isInteger(value) || value < 0 || value > UINT16_MAX) {
+    throw new PeginFingerprintInputError(
+      `${field} must be an integer fitting Solidity uint16 (0..${UINT16_MAX}), got ${value}`,
+    );
+  }
+}
+
+/**
+ * Validate a `bytes32` field and return it lowercased.
+ *
+ * viem echoes the caller's hex casing straight into the encoded output, so an
+ * upper-case key would yield a correct fingerprint (keccak hashes bytes, not
+ * text) beside a preimage that no longer compares equal to the contract's.
+ * That would defeat the one job {@link encodePeginFingerprintPreimage} has.
+ */
+function normalizeBytes32(field: string, value: Hex): Hex {
+  if (!BYTES32_PATTERN.test(value)) {
+    throw new PeginFingerprintInputError(
+      `${field} must be 32 bytes as 0x-prefixed hex (66 characters), got "${value}"`,
+    );
+  }
+  return value.toLowerCase() as Hex;
+}
+
+/**
+ * Validate the registry address and return it in the form the ABI word encodes.
+ *
+ * EIP-55 mixed-case is a display checksum over the same 20 bytes, and Solidity
+ * never sees it. viem does: `encodeAbiParameters` rejects a mixed-case address
+ * whose checksum does not verify, which would make legitimate inputs — the
+ * contract's own `maximum_field_values` vector among them — fail to encode. So
+ * the checksum is not enforced and the value is lowercased before encoding.
+ *
+ * This is normalisation, not a fallback: an address that is not 20 bytes of hex
+ * is still rejected, loudly, before anything is encoded, as is the zero address
+ * (the shape an unresolved contract-address read takes).
+ */
+function normalizeRegistryAddress(registryAddress: Address): Address {
+  if (!isAddress(registryAddress, { strict: false })) {
+    throw new PeginFingerprintInputError(
+      `registryAddress must be a 20-byte 0x-prefixed address, got "${registryAddress}"`,
+    );
+  }
+  const normalized = registryAddress.toLowerCase() as Address;
+  if (normalized === zeroAddress) {
+    throw new PeginFingerprintInputError(
+      "registryAddress must not be the zero address; a zero here means the registry address was never resolved",
+    );
+  }
+  return normalized;
+}
+
+/**
+ * The encoded tuple, as one list so the ordering lives in exactly one place.
+ *
+ * Not re-exported from the module barrel — this is internal, and exists in
+ * this shape so the golden test can render it back into the type string the
+ * contract's vector file publishes and compare the two. That comparison is a
+ * second, independent check on the field order, one that does not depend on
+ * the sample values in the vectors.
+ */
+export const PEGIN_FINGERPRINT_ABI_PARAMETERS = [
+  { name: "domain", type: "bytes32" },
+  { name: "chainId", type: "uint256" },
+  { name: "registry", type: "address" },
+  { name: "vaultProviderBtcKey", type: "bytes32" },
+  { name: "appKeeperKeyEpoch", type: "uint64" },
+  { name: "ucKeyEpoch", type: "uint64" },
+  { name: "appVaultKeepersVersion", type: "uint16" },
+  { name: "universalChallengersVersion", type: "uint16" },
+  { name: "offchainParamsVersion", type: "uint16" },
+  { name: "vaultCoreVersion", type: "uint16" },
+] as const;
+
+/**
+ * The `abi.encode` preimage the contract hashes — ten 32-byte words, 320 bytes.
+ *
+ * Exposed alongside {@link computePeginFingerprint} because a fingerprint
+ * mismatch is otherwise two opaque hashes: comparing preimages word by word
+ * localises the disagreement to a field. The contract's vector file ships the
+ * same preimage next to each hash for exactly that reason.
+ *
+ * Three fields are held to a tighter bound than the contract's own width — a
+ * zero `chainId`, a zero `registryAddress`, and a `vaultCoreVersion` below 1 —
+ * because for each of them a zero is unreachable on-chain and so can only mean
+ * a read that failed or was mis-decoded. No chain has id 0, no registry lives
+ * at the zero address, and
+ * `activeVaultCoreVersion()` is documented `uint16 >= 1` with a setter that
+ * rejects 0. Encoding any of them would produce a well-formed fingerprint that
+ * cannot ever match, turning a local mistake into an opaque on-chain revert.
+ *
+ * The three roster and params versions are NOT tightened: 0 is a legitimate
+ * value on those axes.
+ *
+ * @throws {PeginFingerprintInputError} If any field is missing, malformed, or
+ *   outside the accepted range, naming the field and what was expected.
+ */
+export function encodePeginFingerprintPreimage(
+  input: PeginFingerprintInput,
+): Hex {
+  assertUnsignedRange("chainId", input.chainId, UINT256_MAX, "uint256");
+  if (input.chainId === 0n) {
+    throw new PeginFingerprintInputError(
+      "chainId must not be 0; a zero here means the chain id was never resolved",
+    );
+  }
+  const registry = normalizeRegistryAddress(input.registryAddress);
+  const vaultProviderBtcKey = normalizeBytes32(
+    "vaultProviderBtcKey",
+    input.vaultProviderBtcKey,
+  );
+  assertUnsignedRange(
+    "appKeeperKeyEpoch",
+    input.appKeeperKeyEpoch,
+    UINT64_MAX,
+    "uint64",
+  );
+  assertUnsignedRange("ucKeyEpoch", input.ucKeyEpoch, UINT64_MAX, "uint64");
+  assertUint16("appVaultKeepersVersion", input.appVaultKeepersVersion);
+  assertUint16(
+    "universalChallengersVersion",
+    input.universalChallengersVersion,
+  );
+  assertUint16("offchainParamsVersion", input.offchainParamsVersion);
+  assertUint16("vaultCoreVersion", input.vaultCoreVersion);
+  if (input.vaultCoreVersion < VAULT_CORE_VERSION_MIN) {
+    throw new PeginFingerprintInputError(
+      `vaultCoreVersion must be at least ${VAULT_CORE_VERSION_MIN}; ` +
+        `${input.vaultCoreVersion} means the version was never resolved`,
+    );
+  }
+
+  // Field order is the whole specification. The parameter list, this value
+  // list, and the contract's `abi.encode(...)` call move together.
+  return encodeAbiParameters(PEGIN_FINGERPRINT_ABI_PARAMETERS, [
+    PEGIN_FINGERPRINT_DOMAIN,
+    input.chainId,
+    registry,
+    vaultProviderBtcKey,
+    input.appKeeperKeyEpoch,
+    input.ucKeyEpoch,
+    input.appVaultKeepersVersion,
+    input.universalChallengersVersion,
+    input.offchainParamsVersion,
+    input.vaultCoreVersion,
+  ]);
+}
+
+/**
+ * The fingerprint to send as `expectedFingerprint` on a peg-in registration.
+ *
+ * Must equal what the registry recomputes at inclusion, byte for byte — the
+ * comparison is exact equality, never "no older than", because resolving at a
+ * superseded epoch would bond a new vault to a retired key.
+ *
+ * @throws {PeginFingerprintInputError} If any field is outside the width the
+ *   contract declares for it.
+ */
+export function computePeginFingerprint(input: PeginFingerprintInput): Hex {
+  return keccak256(encodePeginFingerprintPreimage(input));
+}

--- a/packages/babylon-ts-sdk/typedoc.json
+++ b/packages/babylon-ts-sdk/typedoc.json
@@ -5,6 +5,7 @@
     "src/tbv/core/services/index.ts",
     "src/tbv/core/managers/index.ts",
     "src/tbv/core/deposit-terms/index.ts",
+    "src/tbv/core/pegin-fingerprint/index.ts",
     "src/tbv/core/utils/index.ts",
     "src/tbv/core/clients/index.ts",
     "src/tbv/integrations/aave/index.ts",


### PR DESCRIPTION
# Peg-in config fingerprint: the encoder

Part of https://github.com/babylonlabs-io/babylon-toolkit/issues/2383 (Workstream B). Follows https://github.com/babylonlabs-io/babylon-toolkit/pull/2385 (Workstream A), which is merged.

## Why we need this

When you deposit, the app builds a Bitcoin transaction that locks your BTC. The shape of that lock depends on protocol state that lives on Ethereum: which vault provider key is used, which keepers and challengers are in the list, and which parameter versions are active.

That state can move. If a key rotates, or a list changes, or a version is bumped in the seconds between the app building your Bitcoin lock and your registration landing on Ethereum, the contract would bond your vault to one set of values while your Bitcoin lock commits to a different set. The two no longer match, and the deposit is stuck.

The contracts are closing this by having the depositor send a **fingerprint** — a single hash over all the state the lock was built from. The contract recomputes that hash when the request is included and rejects it if the two differ. Nothing is signed or paid before the check, so a mismatch is a clean, early failure instead of a stranded vault.

For that to work, our TypeScript has to compute the exact same hash as the Solidity contract, byte for byte. **This PR is that computation, and nothing else.**

## What is in this PR

A new SDK module, `packages/babylon-ts-sdk/src/tbv/core/pegin-fingerprint/`:

- `computePeginFingerprint(input)` — the hash to send with a registration.
- `encodePeginFingerprintPreimage(input)` — the bytes that get hashed, exposed separately so a mismatch can be traced to a specific field instead of being two hashes that just look different.
- The contract team's golden-vector file, copied in unchanged, plus tests that check our output against every entry.

## What is deliberately NOT in this PR

No call site. Nothing calls this yet, and the contract call is untouched, so **this PR cannot change the behaviour of the running app.** It is safe to merge and deploy at any time, and it does not wait on the contracts PR.

Also left out: the two new contract reads (`appKeeperKeyEpochCurrent`, `ucKeyEpochCurrent`) and reading the application entry point from the registry. Those exist on the deployed contract today, so we could have added them here — but nothing would call them until the next PR, and the repo's zero-dead-code rule is there for a reason. They go in the PR that actually uses them.

## The approaches we considered

### Where the test vectors come from

**Option A — generate our own.** Write our own fixture, compute the expected hashes ourselves, commit them.

**Option B — use the contract team's committed vectors.** ← chosen

Option A means our test proves only that our code agrees with itself. If we misread the field order, we would generate vectors matching our misreading and the test would pass. Option B pins us to a file the contract team owns and tests on their side, so if the encoding ever moves, their CI notices and our copy stops matching. It also means the web app and the Rust `depositor-cli` are checked against one shared artifact rather than two separate transcriptions of it.

We copied their file **byte for byte** rather than retyping the values into TypeScript. That keeps re-checking it a one-line `diff` instead of a careful read, and it removes any chance of a typo in a 64-character hex string. The test header records the exact upstream commit and the command to verify the copy.

### How strict to be about field widths

The encoding is Solidity's `abi.encode`. A thing worth knowing before reviewing: under `abi.encode`, every field here is padded out to the same 32 bytes, so **the declared width of a number never reaches the output**. We confirmed this — encoding all ten fields as `uint256` produces an identical hash to the real widths.

So the only things that can actually break the hash are the **order** of the fields, the **number** of fields, and whether a type is fixed-size or variable-size. Review attention belongs on the field order, not on the widths. The widths are still declared, because they document what the contract says and they bound what we accept, but they are not what makes the bytes correct.

### How to test it

A golden-vector test that passes tells you very little on its own — a test that cannot fail also passes. So we did two things.

First, the vectors give **every field a different non-zero value**. This matters more than it sounds: if a fixture used `1, 1, 1, 1` for the four version fields, swapping two of them would produce the identical hash and a wrong field order would be undetectable. The contract team enforces this rule on their side with a test, which is another reason to use their file rather than ours.

Second, we deliberately broke the encoder and checked the tests caught it. The golden file runs 12 assertions. Swapping two field values fails 8 of them, dropping a field fails the same 8, and quietly using one field twice fails exactly one test, by name. The code was restored byte-identical after each.

Third, the vectors alone turn out not to be enough, and review caught this. Because every field is padded to the same 32 bytes, **changing a field's declared type upstream can leave all four vectors byte-identical** — every value in them fits the narrower type — so our golden test would stay green while our own range checks started rejecting values the contract accepts. We verified it: widening one field from `uint16` to `uint32` passes all 8 byte assertions and is caught by nothing else. So the test now also compares our declared field list against the type list the vector file itself publishes.

That check turns out to be genuinely complementary rather than belt-and-braces, and we measured both halves: a swap in the *values* fails the 8 byte assertions and not the type-list check, while a swap in the *declared list* leaves the bytes identical and fails only the type-list check. Neither catches the other's case.

We also copied the vector file's own rule — every numeric field distinct and non-zero — into a test on our side. It was enforced only in the contract repo, so a future re-copy with weaker vectors would have silently downgraded this whole file to "the encoder agrees with itself".

One honest note on what the *second* test file does and does not prove: its cases change one field at a time and assert the hash moves, which shows no field is silently ignored or aliased. **They do not pin the field order** — swapping two inputs still gives two different hashes even if the encoder has those same two fields the wrong way round. Order is pinned by the golden vectors and by the type-list check above, not by that file. It says so, so nobody takes it on trust.

## Three problems found along the way

All three would have compiled and looked correct. The first two we hit by running the code; the third came out of review.

**1. viem refuses one of the contract's own test addresses.** The `maximum_field_values` vector uses `0xfFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF`. That is a valid 20-byte address, but its upper/lower-case pattern is not a valid EIP-55 checksum. Solidity and Foundry do not care. viem does, and throws instead of encoding. The mixed case is only a display checksum over the same 20 bytes, so the encoder lowercases the address before encoding — which produces identical bytes. An address that is not 20 bytes of hex is still rejected loudly; this only relaxes the checksum, not the format. There is a test guarding it, because without one this breaks that single vector and nothing else.

The vault provider key is lowercased for a related but separate reason, found in review. viem copies the caller's hex casing straight into its output, so an upper-case key would still hash to the correct fingerprint — keccak hashes bytes, not text — but the *preimage* string would come back mixed-case and no longer compare equal to the contract's. Since the preimage exists precisely so a mismatch can be compared word by word, that would quietly defeat it.

**2. Reading the fixture the obvious way corrupts it.** Two epochs in the vectors are near the maximum a 64-bit number can hold, which is larger than JavaScript can hold in a normal number. A plain `import vectors from "./file.json"` silently rounds `18446744073709551615` up to `18446744073709551616` — and the encoder then correctly rejects it as out of range. The test reads the file as text and parses it keeping the original digits, with a comment explaining why, so nobody "simplifies" it back into an import later.

**3. The range checks did not check the type, so some bad values encoded silently.** Found in review. A check like `value < 0n || value > max` looks complete, but every comparison against `undefined`, `null` or `NaN` is `false`, so all three passed straight through — and `"7"` and `true` passed through *and then encoded*, as 7 and as 1. That is a well-formed fingerprint built from a value nobody supplied. TypeScript does not prevent it: a JS consumer, an object built from a partial snapshot, or an unawaited read all reach that code. The guards now check the type first, and there are tests for each case.

While fixing that we also tightened three fields that can only be zero if a read failed: `chainId`, the registry address, and `vaultCoreVersion` (the contract's own setter rejects 0, and the rest of the SDK already fails closed on it). Encoding any of those produces a fingerprint that can never match, so the deposit would fail on-chain with two opaque hashes instead of failing here with a named error. The three roster and params versions are deliberately left alone — 0 is a legitimate value on those axes.

## How to check this yourself

```bash
nvm use 24
pnpm --filter @babylonlabs-io/ts-sdk run test
```

1859 tests pass, including the build and the WASM-facade check that CI runs.

Confirm our copy of the vectors matches upstream:

```bash
gh api "repos/babylonlabs-io/vault-contracts-aave-v4/contents/test/data/pegin_fingerprint_vectors.json?ref=ec62ac62da7a590408ccdcd0a6339a2fa36126b0" \
  --jq '.content' | base64 -d \
  | diff - packages/babylon-ts-sdk/src/tbv/core/pegin-fingerprint/__tests__/vectors/pegin_fingerprint_vectors.json
```

Confirm a vector independently, with Foundry rather than our code:

```bash
cast abi-encode 'f(bytes32,uint256,address,bytes32,uint64,uint64,uint16,uint16,uint16,uint16)' \
  0x7a76c7af21338f0474e4755a879f9ae8b6351b37d1a2e79e88e1ae95f20ea24b \
  1 0x5FbDB2315678afecb367f032d93F642f64180aa3 \
  0x79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798 \
  3 5 7 11 13 17 | cast keccak
# 0xe18d2cbf355cd69b44df7797eac6ad8c2dc522d328b63d20faa4f0be432cd73c
```

All four vectors were checked this way, and the built package (not just the source) was checked to reproduce them.

## Notes for review

- The API docs under `docs/api/` are generated. They are regenerated and included here because the SDK's public surface grew; CI fails if they are stale.
- The upstream contracts PR is still open at the commit we pinned. If it changes before this merges, the vector file needs re-copying. **Nothing automatic checks this** — no test or CI job re-fetches upstream, so our tests stay green against a stale copy. The pinned commit and the `diff` command in the test header make a re-copy *checkable by a person*, not automatic. Wiring that into CI belongs with the PR that actually depends on the value.
- The vault app is untouched.

## What comes next

The following PR adds the two contract reads, reads the application entry point from the registry instead of env config, computes the fingerprint from the same block-pinned snapshot the Bitcoin lock is built from, and passes it to `submitPeginRequestBatch`. That one changes the contract call, so it is held until the contract upgrade is deployed.
