### PR TITLE
fix(vault): drop the removed unconfirmed-balance flag from the split-unavailable test

### DIFF
--- a/services/vault/src/components/simple/__tests__/DepositForm.splitUnavailable.test.tsx
+++ b/services/vault/src/components/simple/__tests__/DepositForm.splitUnavailable.test.tsx
@@ -61,7 +61,6 @@ const amountState: DepositAmountState = {
   amountSats: 0n,
   btcBalance: 100_000_000n,
   unconfirmedBalance: 0n,
-  hasUnconfirmedBalanceOnly: false,
   minDeposit: 10_000n,
   maxDeposit: 100_000_000n,
   maxDepositSats: 100_000_000n,


### PR DESCRIPTION
## What this fixes

`main` is currently red and cannot be built or released. This one-line change makes it green again.

Every commit from [0464dc0](https://github.com/babylonlabs-io/babylon-toolkit/commit/0464dc0ad3b1d1a2f33a68c8849a4b912e4febca) onward fails three CI checks — `build_and_release` and both `lint_test` jobs — on the same single TypeScript error:

```
src/components/simple/__tests__/DepositForm.splitUnavailable.test.tsx(64,3): error TS2561:
Object literal may only specify known properties, but 'hasUnconfirmedBalanceOnly'
does not exist in type 'DepositAmountState'. Did you mean to write 'unconfirmedBalance'?
```

The last fully green commit was [8602eb0](https://github.com/babylonlabs-io/babylon-toolkit/commit/8602eb0fd) (https://github.com/babylonlabs-io/babylon-toolkit/pull/2393).

## Why it broke

Neither of the two PRs involved did anything wrong. They collided in a way that neither one's CI was able to see — a semantic merge conflict.

- https://github.com/babylonlabs-io/babylon-toolkit/pull/2403 added a new test file, `DepositForm.splitUnavailable.test.tsx`. Its `amountState` fixture sets `hasUnconfirmedBalanceOnly: false`, which was a real field on `DepositAmountState` at the time.
- https://github.com/babylonlabs-io/babylon-toolkit/pull/2395 deleted `hasUnconfirmedBalanceOnly` from `DepositAmountState`, because the "Max" tooltip that was its only reader had been removed. That branch was cut before the new test file existed.

Each PR was green against its own base. Only the merged combination — the deleted field plus the new fixture that still sets it — fails, and that combination first existed on `main`.

Worth noting for anyone debugging a similar failure: this is a **test-only** file, but it broke the **build and release** job, not the test job. The vault build type-checks test files, so a stale property in a fixture is a compile error, not a failing assertion. Running `test` alone would not have caught it.

## The fix

Delete one line from the test fixture:

```diff
   unconfirmedBalance: 0n,
-  hasUnconfirmedBalanceOnly: false,
   minDeposit: 10_000n,
```

`unconfirmedBalance` stays — that field still exists on `DepositAmountState` and is required. The two `it(...)` cases in the file never read the deleted flag, so their behaviour is unchanged.

A repo-wide grep for `hasUnconfirmedBalanceOnly` now returns zero hits, so nothing is left dangling.

## Approaches considered

**1. Delete the stale line from the test fixture — chosen.** The field no longer exists in production code. The fixture was simply carrying a dead property that the type checker correctly rejects. This is the smallest possible change that restores the truth of the type, and it leaves no dead code behind.

**2. Revert https://github.com/babylonlabs-io/babylon-toolkit/pull/2395.** Rejected. That PR is correct and shipped real work — the Deposit modal polish and the glossary alignment. Reverting it to fix a stale line in a test fixture would throw away good code to work around a one-line problem, and `main` would then be missing a merged feature.

**3. Add `hasUnconfirmedBalanceOnly` back to `DepositAmountState`.** Rejected. Nothing reads it any more; the tooltip that did was deliberately removed. Re-adding the field purely to satisfy a test fixture would put dead code into production types and invert the dependency — production shape should not be dictated by a test's leftovers.

## How this was verified

Run on Node 24, on this branch:

| Check | Result |
| --- | --- |
| `pnpm nx run @services/vault:build` | passes — this is the check that was failing |
| `pnpm nx run @services/vault:lint` | 0 errors (136 pre-existing warnings, unchanged) |
| `pnpm nx run @services/vault:test` | 313 files, 3745 tests passed, 6 skipped |

Targeted re-run of the affected file:

```bash
pnpm --filter vault exec vitest run src/components/simple/__tests__/DepositForm.splitUnavailable.test.tsx
```

After merge, confirm `main` is green:

```bash
gh api repos/babylonlabs-io/babylon-toolkit/commits/main/check-runs \
  --jq '.check_runs[] | "\(.conclusion // .status)\t\(.name)"' | sort
```

## Scope notes for the reviewer

- One file, one deleted line. No production code is touched.
- No critical path from `CLAUDE.md` (sections 1–9) is involved — no value computation, fee math, presigning, secret derivation, or Bitcoin primitive.
- No change to the `ts-sdk` public surface, so `docs:clean` is not required.
- No user-facing copy changes, so `copy.ts` is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
