### PR TITLE
fix(vault): re-check deposit limits against the block the lock is built from

### DIFF
--- a/services/vault/src/components/simple/DepositForm.tsx
+++ b/services/vault/src/components/simple/DepositForm.tsx
@@ -6,6 +6,7 @@ import { DepositButton } from "@/components/shared";
 import { getNetworkConfigBTC } from "@/config";
 import { COPY } from "@/copy";
 import { depositService } from "@/services/deposit";
+import type { SplitUnavailableReason } from "@/services/deposit/vaultCap";
 import type { VaultProviderListItem } from "@/types/vaultProvider";
 
 import { CollateralFactorRow } from "./CollateralFactorRow";
@@ -168,10 +169,11 @@ export interface DepositGatingState {
   /**
    * True when a single vault still fits but a 2-vault split would exceed the
    * cap — the deposit proceeds as a single vault and we surface the inline
-   * "vaults used / split unavailable" hint.
+   * "split unavailable" hint. The reason picks which hint: only the
+   * per-position cap can quote usage figures.
    */
-  vaultCapSplitUnavailable?: boolean;
-  /** Vault usage (used / cap) for the split-unavailable hint copy. */
+  splitUnavailableReason?: SplitUnavailableReason | null;
+  /** Vault usage (used / cap), set only for the per-position reason. */
   vaultCapUsage?: { used: number; cap: number };
 }
 
@@ -249,7 +251,7 @@ export function DepositForm({
     ordinalsCheckPending = false,
     isVaultCapReached = false,
     vaultCountCapUnavailable = false,
-    vaultCapSplitUnavailable = false,
+    splitUnavailableReason = null,
     vaultCapUsage,
   } = gatingState;
   const [openPanel, setOpenPanel] = useState<"split" | "provider" | null>(null);
@@ -450,9 +452,11 @@ export function DepositForm({
             }
           />
         )}
