### PR TITLE
chore(repo): add @kirugan as a code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # Default owners
-* @jonybur @jeremy-babylonlabs @jrwbabylonlab @gbarkhatov
+* @jonybur @jeremy-babylonlabs @jrwbabylonlab @gbarkhatov @kirugan
 
 # -----------------------------------------------------------------------------
 # CRITICAL PATHS (see CLAUDE.md > "CRITICAL PATHS — HUMAN REVIEW REQUIRED")
@@ -14,55 +14,55 @@
 # -----------------------------------------------------------------------------
 
 # 1. WASM boundary (value computation)
-/packages/babylon-tbv-rust-wasm/src/index.ts @jonybur @jeremy-babylonlabs @jrwbabylonlab @gbarkhatov
-/packages/babylon-tbv-rust-wasm/src/index-node.ts @jonybur @jeremy-babylonlabs @jrwbabylonlab @gbarkhatov
-/packages/babylon-tbv-rust-wasm/scripts/build-wasm.js @jonybur @jeremy-babylonlabs @jrwbabylonlab @gbarkhatov
-/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/assertWasmPeginSizing.ts @jonybur @jeremy-babylonlabs @jrwbabylonlab @gbarkhatov
-/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/constants.ts @jonybur @jeremy-babylonlabs @jrwbabylonlab @gbarkhatov
-/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts @jonybur @jeremy-babylonlabs @jrwbabylonlab @gbarkhatov
-/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/peginInput.ts @jonybur @jeremy-babylonlabs @jrwbabylonlab @gbarkhatov
-/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/refund.ts @jonybur @jeremy-babylonlabs @jrwbabylonlab @gbarkhatov
-/packages/babylon-ts-sdk/src/tbv/core/utils/transaction/fundPeginTransaction.ts @jonybur @jeremy-babylonlabs @jrwbabylonlab @gbarkhatov
+/packages/babylon-tbv-rust-wasm/src/index.ts @jonybur @jeremy-babylonlabs @jrwbabylonlab @gbarkhatov @kirugan
+/packages/babylon-tbv-rust-wasm/src/index-node.ts @jonybur @jeremy-babylonlabs @jrwbabylonlab @gbarkhatov @kirugan
+/packages/babylon-tbv-rust-wasm/scripts/build-wasm.js @jonybur @jeremy-babylonlabs @jrwbabylonlab @gbarkhatov @kirugan
+/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/assertWasmPeginSizing.ts @jonybur @jeremy-babylonlabs @jrwbabylonlab @gbarkhatov @kirugan
+/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/constants.ts @jonybur @jeremy-babylonlabs @jrwbabylonlab @gbarkhatov @kirugan
+/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/pegin.ts @jonybur @jeremy-babylonlabs @jrwbabylonlab @gbarkhatov @kirugan
+/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/peginInput.ts @jonybur @jeremy-babylonlabs @jrwbabylonlab @gbarkhatov @kirugan
+/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/refund.ts @jonybur @jeremy-babylonlabs @jrwbabylonlab @gbarkhatov @kirugan
+/packages/babylon-ts-sdk/src/tbv/core/utils/transaction/fundPeginTransaction.ts @jonybur @jeremy-babylonlabs @jrwbabylonlab @gbarkhatov @kirugan
 
 # 2. Fee calculation consistency
-/packages/babylon-ts-sdk/src/tbv/core/utils/fee/constants.ts @jonybur @jeremy-babylonlabs @jrwbabylonlab @gbarkhatov
-/packages/babylon-ts-sdk/src/tbv/core/utils/utxo/selectUtxos.ts @jonybur @jeremy-babylonlabs @jrwbabylonlab @gbarkhatov
-/packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts @jonybur @jeremy-babylonlabs @jrwbabylonlab @gbarkhatov
-/services/vault/src/hooks/deposit/useEstimatedBtcFee.ts @jonybur @jeremy-babylonlabs @jrwbabylonlab @gbarkhatov
+/packages/babylon-ts-sdk/src/tbv/core/utils/fee/constants.ts @jonybur @jeremy-babylonlabs @jrwbabylonlab @gbarkhatov @kirugan
+/packages/babylon-ts-sdk/src/tbv/core/utils/utxo/selectUtxos.ts @jonybur @jeremy-babylonlabs @jrwbabylonlab @gbarkhatov @kirugan
+/packages/babylon-ts-sdk/src/tbv/core/utils/fee/peginFeeMath.ts @jonybur @jeremy-babylonlabs @jrwbabylonlab @gbarkhatov @kirugan
+/services/vault/src/hooks/deposit/useEstimatedBtcFee.ts @jonybur @jeremy-babylonlabs @jrwbabylonlab @gbarkhatov @kirugan
 
 # 3. Presigning payout transactions
