### PR TITLE
fix(vault): drop a removed field from the deposit-form test

### DIFF
--- a/services/vault/src/components/simple/__tests__/DepositForm.splitUnavailable.test.tsx
+++ b/services/vault/src/components/simple/__tests__/DepositForm.splitUnavailable.test.tsx
@@ -61,7 +61,6 @@ const amountState: DepositAmountState = {
   amountSats: 0n,
   btcBalance: 100_000_000n,
   unconfirmedBalance: 0n,
-  hasUnconfirmedBalanceOnly: false,
   minDeposit: 10_000n,
   maxDeposit: 100_000_000n,
   maxDepositSats: 100_000_000n,


### PR DESCRIPTION
## What
Fixes the `verify` check, which fails on main and on every open pull request.

## Why
Two recent pull requests each passed their own checks, but together they left a test on main referring to a field that no longer exists. Nothing runs the checks on main itself after a merge, so the break only showed up on the next pull requests.

## How
Removes the stale field from the test. The test still passes.