-        {/* Near the per-position vault cap: a split would overflow, so the
-            deposit proceeds as a single vault. Surface usage + why split is off. */}
-        {vaultCapSplitUnavailable && vaultCapUsage && (
+        {/* A split is not on offer, so the deposit proceeds as a single
+            BTCVault. Two unrelated caps can cause this and they need different
+            explanations — the per-position one can quote usage, the protocol
+            one applies even to an empty position. */}
+        {splitUnavailableReason !== null && (
           <div
             role="status"
             aria-live="polite"
@@ -463,10 +467,12 @@ export function DepositForm({
               className="mt-px shrink-0 text-accent-primary"
             />
             <span className="min-w-0 text-sm text-accent-secondary">
-              {COPY.deposit.maxVaultsReached.splitUnavailable(
-                vaultCapUsage.used,
-                vaultCapUsage.cap,
-              )}
+              {splitUnavailableReason === "per-position" && vaultCapUsage
+                ? COPY.deposit.maxVaultsReached.splitUnavailable(
+                    vaultCapUsage.used,
+                    vaultCapUsage.cap,
+                  )
+                : COPY.deposit.maxVaultsReached.splitUnavailableProtocolLimit}
             </span>
           </div>
         )}

--- a/services/vault/src/components/simple/SimpleDeposit.tsx
+++ b/services/vault/src/components/simple/SimpleDeposit.tsx
@@ -9,7 +9,10 @@ import { V3ModalShell } from "@/components/shared/V3ModalShell";
 import { FeatureFlags } from "@/config";
 import { useAddressScreening } from "@/context/addressScreening";
 import { useGeoFencing } from "@/context/geofencing";
-import { ProtocolParamsProvider } from "@/context/ProtocolParamsContext";
+import {
+  ProtocolParamsProvider,
+  useProtocolParamsContext,
+} from "@/context/ProtocolParamsContext";
 import { useBTCWallet, useETHWallet } from "@/context/wallet";
 import { COPY } from "@/copy";
 import { useBtcWalletState } from "@/hooks/deposit/useBtcWalletState";
@@ -177,6 +180,8 @@ function SimpleDepositContent({
     setFeeRate,
   } = useDepositPageFlow();
 
+  const { config } = useProtocolParamsContext();
+
   // Per-position BTC Vault cap (on-chain). Always-on value-protection guard:
   // block the deposit when even a single vault won't fit (`isAtCap`), force a
   // single vault when a split would overflow (`isSplitUnavailable`), and fail
@@ -189,11 +194,12 @@ function SimpleDepositContent({
     currentCount: collateralizableVaultCount,
     capUnavailable: vaultCountCapUnavailable,
   } = useVaultCountCap(connectedEthAddress);
-  const { isAtCap: isVaultCapReached, isSplitUnavailable: isSplitCapReached } =
+  const { isAtCap: isVaultCapReached, splitUnavailableReason } =
     resolveVaultCapState({
       existingVaultCount: collateralizableVaultCount,
       maxVaultsPerPosition: maxVaults,
       enabled: true,
+      maxHtlcOutputCount: config.maxHtlcOutputCount,
     });
 
   const isSupplementalDeposit = !!initialAmountBtc;
@@ -202,7 +208,7 @@ function SimpleDepositContent({
     : null;
   const allowSplit =
     !isSupplementalDeposit &&
-    !isSplitCapReached &&
+    splitUnavailableReason === null &&
     (!hasActiveVaults || FeatureFlags.isForcePartialLiquidationSplit);
 
   // Effective split = the same condition handleDeposit uses at submit
@@ -518,9 +524,13 @@ function SimpleDepositContent({
                   ordinalsCheckPending,
                   isVaultCapReached,
                   vaultCountCapUnavailable,
-                  vaultCapSplitUnavailable: isSplitCapReached,
+                  splitUnavailableReason,
+                  // Usage figures only make sense for the per-position cap; the
+                  // protocol cap can bite with an empty position and an unknown
+                  // per-position cap, so its hint quotes no numbers.
                   vaultCapUsage:
-                    isSplitCapReached && maxVaults != null
+                    splitUnavailableReason === "per-position" &&
+                    maxVaults != null
                       ? {
                           used: collateralizableVaultCount,
                           cap: maxVaults,

--- a/services/vault/src/components/simple/__tests__/DepositForm.splitUnavailable.test.tsx
+++ b/services/vault/src/components/simple/__tests__/DepositForm.splitUnavailable.test.tsx
@@ -1,0 +1,181 @@
+/**
+ * The inline hint shown when a BTCVault split is not on offer.
+ *
+ * Two unrelated caps suppress the split: the per-position vault cap, and the
+ * protocol's cap on HTLC outputs per transaction. They need different
+ * explanations, and for a while they shared one — so a depositor holding 0 of
+ * 10 vaults could be told "0 of 10 BTCVaults used" as the reason a split was
+ * unavailable, which was simply untrue. These pin each reason to its own copy.
+ */
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { COPY } from "@/copy";
+
+import {
+  DepositForm,
+  type DepositAmountState,
+  type DepositFeeState,
+  type DepositGatingState,
+  type DepositProviderState,
+  type DepositWalletState,
+} from "../DepositForm";
+
+vi.mock("@/config", () => ({
+  getNetworkConfigBTC: () => ({
+    coinSymbol: "BTC",
+    name: "Bitcoin",
+    icon: "bitcoin.svg",
+  }),
+}));
+
+vi.mock("@/services/deposit", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/services/deposit")>(
+      "@/services/deposit",
+    );
+  return {
+    ...actual,
+    depositService: {
+      ...actual.depositService,
+      getDepositCtaState: () => ({ disabled: false, label: "Deposit" }),
+    },
+  };
+});
+
+vi.mock("../DepositFeesBreakdown", () => ({
+  DepositFeesBreakdown: () => null,
+}));
+vi.mock("../VaultProviderSelectorV3", () => ({
+  VaultProviderSelectorV3: () => null,
+}));
+vi.mock("@/components/shared", () => ({
+  DepositButton: ({ children }: { children: React.ReactNode }) => (
+    <button type="button">{children}</button>
+  ),
+}));
+
+const amountState: DepositAmountState = {
+  amount: "",
+  amountSats: 0n,
+  btcBalance: 100_000_000n,
+  unconfirmedBalance: 0n,
+  hasUnconfirmedBalanceOnly: false,
+  minDeposit: 10_000n,
+  maxDeposit: 100_000_000n,
+  maxDepositSats: 100_000_000n,
+  effectiveRemaining: null,
+  capUnavailable: false,
+  suggestedAmountSats: null,
+};
+
+const feeState: DepositFeeState = {
+  minPeginFee: 0n,
+  minPeginFeeError: null,
+  btcPrice: 60_000,
+  hasPriceFetchError: false,
+  estimatedFeeSats: 0n,
+  estimatedFeeRate: 1,
+  isLoadingFee: false,
+  feeError: null,
+  depositorClaimValue: 0n,
+  commissionBaseValues: undefined,
+  appVersionUnsupported: false,
+  p2aAnchorValueSats: 0n,
+  depositorClaimValueError: null,
+  protocolFeeAmount: "--",
+  protocolFeePrice: "",
+  protocolFeeIsError: false,
+  feeRows: [],
+};
+
+const providerState: DepositProviderState = {
+  providers: [],
+  isLoadingProviders: false,
+  selectedProvider: "",
+  onProviderSelect: vi.fn(),
+};
+
+const walletState: DepositWalletState = {
+  isWalletConnected: true,
+};
+
+function renderForm(gatingOverrides: Partial<DepositGatingState>) {
+  const gatingState: DepositGatingState = {
+    isDepositDisabled: false,
+    isGeoBlocked: false,
+    isAddressBlocked: false,
+    ...gatingOverrides,
+  };
+  render(
+    <DepositForm
+      amountState={amountState}
+      feeState={feeState}
+      providerState={providerState}
+      walletState={walletState}
+      gatingState={gatingState}
+      collateralFactor={null}
+      twoVaultSplit={undefined}
+      onAmountChange={vi.fn()}
+      onMaxClick={vi.fn()}
+      onDeposit={vi.fn()}
+    />,
+  );
+}
+
+describe("DepositForm split-unavailable hint", () => {
+  const PROTOCOL_HINT =
+    COPY.deposit.maxVaultsReached.splitUnavailableProtocolLimit;
+
+  it("shows no hint when a split is available", () => {
+    renderForm({ splitUnavailableReason: null });
+    expect(
+      screen.queryByText(COPY.deposit.maxVaultsReached.splitUnavailable(9, 10)),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText(PROTOCOL_HINT)).not.toBeInTheDocument();
+  });
+
+  it("quotes vault usage for the per-position cap", () => {
+    renderForm({
+      splitUnavailableReason: "per-position",
+      vaultCapUsage: { used: 9, cap: 10 },
+    });
+    expect(
+      screen.getByText(COPY.deposit.maxVaultsReached.splitUnavailable(9, 10)),
+    ).toBeInTheDocument();
+  });
+
+  it("explains the protocol cap without quoting vault usage", () => {
+    // The position can be empty when this fires, so any "N of M used" figure
+    // would name a cause that is not the reason.
+    renderForm({ splitUnavailableReason: "htlc-output-cap" });
+    expect(screen.getByText(PROTOCOL_HINT)).toBeInTheDocument();
+    expect(screen.queryByText(/of \d+ BTCVaults used/)).not.toBeInTheDocument();
+  });
+
+  it("picks the hint from the reason, not from whether usage happens to be set", () => {
+    // The reason is the discriminator. Keying off `vaultCapUsage` instead would
+    // pass every other case here and still show the wrong explanation the
+    // moment both are present — which is the bug this whole split exists for.
+    renderForm({
+      splitUnavailableReason: "htlc-output-cap",
+      vaultCapUsage: { used: 9, cap: 10 },
+    });
+    expect(screen.getByText(PROTOCOL_HINT)).toBeInTheDocument();
+    expect(
+      screen.queryByText(COPY.deposit.maxVaultsReached.splitUnavailable(9, 10)),
+    ).not.toBeInTheDocument();
+  });
+
+  it("still shows the protocol-cap hint when the per-position cap is unknown", () => {
+    // `vaultCapUsage` is undefined here. Gating the hint on it — as the
+    // per-position-only version did — made the split vanish with no
+    // explanation at all.
+    renderForm({
+      splitUnavailableReason: "htlc-output-cap",
+      vaultCapUsage: undefined,
+    });
+    expect(screen.getByText(PROTOCOL_HINT)).toBeInTheDocument();
+  });
+});

--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -51,6 +51,10 @@ const connectToView = (subject: string) =>
   `Connect your wallet to view your ${subject}`;
 // Generic deposit-failure title; shared so per-bucket titles can't drift.
 const TRANSACTION_FAILED_TITLE = "Transaction failed";
+// The reassurance every pre-signing abort carries. It is the load-bearing half
+// of those messages — it is what distinguishes them from the post-registration
+// failures, which have spent an Ethereum fee — so it lives in one place.
+const NOTHING_SIGNED_OR_SPENT = "Nothing was signed and no funds were spent";
 // Shared between the resume WOTS error string and the mapped callout body so
 // the wording stays in one place.
 const WRONG_WALLET_BODY =
@@ -292,6 +296,12 @@ export const COPY = {
       unavailableCta: "Unable to verify BTCVault count — please try again",
       splitUnavailable: (used: number, cap: number) =>
         `${used} of ${cap} BTCVaults used. BTCVault split unavailable.`,
+      // The protocol's own cap on BTCVaults per transaction, which is a
+      // separate limit from the per-position one above. It quotes no usage
+      // figures: it can apply with an empty position, where "0 of 10 used"
+      // would name a cause that is not the reason.
+      splitUnavailableProtocolLimit:
+        "The protocol currently allows one BTCVault per transaction. BTCVault split unavailable.",
     },
     steps: {
       generateSecret: "Generate secret for the deposit",
@@ -956,9 +966,34 @@ export const COPY = {
         title: "Vault provider not found",
         body: "The selected vault provider could not be found. Please refresh and try again.",
       },
+      // Post-registration: the ETH vault is already on-chain and its fee is
+      // spent, so this is the expensive version of "parameters moved". Keep it
+      // distinct from the two pre-signing cases below, which cost nothing.
       versionMismatch: {
         title: "Protocol parameters changed",
         body: "The protocol parameters changed while preparing your deposit. Please restart the deposit.",
+      },
+      // Pre-signing: caught before the build, so nothing has been signed,
+      // broadcast or paid. Says so, rather than sharing the copy above and
+      // leaving the depositor to wonder what it cost them. "No funds", not "no
+      // Bitcoin" as in participantKeyDrift below — that one has already spent
+      // the Ethereum fee, and this one has spent nothing on either chain.
+      versionMismatchBeforeSigning: {
+        title: "Protocol parameters changed",
+        body: `The protocol parameters changed while we were preparing your deposit. ${NOTHING_SIGNED_OR_SPENT} — please start the deposit again.`,
+      },
+      // Pre-signing, and specifically the deposit bounds moved, so the amount
+      // itself is what needs to change. Reopening the form shows the new range.
+      depositLimitsChanged: {
+        title: "Deposit limits changed",
+        body: `The minimum or maximum deposit changed while we were preparing your deposit, and your amount is now outside the allowed range. ${NOTHING_SIGNED_OR_SPENT} — please start the deposit again with an amount in the new range.`,
+      },
+      // Pre-signing, and the cap on BTCVaults per transaction dropped below
+      // what this deposit asked for. Splitting is the thing to change here, not
+      // the amount, so this cannot share the copy above.
+      vaultCountLimitChanged: {
+        title: "BTCVault limit changed",
+        body: `The number of BTCVaults allowed in a single transaction changed while we were preparing your deposit, and this deposit asks for more than the new limit. ${NOTHING_SIGNED_OR_SPENT} — please start the deposit again without splitting across BTCVaults.`,
       },
       participantKeyDrift: {
         title: "Vault operator keys changed",

--- a/services/vault/src/hooks/deposit/__tests__/useDepositFlow.test.tsx
+++ b/services/vault/src/hooks/deposit/__tests__/useDepositFlow.test.tsx
@@ -61,6 +61,11 @@ const chainMocks = vi.hoisted(() => {
       minPrepeginDepth: 6,
     },
     offchainParamsVersion: 7,
+    // Unversioned half of the read. These bounds ACCEPT the 100000n-per-vault
+    // fixtures below; the cached copy's deliberately do not (see there).
+    minimumPegInAmount: 10_000n,
+    maxPegInAmount: 10_000_000n,
+    maxHtlcOutputCount: 5,
   };
   // Every field the lock commits to differs, so an assertion on any of them
   // discriminates between the two sources. The two version labels deliberately
@@ -83,6 +88,16 @@ const chainMocks = vi.hoisted(() => {
       feeRate: 77n,
       minPeginFeeRate: 88n,
     },
+    // Bounds that would REJECT the fixtures: 100000n is below this minimum and
+    // above this maximum, and the default deposit asks for two vaults against a
+    // cap of one. So the happy-path tests below pass only while
+    // `assertBuildWithinPinnedLimits` reads the pinned config. Point it at the
+    // cached one and they fail — which is the whole point of keeping two
+    // objects, since the bounds carry no version label for the drift guard to
+    // compare.
+    minimumPegInAmount: 500_000n,
+    maxPegInAmount: 900_000n,
+    maxHtlcOutputCount: 1,
   };
   return {
     peginConfig,
@@ -132,10 +147,16 @@ vi.mock("@/hooks/useProtocolGate", () => ({
 }));
 
 // Avoid threading a real QueryClientProvider through every renderHook —
-// `useDepositFlow` only uses the client to invalidate the UTXO query
-// after broadcast; a stub is sufficient for adapter-wiring tests.
+// `useDepositFlow` uses the client for two things: invalidating the UTXO query
+// after broadcast, and seeding the peg-in config cache when a drift guard
+// aborts. Hoisted rather than inline so the seed can be asserted.
+const queryClientMocks = vi.hoisted(() => ({
+  invalidateQueries: vi.fn(),
+  setQueryData: vi.fn(),
+}));
+
 vi.mock("@tanstack/react-query", () => ({
-  useQueryClient: () => ({ invalidateQueries: vi.fn() }),
+  useQueryClient: () => queryClientMocks,
 }));
 
 vi.mock("../useBtcWalletState", () => ({
@@ -150,8 +171,25 @@ vi.mock("@/config/pegin", () => ({
   getBTCNetworkForWASM: vi.fn(() => "testnet"),
 }));
 
-vi.mock("@/context/ProtocolParamsContext", () => ({
+// Real implementation by default; one test overrides it to throw a non-drift
+// error, to pin that the cache seed is gated on drift rather than on reaching
+// the catch at all.
+vi.mock("@/services/vault/pinnedBuildLimits", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@/services/vault/pinnedBuildLimits")>();
+  return {
+    ...actual,
+    assertBuildWithinPinnedLimits: vi.fn(actual.assertBuildWithinPinnedLimits),
+  };
+});
+
+vi.mock("@/context/ProtocolParamsContext", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/context/ProtocolParamsContext")>()),
   useProtocolParamsContext: vi.fn(),
+  // `pegInConfigQueryOptions` is deliberately NOT stubbed. The drift path seeds
+  // the cache under its key, and a hand-written copy of that key would keep
+  // passing if the real one were renamed, while production seeded a key nothing
+  // reads. It is a pure factory and pulls in no chain client at call time.
 }));
 
 // Mock btc utils (btcAddressToScriptPubKeyHex needs valid address + bitcoinjs-lib)
@@ -1022,12 +1060,130 @@ describe("useDepositFlow", () => {
       await executeDepositFlow(result);
 
       await waitFor(() => {
-        expect(result.current.error?.title).toBe(
-          COPY.deposit.errors.versionMismatch.title,
+        // Asserted on the whole callout, not the title: the pre-signing and
+        // post-registration callouts share a title, so a title-only assertion
+        // cannot tell the free failure from the expensive one.
+        expect(result.current.error).toEqual(
+          COPY.deposit.errors.versionMismatchBeforeSigning,
         );
       });
       // Nothing signed, nothing broadcast — restarting costs the depositor
       // nothing at this point, which is why the guard sits here.
+      expect(preparePeginTransaction).not.toHaveBeenCalled();
+    });
+
+    it("aborts before building when a pinned bound excludes the chosen amount", async () => {
+      const { preparePeginTransaction } = vi.mocked(
+        await import("@/services/vault/vaultTransactionService"),
+      );
+
+      // A governance change raised the minimum above the 100000n-per-vault the
+      // depositor already approved. No version label moves with it, so the
+      // sibling drift guard passes and only this check can stop the build.
+      chainMocks.getPegInConfiguration.mockResolvedValueOnce({
+        ...chainMocks.peginConfig,
+        minimumPegInAmount: 500_000n,
+      });
+
+      const { result } = renderHook(() => useDepositFlow(MOCK_PARAMS));
+
+      await executeDepositFlow(result);
+
+      await waitFor(() => {
+        expect(result.current.error).toEqual(
+          COPY.deposit.errors.depositLimitsChanged,
+        );
+      });
+      expect(preparePeginTransaction).not.toHaveBeenCalled();
+    });
+
+    it("seeds the config cache with the pinned read so a restart cannot repeat the same failure", async () => {
+      // Both aborts tell the depositor to start again, and restarting means
+      // closing and reopening the form. That form reads the cached config,
+      // which has a five minute staleTime and which nothing invalidates — so
+      // without this seed the restart re-reads the snapshot that just failed.
+      const pinned = {
+        ...chainMocks.peginConfig,
+        minimumPegInAmount: 500_000n,
+      };
+      chainMocks.getPegInConfiguration.mockResolvedValueOnce(pinned);
+
+      const { result } = renderHook(() => useDepositFlow(MOCK_PARAMS));
+
+      await executeDepositFlow(result);
+
+      await waitFor(() => {
+        expect(result.current.error).toEqual(
+          COPY.deposit.errors.depositLimitsChanged,
+        );
+      });
+      // Key comes from the real factory, not a literal: a rename must break
+      // this test rather than leave it green while production seeds a dead key.
+      const { pegInConfigQueryOptions } = await vi.importActual<
+        typeof import("@/context/ProtocolParamsContext")
+      >("@/context/ProtocolParamsContext");
+      expect(queryClientMocks.setQueryData).toHaveBeenCalledWith(
+        pegInConfigQueryOptions().queryKey,
+        pinned,
+      );
+    });
+
+    it("does not touch the config cache when the abort is not drift", async () => {
+      // The seed overwrites a key the blocking ProtocolParamsProvider and the
+      // polling hook both read. A TypeError from the guard establishes nothing
+      // about the chain, so it must not rewrite that cache on its way out.
+      const { assertBuildWithinPinnedLimits } = vi.mocked(
+        await import("@/services/vault/pinnedBuildLimits"),
+      );
+      assertBuildWithinPinnedLimits.mockImplementationOnce(() => {
+        throw new TypeError("not a drift error");
+      });
+
+      const { result } = renderHook(() => useDepositFlow(MOCK_PARAMS));
+
+      await executeDepositFlow(result);
+
+      await waitFor(() => {
+        expect(result.current.error).not.toBeNull();
+      });
+      expect(queryClientMocks.setQueryData).not.toHaveBeenCalled();
+    });
+
+    it("leaves the config cache alone when the build succeeds", async () => {
+      // The seed is a drift-path repair, not something the happy path does —
+      // otherwise this assertion would pass no matter where the call sat.
+      const { result } = renderHook(() => useDepositFlow(MOCK_PARAMS));
+
+      await executeDepositFlow(result);
+
+      await waitFor(() => {
+        expect(chainMocks.getPegInConfiguration).toHaveBeenCalled();
+      });
+      expect(queryClientMocks.setQueryData).not.toHaveBeenCalled();
+    });
+
+    it("aborts before building when the pinned HTLC output cap is below the vault count", async () => {
+      const { preparePeginTransaction } = vi.mocked(
+        await import("@/services/vault/vaultTransactionService"),
+      );
+
+      // The default deposit asks for two vaults, so two HTLC outputs.
+      chainMocks.getPegInConfiguration.mockResolvedValueOnce({
+        ...chainMocks.peginConfig,
+        maxHtlcOutputCount: 1,
+      });
+
+      const { result } = renderHook(() => useDepositFlow(MOCK_PARAMS));
+
+      await executeDepositFlow(result);
+
+      await waitFor(() => {
+        // Not the deposit-limits callout: this one has to say "stop splitting",
+        // not "change your amount".
+        expect(result.current.error).toEqual(
+          COPY.deposit.errors.vaultCountLimitChanged,
+        );
+      });
       expect(preparePeginTransaction).not.toHaveBeenCalled();
     });
 

--- a/services/vault/src/hooks/deposit/useDepositFlow.ts
+++ b/services/vault/src/hooks/deposit/useDepositFlow.ts
@@ -47,7 +47,10 @@ import {
   getVaultRegistryReader,
 } from "@/clients/eth-contract/sdk-readers";
 import { isDepositBlocked } from "@/components/shared/protocolStatus";
-import { useProtocolParamsContext } from "@/context/ProtocolParamsContext";
+import {
+  pegInConfigQueryOptions,
+  useProtocolParamsContext,
+} from "@/context/ProtocolParamsContext";
 import {
   markPayoutSignCanceled,
   markWotsSubmitted,
@@ -63,11 +66,18 @@ import {
 } from "@/infrastructure/telemetryEvents";
 import { LocalStorageStatus } from "@/models/peginStateMachine";
 import { validateMultiVaultDepositInputs } from "@/services/deposit/validations";
-import { assertBuildConfigMatchesForm } from "@/services/vault/buildConfigConsistency";
+import {
+  assertBuildConfigMatchesForm,
+  isBuildConfigDriftError,
+} from "@/services/vault/buildConfigConsistency";
 import {
   waitForEthRegistrationDepth,
   type RegistrationDepthProgress,
 } from "@/services/vault/ethConfirmationGate";
+import {
+  assertBuildWithinPinnedLimits,
+  isBuildLimitsDriftError,
+} from "@/services/vault/pinnedBuildLimits";
 import type { PayoutSigningProgress } from "@/services/vault/vaultPayoutSignatureService";
 import {
   broadcastPrePeginTransaction,
@@ -662,7 +672,45 @@ export function useDepositFlow(
         // pinned one. If a governance change landed in between they are
         // different parameter sets, and the amount the depositor approved was
         // validated against the wrong one. Stop here, where restarting is free.
-        assertBuildConfigMatchesForm(buildConfig, config);
+        try {
+          assertBuildConfigMatchesForm(buildConfig, config);
+
+          // The guard above only sees the two version labels, and the deposit
+          // bounds carry none — they come from the `getTBVProtocolParams` half
+          // of the read, which is unversioned. So a tightened minimum or
+          // maximum, or a lowered HTLC output cap, passes it untouched.
+          // Re-check what the depositor actually approved against the pinned
+          // numbers.
+          assertBuildWithinPinnedLimits(vaultAmounts, buildConfig);
+        } catch (driftError) {
+          // Both aborts tell the depositor to start again, and the only way to
+          // do that is to close and reopen the form, which reads the cached
+          // configuration — five minute `staleTime`, nothing invalidates it. So
+          // a restart would hand back the same snapshot that just caused this
+          // and fail identically. Overwrite it with the pinned read.
+          //
+          // The justification is NOT that the pinned read is fresher: it is
+          // `head - 2`, and `resolvePinnedReadBlock` says freshness is
+          // explicitly not its goal, so a cache entry refilled at `latest`
+          // moments ago can legitimately be newer. It is that this particular
+          // value is the one the build just proved the cache disagrees with, on
+          // the axis that failed. Overwriting rather than invalidating avoids a
+          // refetch race where the form renders the stale bounds first.
+          //
+          // Gated on the drift predicates, not on reaching the catch at all: an
+          // unrelated throw from either assert must not rewrite a cache the
+          // blocking ProtocolParamsProvider and the polling hook also read.
+          if (
+            isBuildConfigDriftError(driftError) ||
+            isBuildLimitsDriftError(driftError)
+          ) {
+            queryClient.setQueryData(
+              pegInConfigQueryOptions().queryKey,
+              buildConfig,
+            );
+          }
+          throw driftError;
+        }
 
         const validatedKeys = await validateOnChainParticipantKeys({
           vaultRegistryReader: getVaultRegistryReader(),

--- a/services/vault/src/services/deposit/__tests__/vaultCap.test.ts
+++ b/services/vault/src/services/deposit/__tests__/vaultCap.test.ts
@@ -2,6 +2,12 @@ import { describe, expect, it } from "vitest";
 
 import { resolveVaultCapState } from "../vaultCap";
 
+/**
+ * A cap high enough that the HTLC-output axis never fires, so the cases below
+ * keep testing only the per-position cap they were written for.
+ */
+const PERMISSIVE_HTLC_CAP = 10;
+
 describe("resolveVaultCapState", () => {
   it("blocks neither when the flag is off", () => {
     expect(
@@ -9,8 +15,9 @@ describe("resolveVaultCapState", () => {
         existingVaultCount: 10,
         maxVaultsPerPosition: 10,
         enabled: false,
+        maxHtlcOutputCount: PERMISSIVE_HTLC_CAP,
       }),
-    ).toEqual({ isAtCap: false, isSplitUnavailable: false });
+    ).toEqual({ isAtCap: false, splitUnavailableReason: null });
   });
 
   it("blocks neither when the cap is unknown (null)", () => {
@@ -19,8 +26,9 @@ describe("resolveVaultCapState", () => {
         existingVaultCount: 10,
         maxVaultsPerPosition: null,
         enabled: true,
+        maxHtlcOutputCount: PERMISSIVE_HTLC_CAP,
       }),
-    ).toEqual({ isAtCap: false, isSplitUnavailable: false });
+    ).toEqual({ isAtCap: false, splitUnavailableReason: null });
   });
 
   it("blocks neither well below the cap (split fits)", () => {
@@ -29,8 +37,9 @@ describe("resolveVaultCapState", () => {
         existingVaultCount: 5,
         maxVaultsPerPosition: 10,
         enabled: true,
+        maxHtlcOutputCount: PERMISSIVE_HTLC_CAP,
       }),
-    ).toEqual({ isAtCap: false, isSplitUnavailable: false });
+    ).toEqual({ isAtCap: false, splitUnavailableReason: null });
   });
 
   it("allows a split exactly when it fits (count + 2 == cap)", () => {
@@ -39,8 +48,9 @@ describe("resolveVaultCapState", () => {
         existingVaultCount: 8,
         maxVaultsPerPosition: 10,
         enabled: true,
+        maxHtlcOutputCount: PERMISSIVE_HTLC_CAP,
       }),
-    ).toEqual({ isAtCap: false, isSplitUnavailable: false });
+    ).toEqual({ isAtCap: false, splitUnavailableReason: null });
   });
 
   it("disables the split near the cap (single fits, split overflows)", () => {
@@ -49,8 +59,9 @@ describe("resolveVaultCapState", () => {
         existingVaultCount: 9,
         maxVaultsPerPosition: 10,
         enabled: true,
+        maxHtlcOutputCount: PERMISSIVE_HTLC_CAP,
       }),
-    ).toEqual({ isAtCap: false, isSplitUnavailable: true });
+    ).toEqual({ isAtCap: false, splitUnavailableReason: "per-position" });
   });
 
   it("blocks the deposit at the cap (single overflows)", () => {
@@ -59,8 +70,9 @@ describe("resolveVaultCapState", () => {
         existingVaultCount: 10,
         maxVaultsPerPosition: 10,
         enabled: true,
+        maxHtlcOutputCount: PERMISSIVE_HTLC_CAP,
       }),
-    ).toEqual({ isAtCap: true, isSplitUnavailable: false });
+    ).toEqual({ isAtCap: true, splitUnavailableReason: null });
   });
 
   it("blocks the deposit over the cap", () => {
@@ -69,7 +81,72 @@ describe("resolveVaultCapState", () => {
         existingVaultCount: 12,
         maxVaultsPerPosition: 10,
         enabled: true,
+        maxHtlcOutputCount: PERMISSIVE_HTLC_CAP,
       }),
-    ).toEqual({ isAtCap: true, isSplitUnavailable: false });
+    ).toEqual({ isAtCap: true, splitUnavailableReason: null });
+  });
+
+  // The protocol's HTLC-output cap is a second, independent reason a split may
+  // be unavailable. It matters because `assertBuildWithinPinnedLimits` aborts a
+  // build that exceeds it and tells the depositor to start again without
+  // splitting — an instruction the form has to make followable.
+  it("disables the split when the protocol allows only one HTLC output", () => {
+    expect(
+      resolveVaultCapState({
+        existingVaultCount: 0,
+        maxVaultsPerPosition: 10,
+        enabled: true,
+        maxHtlcOutputCount: 1,
+      }),
+    ).toEqual({ isAtCap: false, splitUnavailableReason: "htlc-output-cap" });
+  });
+
+  it("allows the split when the protocol allows exactly two HTLC outputs", () => {
+    expect(
+      resolveVaultCapState({
+        existingVaultCount: 0,
+        maxVaultsPerPosition: 10,
+        enabled: true,
+        maxHtlcOutputCount: 2,
+      }),
+    ).toEqual({ isAtCap: false, splitUnavailableReason: null });
+  });
+
+  it("applies the HTLC cap even when per-position enforcement is off", () => {
+    // Different contracts, different flags: the liquidation-notifications flag
+    // gates the per-position cap only, and must not switch off a protocol limit
+    // the build will enforce regardless.
+    expect(
+      resolveVaultCapState({
+        existingVaultCount: 0,
+        maxVaultsPerPosition: null,
+        enabled: false,
+        maxHtlcOutputCount: 1,
+      }),
+    ).toEqual({ isAtCap: false, splitUnavailableReason: "htlc-output-cap" });
+  });
+
+  it("reports the per-position reason first when both caps bite", () => {
+    // It is the one that can quote usage and that the depositor can act on by
+    // withdrawing a vault, so it is the more useful of the two to name.
+    expect(
+      resolveVaultCapState({
+        existingVaultCount: 9,
+        maxVaultsPerPosition: 10,
+        enabled: true,
+        maxHtlcOutputCount: 1,
+      }),
+    ).toEqual({ isAtCap: false, splitUnavailableReason: "per-position" });
+  });
+
+  it("leaves the deposit blocked at the per-position cap regardless of the HTLC cap", () => {
+    expect(
+      resolveVaultCapState({
+        existingVaultCount: 10,
+        maxVaultsPerPosition: 10,
+        enabled: true,
+        maxHtlcOutputCount: 1,
+      }),
+    ).toEqual({ isAtCap: true, splitUnavailableReason: null });
   });
 });

--- a/services/vault/src/services/deposit/vaultCap.ts
+++ b/services/vault/src/services/deposit/vaultCap.ts
@@ -1,14 +1,28 @@
 /**
- * Per-position BTC Vault cap logic, derived from the on-chain
- * `maxVaultsPerPosition` parameter. Drives the deposit-flow behaviour:
+ * Whether a deposit fits, and whether it may be split, given two independent
+ * on-chain caps. Drives the deposit-flow behaviour:
  *
  * - **At cap** — a single vault no longer fits: block the deposit.
- * - **Near cap** — a single vault fits but a 2-vault split would overflow:
- *   keep the deposit, force a single vault (split unavailable).
+ * - **Near cap** — a single vault fits but a 2-vault split would overflow the
+ *   per-position cap: keep the deposit, force a single vault.
+ * - **HTLC output cap** — the protocol allows fewer HTLC outputs in one
+ *   Pre-PegIn than a split needs: force a single vault, whatever the
+ *   per-position cap says.
+ *
+ * The two caps are unrelated and are enforced by different contracts, but they
+ * answer the same question for the form, so they resolve here together. The
+ * HTLC cap matters beyond the form: `assertBuildWithinPinnedLimits` re-checks
+ * it against the pinned read and aborts the build, and its message tells the
+ * depositor to start again without splitting. That instruction is only
+ * followable if the form stops offering the split — otherwise the reopened form
+ * re-enables it and the next attempt fails identically.
  *
  * Pure and side-effect free so it can be unit-tested and reused across the
  * submit guard, the CTA state, and the inline hint.
  */
+
+/** HTLC outputs a two-BTCVault split puts in one Pre-PegIn — one per BTCVault. */
+const HTLC_OUTPUTS_PER_SPLIT_DEPOSIT = 2;
 
 export interface VaultCapStateParams {
   /** Number of BTC Vaults the position already holds. */
@@ -17,25 +31,58 @@ export interface VaultCapStateParams {
   maxVaultsPerPosition: number | null;
   /** Whether cap enforcement is active (the liquidation-notifications flag). */
   enabled: boolean;
+  /**
+   * `ProtocolParams.maxHtlcOutputCount` — HTLC outputs allowed in one
+   * Pre-PegIn. Validated to `[1, 255]` on read, so it is never zero here.
+   */
+  maxHtlcOutputCount: number;
 }
+
+/**
+ * Why a split is not on offer, or `null` when it is.
+ *
+ * A discriminated reason rather than a boolean because the two causes need
+ * different explanations: the per-position one can quote "N of M BTCVaults
+ * used", and the protocol one cannot — the position may be empty and the cap
+ * may be unknown. Collapsing them showed a depositor at 0 of 10 vaults a hint
+ * blaming a cap they were nowhere near.
+ */
+export type SplitUnavailableReason = "per-position" | "htlc-output-cap";
 
 export interface VaultCapState {
   /** Even a single new vault would exceed the cap — block the deposit. */
   isAtCap: boolean;
-  /** A single fits but a 2-vault split would exceed the cap — force single. */
-  isSplitUnavailable: boolean;
+  /** Why a 2-vault split is unavailable, or `null` when it is available. */
+  splitUnavailableReason: SplitUnavailableReason | null;
 }
 
 export function resolveVaultCapState({
   existingVaultCount,
   maxVaultsPerPosition,
   enabled,
+  maxHtlcOutputCount,
 }: VaultCapStateParams): VaultCapState {
+  // Applies whatever the per-position cap says, and whether or not that cap is
+  // enforced — it is a different contract's limit, gated by a different flag.
+  const htlcReason: SplitUnavailableReason | null =
+    maxHtlcOutputCount < HTLC_OUTPUTS_PER_SPLIT_DEPOSIT
+      ? "htlc-output-cap"
+      : null;
+
   if (!enabled || maxVaultsPerPosition == null) {
-    return { isAtCap: false, isSplitUnavailable: false };
+    return { isAtCap: false, splitUnavailableReason: htlcReason };
   }
   const isAtCap = existingVaultCount + 1 > maxVaultsPerPosition;
-  const isSplitUnavailable =
-    !isAtCap && existingVaultCount + 2 > maxVaultsPerPosition;
-  return { isAtCap, isSplitUnavailable };
+  if (isAtCap) {
+    // The deposit is blocked outright, so there is no split to explain.
+    return { isAtCap, splitUnavailableReason: null };
+  }
+  // Per-position is reported first: it is the one that can quote usage, and the
+  // depositor can act on it by withdrawing a vault.
+  const perPositionReason: SplitUnavailableReason | null =
+    existingVaultCount + 2 > maxVaultsPerPosition ? "per-position" : null;
+  return {
+    isAtCap,
+    splitUnavailableReason: perPositionReason ?? htlcReason,
+  };
 }

--- a/services/vault/src/services/vault/__tests__/pinnedBuildLimits.test.ts
+++ b/services/vault/src/services/vault/__tests__/pinnedBuildLimits.test.ts
@@ -1,0 +1,187 @@
+import type { PegInConfiguration } from "@babylonlabs-io/ts-sdk/tbv/core";
+import { describe, expect, it } from "vitest";
+
+import {
+  BuildLimitsDriftError,
+  BuildPreconditionError,
+  assertBuildWithinPinnedLimits,
+  isBuildLimitsDriftError,
+} from "../pinnedBuildLimits";
+
+function config(
+  minimumPegInAmount: bigint,
+  maxPegInAmount: bigint,
+  maxHtlcOutputCount = 2,
+): PegInConfiguration {
+  return {
+    minimumPegInAmount,
+    maxPegInAmount,
+    maxHtlcOutputCount,
+  } as PegInConfiguration;
+}
+
+describe("assertBuildWithinPinnedLimits amount bounds", () => {
+  it("passes an amount inside the pinned bounds", () => {
+    expect(() =>
+      assertBuildWithinPinnedLimits([100_000n], config(10_000n, 1_000_000n)),
+    ).not.toThrow();
+  });
+
+  it("accepts an amount exactly at the minimum", () => {
+    // The bounds are inclusive on both ends, matching the check the form ran.
+    // A re-validation that disagreed here would reject deposits the form
+    // allowed for a reason that has nothing to do with drift.
+    expect(() =>
+      assertBuildWithinPinnedLimits([10_000n], config(10_000n, 1_000_000n)),
+    ).not.toThrow();
+  });
+
+  it("accepts an amount exactly at the maximum", () => {
+    expect(() =>
+      assertBuildWithinPinnedLimits([1_000_000n], config(10_000n, 1_000_000n)),
+    ).not.toThrow();
+  });
+
+  it("throws when the pinned minimum rose above the chosen amount", () => {
+    expect(() =>
+      assertBuildWithinPinnedLimits([100_000n], config(200_000n, 1_000_000n)),
+    ).toThrow(BuildLimitsDriftError);
+  });
+
+  it("throws when the pinned maximum fell below the chosen amount", () => {
+    expect(() =>
+      assertBuildWithinPinnedLimits([100_000n], config(10_000n, 50_000n)),
+    ).toThrow(BuildLimitsDriftError);
+  });
+
+  it("rejects a leg below the minimum wherever it sits in the array", () => {
+    // Each leg is checked, not the total and not just the first entry. Asserted
+    // in both orders so the test pins per-leg coverage on its own rather than
+    // borrowing the SDK's "Vault N" wording, which this module no longer quotes.
+    const bounds = config(150_000n, 1_000_000n);
+    expect(() =>
+      assertBuildWithinPinnedLimits([100_000n, 200_000n], bounds),
+    ).toThrow(BuildLimitsDriftError);
+    expect(() =>
+      assertBuildWithinPinnedLimits([200_000n, 100_000n], bounds),
+    ).toThrow(BuildLimitsDriftError);
+  });
+
+  it("names the offending BTCVault and the pinned bounds, and no amount", () => {
+    // The amount is omitted on purpose: this message reaches Sentry verbatim,
+    // and a precise deposit amount is depositor-identifying.
+    let message = "";
+    try {
+      assertBuildWithinPinnedLimits([100_000n], config(200_000n, 900_000n));
+    } catch (err) {
+      message = (err as Error).message;
+    }
+    expect(message).toMatch(/BTCVault 1 of 1/);
+    expect(message).toMatch(/200000 to 900000 satoshis/);
+    expect(message).not.toMatch(/100000|0\.001/);
+  });
+});
+
+describe("assertBuildWithinPinnedLimits caller-bug inputs", () => {
+  // These are not drift. Reporting them as drift would tell the depositor the
+  // chain moved and send them to change an amount that was never the problem.
+  it("throws a precondition error, not a drift error, for an empty array", () => {
+    // Typed, not plain: an unrecognised error becomes the callout body, which
+    // would show the depositor an internal function name.
+    expect(() =>
+      assertBuildWithinPinnedLimits([], config(10_000n, 1_000_000n)),
+    ).toThrow(BuildPreconditionError);
+    expect(() =>
+      assertBuildWithinPinnedLimits([], config(10_000n, 1_000_000n)),
+    ).not.toThrow(BuildLimitsDriftError);
+  });
+
+  it("throws a precondition error, not a drift error, for a non-positive leg", () => {
+    expect(() =>
+      assertBuildWithinPinnedLimits(
+        [100_000n, 0n],
+        config(10_000n, 1_000_000n),
+      ),
+    ).toThrow(BuildPreconditionError);
+    expect(() =>
+      assertBuildWithinPinnedLimits([0n], config(10_000n, 1_000_000n)),
+    ).not.toThrow(BuildLimitsDriftError);
+  });
+});
+
+describe("assertBuildWithinPinnedLimits HTLC output count", () => {
+  it("accepts a vault count exactly at the pinned cap", () => {
+    expect(() =>
+      assertBuildWithinPinnedLimits(
+        [100_000n, 100_000n],
+        config(10_000n, 1_000_000n, 2),
+      ),
+    ).not.toThrow();
+  });
+
+  it("throws when the pinned cap fell below the vault count", () => {
+    expect(() =>
+      assertBuildWithinPinnedLimits(
+        [100_000n, 100_000n],
+        config(10_000n, 1_000_000n, 1),
+      ),
+    ).toThrow(/2 HTLC outputs.*at most 1/s);
+  });
+});
+
+describe("assertBuildWithinPinnedLimits drift reason", () => {
+  // The reason picks the callout, and the two give opposite instructions —
+  // change the amount, or stop splitting. Tagging the wrong one sends the
+  // depositor to fix something that is not broken.
+  it("tags an out-of-bounds amount as amount-bounds", () => {
+    expect(() =>
+      assertBuildWithinPinnedLimits([100_000n], config(200_000n, 1_000_000n)),
+    ).toThrow(expect.objectContaining({ reason: "amount-bounds" }));
+  });
+
+  it("tags an over-cap vault count as vault-count", () => {
+    expect(() =>
+      assertBuildWithinPinnedLimits(
+        [100_000n, 100_000n],
+        config(10_000n, 1_000_000n, 1),
+      ),
+    ).toThrow(expect.objectContaining({ reason: "vault-count" }));
+  });
+
+  it("reports the amount when both limits are exceeded at once", () => {
+    // Amounts are checked first, deliberately: the amount is what the depositor
+    // typed, so it is the more actionable of the two to name.
+    expect(() =>
+      assertBuildWithinPinnedLimits(
+        [100_000n, 100_000n],
+        config(200_000n, 1_000_000n, 1),
+      ),
+    ).toThrow(expect.objectContaining({ reason: "amount-bounds" }));
+  });
+});
+
+describe("isBuildLimitsDriftError", () => {
+  it("recognises a real instance", () => {
+    expect(
+      isBuildLimitsDriftError(
+        new BuildLimitsDriftError("limits", "amount-bounds"),
+      ),
+    ).toBe(true);
+  });
+
+  it("recognises a structural copy by name, for errors that crossed a realm", () => {
+    const structural = new Error("limits");
+    structural.name = "BuildLimitsDriftError";
+    expect(isBuildLimitsDriftError(structural)).toBe(true);
+  });
+
+  it("rejects an unrelated error", () => {
+    expect(isBuildLimitsDriftError(new Error("something else"))).toBe(false);
+  });
+
+  it("does not swallow the sibling guard's error, which maps to different copy", () => {
+    const sibling = new Error("drift");
+    sibling.name = "BuildConfigDriftError";
+    expect(isBuildLimitsDriftError(sibling)).toBe(false);
+  });
+});

--- a/services/vault/src/services/vault/buildConfigConsistency.ts
+++ b/services/vault/src/services/vault/buildConfigConsistency.ts
@@ -74,16 +74,16 @@ export function isBuildConfigDriftError(
  * `maxHtlcOutputCount`, `expiredPegInGraceBlocks` — carries no version label at
  * all, so a change there moves no field this guard reads. The deposit amount is
  * gated against the cached `minimumPegInAmount` / `maxPegInAmount` before this
- * runs, so a bound tightened inside the cache window is not caught here and the
- * registration reverts on-chain instead.
+ * runs, so a bound tightened inside the cache window gets past this guard
+ * untouched.
  *
- * That axis is deliberately out of scope. It is a pre-existing gap that pinning
- * the build neither opened nor widened — before, the form and the build both
- * read the cached bounds and the same registration reverted in the same place.
- * This guard exists to close the divergence that pinning *did* introduce, which
- * is between the two snapshots, not between a snapshot and the chain. Closing
- * the unversioned axis properly means re-validating the chosen amounts against
- * the pinned bounds, which belongs with the recovery work rather than here.
+ * That axis is deliberately out of scope *for this guard*, which exists to close
+ * the divergence that pinning introduced — between the two snapshots, not
+ * between a snapshot and the chain. It is now covered, one call site later, by
+ * `assertBuildWithinPinnedLimits` in `./pinnedBuildLimits`, which re-validates
+ * the chosen amounts and the vault count against the pinned read rather than
+ * comparing the bounds (a bound that moves *up* leaves the chosen amount valid,
+ * so comparing them would abort a deposit that has nothing wrong with it).
  *
  * @param buildConfig - Read from chain, pinned to the build's block.
  * @param formConfig - The cached snapshot the form gated and sized against.

--- a/services/vault/src/services/vault/pinnedBuildLimits.ts
+++ b/services/vault/src/services/vault/pinnedBuildLimits.ts
@@ -1,0 +1,181 @@
+/**
+ * Guard that the amounts the depositor approved, and the number of vaults they
+ * asked for, are still within the protocol limits the chain is publishing right
+ * now — not the ones the form happened to have cached.
+ *
+ * ## Why this is separate from `buildConfigConsistency`
+ *
+ * That guard compares two *snapshots* to each other: the cached configuration
+ * the form gated on, and the pinned one the build uses. This guard compares the
+ * depositor's *choices* against a single snapshot. Different relation, so a
+ * separate module — and `assertBuildConfigMatchesForm` explicitly scopes this
+ * axis out and points here.
+ *
+ * ## The gap it closes
+ *
+ * `PegInConfiguration` is assembled from two contract reads. The
+ * `getLatestOffchainParams` half carries a version label; the
+ * `getTBVProtocolParams` half — `minimumPegInAmount`, `maxPegInAmount`,
+ * `maxHtlcOutputCount` and three timeouts — carries none. So a governance
+ * change to any of those moves no field `assertBuildConfigMatchesForm` reads,
+ * and it passes.
+ *
+ * The amounts are bound-checked once, early in the flow, against the cached
+ * React Query configuration — a snapshot with a five minute `staleTime` that
+ * nothing invalidates. If a bound tightened after that snapshot was taken, the
+ * build proceeds and the registration reverts on-chain, after the depositor has
+ * completed a signing ceremony. This runs against the pinned read instead, so
+ * the deposit stops while restarting is still free.
+ *
+ * ## Re-validate the choices, do not compare the bounds
+ *
+ * Comparing the cached bounds against the pinned ones is the wrong test, and
+ * deliberately not what this does. A `maxPegInAmount` that moves *up* makes the
+ * two differ while leaving the chosen amount perfectly valid, so a comparison
+ * would abort a deposit that had nothing wrong with it. Re-validating the
+ * amounts catches a bound that tightened and ignores one that loosened.
+ *
+ * @module services/vault/pinnedBuildLimits
+ */
+
+import type { PegInConfiguration } from "@babylonlabs-io/ts-sdk/tbv/core";
+import { validateVaultAmounts } from "@babylonlabs-io/ts-sdk/tbv/core/services";
+
+/**
+ * Which limit was exceeded. Carried on the error because the two need different
+ * copy: an amount outside the bounds is fixed by entering a different amount,
+ * a vault count over the cap by not splitting. One message covering both would
+ * give the wrong instruction for whichever case it was not written for.
+ */
+export type BuildLimitsDriftReason = "amount-bounds" | "vault-count";
+
+/**
+ * The depositor's amounts or vault count fall outside the protocol limits read
+ * at the build's pinned block.
+ */
+export class BuildLimitsDriftError extends Error {
+  readonly reason: BuildLimitsDriftReason;
+
+  constructor(message: string, reason: BuildLimitsDriftReason) {
+    super(message);
+    this.name = "BuildLimitsDriftError";
+    this.reason = reason;
+  }
+}
+
+// `instanceof` alone fails across module boundaries (duplicate copies, test
+// mocks). Fall back to the name field, as the sibling drift guards do.
+export function isBuildLimitsDriftError(
+  err: unknown,
+): err is BuildLimitsDriftError {
+  return (
+    err instanceof BuildLimitsDriftError ||
+    (err instanceof Error && err.name === "BuildLimitsDriftError")
+  );
+}
+
+/**
+ * The caller handed this guard something it cannot judge — no amounts at all,
+ * or a non-positive one.
+ *
+ * Typed rather than a plain `Error` so `mapDepositError` recognises it: the
+ * mapper's last resort renders an unrecognised message straight into the
+ * callout, which would put an internal function name in front of a depositor.
+ * The detail stays on the error for the bug report.
+ */
+export class BuildPreconditionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "BuildPreconditionError";
+  }
+}
+
+// Name fallback for cross-realm recognition, as the sibling guards do.
+export function isBuildPreconditionError(
+  err: unknown,
+): err is BuildPreconditionError {
+  return (
+    err instanceof BuildPreconditionError ||
+    (err instanceof Error && err.name === "BuildPreconditionError")
+  );
+}
+
+/**
+ * Throw when the chosen amounts or the vault count exceed the pinned limits.
+ *
+ * The bounds comparison delegates to the SDK's {@link validateVaultAmounts} —
+ * the same function the flow already ran against the cached bounds earlier —
+ * rather than being re-derived here. Two gates that must agree on what "within
+ * bounds" means should not each own a copy of it, and the bounds are inclusive
+ * at both ends, which is easy to get subtly wrong on a second writing.
+ *
+ * It is called per leg rather than over the whole array, for two reasons. It
+ * yields the index, so the message can name the offending BTCVault without
+ * quoting the SDK's string. And it leaves the validator's non-bounds failures —
+ * an empty array, a non-positive leg — to the explicit checks below, which
+ * throw {@link BuildPreconditionError}. Those are application bugs, not
+ * governance changes, and tagging them as drift would tell the depositor the
+ * chain moved and send them to change an amount that was never the problem.
+ *
+ * No vault amount is interpolated into any message here. The flow hands a
+ * thrown error straight to `logger.error`, which scrubs only the console mirror
+ * and passes the message to Sentry verbatim; a precise deposit amount is
+ * depositor-identifying, which is the rule `telemetryEvents.amountBucket`
+ * states. The bounds themselves are public protocol parameters and are safe to
+ * name.
+ *
+ * The SDK validator documents vault-count limits as the caller's
+ * responsibility, so the `maxHtlcOutputCount` check lives here. Every vault in
+ * a batch is one HTLC output in the single Pre-PegIn transaction, so the vault
+ * count is the output count the contract bounds.
+ *
+ * @param vaultAmounts - Per-vault amounts in satoshis, one entry per vault.
+ * @param buildConfig - Configuration read at the build's pinned block.
+ * @throws {BuildLimitsDriftError} when a limit read at the pinned block
+ *   excludes what the depositor approved.
+ * @throws {BuildPreconditionError} when `vaultAmounts` is empty or holds a
+ *   non-positive leg — caller bugs, deliberately not tagged as drift.
+ */
+export function assertBuildWithinPinnedLimits(
+  vaultAmounts: bigint[],
+  buildConfig: PegInConfiguration,
+): void {
+  if (vaultAmounts.length === 0) {
+    throw new BuildPreconditionError(
+      "assertBuildWithinPinnedLimits requires at least one vault amount",
+    );
+  }
+
+  vaultAmounts.forEach((amount, index) => {
+    if (amount <= 0n) {
+      throw new BuildPreconditionError(
+        `assertBuildWithinPinnedLimits: vault amount at index ${index} must be positive`,
+      );
+    }
+
+    const leg = validateVaultAmounts(
+      [amount],
+      buildConfig.minimumPegInAmount,
+      buildConfig.maxPegInAmount,
+    );
+
+    if (!leg.valid) {
+      throw new BuildLimitsDriftError(
+        `Deposit limits changed while preparing this deposit: BTCVault ` +
+          `${index + 1} of ${vaultAmounts.length} falls outside the range the ` +
+          `chain now reports, ${buildConfig.minimumPegInAmount} to ` +
+          `${buildConfig.maxPegInAmount} satoshis per BTCVault.`,
+        "amount-bounds",
+      );
+    }
+  });
+
+  if (vaultAmounts.length > buildConfig.maxHtlcOutputCount) {
+    throw new BuildLimitsDriftError(
+      `Deposit limits changed while preparing this deposit: this deposit needs ` +
+        `${vaultAmounts.length} HTLC outputs, and the chain now allows at most ` +
+        `${buildConfig.maxHtlcOutputCount} per Pre-PegIn transaction.`,
+      "vault-count",
+    );
+  }
+}

--- a/services/vault/src/utils/errors/__tests__/depositErrors.test.ts
+++ b/services/vault/src/utils/errors/__tests__/depositErrors.test.ts
@@ -110,6 +110,66 @@ describe("mapDepositError", () => {
     expect(mapDepositError(err)).toEqual(ERRORS.versionMismatch);
   });
 
+  it("maps a pre-signing config drift to the nothing-was-spent callout", () => {
+    const err = new Error("Protocol parameters changed while preparing");
+    err.name = "BuildConfigDriftError";
+    expect(mapDepositError(err)).toEqual(ERRORS.versionMismatchBeforeSigning);
+  });
+
+  it("maps an amount-bounds drift to the deposit-limits callout", () => {
+    const err = Object.assign(new Error("Deposit limits changed"), {
+      name: "BuildLimitsDriftError",
+      reason: "amount-bounds",
+    });
+    expect(mapDepositError(err)).toEqual(ERRORS.depositLimitsChanged);
+  });
+
+  it("maps a vault-count drift to the BTCVault-limit callout", () => {
+    // Different instruction: stop splitting, rather than change the amount.
+    const err = Object.assign(new Error("Deposit limits changed"), {
+      name: "BuildLimitsDriftError",
+      reason: "vault-count",
+    });
+    expect(mapDepositError(err)).toEqual(ERRORS.vaultCountLimitChanged);
+  });
+
+  it("falls back to the amount-bounds callout when the reason did not survive", () => {
+    // A structurally-cloned error matches by name but loses its fields. Both
+    // callouts send the depositor back to the form, so the common case is the
+    // safe default — but it must be a decision, not an accident.
+    const err = new Error("Deposit limits changed while preparing");
+    err.name = "BuildLimitsDriftError";
+    expect(mapDepositError(err)).toEqual(ERRORS.depositLimitsChanged);
+  });
+
+  it("hides an internal precondition message behind the generic callout", () => {
+    // The message names a function; the depositor must not see it, but a bug
+    // report still needs it, so it survives in diagnostics.
+    const err = new Error(
+      "assertBuildWithinPinnedLimits requires at least one vault amount",
+    );
+    err.name = "BuildPreconditionError";
+    const mapped = mapDepositError(err);
+    expect(mapped.body).toBe(ERRORS.genericBody);
+    expect(mapped.body).not.toContain("assertBuildWithinPinnedLimits");
+    expect(mapped.diagnostics).toContain("assertBuildWithinPinnedLimits");
+  });
+
+  it("keeps the two pre-signing aborts distinct from the post-registration one", () => {
+    // The post-registration mismatch has already spent the ETH fee and left a
+    // vault stranded until it times out; the two above have spent nothing.
+    // Sharing one callout across all three would tell the depositor the cheap
+    // failure cost them what the expensive one does.
+    const registered = new Error("on-chain version differs");
+    registered.name = "RegisteredVaultVersionMismatchError";
+    const preSigning = new Error("parameters changed");
+    preSigning.name = "BuildConfigDriftError";
+
+    expect(mapDepositError(registered)).not.toEqual(
+      mapDepositError(preSigning),
+    );
+  });
+
   it("maps a wallet account change to the account-changed callout", () => {
     const err = new Error(
       "BTC wallet account changed during deposit flow. Please restart.",

--- a/services/vault/src/utils/errors/depositErrors.ts
+++ b/services/vault/src/utils/errors/depositErrors.ts
@@ -52,6 +52,10 @@ import { type ReactNode } from "react";
 
 import { COPY } from "@/copy";
 import { isBuildConfigDriftError } from "@/services/vault/buildConfigConsistency";
+import {
+  isBuildLimitsDriftError,
+  isBuildPreconditionError,
+} from "@/services/vault/pinnedBuildLimits";
 
 import { isDepositorWalletMismatchError } from "./depositorWalletMismatch";
 import {
@@ -171,11 +175,39 @@ export function mapDepositError(err: unknown): DepositErrorContent {
 
   // 3a. The same drift caught earlier: the cached snapshot the form gated and
   // sized against no longer matches the pinned read the build would use.
-  // Shares the copy above because the depositor's situation is identical —
-  // parameters moved mid-deposit, start again — and here it is strictly
-  // cheaper, since nothing has been signed, broadcast or paid.
+  // Deliberately NOT the copy above. That one fires after registration, where
+  // the ETH fee is spent and the vault is stranded until it times out; this one
+  // fires before anything is signed, broadcast or paid, and the copy says so.
+  // Rendering the free failure as if it were the expensive one costs the
+  // depositor nothing but tells them nothing either.
   if (isBuildConfigDriftError(err)) {
-    return ERRORS.versionMismatch;
+    return ERRORS.versionMismatchBeforeSigning;
+  }
+
+  // 3a''. The build guard was handed amounts it cannot judge — a bug in our
+  // own code, not a chain change. Mapped so the internal message stays on the
+  // error for the bug report instead of becoming the callout body, which is
+  // what the final bucket would do with an unrecognised error.
+  if (isBuildPreconditionError(err)) {
+    return {
+      title: ERRORS.defaultTitle,
+      body: ERRORS.genericBody,
+      diagnostics: formatErrorDiagnostics(err),
+    };
+  }
+
+  // 3a'. Same pre-signing point, but an unversioned limit moved rather than a
+  // version label — so something the depositor chose has to change, and the
+  // copy has to say which. The amount and the BTCVault count need opposite
+  // instructions, hence two callouts rather than one covering both badly.
+  // The reason is read defensively: an error that crossed a realm boundary
+  // matches by `name` but may have lost its fields, and the amount-bounds copy
+  // is both the far likelier case and the safe thing to show when the tag is
+  // unreadable — it sends the depositor back to the form either way.
+  if (isBuildLimitsDriftError(err)) {
+    return err.reason === "vault-count"
+      ? ERRORS.vaultCountLimitChanged
+      : ERRORS.depositLimitsChanged;
   }
 
   // 3b. RFC-006 participant key drift. Distinct from the version mismatch


### PR DESCRIPTION
# Deposit limits: check them against the chain, not against a five-minute-old copy

Part of https://github.com/babylonlabs-io/babylon-toolkit/issues/2383 (Workstream D). Follows https://github.com/babylonlabs-io/babylon-toolkit/pull/2385 (Workstream A) and https://github.com/babylonlabs-io/babylon-toolkit/pull/2400 (Workstream B), both merged.

## The problem

The deposit form checks your amount against the minimum and maximum the protocol allows. Those numbers come from a cached copy that is up to five minutes old, and nothing refreshes it while the form is open.

The actual Bitcoin transaction is built later, from parameters read fresh off the chain. If the minimum or maximum moved in between, nobody notices. The deposit is built anyway, you complete the whole signing ceremony, and then the registration fails on-chain because your amount is no longer allowed.

The guard added in [#2385](https://github.com/babylonlabs-io/babylon-toolkit/pull/2385) does not catch this, and cannot. It compares two version numbers, and the deposit limits do not have a version number — they come from a different part of the contract read, one that carries no version label at all. So the limits can move without either version number changing, and the guard sees nothing.

To be clear about scope: **this is not something [#2385](https://github.com/babylonlabs-io/babylon-toolkit/pull/2385) broke.** The same on-chain failure happened before it. That PR closed a gap between two snapshots; this one closes a gap between a snapshot and the chain. It was raised during that PR's review, deliberately deferred with the reasoning written down, and tracked here.

## What this PR does

Four things, all in the same story: catch the problem early, and make the recovery actually work.

**1. Re-check the amounts against the fresh parameters.** Right before the Bitcoin transaction is built, the amounts are validated again — this time against the numbers just read from the chain. The deposit stops there, where nothing has been signed and nothing has been paid.

**2. Check the number of BTCVaults too.** The contract limits how many BTCVaults one transaction can create. Nothing in the app read that limit at all — the only checks were hardcoded "maximum 2" literals, one of which is live on this very flow and still does not read the contract. It lives in the same unversioned part of the config as the amount limits, so it can drift the same way. The form now stops offering the split when the contract allows fewer outputs than a split needs, and the build re-checks it against the pinned read. Note the build-time branch is only reachable when the on-chain cap is exactly 1, since the cap is validated into `[1, 255]` on read.

**3. Make "start again" actually work.** The failure message says to restart. But restarting means closing and reopening the form, and the form reads that same five-minute cache — the one that just caused the failure. So you could be handed the identical error. The fresh parameters are now written into the cache when this fires, so the reopened form shows the limits that actually apply. For the BTCVault-count case the cache alone is not enough — nothing in the form read that limit — which is why the split-availability check now reads it too. Without that, "start again without splitting" was an instruction the form immediately undid by re-enabling the split.

**4. Say that nothing was spent.** This failure happened before anything was signed, broadcast or paid, but it was showing the same message as a much more expensive failure that happens after registration, where an Ethereum fee is already gone and a vault is stranded until it times out. Same words for both told nobody anything useful. The early failures now say plainly that nothing was signed and no funds were spent.

## The approaches we considered

### Compare the limits, or re-check the amount?

**Option A — compare the cached limits against the fresh ones**, and stop if they differ. **Option B — re-check the chosen amount against the fresh limits.** ← chosen

Option A is the obvious one and it is wrong. If the maximum moves *up*, the two copies differ but your amount is still perfectly fine — and the deposit would be aborted for nothing. Option B catches a limit that tightened and ignores one that loosened, which is the only behaviour that matches what actually breaks. This was settled during the review of [#2385](https://github.com/babylonlabs-io/babylon-toolkit/pull/2385) and is implemented as agreed there.

### Write the check, or reuse the existing one?

The app already has a function that checks amounts against limits — the same one the deposit flow runs earlier against the cached numbers. We call that function with the fresh numbers instead of writing a second copy of the comparison.

This is not just tidiness. The two checks have to agree on what "within the limits" means, and the limits are inclusive at both ends — easy to get subtly wrong on a second writing, and a difference would reject deposits for a reason that has nothing to do with drift. It is called once per BTCVault rather than over the whole list, which also gives us the index, so the error can name the offending BTCVault without quoting the shared function's wording.

### One message, or two?

We started with one message for both new failures and it was wrong. The amount case and the BTCVault-count case need **opposite instructions**: one says change your amount, the other says do not split across two BTCVaults. A single message would give the wrong advice for whichever case it was not written for. The error now carries a tag saying which limit was hit, and there are two messages.

The same mistake turned up a second time, in the form. Making the split unavailable for a new reason meant the existing "N of M BTCVaults used" hint started explaining it — so a depositor holding 0 of 10 vaults could be told the per-position cap was why, which is simply untrue, and when that cap was unknown the split vanished with no explanation at all. Split availability now returns *why* it is unavailable rather than a bare boolean, and each reason has its own hint.

### What counts as a chain change, and what is our own bug

The shared amount checker also rejects an empty list and a zero amount. Those are bugs in our code, not governance changes, so they throw a distinct error type that maps to the generic failure message. Two things follow: the depositor is not told the chain moved when it did not, and the internal detail stays on the error for the bug report instead of becoming the message on screen.

### Refresh the cache, or clear it?

Clearing it means the next read goes back to the network, and the form can render the old numbers for a moment before the new ones arrive. We already hold the fresh numbers at the point of failure, so we write those straight into the cache. The reopened form is correct immediately with no refetch.

### Where the check lives

It could have gone into the existing guard file. It did not, because that guard answers a different question — it compares two snapshots to each other, while this one compares your choices against one snapshot. They fail for different reasons and produce different advice. That file's comment said this work "belongs with the recovery work rather than here"; it now names this module, and its claim that the gap is still open has been corrected, since it no longer is.

## What is deliberately not here

No changes to the deposit progress screen. It already shows a "Close" button for this kind of failure, which is the right thing, and [#2396](https://github.com/babylonlabs-io/babylon-toolkit/pull/2396) is currently rewriting that whole directory — editing it would mean a conflict for no gain. [#2290](https://github.com/babylonlabs-io/babylon-toolkit/pull/2290) (draft) also touches two of the files here, but those overlaps are small and additive.

## How to check this

```bash
nvm use 24
pnpm --filter @services/vault run test
pnpm --filter @services/vault run lint
```

3747 tests pass, up from 3708. Lint is clean (0 errors), and `tsc --noEmit` passes.

We also deliberately broke each new check and confirmed the tests caught it, rather than trusting a green run:

- Point the check at the cached parameters instead of the fresh ones → **81 tests fail**
- Remove the amount check → 6 fail
- Remove the BTCVault-count check → 2 fail
- Remove the cache refresh → exactly 1 fails, the test written for it
- Swap the two "which limit was hit" tags → 6 fail
- Drop the BTCVault cap from the split-availability rule → 2 fail
- Pick the form's hint from whether usage data is present instead of from the reason → 1 fails
- Untype the two "our own bug" errors so they render raw → 2 fail
- Refresh the cache on any error instead of only on drift → 1 fails
- Tag a caller-bug input as drift → 1 fails
- Put the deposit amount back into the error message → 1 fails

Every file was restored byte-identical afterwards.

That first result is the one worth understanding. The test fixture holds two sets of parameters — the fresh ones and the cached ones — and they deliberately **disagree**, with the cached copy set to values that would reject the test deposit. So the normal tests only pass while the check is reading the fresh parameters. Point it at the cache and 81 tests fall over. Without that disagreement the tests would pass either way and prove nothing, which is the exact trap that got caught during review of [#2385](https://github.com/babylonlabs-io/babylon-toolkit/pull/2385).

## Privacy note

Error messages from this guard reach Sentry as written — the logger scrubs only the browser console, not the reported exception. So the messages name the BTCVault index and the protocol limits, and never the depositor's amount, which the repo treats as identifying. There is a test asserting the amount does not appear.

## Notes for review

- No file in this PR is on the critical-path list, so the two-reviewer rule does not apply. Worth re-checking if the file list grows.
- The form checks your **total** against the limits, while the contract enforces them **per BTCVault**, and the split threshold comes from Aave rather than from the protocol. The flow already checked per BTCVault against the *cached* limits; what this PR adds on that axis is the *pinned* limits, not the per-BTCVault check itself. Moving the per-BTCVault check into the form is a separate change, noted on the issue.
- `validateVaultAmounts` in `services/deposit/validations.ts` is exported with zero callers — a pre-existing dead-code violation, in a file this PR does not touch. Separately, the **live** hardcoded `"Maximum 2 BTCVaults supported"` in that same file still runs on this flow and still never reads `maxHtlcOutputCount`. Both left alone deliberately; worth clearing together.
- The one place with no direct test is the JSX wiring in `SimpleDeposit.tsx` — that component has no test file, which predates this change. What it passes into the split-availability rule is compile-checked (the parameter is required), and the rule itself and the hint it drives are both unit-tested; but deleting the availability check from the form would compile and stay green.