-/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts @jonybur @jeremy-babylonlabs @jrwbabylonlab @gbarkhatov
-/packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts @jonybur @jeremy-babylonlabs @jrwbabylonlab @gbarkhatov
-/services/vault/src/hooks/deposit/depositFlowSteps/payoutSigning.ts @jonybur @jeremy-babylonlabs @jrwbabylonlab @gbarkhatov
+/packages/babylon-ts-sdk/src/tbv/core/primitives/psbt/payout.ts @jonybur @jeremy-babylonlabs @jrwbabylonlab @gbarkhatov @kirugan
+/packages/babylon-ts-sdk/src/tbv/core/services/deposit/signDepositorGraph.ts @jonybur @jeremy-babylonlabs @jrwbabylonlab @gbarkhatov @kirugan
+/services/vault/src/hooks/deposit/depositFlowSteps/payoutSigning.ts @jonybur @jeremy-babylonlabs @jrwbabylonlab @gbarkhatov @kirugan
 
 # 4. Vault-secret derivation (frozen on-chain-binding API)
-/packages/babylon-ts-sdk/src/tbv/core/vault-secrets/ @jonybur @jeremy-babylonlabs @jrwbabylonlab @gbarkhatov
-/packages/babylon-ts-sdk/src/tbv/core/wots/blockDerivation.ts @jonybur @jeremy-babylonlabs @jrwbabylonlab @gbarkhatov
-/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts @jonybur @jeremy-babylonlabs @jrwbabylonlab @gbarkhatov
+/packages/babylon-ts-sdk/src/tbv/core/vault-secrets/ @jonybur @jeremy-babylonlabs @jrwbabylonlab @gbarkhatov @kirugan
+/packages/babylon-ts-sdk/src/tbv/core/wots/blockDerivation.ts @jonybur @jeremy-babylonlabs @jrwbabylonlab @gbarkhatov @kirugan
+/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts @jonybur @jeremy-babylonlabs @jrwbabylonlab @gbarkhatov @kirugan
 
 # 5. HTLC secret & vault activation
-/services/vault/src/services/vault/vaultActivationService.ts @jonybur @jeremy-babylonlabs @jrwbabylonlab @gbarkhatov
+/services/vault/src/services/vault/vaultActivationService.ts @jonybur @jeremy-babylonlabs @jrwbabylonlab @gbarkhatov @kirugan
 
 # 6. Multi-vault split transactions
-/packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/vaultSplit.ts @jonybur @jeremy-babylonlabs @jrwbabylonlab @gbarkhatov
+/packages/babylon-ts-sdk/src/tbv/integrations/aave/utils/vaultSplit.ts @jonybur @jeremy-babylonlabs @jrwbabylonlab @gbarkhatov @kirugan
 
 # 7. Ledger vault signer package
-/packages/babylon-ledger-vault-signer/src/ @jonybur @jeremy-babylonlabs @jrwbabylonlab @gbarkhatov
-/packages/babylon-ledger-vault-signer/scripts/ @jonybur @jeremy-babylonlabs @jrwbabylonlab @gbarkhatov
+/packages/babylon-ledger-vault-signer/src/ @jonybur @jeremy-babylonlabs @jrwbabylonlab @gbarkhatov @kirugan
+/packages/babylon-ledger-vault-signer/scripts/ @jonybur @jeremy-babylonlabs @jrwbabylonlab @gbarkhatov @kirugan
 
 # 8. Non-standard wallet signing options
-/packages/babylon-ts-sdk/src/tbv/core/utils/signing.ts @jonybur @jeremy-babylonlabs @jrwbabylonlab @gbarkhatov
+/packages/babylon-ts-sdk/src/tbv/core/utils/signing.ts @jonybur @jeremy-babylonlabs @jrwbabylonlab @gbarkhatov @kirugan
 
 # 9. Dependency-free reimplementations of Bitcoin primitives
 # All are in the tree except scriptPubKeyAddress.ts, which is registered ahead
 # of the remaining optional-BTC work (#2228).
-/packages/babylon-ts-sdk/src/tbv/core/clients/eth/onChainBtcPubkey.ts @jonybur @jeremy-babylonlabs @jrwbabylonlab @gbarkhatov
-/packages/babylon-ts-sdk/src/tbv/core/clients/eth/pegin-transaction.ts @jonybur @jeremy-babylonlabs @jrwbabylonlab @gbarkhatov
-/packages/babylon-ts-sdk/src/tbv/core/clients/eth/pegin-registration-client.ts @jonybur @jeremy-babylonlabs @jrwbabylonlab @gbarkhatov
-/packages/babylon-ts-sdk/src/tbv/core/clients/eth/payout-script.ts @jonybur @jeremy-babylonlabs @jrwbabylonlab @gbarkhatov
-/packages/babylon-ts-sdk/src/tbv/core/wasm/ @jonybur @jeremy-babylonlabs @jrwbabylonlab @gbarkhatov
-/packages/babylon-tbv-rust-wasm/src/wasm-loader.ts @jonybur @jeremy-babylonlabs @jrwbabylonlab @gbarkhatov
-/packages/babylon-tbv-rust-wasm/src/wasm-loader-node.ts @jonybur @jeremy-babylonlabs @jrwbabylonlab @gbarkhatov
-/packages/babylon-tbv-rust-wasm/src/raw.ts @jonybur @jeremy-babylonlabs @jrwbabylonlab @gbarkhatov
-/packages/babylon-tbv-rust-wasm/src/raw-node.ts @jonybur @jeremy-babylonlabs @jrwbabylonlab @gbarkhatov
-/services/vault/src/utils/btc/scriptPubKeyAddress.ts @jonybur @jeremy-babylonlabs @jrwbabylonlab @gbarkhatov
+/packages/babylon-ts-sdk/src/tbv/core/clients/eth/onChainBtcPubkey.ts @jonybur @jeremy-babylonlabs @jrwbabylonlab @gbarkhatov @kirugan
+/packages/babylon-ts-sdk/src/tbv/core/clients/eth/pegin-transaction.ts @jonybur @jeremy-babylonlabs @jrwbabylonlab @gbarkhatov @kirugan
+/packages/babylon-ts-sdk/src/tbv/core/clients/eth/pegin-registration-client.ts @jonybur @jeremy-babylonlabs @jrwbabylonlab @gbarkhatov @kirugan
+/packages/babylon-ts-sdk/src/tbv/core/clients/eth/payout-script.ts @jonybur @jeremy-babylonlabs @jrwbabylonlab @gbarkhatov @kirugan
+/packages/babylon-ts-sdk/src/tbv/core/wasm/ @jonybur @jeremy-babylonlabs @jrwbabylonlab @gbarkhatov @kirugan
+/packages/babylon-tbv-rust-wasm/src/wasm-loader.ts @jonybur @jeremy-babylonlabs @jrwbabylonlab @gbarkhatov @kirugan
+/packages/babylon-tbv-rust-wasm/src/wasm-loader-node.ts @jonybur @jeremy-babylonlabs @jrwbabylonlab @gbarkhatov @kirugan
+/packages/babylon-tbv-rust-wasm/src/raw.ts @jonybur @jeremy-babylonlabs @jrwbabylonlab @gbarkhatov @kirugan
+/packages/babylon-tbv-rust-wasm/src/raw-node.ts @jonybur @jeremy-babylonlabs @jrwbabylonlab @gbarkhatov @kirugan
+/services/vault/src/utils/btc/scriptPubKeyAddress.ts @jonybur @jeremy-babylonlabs @jrwbabylonlab @gbarkhatov @kirugan


### PR DESCRIPTION
Adds `@kirugan` to the default owners and to every critical-path entry in `.github/CODEOWNERS`, so the owner list stays identical across all rules.