### PR TITLE
fix(wallet-connector): preserve the other wallet on partial disconnect

### DIFF
--- a/packages/babylon-wallet-connector/src/components/Chains/__tests__/container.test.tsx
+++ b/packages/babylon-wallet-connector/src/components/Chains/__tests__/container.test.tsx
@@ -3,13 +3,14 @@ import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from "vite
 
 import type { IChain } from "@/core/types";
 import { APPKIT_BTC_CONNECTOR_ID, APPKIT_OPEN_EVENT } from "@/core/wallets/appkit/constants";
+import { ERROR_CODES, WalletError } from "@/error";
 
 import { ChainsContainer } from "../container";
 
 const harness = vi.hoisted(() => ({
   widgetState: {} as Record<string, unknown>,
   connectors: {} as Record<string, unknown>,
-  wouldDropEthereum: false,
+  disconnect: vi.fn(),
   onSelectChain: undefined as ((chain: IChain) => Promise<void>) | undefined,
 }));
 
@@ -20,10 +21,7 @@ vi.mock("@/context/Chain.context", () => ({
   useChainProviders: () => harness.connectors,
 }));
 vi.mock("@/hooks/useWalletConnect", () => ({
-  useWalletConnect: () => ({ selected: true }),
-}));
-vi.mock("@/core/wallets/btc/appkit/sharedConfig", () => ({
-  btcDisconnectWouldDropEthereum: () => harness.wouldDropEthereum,
+  useWalletConnect: () => ({ selected: true, disconnect: harness.disconnect }),
 }));
 
 // Stand-in that captures the chain-selection handler instead of rendering the list.
@@ -36,7 +34,6 @@ vi.mock("../index", () => ({
 
 const BTC_CHAIN = { id: "BTC" } as IChain;
 
-let disconnect: ReturnType<typeof vi.fn>;
 let connect: ReturnType<typeof vi.fn>;
 let displayWallets: ReturnType<typeof vi.fn>;
 let appKitOpened: Mock<(event: Event) => void>;
@@ -47,11 +44,11 @@ function selectBtc() {
 }
 
 beforeEach(() => {
-  disconnect = vi.fn().mockResolvedValue(undefined);
+  harness.disconnect.mockReset();
+  harness.disconnect.mockResolvedValue(undefined);
   connect = vi.fn().mockResolvedValue(undefined);
   displayWallets = vi.fn();
   appKitOpened = vi.fn<(event: Event) => void>();
-  harness.wouldDropEthereum = false;
   harness.onSelectChain = undefined;
   harness.widgetState = {
     chains: { BTC: BTC_CHAIN },
@@ -64,7 +61,6 @@ beforeEach(() => {
       wallets: [{ id: APPKIT_BTC_CONNECTOR_ID }],
       connectedWallet: { id: APPKIT_BTC_CONNECTOR_ID },
       connect,
-      disconnect,
     },
   };
   window.addEventListener(APPKIT_OPEN_EVENT, appKitOpened);
@@ -75,29 +71,36 @@ afterEach(() => {
 });
 
 describe("selecting an already-connected AppKit Bitcoin row", () => {
-  it("disconnects bitcoin instead of opening the AppKit modal when the session also carries ethereum", async () => {
-    harness.wouldDropEthereum = true;
-
+  it("disconnects bitcoin through the connector instead of opening the AppKit modal", async () => {
     await selectBtc();
 
-    expect(disconnect).toHaveBeenCalledTimes(1);
-    expect(disconnect).toHaveBeenCalledWith();
+    expect(harness.disconnect).toHaveBeenCalledTimes(1);
+    expect(harness.disconnect).toHaveBeenCalledWith("BTC");
     expect(appKitOpened).not.toHaveBeenCalled();
+    expect(connect).not.toHaveBeenCalled();
   });
 
-  it("opens the AppKit modal when bitcoin does not share its session with ethereum", async () => {
-    await selectBtc();
-
-    expect(appKitOpened).toHaveBeenCalledTimes(1);
-    expect(disconnect).not.toHaveBeenCalled();
-  });
-
-  it("swallows a refused disconnect so the click handler still settles", async () => {
-    harness.wouldDropEthereum = true;
-    disconnect.mockRejectedValue(new Error("refused"));
+  it("settles quietly when the disconnect is refused for a shared session", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    harness.disconnect.mockRejectedValue(
+      new WalletError({ code: ERROR_CODES.SHARED_SESSION_DISCONNECT_REFUSED, message: "shared", chainId: "BTC" }),
+    );
 
     await expect(selectBtc()).resolves.toBeUndefined();
 
+    expect(consoleError).not.toHaveBeenCalled();
     expect(appKitOpened).not.toHaveBeenCalled();
+    consoleError.mockRestore();
+  });
+
+  it("logs any other disconnect failure and still settles", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    harness.disconnect.mockRejectedValue(new Error("relay down"));
+
+    await expect(selectBtc()).resolves.toBeUndefined();
+
+    expect(consoleError).toHaveBeenCalledWith("Failed to disconnect AppKit BTC:", "relay down");
+    expect(appKitOpened).not.toHaveBeenCalled();
+    consoleError.mockRestore();
   });
 });

--- a/packages/babylon-wallet-connector/src/components/Chains/__tests__/container.test.tsx
+++ b/packages/babylon-wallet-connector/src/components/Chains/__tests__/container.test.tsx
@@ -1,0 +1,103 @@
+import { render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from "vitest";
+
+import type { IChain } from "@/core/types";
+import { APPKIT_BTC_CONNECTOR_ID, APPKIT_OPEN_EVENT } from "@/core/wallets/appkit/constants";
+
+import { ChainsContainer } from "../container";
+
+const harness = vi.hoisted(() => ({
+  widgetState: {} as Record<string, unknown>,
+  connectors: {} as Record<string, unknown>,
+  wouldDropEthereum: false,
+  onSelectChain: undefined as ((chain: IChain) => Promise<void>) | undefined,
+}));
+
+vi.mock("@/hooks/useWidgetState", () => ({
+  useWidgetState: () => harness.widgetState,
+}));
+vi.mock("@/context/Chain.context", () => ({
+  useChainProviders: () => harness.connectors,
+}));
+vi.mock("@/hooks/useWalletConnect", () => ({
+  useWalletConnect: () => ({ selected: true }),
+}));
+vi.mock("@/core/wallets/btc/appkit/sharedConfig", () => ({
+  btcDisconnectWouldDropEthereum: () => harness.wouldDropEthereum,
+}));
+
+// Stand-in that captures the chain-selection handler instead of rendering the list.
+vi.mock("../index", () => ({
+  Chains: ({ onSelectChain }: { onSelectChain: (chain: IChain) => Promise<void> }) => {
+    harness.onSelectChain = onSelectChain;
+    return null;
+  },
+}));
+
+const BTC_CHAIN = { id: "BTC" } as IChain;
+
+let disconnect: ReturnType<typeof vi.fn>;
+let connect: ReturnType<typeof vi.fn>;
+let displayWallets: ReturnType<typeof vi.fn>;
+let appKitOpened: Mock<(event: Event) => void>;
+
+function selectBtc() {
+  render(<ChainsContainer />);
+  return harness.onSelectChain!(BTC_CHAIN);
+}
+
+beforeEach(() => {
+  disconnect = vi.fn().mockResolvedValue(undefined);
+  connect = vi.fn().mockResolvedValue(undefined);
+  displayWallets = vi.fn();
+  appKitOpened = vi.fn<(event: Event) => void>();
+  harness.wouldDropEthereum = false;
+  harness.onSelectChain = undefined;
+  harness.widgetState = {
+    chains: { BTC: BTC_CHAIN },
+    requiredChainIds: ["BTC"],
+    selectedWallets: {},
+    displayWallets,
+  };
+  harness.connectors = {
+    BTC: {
+      wallets: [{ id: APPKIT_BTC_CONNECTOR_ID }],
+      connectedWallet: { id: APPKIT_BTC_CONNECTOR_ID },
+      connect,
+      disconnect,
+    },
+  };
+  window.addEventListener(APPKIT_OPEN_EVENT, appKitOpened);
+});
+
+afterEach(() => {
+  window.removeEventListener(APPKIT_OPEN_EVENT, appKitOpened);
+});
+
+describe("selecting an already-connected AppKit Bitcoin row", () => {
+  it("disconnects bitcoin instead of opening the AppKit modal when the session also carries ethereum", async () => {
+    harness.wouldDropEthereum = true;
+
+    await selectBtc();
+
+    expect(disconnect).toHaveBeenCalledTimes(1);
+    expect(disconnect).toHaveBeenCalledWith();
+    expect(appKitOpened).not.toHaveBeenCalled();
+  });
+
+  it("opens the AppKit modal when bitcoin does not share its session with ethereum", async () => {
+    await selectBtc();
+
+    expect(appKitOpened).toHaveBeenCalledTimes(1);
+    expect(disconnect).not.toHaveBeenCalled();
+  });
+
+  it("swallows a refused disconnect so the click handler still settles", async () => {
+    harness.wouldDropEthereum = true;
+    disconnect.mockRejectedValue(new Error("refused"));
+
+    await expect(selectBtc()).resolves.toBeUndefined();
+
+    expect(appKitOpened).not.toHaveBeenCalled();
+  });
+});

--- a/packages/babylon-wallet-connector/src/components/Chains/__tests__/container.test.tsx
+++ b/packages/babylon-wallet-connector/src/components/Chains/__tests__/container.test.tsx
@@ -139,13 +139,13 @@ describe.each(["BTC", "ETH"] as const)("selecting a connected AppKit %s row in a
   });
 });
 
-it("guards the connected Ethereum row for an Auth session", async () => {
+it("allows the Ethereum account modal for an independent Auth session", async () => {
   configureEthereum("AUTH");
 
   await selectChain("ETH");
 
-  expect(harness.disconnect).toHaveBeenCalledWith("ETH");
-  expect(appKitOpened).not.toHaveBeenCalled();
+  expect(harness.disconnect).not.toHaveBeenCalled();
+  expect(appKitOpened).toHaveBeenCalledTimes(1);
 });
 
 it.each([

--- a/packages/babylon-wallet-connector/src/components/Chains/__tests__/container.test.tsx
+++ b/packages/babylon-wallet-connector/src/components/Chains/__tests__/container.test.tsx
@@ -2,7 +2,8 @@ import { render } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from "vitest";
 
 import type { IChain } from "@/core/types";
-import { APPKIT_BTC_CONNECTOR_ID, APPKIT_OPEN_EVENT } from "@/core/wallets/appkit/constants";
+import { APPKIT_BTC_CONNECTOR_ID, APPKIT_ETH_CONNECTOR_ID, APPKIT_OPEN_EVENT } from "@/core/wallets/appkit/constants";
+import { __resetSharedBtcAppKitConfigForTests, setSharedBtcAppKitConfig } from "@/core/wallets/btc/appkit/sharedConfig";
 import { ERROR_CODES, WalletError } from "@/error";
 
 import { ChainsContainer } from "../container";
@@ -38,9 +39,25 @@ let connect: ReturnType<typeof vi.fn>;
 let displayWallets: ReturnType<typeof vi.fn>;
 let appKitOpened: Mock<(event: Event) => void>;
 
-function selectBtc() {
+function selectChain(id: "BTC" | "ETH") {
   render(<ChainsContainer />);
-  return harness.onSelectChain!(BTC_CHAIN);
+  return harness.onSelectChain!({ id } as IChain);
+}
+
+function configureEthereum(providerType: string, btcConnected = true) {
+  harness.connectors.ETH = {
+    wallets: [{ id: APPKIT_ETH_CONNECTOR_ID }],
+    connectedWallet: { id: APPKIT_ETH_CONNECTOR_ID },
+    connect,
+  };
+  setSharedBtcAppKitConfig({
+    modal: {
+      getProviderType: (namespace: string) => (namespace === "eip155" ? providerType : "ANNOUNCED"),
+      getAccount: (namespace: string) => (namespace === "bip122" ? { isConnected: btcConnected } : undefined),
+    } as never,
+    adapter: {} as never,
+    network: "signet",
+  });
 }
 
 beforeEach(() => {
@@ -68,14 +85,31 @@ beforeEach(() => {
 
 afterEach(() => {
   window.removeEventListener(APPKIT_OPEN_EVENT, appKitOpened);
+  __resetSharedBtcAppKitConfigForTests();
 });
 
-describe("selecting an already-connected AppKit Bitcoin row", () => {
-  it("disconnects bitcoin through the connector instead of opening the AppKit modal", async () => {
-    await selectBtc();
+it.each(["BTC", "ETH"] as const)("connects the selected %s wallet when disconnected", async (chain) => {
+  if (chain === "ETH") configureEthereum("WALLET_CONNECT");
+  const connector = harness.connectors[chain] as { connectedWallet?: unknown };
+  connector.connectedWallet = undefined;
+
+  await selectChain(chain);
+
+  expect(connect).toHaveBeenCalledWith(chain === "ETH" ? APPKIT_ETH_CONNECTOR_ID : APPKIT_BTC_CONNECTOR_ID);
+  expect(harness.disconnect).not.toHaveBeenCalled();
+  expect(appKitOpened).not.toHaveBeenCalled();
+});
+
+describe.each(["BTC", "ETH"] as const)("selecting a connected AppKit %s row in a shared session", (chain) => {
+  beforeEach(() => {
+    if (chain === "ETH") configureEthereum("WALLET_CONNECT");
+  });
+
+  it("uses the guarded disconnect without opening the AppKit modal", async () => {
+    await selectChain(chain);
 
     expect(harness.disconnect).toHaveBeenCalledTimes(1);
-    expect(harness.disconnect).toHaveBeenCalledWith("BTC");
+    expect(harness.disconnect).toHaveBeenCalledWith(chain);
     expect(appKitOpened).not.toHaveBeenCalled();
     expect(connect).not.toHaveBeenCalled();
   });
@@ -83,10 +117,10 @@ describe("selecting an already-connected AppKit Bitcoin row", () => {
   it("settles quietly when the disconnect is refused for a shared session", async () => {
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
     harness.disconnect.mockRejectedValue(
-      new WalletError({ code: ERROR_CODES.SHARED_SESSION_DISCONNECT_REFUSED, message: "shared", chainId: "BTC" }),
+      new WalletError({ code: ERROR_CODES.SHARED_SESSION_DISCONNECT_REFUSED, message: "shared", chainId: chain }),
     );
 
-    await expect(selectBtc()).resolves.toBeUndefined();
+    await expect(selectChain(chain)).resolves.toBeUndefined();
 
     expect(consoleError).not.toHaveBeenCalled();
     expect(appKitOpened).not.toHaveBeenCalled();
@@ -97,10 +131,35 @@ describe("selecting an already-connected AppKit Bitcoin row", () => {
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
     harness.disconnect.mockRejectedValue(new Error("relay down"));
 
-    await expect(selectBtc()).resolves.toBeUndefined();
+    await expect(selectChain(chain)).resolves.toBeUndefined();
 
-    expect(consoleError).toHaveBeenCalledWith("Failed to disconnect AppKit BTC:", "relay down");
+    expect(consoleError).toHaveBeenCalledWith(`Failed to disconnect AppKit ${chain}:`, "relay down");
     expect(appKitOpened).not.toHaveBeenCalled();
     consoleError.mockRestore();
   });
 });
+
+it("guards the connected Ethereum row for an Auth session", async () => {
+  configureEthereum("AUTH");
+
+  await selectChain("ETH");
+
+  expect(harness.disconnect).toHaveBeenCalledWith("ETH");
+  expect(appKitOpened).not.toHaveBeenCalled();
+});
+
+it.each([
+  ["ANNOUNCED", true],
+  ["WALLET_CONNECT", false],
+] as const)(
+  "allows the Ethereum account modal for %s with Bitcoin connected=%s",
+  async (providerType, btcConnected) => {
+    configureEthereum(providerType, btcConnected);
+
+    await selectChain("ETH");
+
+    expect(harness.disconnect).not.toHaveBeenCalled();
+    expect(appKitOpened).toHaveBeenCalledTimes(1);
+    expect(connect).not.toHaveBeenCalled();
+  },
+);

--- a/packages/babylon-wallet-connector/src/components/Chains/container.tsx
+++ b/packages/babylon-wallet-connector/src/components/Chains/container.tsx
@@ -6,6 +6,7 @@ import type { IChain } from "@/core/types";
 // adapter into the `./eth` graph, since this screen is part of the dialog.
 import { useChainProviders } from "@/context/Chain.context";
 import { APPKIT_BTC_CONNECTOR_ID, APPKIT_ETH_CONNECTOR_ID, APPKIT_OPEN_EVENT } from "@/core/wallets/appkit/constants";
+import { ethDisconnectWouldDropBitcoin } from "@/core/wallets/eth/appkit/sharedConfig";
 import { isSharedSessionRefusal } from "@/error";
 import { useWalletConnect } from "@/hooks/useWalletConnect";
 import { useWidgetState } from "@/hooks/useWidgetState";
@@ -36,59 +37,27 @@ export function ChainsContainer(props: ContainerProps) {
 
   const handleSelectChain = useCallback(
     async (chain: IChain) => {
-      // Special handling for ETH chain with only AppKit wallet
-      if (chain.id === "ETH") {
-        const ethConnector = connectors.ETH;
-        const appkitWallet = ethConnector?.wallets.find((w) => w.id === APPKIT_ETH_CONNECTOR_ID);
-
-        if (appkitWallet && ethConnector?.wallets.length === 1) {
-          // Already connected: reopen the AppKit modal so the user can switch/disconnect.
-          if (ethConnector.connectedWallet) {
-            openAppKitModal();
-            return;
-          }
-
-          // Only AppKit available, connect it directly
-          // This will trigger the AppKitProvider.connectWallet() which dispatches the event
+      if (chain.id === "ETH" || chain.id === "BTC") {
+        const connector = connectors[chain.id];
+        const appkitId = chain.id === "ETH" ? APPKIT_ETH_CONNECTOR_ID : APPKIT_BTC_CONNECTOR_ID;
+        const wallet = connector?.wallets.find((candidate) => candidate.id === appkitId);
+        if (wallet && connector?.wallets.length === 1) {
+          const connected = Boolean(connector.connectedWallet);
           try {
-            await ethConnector.connect(appkitWallet);
-          } catch (error) {
-            console.error("Failed to connect AppKit:", error);
-          }
-          return;
-        }
-      }
-
-      // Special handling for BTC chain with only AppKit wallet
-      if (chain.id === "BTC") {
-        const btcConnector = connectors.BTC;
-        const appkitBtcWallet = btcConnector?.wallets.find((w) => w.id === APPKIT_BTC_CONNECTOR_ID);
-
-        if (appkitBtcWallet && btcConnector?.wallets.length === 1) {
-          // Already connected: disconnect through the connector rather than
-          // reopening Reown, whose own Disconnect control drops a shared
-          // session for every chain. A shared session is refused and the
-          // dialog explains why; the row can be clicked again to connect.
-          if (btcConnector.connectedWallet) {
-            try {
-              await disconnect("BTC");
-            } catch (error) {
-              if (!isSharedSessionRefusal(error)) {
-                console.error(
-                  "Failed to disconnect AppKit BTC:",
-                  error instanceof Error ? error.message : "Unknown error",
-                );
-              }
+            if (!connected) {
+              await connector.connect(wallet.id);
+            } else if (chain.id === "ETH" && !ethDisconnectWouldDropBitcoin()) {
+              openAppKitModal();
+            } else {
+              await disconnect(chain.id);
             }
-            return;
-          }
-
-          // Only AppKit available, connect it directly
-          // This will trigger the AppKitBTCProvider.connectWallet() which dispatches the event
-          try {
-            await btcConnector.connect(appkitBtcWallet);
           } catch (error) {
-            console.error("Failed to connect AppKit BTC:", error);
+            if (!isSharedSessionRefusal(error)) {
+              console.error(
+                `Failed to ${connected ? "disconnect" : "connect"} AppKit ${chain.id}:`,
+                error instanceof Error ? error.message : "Unknown error",
+              );
+            }
           }
           return;
         }

--- a/packages/babylon-wallet-connector/src/components/Chains/container.tsx
+++ b/packages/babylon-wallet-connector/src/components/Chains/container.tsx
@@ -4,14 +4,11 @@ import type { IChain } from "@/core/types";
 // Connector ids come from the shared constants module, not from each chain's
 // wallet metadata — importing the metadata here would put every Bitcoin wallet
 // adapter into the `./eth` graph, since this screen is part of the dialog.
-import {
-  APPKIT_BTC_CONNECTOR_ID,
-  APPKIT_ETH_CONNECTOR_ID,
-  APPKIT_OPEN_EVENT,
-} from "@/core/wallets/appkit/constants";
+import { useChainProviders } from "@/context/Chain.context";
+import { APPKIT_BTC_CONNECTOR_ID, APPKIT_ETH_CONNECTOR_ID, APPKIT_OPEN_EVENT } from "@/core/wallets/appkit/constants";
+import { isSharedSessionRefusal } from "@/error";
 import { useWalletConnect } from "@/hooks/useWalletConnect";
 import { useWidgetState } from "@/hooks/useWidgetState";
-import { useChainProviders } from "@/context/Chain.context";
 
 import { Chains } from "./index";
 
@@ -32,7 +29,7 @@ interface ContainerProps {
 
 export function ChainsContainer(props: ContainerProps) {
   const { chains, requiredChainIds, selectedWallets, displayWallets } = useWidgetState();
-  const { selected } = useWalletConnect();
+  const { selected, disconnect } = useWalletConnect();
   const connectors = useChainProviders();
 
   const chainArr = useMemo(() => Object.values(chains), [chains]);
@@ -42,7 +39,7 @@ export function ChainsContainer(props: ContainerProps) {
       // Special handling for ETH chain with only AppKit wallet
       if (chain.id === "ETH") {
         const ethConnector = connectors.ETH;
-        const appkitWallet = ethConnector?.wallets.find(w => w.id === APPKIT_ETH_CONNECTOR_ID);
+        const appkitWallet = ethConnector?.wallets.find((w) => w.id === APPKIT_ETH_CONNECTOR_ID);
 
         if (appkitWallet && ethConnector?.wallets.length === 1) {
           // Already connected: reopen the AppKit modal so the user can switch/disconnect.
@@ -65,18 +62,24 @@ export function ChainsContainer(props: ContainerProps) {
       // Special handling for BTC chain with only AppKit wallet
       if (chain.id === "BTC") {
         const btcConnector = connectors.BTC;
-        const appkitBtcWallet = btcConnector?.wallets.find(w => w.id === APPKIT_BTC_CONNECTOR_ID);
+        const appkitBtcWallet = btcConnector?.wallets.find((w) => w.id === APPKIT_BTC_CONNECTOR_ID);
 
         if (appkitBtcWallet && btcConnector?.wallets.length === 1) {
+          // Already connected: disconnect through the connector rather than
+          // reopening Reown, whose own Disconnect control drops a shared
+          // session for every chain. A shared session is refused and the
+          // dialog explains why; the row can be clicked again to connect.
           if (btcConnector.connectedWallet) {
-            const { btcDisconnectWouldDropEthereum } = await import("@/core/wallets/btc/appkit/sharedConfig");
-            if (btcDisconnectWouldDropEthereum()) {
-              await btcConnector.disconnect().catch(() => undefined);
-              return;
+            try {
+              await disconnect("BTC");
+            } catch (error) {
+              if (!isSharedSessionRefusal(error)) {
+                console.error(
+                  "Failed to disconnect AppKit BTC:",
+                  error instanceof Error ? error.message : "Unknown error",
+                );
+              }
             }
-
-            // Already connected: reopen the AppKit modal so the user can switch/disconnect.
-            openAppKitModal();
             return;
           }
 
@@ -94,7 +97,7 @@ export function ChainsContainer(props: ContainerProps) {
       // Normal flow for other chains or if chain has multiple wallets
       displayWallets?.(chain.id);
     },
-    [displayWallets, connectors],
+    [displayWallets, connectors, disconnect],
   );
 
   return (

--- a/packages/babylon-wallet-connector/src/components/Chains/container.tsx
+++ b/packages/babylon-wallet-connector/src/components/Chains/container.tsx
@@ -68,8 +68,14 @@ export function ChainsContainer(props: ContainerProps) {
         const appkitBtcWallet = btcConnector?.wallets.find(w => w.id === APPKIT_BTC_CONNECTOR_ID);
 
         if (appkitBtcWallet && btcConnector?.wallets.length === 1) {
-          // Already connected: reopen the AppKit modal so the user can switch/disconnect.
           if (btcConnector.connectedWallet) {
+            const { btcDisconnectWouldDropEthereum } = await import("@/core/wallets/btc/appkit/sharedConfig");
+            if (btcDisconnectWouldDropEthereum()) {
+              await btcConnector.disconnect().catch(() => undefined);
+              return;
+            }
+
+            // Already connected: reopen the AppKit modal so the user can switch/disconnect.
             openAppKitModal();
             return;
           }

--- a/packages/babylon-wallet-connector/src/core/WalletConnector.ts
+++ b/packages/babylon-wallet-connector/src/core/WalletConnector.ts
@@ -2,7 +2,7 @@ import { createNanoEvents } from "nanoevents";
 
 import { Wallet } from "@/core/Wallet";
 import type { DisconnectScope, IConnector, IProvider } from "@/core/types";
-import { ERROR_CODES, WalletError } from "@/error";
+import { ERROR_CODES, WalletError, isSharedSessionRefusal } from "@/error";
 
 type DisconnectableProvider = IProvider & { disconnect?: (scope: DisconnectScope) => Promise<void> };
 
@@ -55,19 +55,22 @@ export class WalletConnector<N extends string, P extends IProvider, C> implement
   }
 
   async disconnect(scope: DisconnectScope = "chain") {
-    if (!this._connectedWallet) return;
+    const wallet = this._connectedWallet;
+    if (!wallet) return;
 
-    const provider = this._connectedWallet.provider as DisconnectableProvider | null;
+    const provider = wallet.provider as DisconnectableProvider | null;
     if (provider?.disconnect) {
       try {
         await provider.disconnect(scope);
       } catch (error) {
+        if (scope === "chain" && isSharedSessionRefusal(error)) throw error;
         this._ee.emit("error", error instanceof Error ? error : new Error(String(error)));
-        if (scope === "chain" && this._connectedWallet?.account !== null) throw error;
+        if (scope === "chain") throw error;
       }
     }
-    this._ee.emit("disconnect", this._connectedWallet);
+    if (this._connectedWallet !== wallet) return;
     this._connectedWallet = null;
+    this._ee.emit("disconnect", wallet);
   }
 
   clone() {

--- a/packages/babylon-wallet-connector/src/core/WalletConnector.ts
+++ b/packages/babylon-wallet-connector/src/core/WalletConnector.ts
@@ -15,6 +15,7 @@ export interface ConnectorEvents<P extends IProvider> {
 
 export class WalletConnector<N extends string, P extends IProvider, C> implements IConnector<N, P, C> {
   private _connectedWallet: Wallet<P> | null = null;
+  private _connectionGeneration = 0;
   private _ee = createNanoEvents<ConnectorEvents<P>>();
 
   constructor(
@@ -45,6 +46,7 @@ export class WalletConnector<N extends string, P extends IProvider, C> implement
         this._ee.emit("connecting", message, description);
       await selectedWallet.connect(reportProgress);
       this._connectedWallet = selectedWallet;
+      this._connectionGeneration += 1;
       this._ee.emit("connect", this._connectedWallet);
 
       return this.connectedWallet;
@@ -56,6 +58,7 @@ export class WalletConnector<N extends string, P extends IProvider, C> implement
 
   async disconnect(scope: DisconnectScope = "chain") {
     const wallet = this._connectedWallet;
+    const generation = this._connectionGeneration;
     if (!wallet) return;
 
     const provider = wallet.provider as DisconnectableProvider | null;
@@ -68,7 +71,7 @@ export class WalletConnector<N extends string, P extends IProvider, C> implement
         if (scope === "chain") throw error;
       }
     }
-    if (this._connectedWallet !== wallet) return;
+    if (this._connectedWallet !== wallet || this._connectionGeneration !== generation) return;
     this._connectedWallet = null;
     this._ee.emit("disconnect", wallet);
   }

--- a/packages/babylon-wallet-connector/src/core/WalletConnector.ts
+++ b/packages/babylon-wallet-connector/src/core/WalletConnector.ts
@@ -63,7 +63,7 @@ export class WalletConnector<N extends string, P extends IProvider, C> implement
         await provider.disconnect(scope);
       } catch (error) {
         this._ee.emit("error", error instanceof Error ? error : new Error(String(error)));
-        if (scope === "chain") throw error;
+        if (scope === "chain" && this._connectedWallet?.account !== null) throw error;
       }
     }
     this._ee.emit("disconnect", this._connectedWallet);

--- a/packages/babylon-wallet-connector/src/core/WalletConnector.ts
+++ b/packages/babylon-wallet-connector/src/core/WalletConnector.ts
@@ -1,10 +1,10 @@
 import { createNanoEvents } from "nanoevents";
 
 import { Wallet } from "@/core/Wallet";
-import type { IConnector, IProvider } from "@/core/types";
+import type { DisconnectScope, IConnector, IProvider } from "@/core/types";
 import { ERROR_CODES, WalletError } from "@/error";
 
-type DisconnectableProvider = IProvider & { disconnect?: () => Promise<void> };
+type DisconnectableProvider = IProvider & { disconnect?: (scope: DisconnectScope) => Promise<void> };
 
 export interface ConnectorEvents<P extends IProvider> {
   connecting: (message?: string, description?: string) => void;
@@ -54,19 +54,20 @@ export class WalletConnector<N extends string, P extends IProvider, C> implement
     }
   }
 
-  async disconnect() {
-    if (this._connectedWallet) {
-      const provider = this._connectedWallet.provider as DisconnectableProvider | null;
-      if (provider?.disconnect && typeof provider.disconnect === "function") {
-        try {
-          await provider.disconnect();
-        } catch {
-          // ignore provider disconnect errors
-        }
+  async disconnect(scope: DisconnectScope = "chain") {
+    if (!this._connectedWallet) return;
+
+    const provider = this._connectedWallet.provider as DisconnectableProvider | null;
+    if (provider?.disconnect) {
+      try {
+        await provider.disconnect(scope);
+      } catch (error) {
+        this._ee.emit("error", error instanceof Error ? error : new Error(String(error)));
+        if (scope === "chain") throw error;
       }
-      this._ee.emit("disconnect", this._connectedWallet);
-      this._connectedWallet = null;
     }
+    this._ee.emit("disconnect", this._connectedWallet);
+    this._connectedWallet = null;
   }
 
   clone() {

--- a/packages/babylon-wallet-connector/src/core/__tests__/WalletConnector.disconnect.test.ts
+++ b/packages/babylon-wallet-connector/src/core/__tests__/WalletConnector.disconnect.test.ts
@@ -76,26 +76,7 @@ describe("WalletConnector disconnect", () => {
     expect(connector.connectedWallet).toBe(wallet);
   });
 
-  it("clears the wallet before it emits disconnect", async () => {
-    const wallet = createWallet({
-      connectWallet: vi.fn().mockResolvedValue(undefined),
-      getAddress: vi.fn().mockResolvedValue("bc1p"),
-      getPublicKeyHex: vi.fn().mockResolvedValue("02ab"),
-      disconnect: vi.fn().mockResolvedValue(undefined),
-    });
-    const connector = new WalletConnector("BTC", "Bitcoin", "icon", [wallet], {});
-    await connector.connect(wallet);
-    let walletDuringEvent: unknown = wallet;
-    connector.on("disconnect", () => {
-      walletDuringEvent = connector.connectedWallet;
-    });
-
-    await connector.disconnect();
-
-    expect(walletDuringEvent).toBeNull();
-  });
-
-  it("emits disconnect and clears the wallet when the provider disconnects", async () => {
+  it("clears the wallet before it emits disconnect when the provider disconnects", async () => {
     const wallet = createWallet({
       connectWallet: vi.fn().mockResolvedValue(undefined),
       getAddress: vi.fn().mockResolvedValue("bc1p"),
@@ -107,11 +88,16 @@ describe("WalletConnector disconnect", () => {
     const onError = vi.fn();
     const onDisconnect = vi.fn();
     connector.on("error", onError);
-    connector.on("disconnect", onDisconnect);
+    let walletDuringEvent: unknown = wallet;
+    connector.on("disconnect", (disconnectedWallet) => {
+      walletDuringEvent = connector.connectedWallet;
+      onDisconnect(disconnectedWallet);
+    });
 
     await connector.disconnect();
 
     expect(onDisconnect).toHaveBeenCalledWith(wallet);
+    expect(walletDuringEvent).toBeNull();
     expect(connector.connectedWallet).toBeNull();
     expect(onError).not.toHaveBeenCalled();
   });
@@ -197,30 +183,36 @@ describe("WalletConnector disconnect", () => {
     expect(connector.connectedWallet).toBeNull();
   });
 
-  it("emits disconnect once when a local disconnect lands during an in-flight chain disconnect", async () => {
-    let settleChainDisconnect!: () => void;
-    const chainDisconnect = new Promise<void>((resolve) => {
-      settleChainDisconnect = resolve;
-    });
-    const wallet = createWallet({
-      connectWallet: vi.fn().mockResolvedValue(undefined),
-      getAddress: vi.fn().mockResolvedValue("bc1p"),
-      getPublicKeyHex: vi.fn().mockResolvedValue("02ab"),
-      disconnect: vi.fn(async (scope: string) => {
-        if (scope === "chain") await chainDisconnect;
-      }),
-    });
-    const connector = new WalletConnector("BTC", "Bitcoin", "icon", [wallet], {});
-    await connector.connect(wallet);
-    const onDisconnect = vi.fn();
-    connector.on("disconnect", onDisconnect);
+  it.each(["disconnect", "reconnect", "disconnect then reconnect"])(
+    "keeps the latest wallet state after %s during a pending chain disconnect",
+    async (action) => {
+      let settleChainDisconnect!: () => void;
+      const chainDisconnect = new Promise<void>((resolve) => {
+        settleChainDisconnect = resolve;
+      });
+      const wallet = createWallet({
+        connectWallet: vi.fn().mockResolvedValue(undefined),
+        getAddress: vi.fn().mockResolvedValue("bc1p"),
+        getPublicKeyHex: vi.fn().mockResolvedValue("02ab"),
+        disconnect: vi.fn(async (scope: string) => {
+          if (scope === "chain") await chainDisconnect;
+        }),
+      });
+      const connector = new WalletConnector("BTC", "Bitcoin", "icon", [wallet], {});
+      await connector.connect(wallet);
+      const onDisconnect = vi.fn();
+      connector.on("disconnect", onDisconnect);
 
-    const chainScope = connector.disconnect("chain");
-    await connector.disconnect("local");
-    settleChainDisconnect();
-    await chainScope;
+      const chainScope = connector.disconnect("chain");
+      const localDisconnect = action !== "reconnect";
+      const reconnect = action !== "disconnect";
+      if (localDisconnect) await connector.disconnect("local");
+      if (reconnect) await connector.connect(wallet);
+      settleChainDisconnect();
+      await chainScope;
 
-    expect(onDisconnect.mock.calls).toEqual([[wallet]]);
-    expect(connector.connectedWallet).toBeNull();
-  });
+      expect(onDisconnect.mock.calls).toEqual(localDisconnect ? [[wallet]] : []);
+      expect(connector.connectedWallet).toBe(reconnect ? wallet : null);
+    },
+  );
 });

--- a/packages/babylon-wallet-connector/src/core/__tests__/WalletConnector.disconnect.test.ts
+++ b/packages/babylon-wallet-connector/src/core/__tests__/WalletConnector.disconnect.test.ts
@@ -18,16 +18,17 @@ function createWallet(provider: Record<string, unknown>) {
 }
 
 describe("WalletConnector disconnect", () => {
-  it("keeps the wallet and emits only error when the provider refuses to disconnect", async () => {
+  it("keeps a refused wallet until its account is rejected", async () => {
     const refusal = new WalletError({
       code: ERROR_CODES.SHARED_SESSION_DISCONNECT_REFUSED,
       message: "Bitcoin and Ethereum share one wallet session.",
     });
+    const disconnect = vi.fn().mockRejectedValue(refusal);
     const wallet = createWallet({
       connectWallet: vi.fn().mockResolvedValue(undefined),
       getAddress: vi.fn().mockResolvedValue("bc1p"),
       getPublicKeyHex: vi.fn().mockResolvedValue("02ab"),
-      disconnect: vi.fn().mockRejectedValue(refusal),
+      disconnect,
     });
     const connector = new WalletConnector("BTC", "Bitcoin", "icon", [wallet], {});
     await connector.connect(wallet);
@@ -42,6 +43,11 @@ describe("WalletConnector disconnect", () => {
     expect(onError).toHaveBeenCalledWith(refusal);
     expect(onDisconnect).not.toHaveBeenCalled();
     expect(connector.connectedWallet).toBe(wallet);
+    wallet.account = null;
+    await connector.disconnect();
+    expect(disconnect).toHaveBeenLastCalledWith("chain");
+    expect(onDisconnect).toHaveBeenCalledWith(wallet);
+    expect(connector.connectedWallet).toBeNull();
   });
 
   it("emits disconnect and clears the wallet when the provider disconnects", async () => {

--- a/packages/babylon-wallet-connector/src/core/__tests__/WalletConnector.disconnect.test.ts
+++ b/packages/babylon-wallet-connector/src/core/__tests__/WalletConnector.disconnect.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { Wallet } from "@/core/Wallet";
+import { WalletConnector } from "@/core/WalletConnector";
+import type { IBTCProvider } from "@/core/types";
+import { ERROR_CODES, WalletError } from "@/error";
+
+function createWallet(provider: Record<string, unknown>) {
+  return new Wallet({
+    id: "unisat",
+    name: "UniSat",
+    icon: "icon",
+    docs: "https://docs",
+    networks: [],
+    origin: null,
+    provider: provider as unknown as IBTCProvider,
+  });
+}
+
+describe("WalletConnector disconnect", () => {
+  it("keeps the wallet and emits only error when the provider refuses to disconnect", async () => {
+    const refusal = new WalletError({
+      code: ERROR_CODES.SHARED_SESSION_DISCONNECT_REFUSED,
+      message: "Bitcoin and Ethereum share one wallet session.",
+    });
+    const wallet = createWallet({
+      connectWallet: vi.fn().mockResolvedValue(undefined),
+      getAddress: vi.fn().mockResolvedValue("bc1p"),
+      getPublicKeyHex: vi.fn().mockResolvedValue("02ab"),
+      disconnect: vi.fn().mockRejectedValue(refusal),
+    });
+    const connector = new WalletConnector("BTC", "Bitcoin", "icon", [wallet], {});
+    await connector.connect(wallet);
+    const onError = vi.fn();
+    const onDisconnect = vi.fn();
+    connector.on("error", onError);
+    connector.on("disconnect", onDisconnect);
+
+    await expect(connector.disconnect()).rejects.toBe(refusal);
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledWith(refusal);
+    expect(onDisconnect).not.toHaveBeenCalled();
+    expect(connector.connectedWallet).toBe(wallet);
+  });
+
+  it("emits disconnect and clears the wallet when the provider disconnects", async () => {
+    const wallet = createWallet({
+      connectWallet: vi.fn().mockResolvedValue(undefined),
+      getAddress: vi.fn().mockResolvedValue("bc1p"),
+      getPublicKeyHex: vi.fn().mockResolvedValue("02ab"),
+      disconnect: vi.fn().mockResolvedValue(undefined),
+    });
+    const connector = new WalletConnector("BTC", "Bitcoin", "icon", [wallet], {});
+    await connector.connect(wallet);
+    const onError = vi.fn();
+    const onDisconnect = vi.fn();
+    connector.on("error", onError);
+    connector.on("disconnect", onDisconnect);
+
+    await connector.disconnect();
+
+    expect(onDisconnect).toHaveBeenCalledWith(wallet);
+    expect(connector.connectedWallet).toBeNull();
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it("completes an explicit disconnect-all and reports a provider failure as error", async () => {
+    const failure = new Error("boom");
+    const wallet = createWallet({
+      connectWallet: vi.fn().mockResolvedValue(undefined),
+      getAddress: vi.fn().mockResolvedValue("bc1p"),
+      getPublicKeyHex: vi.fn().mockResolvedValue("02ab"),
+      disconnect: vi.fn().mockRejectedValue(failure),
+    });
+    const connector = new WalletConnector("BTC", "Bitcoin", "icon", [wallet], {});
+    await connector.connect(wallet);
+    const onError = vi.fn();
+    const onDisconnect = vi.fn();
+    connector.on("error", onError);
+    connector.on("disconnect", onDisconnect);
+
+    await connector.disconnect("all");
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledWith(failure);
+    expect(onDisconnect).toHaveBeenCalledWith(wallet);
+    expect(connector.connectedWallet).toBeNull();
+  });
+
+  it("forwards the scope to the provider and defaults to chain", async () => {
+    const disconnect = vi.fn().mockResolvedValue(undefined);
+    const wallet = createWallet({
+      connectWallet: vi.fn().mockResolvedValue(undefined),
+      getAddress: vi.fn().mockResolvedValue("bc1p"),
+      getPublicKeyHex: vi.fn().mockResolvedValue("02ab"),
+      disconnect,
+    });
+    const connector = new WalletConnector("BTC", "Bitcoin", "icon", [wallet], {});
+    await connector.connect(wallet);
+
+    await connector.disconnect("all");
+    await connector.connect(wallet);
+    await connector.disconnect();
+
+    expect(disconnect.mock.calls).toEqual([["all"], ["chain"]]);
+  });
+
+  it("disconnects without a provider disconnect method", async () => {
+    const wallet = createWallet({
+      connectWallet: vi.fn().mockResolvedValue(undefined),
+      getAddress: vi.fn().mockResolvedValue("bc1p"),
+      getPublicKeyHex: vi.fn().mockResolvedValue("02ab"),
+    });
+    const connector = new WalletConnector("BTC", "Bitcoin", "icon", [wallet], {});
+    await connector.connect(wallet);
+    const onDisconnect = vi.fn();
+    connector.on("disconnect", onDisconnect);
+
+    await connector.disconnect();
+
+    expect(onDisconnect).toHaveBeenCalledWith(wallet);
+    expect(connector.connectedWallet).toBeNull();
+  });
+});

--- a/packages/babylon-wallet-connector/src/core/__tests__/WalletConnector.disconnect.test.ts
+++ b/packages/babylon-wallet-connector/src/core/__tests__/WalletConnector.disconnect.test.ts
@@ -18,12 +18,14 @@ function createWallet(provider: Record<string, unknown>) {
 }
 
 describe("WalletConnector disconnect", () => {
-  it("keeps a refused wallet until its account is rejected", async () => {
+  it("keeps a refused wallet without reporting an error until a local disconnect drops it", async () => {
     const refusal = new WalletError({
       code: ERROR_CODES.SHARED_SESSION_DISCONNECT_REFUSED,
       message: "Bitcoin and Ethereum share one wallet session.",
     });
-    const disconnect = vi.fn().mockRejectedValue(refusal);
+    const disconnect = vi.fn(async (scope: string) => {
+      if (scope === "chain") throw refusal;
+    });
     const wallet = createWallet({
       connectWallet: vi.fn().mockResolvedValue(undefined),
       getAddress: vi.fn().mockResolvedValue("bc1p"),
@@ -39,15 +41,58 @@ describe("WalletConnector disconnect", () => {
 
     await expect(connector.disconnect()).rejects.toBe(refusal);
 
-    expect(onError).toHaveBeenCalledTimes(1);
-    expect(onError).toHaveBeenCalledWith(refusal);
+    expect(onError).not.toHaveBeenCalled();
     expect(onDisconnect).not.toHaveBeenCalled();
     expect(connector.connectedWallet).toBe(wallet);
-    wallet.account = null;
-    await connector.disconnect();
-    expect(disconnect).toHaveBeenLastCalledWith("chain");
+
+    await connector.disconnect("local");
+
+    expect(disconnect.mock.calls).toEqual([["chain"], ["local"]]);
+    expect(onError).not.toHaveBeenCalled();
     expect(onDisconnect).toHaveBeenCalledWith(wallet);
     expect(connector.connectedWallet).toBeNull();
+  });
+
+  it("keeps the wallet and reports a failed chain disconnect as error", async () => {
+    const failure = new Error("boom");
+    const wallet = createWallet({
+      connectWallet: vi.fn().mockResolvedValue(undefined),
+      getAddress: vi.fn().mockResolvedValue("bc1p"),
+      getPublicKeyHex: vi.fn().mockResolvedValue("02ab"),
+      disconnect: vi.fn().mockRejectedValue(failure),
+    });
+    const connector = new WalletConnector("BTC", "Bitcoin", "icon", [wallet], {});
+    await connector.connect(wallet);
+    const onError = vi.fn();
+    const onDisconnect = vi.fn();
+    connector.on("error", onError);
+    connector.on("disconnect", onDisconnect);
+
+    await expect(connector.disconnect()).rejects.toBe(failure);
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledWith(failure);
+    expect(onDisconnect).not.toHaveBeenCalled();
+    expect(connector.connectedWallet).toBe(wallet);
+  });
+
+  it("clears the wallet before it emits disconnect", async () => {
+    const wallet = createWallet({
+      connectWallet: vi.fn().mockResolvedValue(undefined),
+      getAddress: vi.fn().mockResolvedValue("bc1p"),
+      getPublicKeyHex: vi.fn().mockResolvedValue("02ab"),
+      disconnect: vi.fn().mockResolvedValue(undefined),
+    });
+    const connector = new WalletConnector("BTC", "Bitcoin", "icon", [wallet], {});
+    await connector.connect(wallet);
+    let walletDuringEvent: unknown = wallet;
+    connector.on("disconnect", () => {
+      walletDuringEvent = connector.connectedWallet;
+    });
+
+    await connector.disconnect();
+
+    expect(walletDuringEvent).toBeNull();
   });
 
   it("emits disconnect and clears the wallet when the provider disconnects", async () => {
@@ -94,6 +139,29 @@ describe("WalletConnector disconnect", () => {
     expect(connector.connectedWallet).toBeNull();
   });
 
+  it("completes a local disconnect and reports a provider failure as error", async () => {
+    const failure = new Error("boom");
+    const wallet = createWallet({
+      connectWallet: vi.fn().mockResolvedValue(undefined),
+      getAddress: vi.fn().mockResolvedValue("bc1p"),
+      getPublicKeyHex: vi.fn().mockResolvedValue("02ab"),
+      disconnect: vi.fn().mockRejectedValue(failure),
+    });
+    const connector = new WalletConnector("BTC", "Bitcoin", "icon", [wallet], {});
+    await connector.connect(wallet);
+    const onError = vi.fn();
+    const onDisconnect = vi.fn();
+    connector.on("error", onError);
+    connector.on("disconnect", onDisconnect);
+
+    await connector.disconnect("local");
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledWith(failure);
+    expect(onDisconnect).toHaveBeenCalledWith(wallet);
+    expect(connector.connectedWallet).toBeNull();
+  });
+
   it("forwards the scope to the provider and defaults to chain", async () => {
     const disconnect = vi.fn().mockResolvedValue(undefined);
     const wallet = createWallet({
@@ -126,6 +194,33 @@ describe("WalletConnector disconnect", () => {
     await connector.disconnect();
 
     expect(onDisconnect).toHaveBeenCalledWith(wallet);
+    expect(connector.connectedWallet).toBeNull();
+  });
+
+  it("emits disconnect once when a local disconnect lands during an in-flight chain disconnect", async () => {
+    let settleChainDisconnect!: () => void;
+    const chainDisconnect = new Promise<void>((resolve) => {
+      settleChainDisconnect = resolve;
+    });
+    const wallet = createWallet({
+      connectWallet: vi.fn().mockResolvedValue(undefined),
+      getAddress: vi.fn().mockResolvedValue("bc1p"),
+      getPublicKeyHex: vi.fn().mockResolvedValue("02ab"),
+      disconnect: vi.fn(async (scope: string) => {
+        if (scope === "chain") await chainDisconnect;
+      }),
+    });
+    const connector = new WalletConnector("BTC", "Bitcoin", "icon", [wallet], {});
+    await connector.connect(wallet);
+    const onDisconnect = vi.fn();
+    connector.on("disconnect", onDisconnect);
+
+    const chainScope = connector.disconnect("chain");
+    await connector.disconnect("local");
+    settleChainDisconnect();
+    await chainScope;
+
+    expect(onDisconnect.mock.calls).toEqual([[wallet]]);
     expect(connector.connectedWallet).toBeNull();
   });
 });

--- a/packages/babylon-wallet-connector/src/core/types.ts
+++ b/packages/babylon-wallet-connector/src/core/types.ts
@@ -224,6 +224,9 @@ export interface IWallet<P extends IProvider = IProvider> {
 /** Every chain the connector can build a wallet connector for. */
 export type ChainId = "BTC" | "BBN" | "ETH";
 
+/** `"chain"` asks the provider to disconnect only this connector's chain. `"all"` is an explicit disconnect-everything request. */
+export type DisconnectScope = "chain" | "all";
+
 export interface IChain<K extends string = string, P extends IProvider = IProvider, C = any> {
   id: K;
   name: string;
@@ -235,7 +238,7 @@ export interface IChain<K extends string = string, P extends IProvider = IProvid
 export interface IConnector<K extends string = string, P extends IProvider = IProvider, C = any>
   extends IChain<K, P, C> {
   connect(wallet: string | IWallet<P>): Promise<IWallet<P> | null>;
-  disconnect(): Promise<void>;
+  disconnect(scope?: DisconnectScope): Promise<void>;
   on(event: string, cb: (wallet: IWallet<P>) => void): () => void;
 }
 

--- a/packages/babylon-wallet-connector/src/core/types.ts
+++ b/packages/babylon-wallet-connector/src/core/types.ts
@@ -224,8 +224,16 @@ export interface IWallet<P extends IProvider = IProvider> {
 /** Every chain the connector can build a wallet connector for. */
 export type ChainId = "BTC" | "BBN" | "ETH";
 
-/** `"chain"` asks the provider to disconnect only this connector's chain. `"all"` is an explicit disconnect-everything request. */
-export type DisconnectScope = "chain" | "all";
+/**
+ * `"chain"` asks the provider to disconnect only this connector's chain; the
+ * provider refuses with `SHARED_SESSION_DISCONNECT_REFUSED` when that would
+ * also disconnect another chain. `"all"` is an explicit disconnect-everything
+ * request and is never refused. `"local"` drops this connector's wallet and
+ * the provider's cached session without any remote call: for a wallet the app
+ * rejected after connecting, or one the provider's backend already reports
+ * disconnected. It is never refused.
+ */
+export type DisconnectScope = "chain" | "all" | "local";
 
 export interface IChain<K extends string = string, P extends IProvider = IProvider, C = any> {
   id: K;
@@ -238,6 +246,14 @@ export interface IChain<K extends string = string, P extends IProvider = IProvid
 export interface IConnector<K extends string = string, P extends IProvider = IProvider, C = any>
   extends IChain<K, P, C> {
   connect(wallet: string | IWallet<P>): Promise<IWallet<P> | null>;
+  /**
+   * Rejects only for `"chain"`: with `SHARED_SESSION_DISCONNECT_REFUSED` when
+   * the provider refused, or with the provider's error when the remote
+   * disconnect failed. Either way nothing was disconnected, so the wallet
+   * stays connected and no `disconnect` event fires; only a genuine failure
+   * is also reported on `error`. `"all"` and `"local"` always finish the
+   * local teardown and report a provider failure on `error`.
+   */
   disconnect(scope?: DisconnectScope): Promise<void>;
   on(event: string, cb: (wallet: IWallet<P>) => void): () => void;
 }

--- a/packages/babylon-wallet-connector/src/core/wallets/appkit/state.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/appkit/state.ts
@@ -96,6 +96,7 @@ export function createAppKitCapabilities({
  * the Bitcoin adapter through its sibling.
  */
 let appKitState: AppKitState | null = null;
+let manualAppKitModal: AppKitModal | null = null;
 const manualAppKitCapabilities = new Set<"Ethereum" | "Bitcoin">();
 
 export function failInitialization(message: string, chainId?: string): never {
@@ -107,10 +108,10 @@ export function getAppKitState(): AppKitState | null {
 }
 
 export function getAppKitModal(): AppKitModal | null {
-  return appKitState?.modal ?? null;
+  return appKitState?.modal ?? manualAppKitModal;
 }
 
-export function registerManualAppKitConfig(capability: "Ethereum" | "Bitcoin"): void {
+export function registerManualAppKitConfig(capability: "Ethereum" | "Bitcoin", modal?: AppKitModal): void {
   if (appKitState) {
     failInitialization(
       `Cannot set a manual ${capability} AppKit configuration after AppKit initialization. Use the canonical AppKit state.`,
@@ -118,11 +119,13 @@ export function registerManualAppKitConfig(capability: "Ethereum" | "Bitcoin"): 
   }
 
   manualAppKitCapabilities.add(capability);
+  if (modal) manualAppKitModal = modal;
 }
 
 /** @internal */
 export function __resetManualAppKitConfigForTests(capability: "Ethereum" | "Bitcoin"): void {
   manualAppKitCapabilities.delete(capability);
+  if (capability === "Bitcoin") manualAppKitModal = null;
 }
 
 export function validateAppKitInitialization(projectId?: string): projectId is string {

--- a/packages/babylon-wallet-connector/src/core/wallets/btc/appkit/__tests__/provider.disconnect.test.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/appkit/__tests__/provider.disconnect.test.ts
@@ -23,12 +23,12 @@ async function connect(provider: AppKitBTCProvider, connectionEvents: EventTarge
 }
 
 describe("AppKitBTCProvider disconnect", () => {
-  it("disconnects only the bitcoin namespace for an injected wallet while ethereum stays connected", async () => {
+  it("disconnects only the bitcoin namespace for an announced extension while ethereum stays connected", async () => {
     const connectionEvents = new EventTarget();
     const unsubscribeNetwork = vi.fn();
     const modal = {
       disconnect: vi.fn().mockResolvedValue(undefined),
-      getProviderType: vi.fn(() => "INJECTED"),
+      getProviderType: vi.fn(() => "ANNOUNCED"),
       getAccount: vi.fn(() => ({ isConnected: true })),
       subscribeNetwork: vi.fn(() => unsubscribeNetwork),
     };
@@ -154,11 +154,11 @@ describe("AppKitBTCProvider disconnect", () => {
     expect(modal.disconnect).toHaveBeenCalledWith("bip122");
   });
 
-  it("disconnects an injected bitcoin wallet even when ethereum uses walletconnect", async () => {
+  it("disconnects an announced bitcoin extension even when ethereum uses walletconnect", async () => {
     const connectionEvents = new EventTarget();
     const modal = {
       disconnect: vi.fn().mockResolvedValue(undefined),
-      getProviderType: vi.fn(() => "INJECTED"),
+      getProviderType: vi.fn((namespace: string) => (namespace === "bip122" ? "ANNOUNCED" : "WALLET_CONNECT")),
       getAccount: vi.fn(() => ({ isConnected: true })),
       subscribeNetwork: vi.fn(() => vi.fn()),
     };
@@ -173,7 +173,40 @@ describe("AppKitBTCProvider disconnect", () => {
 
     await provider.disconnect("chain");
 
+    expect(modal.getProviderType).toHaveBeenCalledWith("bip122");
     expect(modal.disconnect).toHaveBeenCalledWith("bip122");
+  });
+
+  it("clears only local state on a local disconnect and never calls appkit", async () => {
+    const connectionEvents = new EventTarget();
+    const unsubscribeNetwork = vi.fn();
+    const modal = {
+      disconnect: vi.fn().mockResolvedValue(undefined),
+      getProviderType: vi.fn(() => "WALLET_CONNECT"),
+      getAccount: vi.fn(() => ({ isConnected: true })),
+      subscribeNetwork: vi.fn(() => unsubscribeNetwork),
+    };
+    setSharedBtcAppKitConfig({
+      modal: modal as never,
+      adapter: {} as never,
+      network: "signet",
+      connectionEvents,
+    });
+    const provider = new AppKitBTCProvider({ network: Network.SIGNET } as BTCConfig);
+    await connect(provider, connectionEvents, "bc1pdepositor");
+
+    await provider.disconnect("local");
+
+    expect(modal.disconnect).not.toHaveBeenCalled();
+    expect(modal.getProviderType).not.toHaveBeenCalled();
+    expect(unsubscribeNetwork).toHaveBeenCalledTimes(1);
+    await expect(provider.getAddress()).rejects.toThrow("Bitcoin wallet not connected");
+  });
+
+  it("completes a local disconnect before appkit is initialized", async () => {
+    const provider = new AppKitBTCProvider({ network: Network.SIGNET } as BTCConfig);
+
+    await expect(provider.disconnect("local")).resolves.toBeUndefined();
   });
 
   it("disconnects every chain on an explicit disconnect-all even over a shared walletconnect session", async () => {
@@ -227,12 +260,12 @@ describe("AppKitBTCProvider disconnect", () => {
     expect(unsubscribeNetwork).toHaveBeenCalledTimes(1);
   });
 
-  it("keeps local state when appkit fails to disconnect", async () => {
+  it("keeps local state when appkit fails to disconnect bitcoin", async () => {
     const connectionEvents = new EventTarget();
     const unsubscribeNetwork = vi.fn();
     const modal = {
       disconnect: vi.fn().mockRejectedValue(new Error("boom")),
-      getProviderType: vi.fn(() => "INJECTED"),
+      getProviderType: vi.fn(() => "ANNOUNCED"),
       getAccount: vi.fn(() => undefined),
       subscribeNetwork: vi.fn(() => unsubscribeNetwork),
     };

--- a/packages/babylon-wallet-connector/src/core/wallets/btc/appkit/__tests__/provider.disconnect.test.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/appkit/__tests__/provider.disconnect.test.ts
@@ -1,0 +1,253 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { BTCConfig } from "@/core/types";
+import { Network } from "@/core/types";
+import { ERROR_CODES, WalletError } from "@/error";
+
+import { APPKIT_BTC_CONNECTED_EVENT } from "../constants";
+import { AppKitBTCProvider } from "../provider";
+import { __resetSharedBtcAppKitConfigForTests, setSharedBtcAppKitConfig } from "../sharedConfig";
+
+afterEach(() => {
+  __resetSharedBtcAppKitConfigForTests();
+});
+
+async function connect(provider: AppKitBTCProvider, connectionEvents: EventTarget, address: string) {
+  const connection = provider.connectWallet();
+  connectionEvents.dispatchEvent(
+    new CustomEvent(APPKIT_BTC_CONNECTED_EVENT, {
+      detail: { address, publicKey: `02${"a".repeat(64)}` },
+    }),
+  );
+  await connection;
+}
+
+describe("AppKitBTCProvider disconnect", () => {
+  it("disconnects only the bitcoin namespace for an injected wallet while ethereum stays connected", async () => {
+    const connectionEvents = new EventTarget();
+    const unsubscribeNetwork = vi.fn();
+    const modal = {
+      disconnect: vi.fn().mockResolvedValue(undefined),
+      getProviderType: vi.fn(() => "INJECTED"),
+      getAccount: vi.fn(() => ({ isConnected: true })),
+      subscribeNetwork: vi.fn(() => unsubscribeNetwork),
+    };
+    setSharedBtcAppKitConfig({
+      modal: modal as never,
+      adapter: {} as never,
+      network: "signet",
+      connectionEvents,
+    });
+    const provider = new AppKitBTCProvider({ network: Network.SIGNET } as BTCConfig);
+    await connect(provider, connectionEvents, "bc1pdepositor");
+
+    await provider.disconnect("chain");
+
+    expect(modal.disconnect).toHaveBeenCalledTimes(1);
+    expect(modal.disconnect).toHaveBeenCalledWith("bip122");
+    await expect(provider.getAddress()).rejects.toThrow("Bitcoin wallet not connected");
+    expect(unsubscribeNetwork).toHaveBeenCalledTimes(1);
+  });
+
+  it("refuses a bitcoin-only disconnect when a walletconnect session also carries ethereum", async () => {
+    const connectionEvents = new EventTarget();
+    const modal = {
+      disconnect: vi.fn().mockResolvedValue(undefined),
+      getProviderType: vi.fn(() => "WALLET_CONNECT"),
+      getAccount: vi.fn(() => ({ isConnected: true })),
+      subscribeNetwork: vi.fn(() => vi.fn()),
+    };
+    setSharedBtcAppKitConfig({
+      modal: modal as never,
+      adapter: {} as never,
+      network: "signet",
+      connectionEvents,
+    });
+    const provider = new AppKitBTCProvider({ network: Network.SIGNET } as BTCConfig);
+    await connect(provider, connectionEvents, "bc1pdepositor");
+
+    const error = await provider.disconnect("chain").catch((e: unknown) => e);
+
+    expect(error).toBeInstanceOf(WalletError);
+    expect((error as WalletError).code).toBe(ERROR_CODES.SHARED_SESSION_DISCONNECT_REFUSED);
+    expect((error as WalletError).chainId).toBe("BTC");
+    expect(modal.disconnect).not.toHaveBeenCalled();
+    await expect(provider.getAddress()).resolves.toBe("bc1pdepositor");
+
+    const onAccountsChanged = vi.fn();
+    provider.on("accountsChanged", onAccountsChanged);
+    connectionEvents.dispatchEvent(
+      new CustomEvent(APPKIT_BTC_CONNECTED_EVENT, {
+        detail: { address: "bc1pother", publicKey: `02${"b".repeat(64)}` },
+      }),
+    );
+
+    expect(onAccountsChanged).toHaveBeenCalledWith(["bc1pother"]);
+  });
+
+  it("refuses when the bitcoin connector is auth and ethereum is connected", async () => {
+    const connectionEvents = new EventTarget();
+    const modal = {
+      disconnect: vi.fn().mockResolvedValue(undefined),
+      getProviderType: vi.fn(() => "AUTH"),
+      getAccount: vi.fn(() => ({ isConnected: true })),
+      subscribeNetwork: vi.fn(() => vi.fn()),
+    };
+    setSharedBtcAppKitConfig({
+      modal: modal as never,
+      adapter: {} as never,
+      network: "signet",
+      connectionEvents,
+    });
+    const provider = new AppKitBTCProvider({ network: Network.SIGNET } as BTCConfig);
+    await connect(provider, connectionEvents, "bc1pdepositor");
+
+    const error = await provider.disconnect("chain").catch((e: unknown) => e);
+
+    expect((error as WalletError).code).toBe(ERROR_CODES.SHARED_SESSION_DISCONNECT_REFUSED);
+    expect(modal.disconnect).not.toHaveBeenCalled();
+  });
+
+  it("disconnects bitcoin over walletconnect when ethereum is not connected", async () => {
+    const connectionEvents = new EventTarget();
+    const modal = {
+      disconnect: vi.fn().mockResolvedValue(undefined),
+      getProviderType: vi.fn(() => "WALLET_CONNECT"),
+      getAccount: vi.fn(() => undefined),
+      subscribeNetwork: vi.fn(() => vi.fn()),
+    };
+    setSharedBtcAppKitConfig({
+      modal: modal as never,
+      adapter: {} as never,
+      network: "signet",
+      connectionEvents,
+    });
+    const provider = new AppKitBTCProvider({ network: Network.SIGNET } as BTCConfig);
+    await connect(provider, connectionEvents, "bc1pdepositor");
+
+    await provider.disconnect("chain");
+
+    expect(modal.disconnect).toHaveBeenCalledTimes(1);
+    expect(modal.disconnect).toHaveBeenCalledWith("bip122");
+  });
+
+  it("disconnects bitcoin over walletconnect when the ethereum account exists but is not connected", async () => {
+    const connectionEvents = new EventTarget();
+    const modal = {
+      disconnect: vi.fn().mockResolvedValue(undefined),
+      getProviderType: vi.fn(() => "WALLET_CONNECT"),
+      getAccount: vi.fn(() => ({ isConnected: false })),
+      subscribeNetwork: vi.fn(() => vi.fn()),
+    };
+    setSharedBtcAppKitConfig({
+      modal: modal as never,
+      adapter: {} as never,
+      network: "signet",
+      connectionEvents,
+    });
+    const provider = new AppKitBTCProvider({ network: Network.SIGNET } as BTCConfig);
+    await connect(provider, connectionEvents, "bc1pdepositor");
+
+    await provider.disconnect("chain");
+
+    expect(modal.disconnect).toHaveBeenCalledTimes(1);
+    expect(modal.disconnect).toHaveBeenCalledWith("bip122");
+  });
+
+  it("disconnects an injected bitcoin wallet even when ethereum uses walletconnect", async () => {
+    const connectionEvents = new EventTarget();
+    const modal = {
+      disconnect: vi.fn().mockResolvedValue(undefined),
+      getProviderType: vi.fn(() => "INJECTED"),
+      getAccount: vi.fn(() => ({ isConnected: true })),
+      subscribeNetwork: vi.fn(() => vi.fn()),
+    };
+    setSharedBtcAppKitConfig({
+      modal: modal as never,
+      adapter: {} as never,
+      network: "signet",
+      connectionEvents,
+    });
+    const provider = new AppKitBTCProvider({ network: Network.SIGNET } as BTCConfig);
+    await connect(provider, connectionEvents, "bc1pdepositor");
+
+    await provider.disconnect("chain");
+
+    expect(modal.disconnect).toHaveBeenCalledWith("bip122");
+  });
+
+  it("disconnects every chain on an explicit disconnect-all even over a shared walletconnect session", async () => {
+    const connectionEvents = new EventTarget();
+    const modal = {
+      disconnect: vi.fn().mockResolvedValue(undefined),
+      getProviderType: vi.fn(() => "WALLET_CONNECT"),
+      getAccount: vi.fn(() => ({ isConnected: true })),
+      subscribeNetwork: vi.fn(() => vi.fn()),
+    };
+    setSharedBtcAppKitConfig({
+      modal: modal as never,
+      adapter: {} as never,
+      network: "signet",
+      connectionEvents,
+    });
+    const provider = new AppKitBTCProvider({ network: Network.SIGNET } as BTCConfig);
+    await connect(provider, connectionEvents, "bc1pdepositor");
+
+    await provider.disconnect("all");
+
+    expect(modal.disconnect).toHaveBeenCalledTimes(1);
+    expect(modal.disconnect).toHaveBeenCalledWith();
+    expect(modal.disconnect.mock.calls[0]).toEqual([]);
+    expect(modal.getProviderType).not.toHaveBeenCalled();
+    expect(modal.getAccount).not.toHaveBeenCalled();
+    await expect(provider.getAddress()).rejects.toThrow("Bitcoin wallet not connected");
+  });
+
+  it("clears local state when an explicit disconnect-all fails part way", async () => {
+    const connectionEvents = new EventTarget();
+    const unsubscribeNetwork = vi.fn();
+    const modal = {
+      disconnect: vi.fn().mockRejectedValue(new Error("Failed to disconnect chains: boom")),
+      getProviderType: vi.fn(() => "WALLET_CONNECT"),
+      getAccount: vi.fn(() => ({ isConnected: true })),
+      subscribeNetwork: vi.fn(() => unsubscribeNetwork),
+    };
+    setSharedBtcAppKitConfig({
+      modal: modal as never,
+      adapter: {} as never,
+      network: "signet",
+      connectionEvents,
+    });
+    const provider = new AppKitBTCProvider({ network: Network.SIGNET } as BTCConfig);
+    await connect(provider, connectionEvents, "bc1pdepositor");
+
+    await expect(provider.disconnect("all")).rejects.toThrow("boom");
+
+    await expect(provider.getAddress()).rejects.toThrow("Bitcoin wallet not connected");
+    expect(unsubscribeNetwork).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps local state when appkit fails to disconnect", async () => {
+    const connectionEvents = new EventTarget();
+    const unsubscribeNetwork = vi.fn();
+    const modal = {
+      disconnect: vi.fn().mockRejectedValue(new Error("boom")),
+      getProviderType: vi.fn(() => "INJECTED"),
+      getAccount: vi.fn(() => undefined),
+      subscribeNetwork: vi.fn(() => unsubscribeNetwork),
+    };
+    setSharedBtcAppKitConfig({
+      modal: modal as never,
+      adapter: {} as never,
+      network: "signet",
+      connectionEvents,
+    });
+    const provider = new AppKitBTCProvider({ network: Network.SIGNET } as BTCConfig);
+    await connect(provider, connectionEvents, "bc1pdepositor");
+
+    await expect(provider.disconnect("chain")).rejects.toThrow("boom");
+
+    await expect(provider.getAddress()).resolves.toBe("bc1pdepositor");
+    expect(unsubscribeNetwork).not.toHaveBeenCalled();
+  });
+});

--- a/packages/babylon-wallet-connector/src/core/wallets/btc/appkit/__tests__/provider.network.test.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/appkit/__tests__/provider.network.test.ts
@@ -26,6 +26,8 @@ describe("AppKitBTCProvider network events", () => {
     let networkListener: ((state: NetworkState) => void) | undefined;
     const modal = {
       disconnect: vi.fn().mockResolvedValue(undefined),
+      getProviderType: vi.fn(() => "INJECTED"),
+      getAccount: vi.fn(() => undefined),
       subscribeNetwork: vi.fn((listener: (state: NetworkState) => void) => {
         networkListener = listener;
         return unsubscribeNetwork;
@@ -58,7 +60,7 @@ describe("AppKitBTCProvider network events", () => {
     networkListener?.({ caipNetwork: { chainNamespace: "bip122", caipNetworkId: mainnetId } });
     expect(onNetworkChanged).toHaveBeenCalledWith(mainnetId);
 
-    await provider.disconnect();
+    await provider.disconnect("chain");
     expect(unsubscribeNetwork).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/babylon-wallet-connector/src/core/wallets/btc/appkit/__tests__/provider.network.test.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/appkit/__tests__/provider.network.test.ts
@@ -26,7 +26,7 @@ describe("AppKitBTCProvider network events", () => {
     let networkListener: ((state: NetworkState) => void) | undefined;
     const modal = {
       disconnect: vi.fn().mockResolvedValue(undefined),
-      getProviderType: vi.fn(() => "INJECTED"),
+      getProviderType: vi.fn(() => "ANNOUNCED"),
       getAccount: vi.fn(() => undefined),
       subscribeNetwork: vi.fn((listener: (state: NetworkState) => void) => {
         networkListener = listener;

--- a/packages/babylon-wallet-connector/src/core/wallets/btc/appkit/__tests__/sharedConfig.test.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/appkit/__tests__/sharedConfig.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { __resetSharedBtcAppKitConfigForTests, btcDisconnectWouldDropEthereum, setSharedBtcAppKitConfig } from "../sharedConfig";
+
+afterEach(() => {
+  __resetSharedBtcAppKitConfigForTests();
+});
+
+function setModal(getProviderType: () => string, getAccount: () => { isConnected: boolean } | undefined) {
+  setSharedBtcAppKitConfig({
+    modal: { getProviderType: vi.fn(getProviderType), getAccount: vi.fn(getAccount) } as never,
+    adapter: {} as never,
+    network: "signet",
+  });
+}
+
+describe("btcDisconnectWouldDropEthereum", () => {
+  it("reports true when bitcoin runs over walletconnect and ethereum is connected", () => {
+    setModal(
+      () => "WALLET_CONNECT",
+      () => ({ isConnected: true }),
+    );
+
+    expect(btcDisconnectWouldDropEthereum()).toBe(true);
+  });
+
+  it("reports true when bitcoin runs over auth and ethereum is connected", () => {
+    setModal(
+      () => "AUTH",
+      () => ({ isConnected: true }),
+    );
+
+    expect(btcDisconnectWouldDropEthereum()).toBe(true);
+  });
+
+  it("reports false for an injected bitcoin wallet even while ethereum is connected", () => {
+    setModal(
+      () => "INJECTED",
+      () => ({ isConnected: true }),
+    );
+
+    expect(btcDisconnectWouldDropEthereum()).toBe(false);
+  });
+
+  it("reports false over walletconnect when there is no ethereum account", () => {
+    setModal(
+      () => "WALLET_CONNECT",
+      () => undefined,
+    );
+
+    expect(btcDisconnectWouldDropEthereum()).toBe(false);
+  });
+
+  it("reports false over walletconnect when the ethereum account is disconnected", () => {
+    setModal(
+      () => "WALLET_CONNECT",
+      () => ({ isConnected: false }),
+    );
+
+    expect(btcDisconnectWouldDropEthereum()).toBe(false);
+  });
+
+  it("reports false when no shared bitcoin config is registered", () => {
+    expect(btcDisconnectWouldDropEthereum()).toBe(false);
+  });
+});

--- a/packages/babylon-wallet-connector/src/core/wallets/btc/appkit/__tests__/sharedConfig.test.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/appkit/__tests__/sharedConfig.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { ethDisconnectWouldDropBitcoin } from "@/core/wallets/eth/appkit/sharedConfig";
+
 import {
   __resetSharedBtcAppKitConfigForTests,
   btcDisconnectWouldDropEthereum,
@@ -26,55 +28,58 @@ function setModal(session: {
   return modal;
 }
 
-describe("btcDisconnectWouldDropEthereum", () => {
-  it("reports true when bitcoin runs over walletconnect and ethereum is connected", () => {
+describe.each([
+  ["Bitcoin", "bip122", "eip155", btcDisconnectWouldDropEthereum],
+  ["Ethereum", "eip155", "bip122", ethDisconnectWouldDropBitcoin],
+] as const)("%s shared disconnect", (_chain, namespace, otherNamespace, wouldDropOther) => {
+  it("refuses WalletConnect while the other chain is connected", () => {
     const modal = setModal({
-      providerTypes: { bip122: "WALLET_CONNECT", eip155: "ANNOUNCED" },
-      accounts: { bip122: { isConnected: false }, eip155: { isConnected: true } },
+      providerTypes: { [namespace]: "WALLET_CONNECT", [otherNamespace]: "ANNOUNCED" },
+      accounts: { [namespace]: { isConnected: false }, [otherNamespace]: { isConnected: true } },
     });
 
-    expect(btcDisconnectWouldDropEthereum()).toBe(true);
-    expect(modal.getProviderType).toHaveBeenCalledWith("bip122");
-    expect(modal.getAccount).toHaveBeenCalledWith("eip155");
+    expect(wouldDropOther()).toBe(true);
+    expect(modal.getProviderType).toHaveBeenCalledWith(namespace);
+    expect(modal.getAccount).toHaveBeenCalledWith(otherNamespace);
   });
 
-  it("reports true when bitcoin runs over auth and ethereum is connected", () => {
+  it("refuses Auth while the other chain is connected", () => {
     setModal({
-      providerTypes: { bip122: "AUTH", eip155: "ANNOUNCED" },
-      accounts: { bip122: { isConnected: false }, eip155: { isConnected: true } },
+      providerTypes: { [namespace]: "AUTH", [otherNamespace]: "ANNOUNCED" },
+      accounts: { [namespace]: { isConnected: false }, [otherNamespace]: { isConnected: true } },
     });
 
-    expect(btcDisconnectWouldDropEthereum()).toBe(true);
+    expect(wouldDropOther()).toBe(true);
   });
 
-  it("reports false for an announced bitcoin extension even while ethereum is connected over walletconnect", () => {
+  it("allows an announced extension while the other chain uses WalletConnect", () => {
     setModal({
-      providerTypes: { bip122: "ANNOUNCED", eip155: "WALLET_CONNECT" },
+      providerTypes: { [namespace]: "ANNOUNCED", [otherNamespace]: "WALLET_CONNECT" },
       accounts: { bip122: { isConnected: true }, eip155: { isConnected: true } },
     });
 
-    expect(btcDisconnectWouldDropEthereum()).toBe(false);
+    expect(wouldDropOther()).toBe(false);
   });
 
-  it("reports false over walletconnect when there is no ethereum account", () => {
+  it("allows WalletConnect when the other account is absent", () => {
     setModal({
-      providerTypes: { bip122: "WALLET_CONNECT" },
-      accounts: { bip122: { isConnected: true } },
+      providerTypes: { [namespace]: "WALLET_CONNECT" },
+      accounts: { [namespace]: { isConnected: true } },
     });
 
-    expect(btcDisconnectWouldDropEthereum()).toBe(false);
+    expect(wouldDropOther()).toBe(false);
   });
 
-  it("reports false over walletconnect when the ethereum account is disconnected", () => {
+  it("allows WalletConnect when the other account is disconnected", () => {
     setModal({
       providerTypes: { bip122: "WALLET_CONNECT", eip155: "WALLET_CONNECT" },
-      accounts: { bip122: { isConnected: true }, eip155: { isConnected: false } },
+      accounts: { [namespace]: { isConnected: true }, [otherNamespace]: { isConnected: false } },
     });
 
-    expect(btcDisconnectWouldDropEthereum()).toBe(false);
+    expect(wouldDropOther()).toBe(false);
   });
 
-  it("reports false when no shared bitcoin config is registered", () => {
-    expect(btcDisconnectWouldDropEthereum()).toBe(false);
+  it("reports no shared session before initialization", () => {
+    expect(wouldDropOther()).toBe(false);
   });
 });

--- a/packages/babylon-wallet-connector/src/core/wallets/btc/appkit/__tests__/sharedConfig.test.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/appkit/__tests__/sharedConfig.test.ts
@@ -1,61 +1,75 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { __resetSharedBtcAppKitConfigForTests, btcDisconnectWouldDropEthereum, setSharedBtcAppKitConfig } from "../sharedConfig";
+import {
+  __resetSharedBtcAppKitConfigForTests,
+  btcDisconnectWouldDropEthereum,
+  setSharedBtcAppKitConfig,
+} from "../sharedConfig";
 
 afterEach(() => {
   __resetSharedBtcAppKitConfigForTests();
 });
 
-function setModal(getProviderType: () => string, getAccount: () => { isConnected: boolean } | undefined) {
-  setSharedBtcAppKitConfig({
-    modal: { getProviderType: vi.fn(getProviderType), getAccount: vi.fn(getAccount) } as never,
-    adapter: {} as never,
-    network: "signet",
-  });
+type Namespace = "bip122" | "eip155";
+
+// Both AppKit accessors are per-namespace lookups, so every fixture gives the
+// two namespaces different values: a predicate that read the wrong one fails.
+function setModal(session: {
+  providerTypes: Partial<Record<Namespace, string>>;
+  accounts: Partial<Record<Namespace, { isConnected: boolean }>>;
+}) {
+  const modal = {
+    getProviderType: vi.fn((namespace: Namespace) => session.providerTypes[namespace]),
+    getAccount: vi.fn((namespace: Namespace) => session.accounts[namespace]),
+  };
+  setSharedBtcAppKitConfig({ modal: modal as never, adapter: {} as never, network: "signet" });
+  return modal;
 }
 
 describe("btcDisconnectWouldDropEthereum", () => {
   it("reports true when bitcoin runs over walletconnect and ethereum is connected", () => {
-    setModal(
-      () => "WALLET_CONNECT",
-      () => ({ isConnected: true }),
-    );
+    const modal = setModal({
+      providerTypes: { bip122: "WALLET_CONNECT", eip155: "ANNOUNCED" },
+      accounts: { bip122: { isConnected: false }, eip155: { isConnected: true } },
+    });
 
     expect(btcDisconnectWouldDropEthereum()).toBe(true);
+    expect(modal.getProviderType).toHaveBeenCalledWith("bip122");
+    expect(modal.getAccount).toHaveBeenCalledWith("eip155");
   });
 
   it("reports true when bitcoin runs over auth and ethereum is connected", () => {
-    setModal(
-      () => "AUTH",
-      () => ({ isConnected: true }),
-    );
+    setModal({
+      providerTypes: { bip122: "AUTH", eip155: "ANNOUNCED" },
+      accounts: { bip122: { isConnected: false }, eip155: { isConnected: true } },
+    });
 
     expect(btcDisconnectWouldDropEthereum()).toBe(true);
   });
 
-  it("reports false for an injected bitcoin wallet even while ethereum is connected", () => {
-    setModal(
-      () => "INJECTED",
-      () => ({ isConnected: true }),
-    );
+  it("reports false for an announced bitcoin extension even while ethereum is connected over walletconnect", () => {
+    setModal({
+      providerTypes: { bip122: "ANNOUNCED", eip155: "WALLET_CONNECT" },
+      accounts: { bip122: { isConnected: true }, eip155: { isConnected: true } },
+    });
 
     expect(btcDisconnectWouldDropEthereum()).toBe(false);
   });
 
   it("reports false over walletconnect when there is no ethereum account", () => {
-    setModal(
-      () => "WALLET_CONNECT",
-      () => undefined,
-    );
+    setModal({
+      providerTypes: { bip122: "WALLET_CONNECT" },
+      accounts: { bip122: { isConnected: true } },
+    });
 
     expect(btcDisconnectWouldDropEthereum()).toBe(false);
   });
 
   it("reports false over walletconnect when the ethereum account is disconnected", () => {
-    setModal(
-      () => "WALLET_CONNECT",
-      () => ({ isConnected: false }),
-    );
+    setModal({
+      providerTypes: { bip122: "WALLET_CONNECT", eip155: "WALLET_CONNECT" },
+      accounts: { bip122: { isConnected: true }, eip155: { isConnected: false } },
+    });
 
     expect(btcDisconnectWouldDropEthereum()).toBe(false);
   });

--- a/packages/babylon-wallet-connector/src/core/wallets/btc/appkit/__tests__/sharedConfig.test.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/appkit/__tests__/sharedConfig.test.ts
@@ -43,13 +43,14 @@ describe.each([
     expect(modal.getAccount).toHaveBeenCalledWith(otherNamespace);
   });
 
-  it("refuses Auth while the other chain is connected", () => {
+  it("allows Ethereum Auth and retains the defensive Bitcoin guard", () => {
     setModal({
       providerTypes: { [namespace]: "AUTH", [otherNamespace]: "ANNOUNCED" },
       accounts: { [namespace]: { isConnected: false }, [otherNamespace]: { isConnected: true } },
     });
 
-    expect(wouldDropOther()).toBe(true);
+    // AppKit 1.8.12 has no Bitcoin Auth connector.
+    expect(wouldDropOther()).toBe(namespace === "bip122");
   });
 
   it("allows an announced extension while the other chain uses WalletConnect", () => {

--- a/packages/babylon-wallet-connector/src/core/wallets/btc/appkit/provider.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/appkit/provider.ts
@@ -12,11 +12,7 @@ import { ERROR_CODES, WalletError, isUserRejectionMessage } from "@/error";
 import { APPKIT_BTC_CONNECTED_EVENT } from "./constants";
 import icon from "./icon.svg";
 import { getCaipNetworkForNetwork, resolveLiveNetwork } from "./network";
-import {
-  btcDisconnectWouldDropEthereum,
-  getSharedBtcAppKitConfig,
-  hasSharedBtcAppKitConfig,
-} from "./sharedConfig";
+import { btcDisconnectWouldDropEthereum, getSharedBtcAppKitConfig, hasSharedBtcAppKitConfig } from "./sharedConfig";
 
 const APPKIT_PROVIDER_NAME = "AppKit";
 
@@ -40,11 +36,7 @@ interface AppKitBtcWalletProvider {
     signInputs?: AppKitSignInput[];
     broadcast: boolean;
   }) => Promise<{ psbt: string; txid?: string }>;
-  signMessage?: (params: {
-    message: string;
-    address: string;
-    protocol: string;
-  }) => Promise<string>;
+  signMessage?: (params: { message: string; address: string; protocol: string }) => Promise<string>;
 }
 
 interface AdapterConnection {
@@ -155,10 +147,7 @@ export class AppKitBTCProvider implements IBTCProvider {
       return;
     }
 
-    this.boundConnectionEventsTarget.removeEventListener(
-      APPKIT_BTC_CONNECTED_EVENT,
-      this.boundHandleAccountChange,
-    );
+    this.boundConnectionEventsTarget.removeEventListener(APPKIT_BTC_CONNECTED_EVENT, this.boundHandleAccountChange);
     this.boundHandleAccountChange = null;
     this.boundConnectionEventsTarget = null;
     this.unsubscribeNetwork?.();
@@ -174,7 +163,7 @@ export class AppKitBTCProvider implements IBTCProvider {
     if (!hasSharedBtcAppKitConfig()) {
       throw new Error(
         "AppKit BTC not initialized. Ensure AppKit modal is initialized at application startup " +
-        "by calling initializeAppKitModal() with btc config in your app's entry point."
+          "by calling initializeAppKitModal() with btc config in your app's entry point.",
       );
     }
     return getSharedBtcAppKitConfig();
@@ -228,12 +217,29 @@ export class AppKitBTCProvider implements IBTCProvider {
       await waitForConnection;
       this.startListeningForAccountChanges();
     } catch (error) {
-      console.error("[AppKit Provider] Failed to connect Bitcoin wallet:", error instanceof Error ? error.message : "Unknown error");
+      console.error(
+        "[AppKit Provider] Failed to connect Bitcoin wallet:",
+        error instanceof Error ? error.message : "Unknown error",
+      );
       throw new Error(`Failed to connect Bitcoin wallet: ${error instanceof Error ? error.message : "Unknown error"}`);
     }
   }
 
+  /**
+   * `"local"` releases only this provider's cached session: the bridge calls
+   * it once AppKit already reports bip122 disconnected, and the dialog calls
+   * it for a wallet it rejected. `"chain"` disconnects only the bip122
+   * namespace and refuses when AppKit would widen that to eip155 (WalletConnect
+   * and Auth share one connector across namespaces). Local state clears only
+   * after AppKit resolves: when AppKit rejects, its bip122 session is still
+   * up. `"all"` is never refused and always clears local state.
+   */
   async disconnect(scope: DisconnectScope): Promise<void> {
+    if (scope === "local") {
+      this.clearSession();
+      return;
+    }
+
     const { modal } = this.getAppKitConfig();
 
     if (scope === "chain") {

--- a/packages/babylon-wallet-connector/src/core/wallets/btc/appkit/provider.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/appkit/provider.ts
@@ -2,7 +2,7 @@ import type { BitcoinAdapter } from "@reown/appkit-adapter-bitcoin";
 import { Psbt } from "bitcoinjs-lib";
 
 import { NETWORK_CHANGE_EVENT } from "@/constants/walletEvents";
-import type { BTCConfig, IBTCProvider, InscriptionIdentifier, SignPsbtOptions } from "@/core/types";
+import type { BTCConfig, DisconnectScope, IBTCProvider, InscriptionIdentifier, SignPsbtOptions } from "@/core/types";
 import { Network } from "@/core/types";
 import { resolveUseTweakedSigner } from "@/core/utils/psbtOptionsMapper";
 import { APPKIT_OPEN_EVENT } from "@/core/wallets/appkit/constants";
@@ -12,7 +12,11 @@ import { ERROR_CODES, WalletError, isUserRejectionMessage } from "@/error";
 import { APPKIT_BTC_CONNECTED_EVENT } from "./constants";
 import icon from "./icon.svg";
 import { getCaipNetworkForNetwork, resolveLiveNetwork } from "./network";
-import { getSharedBtcAppKitConfig, hasSharedBtcAppKitConfig } from "./sharedConfig";
+import {
+  btcDisconnectWouldDropEthereum,
+  getSharedBtcAppKitConfig,
+  hasSharedBtcAppKitConfig,
+} from "./sharedConfig";
 
 const APPKIT_PROVIDER_NAME = "AppKit";
 
@@ -229,15 +233,35 @@ export class AppKitBTCProvider implements IBTCProvider {
     }
   }
 
-  async disconnect(): Promise<void> {
+  async disconnect(scope: DisconnectScope): Promise<void> {
+    const { modal } = this.getAppKitConfig();
+
+    if (scope === "chain") {
+      if (btcDisconnectWouldDropEthereum()) {
+        throw new WalletError({
+          code: ERROR_CODES.SHARED_SESSION_DISCONNECT_REFUSED,
+          message:
+            "Bitcoin and Ethereum share one wallet session. Disconnecting Bitcoin alone would also disconnect Ethereum. Disconnect all wallets instead.",
+          wallet: APPKIT_PROVIDER_NAME,
+          chainId: "BTC",
+        });
+      }
+      await modal.disconnect("bip122");
+      this.clearSession();
+      return;
+    }
+
     try {
-      const { modal } = this.getAppKitConfig();
       await modal.disconnect();
     } finally {
-      this.stopListeningForAccountChanges();
-      this.address = undefined;
-      this.publicKey = undefined;
+      this.clearSession();
     }
+  }
+
+  private clearSession(): void {
+    this.stopListeningForAccountChanges();
+    this.address = undefined;
+    this.publicKey = undefined;
   }
 
   async getAddress(): Promise<string> {

--- a/packages/babylon-wallet-connector/src/core/wallets/btc/appkit/sharedConfig.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/appkit/sharedConfig.ts
@@ -76,7 +76,7 @@ export function setSharedBtcAppKitConfig(config: SharedBtcAppKitConfigInput): vo
     connectionEvents: config.connectionEvents ?? sharedBtcAppKitConfig?.connectionEvents ?? new EventTarget(),
   };
 
-  registerManualAppKitConfig(BITCOIN_CAPABILITY);
+  registerManualAppKitConfig(BITCOIN_CAPABILITY, config.modal);
   sharedBtcAppKitConfig = resolvedConfig;
 }
 

--- a/packages/babylon-wallet-connector/src/core/wallets/btc/appkit/sharedConfig.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/appkit/sharedConfig.ts
@@ -104,6 +104,17 @@ export function hasSharedBtcAppKitConfig(): boolean {
   return initializedState ? initializedState.btcConfig !== undefined : sharedBtcAppKitConfig !== null;
 }
 
+export function btcDisconnectWouldDropEthereum(): boolean {
+  if (!hasSharedBtcAppKitConfig()) {
+    return false;
+  }
+
+  const { modal } = getSharedBtcAppKitConfig();
+  const btcProviderType = modal.getProviderType("bip122");
+  const sharesSession = btcProviderType === "WALLET_CONNECT" || btcProviderType === "AUTH";
+  return sharesSession && modal.getAccount("eip155")?.isConnected === true;
+}
+
 /**
  * Test-only helper that resets the manual Bitcoin config and registry entry.
  * It does not reset canonical state or Reown modal. Use module isolation.

--- a/packages/babylon-wallet-connector/src/core/wallets/btc/appkit/sharedConfig.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/appkit/sharedConfig.ts
@@ -104,6 +104,12 @@ export function hasSharedBtcAppKitConfig(): boolean {
   return initializedState ? initializedState.btcConfig !== undefined : sharedBtcAppKitConfig !== null;
 }
 
+/**
+ * AppKit widens a WalletConnect or Auth disconnect to every namespace, so a
+ * bip122-only disconnect over either connector would drop eip155 too.
+ * `@reown/appkit-common` 1.8.12 limits Auth to eip155 and solana; the `AUTH`
+ * arm is defensive until AppKit offers Auth for bip122 (#2352 names both).
+ */
 export function btcDisconnectWouldDropEthereum(): boolean {
   if (!hasSharedBtcAppKitConfig()) {
     return false;

--- a/packages/babylon-wallet-connector/src/core/wallets/eth/appkit/__tests__/provider.test.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/eth/appkit/__tests__/provider.test.ts
@@ -1,5 +1,5 @@
-import type { Config } from "wagmi";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { Config } from "wagmi";
 
 import type { ETHConfig } from "@/core/types";
 
@@ -7,13 +7,11 @@ import type { ETHConfig } from "@/core/types";
 // The mocks show whether the constructor attached the watchers.
 // They also keep the heavy `@reown/appkit` graph out of this test.
 const wagmiActions = vi.hoisted(() => ({
-  getAccount: vi.fn(
-    (): { address?: `0x${string}`; chainId?: number; status: "connected" | "disconnected" } => ({
-      address: undefined,
-      chainId: undefined,
-      status: "disconnected",
-    }),
-  ),
+  getAccount: vi.fn((): { address?: `0x${string}`; chainId?: number; status: "connected" | "disconnected" } => ({
+    address: undefined,
+    chainId: undefined,
+    status: "disconnected",
+  })),
   watchAccount: vi.fn(() => () => {}),
   watchChainId: vi.fn(() => () => {}),
   disconnect: vi.fn(),
@@ -143,7 +141,7 @@ describe("AppKitProvider — constructed after AppKit init (shared wagmi config 
 
     wagmiActions.disconnect.mockRejectedValueOnce(new Error("disconnect failed"));
 
-    await expect(provider.disconnect()).rejects.toThrow("disconnect failed");
+    await expect(provider.disconnect("chain")).rejects.toThrow("disconnect failed");
     await expect(provider.getAddress()).resolves.toBe("0xabc");
 
     provider.destroy();
@@ -162,7 +160,7 @@ describe("AppKitProvider — constructed after AppKit init (shared wagmi config 
 
     wagmiActions.disconnect.mockResolvedValueOnce(undefined);
 
-    await provider.disconnect();
+    await provider.disconnect("chain");
     await expect(provider.getAddress()).rejects.toThrow("Wallet not connected");
 
     provider.destroy();

--- a/packages/babylon-wallet-connector/src/core/wallets/eth/appkit/__tests__/provider.test.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/eth/appkit/__tests__/provider.test.ts
@@ -7,13 +7,16 @@ import type { ETHConfig } from "@/core/types";
 // The mocks show whether the constructor attached the watchers.
 // They also keep the heavy `@reown/appkit` graph out of this test.
 const wagmiActions = vi.hoisted(() => ({
-  getAccount: vi.fn(() => ({
-    address: undefined,
-    chainId: undefined,
-    status: "disconnected" as const,
-  })),
+  getAccount: vi.fn(
+    (): { address?: `0x${string}`; chainId?: number; status: "connected" | "disconnected" } => ({
+      address: undefined,
+      chainId: undefined,
+      status: "disconnected",
+    }),
+  ),
   watchAccount: vi.fn(() => () => {}),
   watchChainId: vi.fn(() => () => {}),
+  disconnect: vi.fn(),
 }));
 
 vi.mock("wagmi/actions", () => ({
@@ -28,7 +31,7 @@ vi.mock("wagmi/actions", () => ({
   watchAccount: wagmiActions.watchAccount,
   watchChainId: wagmiActions.watchChainId,
   connect: vi.fn(),
-  disconnect: vi.fn(),
+  disconnect: wagmiActions.disconnect,
 }));
 
 vi.mock("wagmi/connectors", () => ({
@@ -124,6 +127,44 @@ describe("AppKitProvider — constructed after AppKit init (shared wagmi config 
     const provider = new AppKitProvider(ethConfig);
 
     await expect(provider.getChainId()).rejects.toThrow("Wallet not connected");
+    provider.destroy();
+  });
+
+  it("disconnect() rejects and keeps the cached address when wagmiDisconnect rejects", async () => {
+    vi.resetModules();
+    const { setSharedWagmiConfig } = await import("../sharedConfig");
+    const { AppKitProvider } = await import("../provider");
+
+    setSharedWagmiConfig({} as Config);
+    const provider = new AppKitProvider(ethConfig);
+
+    wagmiActions.getAccount.mockReturnValueOnce({ address: "0xabc", chainId: 1, status: "connected" });
+    await provider.connectWallet();
+
+    wagmiActions.disconnect.mockRejectedValueOnce(new Error("disconnect failed"));
+
+    await expect(provider.disconnect()).rejects.toThrow("disconnect failed");
+    await expect(provider.getAddress()).resolves.toBe("0xabc");
+
+    provider.destroy();
+  });
+
+  it("disconnect() clears the cached address when wagmiDisconnect resolves", async () => {
+    vi.resetModules();
+    const { setSharedWagmiConfig } = await import("../sharedConfig");
+    const { AppKitProvider } = await import("../provider");
+
+    setSharedWagmiConfig({} as Config);
+    const provider = new AppKitProvider(ethConfig);
+
+    wagmiActions.getAccount.mockReturnValueOnce({ address: "0xabc", chainId: 1, status: "connected" });
+    await provider.connectWallet();
+
+    wagmiActions.disconnect.mockResolvedValueOnce(undefined);
+
+    await provider.disconnect();
+    await expect(provider.getAddress()).rejects.toThrow("Wallet not connected");
+
     provider.destroy();
   });
 });

--- a/packages/babylon-wallet-connector/src/core/wallets/eth/appkit/__tests__/provider.test.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/eth/appkit/__tests__/provider.test.ts
@@ -101,7 +101,7 @@ describe("AppKitProvider — constructed after AppKit init (shared wagmi config 
   it.each([
     ["ANNOUNCED", true, "chain", false],
     ["WALLET_CONNECT", true, "chain", true],
-    ["AUTH", true, "chain", true],
+    ["AUTH", true, "chain", false],
     ["WALLET_CONNECT", false, "chain", false],
     ["WALLET_CONNECT", undefined, "chain", false],
     ["WALLET_CONNECT", true, "all", false],

--- a/packages/babylon-wallet-connector/src/core/wallets/eth/appkit/__tests__/provider.test.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/eth/appkit/__tests__/provider.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { Config } from "wagmi";
 
 import type { ETHConfig } from "@/core/types";
+import { ERROR_CODES } from "@/error";
 
 // `createWallet` constructs the provider before AppKit initialization.
 // The mocks show whether the constructor attached the watchers.
@@ -51,6 +52,11 @@ const ethConfig: ETHConfig = {
   nativeCurrency: { name: "Ether", symbol: "ETH", decimals: 18 },
 };
 
+afterEach(async () => {
+  const { getAppKitModal } = await import("@/core/wallets/appkit/state");
+  vi.mocked(getAppKitModal).mockReturnValue(null);
+});
+
 // The shared-config singleton has no reset hook, so each test resets the
 // module registry and imports a fresh provider + sharedConfig pair. The
 // mocked wagmi functions above survive the reset (`vi.hoisted`), so call
@@ -91,6 +97,52 @@ describe("AppKitProvider — constructed after AppKit init (shared wagmi config 
   afterEach(() => {
     vi.clearAllMocks();
   });
+
+  it.each([
+    ["ANNOUNCED", true, "chain", false],
+    ["WALLET_CONNECT", true, "chain", true],
+    ["AUTH", true, "chain", true],
+    ["WALLET_CONNECT", false, "chain", false],
+    ["WALLET_CONNECT", undefined, "chain", false],
+    ["WALLET_CONNECT", true, "all", false],
+    ["AUTH", true, "all", false],
+    ["WALLET_CONNECT", true, "local", false],
+  ] as const)(
+    "handles %s with Bitcoin connected=%s for scope=%s",
+    async (providerType, btcConnected, scope, refused) => {
+      vi.resetModules();
+      const { getAppKitModal } = await import("@/core/wallets/appkit/state");
+      const { setSharedWagmiConfig } = await import("../sharedConfig");
+      const { AppKitProvider } = await import("../provider");
+      vi.mocked(getAppKitModal).mockReturnValue({
+        getProviderType: (namespace: string) => (namespace === "eip155" ? providerType : "ANNOUNCED"),
+        getAccount: (namespace: string) =>
+          namespace === "bip122" && btcConnected !== undefined ? { isConnected: btcConnected } : undefined,
+      } as never);
+      const sharedConfig = {} as Config;
+      setSharedWagmiConfig(sharedConfig);
+      const provider = new AppKitProvider(ethConfig);
+      wagmiActions.getAccount.mockReturnValueOnce({ address: "0xabc", chainId: 1, status: "connected" });
+      await provider.connectWallet();
+
+      if (refused) {
+        await expect(provider.disconnect(scope)).rejects.toMatchObject({
+          code: ERROR_CODES.SHARED_SESSION_DISCONNECT_REFUSED,
+          chainId: "ETH",
+        });
+        expect(wagmiActions.disconnect).not.toHaveBeenCalled();
+        await expect(provider.getAddress()).resolves.toBe("0xabc");
+        await expect(provider.getChainId()).resolves.toBe(1);
+      } else {
+        await provider.disconnect(scope);
+        if (scope === "local") expect(wagmiActions.disconnect).not.toHaveBeenCalled();
+        else expect(wagmiActions.disconnect).toHaveBeenCalledWith(sharedConfig);
+        await expect(provider.getAddress()).rejects.toThrow("Wallet not connected");
+        await expect(provider.getChainId()).rejects.toThrow("Wallet not connected");
+      }
+      provider.destroy();
+    },
+  );
 
   it("starts the account and chain watchers against the shared config on construction", async () => {
     vi.resetModules();

--- a/packages/babylon-wallet-connector/src/core/wallets/eth/appkit/provider.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/eth/appkit/provider.ts
@@ -27,8 +27,9 @@ import { APPKIT_OPEN_EVENT } from "@/core/wallets/appkit/constants";
 // Read the modal from the shared singleton rather than from `appKitModal`,
 // which pulls the Bitcoin adapter in with it.
 import { getAppKitModal } from "@/core/wallets/appkit/state";
+import { ERROR_CODES, WalletError } from "@/error";
 
-import { getSharedWagmiConfig, hasSharedWagmiConfig } from "./sharedConfig";
+import { ethDisconnectWouldDropBitcoin, getSharedWagmiConfig, hasSharedWagmiConfig } from "./sharedConfig";
 
 // Grace period after modal close before rejecting as cancelled, to allow
 // async handoffs (WalletConnect deep-link, mobile wallet return) to publish
@@ -254,6 +255,15 @@ export class AppKitProvider implements IETHProvider {
   }
 
   async disconnect(scope: DisconnectScope): Promise<void> {
+    if (scope === "chain" && ethDisconnectWouldDropBitcoin()) {
+      throw new WalletError({
+        code: ERROR_CODES.SHARED_SESSION_DISCONNECT_REFUSED,
+        message:
+          "Ethereum and Bitcoin share one wallet session. Disconnecting Ethereum alone would also disconnect Bitcoin. Disconnect all wallets instead.",
+        wallet: "AppKit",
+        chainId: "ETH",
+      });
+    }
     if (scope !== "local") await wagmiDisconnect(this.getWagmiConfig());
     this.address = undefined;
     this.chainId = undefined;

--- a/packages/babylon-wallet-connector/src/core/wallets/eth/appkit/provider.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/eth/appkit/provider.ts
@@ -248,12 +248,9 @@ export class AppKitProvider implements IETHProvider {
 
   async disconnect(): Promise<void> {
     const config = this.getWagmiConfig();
-    try {
-      await wagmiDisconnect(config);
-    } finally {
-      this.address = undefined;
-      this.chainId = undefined;
-    }
+    await wagmiDisconnect(config);
+    this.address = undefined;
+    this.chainId = undefined;
   }
 
   async getAddress(): Promise<string> {

--- a/packages/babylon-wallet-connector/src/core/wallets/eth/appkit/provider.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/eth/appkit/provider.ts
@@ -1,7 +1,9 @@
 import { parseEther } from "viem";
 import {
+  connect,
   getAccount,
   getTransactionCount,
+  disconnect as wagmiDisconnect,
   estimateGas as wagmiEstimateGas,
   getBalance as wagmiGetBalance,
   sendTransaction as wagmiSendTransaction,
@@ -10,12 +12,17 @@ import {
   switchChain as wagmiSwitchChain,
   watchAccount,
   watchChainId,
-  connect,
-  disconnect as wagmiDisconnect,
 } from "wagmi/actions";
 import { walletConnect } from "wagmi/connectors";
 
-import type { ETHConfig, ETHTransactionRequest, ETHTypedData, IETHProvider, NetworkInfo } from "@/core/types";
+import type {
+  DisconnectScope,
+  ETHConfig,
+  ETHTransactionRequest,
+  ETHTypedData,
+  IETHProvider,
+  NetworkInfo,
+} from "@/core/types";
 import { APPKIT_OPEN_EVENT } from "@/core/wallets/appkit/constants";
 // Read the modal from the shared singleton rather than from `appKitModal`,
 // which pulls the Bitcoin adapter in with it.
@@ -83,7 +90,7 @@ export class AppKitProvider implements IETHProvider {
     if (!hasSharedWagmiConfig()) {
       throw new Error(
         "AppKit ETH not initialized. Ensure AppKit modal is initialized at application startup " +
-        "by calling initializeAppKitModal() with eth config in your app's entry point."
+          "by calling initializeAppKitModal() with eth config in your app's entry point.",
       );
     }
     return getSharedWagmiConfig();
@@ -94,7 +101,7 @@ export class AppKitProvider implements IETHProvider {
 
     // Check for existing connection on initialization (for auto-reconnection)
     const initialAccount = getAccount(config);
-    if (initialAccount.address && initialAccount.status === 'connected') {
+    if (initialAccount.address && initialAccount.status === "connected") {
       this.address = initialAccount.address;
       this.chainId = initialAccount.chainId;
       // Emit connect event after a short delay to ensure provider is fully initialized
@@ -246,9 +253,8 @@ export class AppKitProvider implements IETHProvider {
     }
   }
 
-  async disconnect(): Promise<void> {
-    const config = this.getWagmiConfig();
-    await wagmiDisconnect(config);
+  async disconnect(scope: DisconnectScope): Promise<void> {
+    if (scope !== "local") await wagmiDisconnect(this.getWagmiConfig());
     this.address = undefined;
     this.chainId = undefined;
   }

--- a/packages/babylon-wallet-connector/src/core/wallets/eth/appkit/sharedConfig.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/eth/appkit/sharedConfig.ts
@@ -1,6 +1,11 @@
 import type { Config } from "wagmi";
 
-import { failInitialization, getAppKitState, registerManualAppKitConfig } from "@/core/wallets/appkit/state";
+import {
+  failInitialization,
+  getAppKitModal,
+  getAppKitState,
+  registerManualAppKitConfig,
+} from "@/core/wallets/appkit/state";
 
 const ETHEREUM_CAPABILITY = "Ethereum";
 const SHARED_WAGMI_REPLACEMENT_WARNING =
@@ -33,7 +38,10 @@ export function getSharedWagmiConfig(): Config {
   const initializedState = getAppKitState();
   if (initializedState) {
     if (!initializedState.wagmiConfig) {
-      failInitialization("AppKit was initialized without Ethereum support. Initialize it with Ethereum support.", "ETH");
+      failInitialization(
+        "AppKit was initialized without Ethereum support. Initialize it with Ethereum support.",
+        "ETH",
+      );
     }
 
     return initializedState.wagmiConfig;
@@ -51,4 +59,11 @@ export function getSharedWagmiConfig(): Config {
 export function hasSharedWagmiConfig(): boolean {
   const initializedState = getAppKitState();
   return initializedState ? initializedState.wagmiConfig !== undefined : sharedWagmiConfig !== null;
+}
+
+export function ethDisconnectWouldDropBitcoin(): boolean {
+  const modal = getAppKitModal();
+  const providerType = modal?.getProviderType("eip155");
+  const sharesSession = providerType === "WALLET_CONNECT" || providerType === "AUTH";
+  return sharesSession && modal?.getAccount("bip122")?.isConnected === true;
 }

--- a/packages/babylon-wallet-connector/src/core/wallets/eth/appkit/sharedConfig.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/eth/appkit/sharedConfig.ts
@@ -64,6 +64,5 @@ export function hasSharedWagmiConfig(): boolean {
 export function ethDisconnectWouldDropBitcoin(): boolean {
   const modal = getAppKitModal();
   const providerType = modal?.getProviderType("eip155");
-  const sharesSession = providerType === "WALLET_CONNECT" || providerType === "AUTH";
-  return sharesSession && modal?.getAccount("bip122")?.isConnected === true;
+  return providerType === "WALLET_CONNECT" && modal?.getAccount("bip122")?.isConnected === true;
 }

--- a/packages/babylon-wallet-connector/src/error/codes.ts
+++ b/packages/babylon-wallet-connector/src/error/codes.ts
@@ -21,6 +21,7 @@ export const ERROR_CODES = {
   WALLET_METHOD_NOT_SUPPORTED: "WALLET_METHOD_NOT_SUPPORTED", // Wallet does not implement a required method
   NETWORK_NOT_ENABLED_IN_WALLET: "NETWORK_NOT_ENABLED_IN_WALLET", // Network not enabled
   WALLET_CONFIG_REQUIRED: "WALLET_CONFIG_REQUIRED", // Wallet configuration required
+  SHARED_SESSION_DISCONNECT_REFUSED: "SHARED_SESSION_DISCONNECT_REFUSED", // Disconnecting one chain would also disconnect another
 
   // ===== Bitcoin/PSBT/Address =====
   INVALID_PUBLIC_KEY: "INVALID_PUBLIC_KEY", // Invalid public key

--- a/packages/babylon-wallet-connector/src/error/index.ts
+++ b/packages/babylon-wallet-connector/src/error/index.ts
@@ -1,3 +1,5 @@
+import { ERROR_CODES } from "./codes";
+
 interface ErrorParams {
   code: string;
   message: string;
@@ -36,6 +38,15 @@ export function isUserRejectionMessage(message: string | undefined): boolean {
     lower.includes("user cancelled") ||
     lower.includes("user canceled")
   );
+}
+
+/**
+ * Returns true when a provider refused a chain-scoped disconnect because that
+ * chain shares its wallet session with another chain. The refusal is a
+ * designed answer, not a fault: nothing was disconnected.
+ */
+export function isSharedSessionRefusal(error: unknown): error is WalletError {
+  return error instanceof WalletError && error.code === ERROR_CODES.SHARED_SESSION_DISCONNECT_REFUSED;
 }
 
 export * from "./codes";

--- a/packages/babylon-wallet-connector/src/hooks/__tests__/useWalletConnect.optionalChains.test.tsx
+++ b/packages/babylon-wallet-connector/src/hooks/__tests__/useWalletConnect.optionalChains.test.tsx
@@ -178,31 +178,36 @@ describe("disconnect", () => {
     expect(reset).not.toHaveBeenCalled();
   });
 
-  it("explains a refused single-chain disconnect in the dialog and still rejects", async () => {
-    const { result } = setup({
-      requiredChainIds: ["ETH"],
-      selectedWallets: { BTC: btcWallet, ETH: ethWallet },
-      confirmed: true,
-    });
-    const refusal = new WalletError({
-      code: ERROR_CODES.SHARED_SESSION_DISCONNECT_REFUSED,
-      message: "Bitcoin and Ethereum share one wallet session.",
-    });
-    disconnectBtc.mockRejectedValueOnce(refusal);
+  it.each(["BTC", "ETH"] as const)(
+    "explains a refused %s disconnect in the dialog and still rejects",
+    async (chain) => {
+      const { result } = setup({
+        requiredChainIds: ["ETH"],
+        selectedWallets: { BTC: btcWallet, ETH: ethWallet },
+        confirmed: true,
+      });
+      const refusal = new WalletError({
+        code: ERROR_CODES.SHARED_SESSION_DISCONNECT_REFUSED,
+        message: "Bitcoin and Ethereum share one wallet session.",
+      });
+      const [disconnect, otherDisconnect] =
+        chain === "BTC" ? [disconnectBtc, disconnectEth] : [disconnectEth, disconnectBtc];
+      disconnect.mockRejectedValueOnce(refusal);
 
-    await expect(result.current.disconnect("BTC")).rejects.toBe(refusal);
+      await expect(result.current.disconnect(chain)).rejects.toBe(refusal);
 
-    expect(displayError).toHaveBeenCalledWith(
-      expect.objectContaining({ title: "Wallets share one session", description: refusal.message }),
-    );
-    expect(displayChains).not.toHaveBeenCalled();
-    expect(disconnectEth).not.toHaveBeenCalled();
-    expect(reset).not.toHaveBeenCalled();
+      expect(displayError).toHaveBeenCalledWith(
+        expect.objectContaining({ title: "Wallets share one session", description: refusal.message }),
+      );
+      expect(displayChains).not.toHaveBeenCalled();
+      expect(otherDisconnect).not.toHaveBeenCalled();
+      expect(reset).not.toHaveBeenCalled();
 
-    displayError.mock.calls[0][0].onCancel();
+      displayError.mock.calls[0][0].onCancel();
 
-    expect(displayChains).toHaveBeenCalled();
-  });
+      expect(displayChains).toHaveBeenCalled();
+    },
+  );
 
   it("passes the chain scope when disconnecting a single chain", async () => {
     const { result } = setup({

--- a/packages/babylon-wallet-connector/src/hooks/__tests__/useWalletConnect.optionalChains.test.tsx
+++ b/packages/babylon-wallet-connector/src/hooks/__tests__/useWalletConnect.optionalChains.test.tsx
@@ -1,9 +1,12 @@
-import { renderHook } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { IWallet } from "@/core/types";
+import type { Wallet } from "@/core/Wallet";
+import { WalletConnector } from "@/core/WalletConnector";
+import type { DisconnectScope, IETHProvider, IWallet } from "@/core/types";
 import { ERROR_CODES, WalletError } from "@/error";
 import { useWalletConnect } from "@/hooks/useWalletConnect";
+import { ETHWalletProvider, useETHWallet } from "@/providers/ETHWalletProvider";
 
 const harness = vi.hoisted(() => ({
   widgetState: {} as Record<string, unknown>,
@@ -29,14 +32,14 @@ let disconnectBtc: ReturnType<typeof vi.fn>;
 let disconnectEth: ReturnType<typeof vi.fn>;
 
 function setup({
-  requiredChainIds,
-  selectedWallets,
-  confirmed = false,
+  requiredChainIds = ["ETH"],
+  selectedWallets = { BTC: btcWallet, ETH: ethWallet },
+  confirmed = true,
 }: {
-  requiredChainIds: string[];
-  selectedWallets: Record<string, IWallet | undefined>;
+  requiredChainIds?: string[];
+  selectedWallets?: Record<string, IWallet | undefined>;
   confirmed?: boolean;
-}) {
+} = {}) {
   harness.widgetState = {
     confirmed,
     chains: { BTC: { id: "BTC" }, ETH: { id: "ETH" } },
@@ -62,17 +65,16 @@ beforeEach(() => {
   disconnectEth = vi.fn().mockResolvedValue(undefined);
   harness.connectors = {
     BTC: { disconnect: disconnectBtc },
-    ETH: { disconnect: disconnectEth },
+    ETH: { disconnect: disconnectEth, wallets: [], on: () => () => {} },
     BBN: null,
   };
 });
+afterEach(() => vi.restoreAllMocks());
 
 describe("required versus displayed chains", () => {
   it("reports connected once the single required chain is connected, with an optional chain still missing", () => {
     const { result } = setup({
-      requiredChainIds: ["ETH"],
       selectedWallets: { ETH: ethWallet },
-      confirmed: true,
     });
 
     expect(result.current.selected).toBe(true);
@@ -92,7 +94,6 @@ describe("required versus displayed chains", () => {
 
   it("does not report connected on selection alone, before the dialog is confirmed", () => {
     const { result } = setup({
-      requiredChainIds: ["ETH"],
       selectedWallets: { ETH: ethWallet },
       confirmed: false,
     });
@@ -123,9 +124,7 @@ describe("open", () => {
 
   it("does not reset widget state, so a confirmed session survives attaching another chain", () => {
     const { result } = setup({
-      requiredChainIds: ["ETH"],
       selectedWallets: { ETH: ethWallet },
-      confirmed: true,
     });
 
     result.current.open("BTC");
@@ -136,25 +135,17 @@ describe("open", () => {
 
 describe("disconnect", () => {
   it("disconnects only the named chain and leaves the other connected", async () => {
-    const { result } = setup({
-      requiredChainIds: ["ETH"],
-      selectedWallets: { BTC: btcWallet, ETH: ethWallet },
-      confirmed: true,
-    });
+    const { result } = setup();
 
     await result.current.disconnect("BTC");
 
-    expect(disconnectBtc).toHaveBeenCalled();
+    expect(disconnectBtc).toHaveBeenCalledWith("chain");
     expect(disconnectEth).not.toHaveBeenCalled();
     expect(reset).not.toHaveBeenCalled();
   });
 
   it("disconnects everything and resets when called with no chain", async () => {
-    const { result } = setup({
-      requiredChainIds: ["ETH"],
-      selectedWallets: { BTC: btcWallet, ETH: ethWallet },
-      confirmed: true,
-    });
+    const { result } = setup();
 
     await result.current.disconnect();
 
@@ -164,11 +155,7 @@ describe("disconnect", () => {
   });
 
   it("rejects a failed single-chain disconnect without a dialog and leaves the other chain and the widget state alone", async () => {
-    const { result } = setup({
-      requiredChainIds: ["ETH"],
-      selectedWallets: { BTC: btcWallet, ETH: ethWallet },
-      confirmed: true,
-    });
+    const { result } = setup();
     disconnectBtc.mockRejectedValueOnce(new Error("relay down"));
 
     await expect(result.current.disconnect("BTC")).rejects.toThrow("relay down");
@@ -181,11 +168,7 @@ describe("disconnect", () => {
   it.each(["BTC", "ETH"] as const)(
     "explains a refused %s disconnect in the dialog and still rejects",
     async (chain) => {
-      const { result } = setup({
-        requiredChainIds: ["ETH"],
-        selectedWallets: { BTC: btcWallet, ETH: ethWallet },
-        confirmed: true,
-      });
+      const { result } = setup();
       const refusal = new WalletError({
         code: ERROR_CODES.SHARED_SESSION_DISCONNECT_REFUSED,
         message: "Bitcoin and Ethereum share one wallet session.",
@@ -194,7 +177,10 @@ describe("disconnect", () => {
         chain === "BTC" ? [disconnectBtc, disconnectEth] : [disconnectEth, disconnectBtc];
       disconnect.mockRejectedValueOnce(refusal);
 
-      await expect(result.current.disconnect(chain)).rejects.toBe(refusal);
+      const eth = renderHook(useETHWallet, { wrapper: ETHWalletProvider });
+      await expect(chain === "ETH" ? eth.result.current.disconnect() : result.current.disconnect(chain)).rejects.toBe(
+        refusal,
+      );
 
       expect(displayError).toHaveBeenCalledWith(
         expect.objectContaining({ title: "Wallets share one session", description: refusal.message }),
@@ -209,24 +195,62 @@ describe("disconnect", () => {
     },
   );
 
-  it("passes the chain scope when disconnecting a single chain", async () => {
-    const { result } = setup({
-      requiredChainIds: ["ETH"],
-      selectedWallets: { BTC: btcWallet, ETH: ethWallet },
-      confirmed: true,
+  it("clears lost ETH accounts locally and keeps Bitcoin connected", async () => {
+    setup();
+    const listeners = new Set<(accounts: string[]) => void>();
+    const provider = {
+      getAddress: vi.fn().mockResolvedValue(ethWallet.account!.address),
+      disconnect: vi.fn(async (scope: DisconnectScope) => {
+        if (scope !== "local")
+          throw new WalletError({
+            code: ERROR_CODES.SHARED_SESSION_DISCONNECT_REFUSED,
+            message: "Bitcoin and Ethereum share one wallet session.",
+          });
+      }),
+      on: (_event: string, listener: (accounts: string[]) => void) => listeners.add(listener),
+      off: (_event: string, listener: (accounts: string[]) => void) => listeners.delete(listener),
+    };
+    const wallet = { ...ethWallet, provider, connect: vi.fn() } as unknown as Wallet<IETHProvider>;
+    const connector = new WalletConnector("ETH", "Ethereum", "", [wallet], {});
+    harness.connectors.ETH = connector;
+    await connector.connect(wallet);
+    const onDisconnect = vi.fn();
+    const { result } = renderHook(useETHWallet, {
+      wrapper: ({ children }) => <ETHWalletProvider callbacks={{ onDisconnect }}>{children}</ETHWalletProvider>,
     });
+    await waitFor(() => expect(result.current.connected).toBe(true));
+    provider.getAddress.mockResolvedValue("");
+    act(() => listeners.forEach((listener) => listener([])));
+    await waitFor(() => expect(result.current.connected).toBe(false));
+    expect(connector.connectedWallet).toBeNull();
+    expect(provider.disconnect).toHaveBeenLastCalledWith("local");
 
-    await result.current.disconnect("BTC");
+    provider.getAddress.mockResolvedValue(ethWallet.account!.address);
+    await act(() => connector.connect(wallet));
+    await waitFor(() => expect(result.current.connected).toBe(true));
+    provider.getAddress.mockResolvedValue("");
+    vi.spyOn(document, "visibilityState", "get").mockReturnValue("visible");
+    document.dispatchEvent(new Event("visibilitychange"));
+    await waitFor(() => expect(result.current.connected).toBe(false));
+    expect(connector.connectedWallet).toBeNull();
+    expect(provider.disconnect).toHaveBeenLastCalledWith("local");
 
-    expect(disconnectBtc).toHaveBeenCalledWith("chain");
+    provider.getAddress.mockResolvedValue(ethWallet.account!.address);
+    await act(() => connector.connect(wallet));
+    await waitFor(() => expect(result.current.connected).toBe(true));
+    provider.getAddress.mockRejectedValue(new Error("Wallet not connected"));
+    document.dispatchEvent(new Event("visibilitychange"));
+    await waitFor(() => expect(result.current.connected).toBe(false));
+    expect(connector.connectedWallet).toBeNull();
+    expect(provider.disconnect.mock.calls).toEqual([["local"], ["local"], ["local"]]);
+    expect(onDisconnect).toHaveBeenCalledTimes(3);
+    expect(disconnectBtc).not.toHaveBeenCalled();
+    expect(displayError).not.toHaveBeenCalled();
+    expect(reset).not.toHaveBeenCalled();
   });
 
   it("treats a click event as disconnect-all rather than as a chain", async () => {
-    const { result } = setup({
-      requiredChainIds: ["ETH"],
-      selectedWallets: { BTC: btcWallet, ETH: ethWallet },
-      confirmed: true,
-    });
+    const { result } = setup();
 
     // React's bivariant handler types allow `onClick={disconnect}`, which calls
     // this with a MouseEvent.

--- a/packages/babylon-wallet-connector/src/hooks/__tests__/useWalletConnect.optionalChains.test.tsx
+++ b/packages/babylon-wallet-connector/src/hooks/__tests__/useWalletConnect.optionalChains.test.tsx
@@ -154,9 +154,36 @@ describe("disconnect", () => {
 
     await result.current.disconnect();
 
-    expect(disconnectBtc).toHaveBeenCalled();
-    expect(disconnectEth).toHaveBeenCalled();
+    expect(disconnectBtc).toHaveBeenCalledWith("all");
+    expect(disconnectEth).toHaveBeenCalledWith("all");
+    expect(disconnectBtc.mock.invocationCallOrder[0]).toBeLessThan(disconnectEth.mock.invocationCallOrder[0]);
     expect(reset).toHaveBeenCalled();
+  });
+
+  it("rejects a refused single-chain disconnect and leaves the other chain and the widget state alone", async () => {
+    const { result } = setup({
+      requiredChainIds: ["ETH"],
+      selectedWallets: { BTC: btcWallet, ETH: ethWallet },
+      confirmed: true,
+    });
+    disconnectBtc.mockRejectedValueOnce(new Error("refused"));
+
+    await expect(result.current.disconnect("BTC")).rejects.toThrow("refused");
+
+    expect(disconnectEth).not.toHaveBeenCalled();
+    expect(reset).not.toHaveBeenCalled();
+  });
+
+  it("passes the chain scope when disconnecting a single chain", async () => {
+    const { result } = setup({
+      requiredChainIds: ["ETH"],
+      selectedWallets: { BTC: btcWallet, ETH: ethWallet },
+      confirmed: true,
+    });
+
+    await result.current.disconnect("BTC");
+
+    expect(disconnectBtc).toHaveBeenCalledWith();
   });
 
   it("treats a click event as disconnect-all rather than as a chain", async () => {

--- a/packages/babylon-wallet-connector/src/hooks/__tests__/useWalletConnect.optionalChains.test.tsx
+++ b/packages/babylon-wallet-connector/src/hooks/__tests__/useWalletConnect.optionalChains.test.tsx
@@ -2,6 +2,7 @@ import { renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { IWallet } from "@/core/types";
+import { ERROR_CODES, WalletError } from "@/error";
 import { useWalletConnect } from "@/hooks/useWalletConnect";
 
 const harness = vi.hoisted(() => ({
@@ -21,6 +22,7 @@ const ethWallet = { id: "metamask", account: { address: "0xabc", publicKeyHex: "
 
 let openModal: ReturnType<typeof vi.fn>;
 let displayChains: ReturnType<typeof vi.fn>;
+let displayError: ReturnType<typeof vi.fn>;
 let displayWallets: ReturnType<typeof vi.fn>;
 let reset: ReturnType<typeof vi.fn>;
 let disconnectBtc: ReturnType<typeof vi.fn>;
@@ -42,6 +44,7 @@ function setup({
     selectedWallets,
     open: openModal,
     displayChains,
+    displayError,
     displayWallets,
     reset,
   };
@@ -52,6 +55,7 @@ function setup({
 beforeEach(() => {
   openModal = vi.fn();
   displayChains = vi.fn();
+  displayError = vi.fn();
   displayWallets = vi.fn();
   reset = vi.fn();
   disconnectBtc = vi.fn().mockResolvedValue(undefined);
@@ -156,22 +160,48 @@ describe("disconnect", () => {
 
     expect(disconnectBtc).toHaveBeenCalledWith("all");
     expect(disconnectEth).toHaveBeenCalledWith("all");
-    expect(disconnectBtc.mock.invocationCallOrder[0]).toBeLessThan(disconnectEth.mock.invocationCallOrder[0]);
     expect(reset).toHaveBeenCalled();
   });
 
-  it("rejects a refused single-chain disconnect and leaves the other chain and the widget state alone", async () => {
+  it("rejects a failed single-chain disconnect without a dialog and leaves the other chain and the widget state alone", async () => {
     const { result } = setup({
       requiredChainIds: ["ETH"],
       selectedWallets: { BTC: btcWallet, ETH: ethWallet },
       confirmed: true,
     });
-    disconnectBtc.mockRejectedValueOnce(new Error("refused"));
+    disconnectBtc.mockRejectedValueOnce(new Error("relay down"));
 
-    await expect(result.current.disconnect("BTC")).rejects.toThrow("refused");
+    await expect(result.current.disconnect("BTC")).rejects.toThrow("relay down");
 
+    expect(displayError).not.toHaveBeenCalled();
     expect(disconnectEth).not.toHaveBeenCalled();
     expect(reset).not.toHaveBeenCalled();
+  });
+
+  it("explains a refused single-chain disconnect in the dialog and still rejects", async () => {
+    const { result } = setup({
+      requiredChainIds: ["ETH"],
+      selectedWallets: { BTC: btcWallet, ETH: ethWallet },
+      confirmed: true,
+    });
+    const refusal = new WalletError({
+      code: ERROR_CODES.SHARED_SESSION_DISCONNECT_REFUSED,
+      message: "Bitcoin and Ethereum share one wallet session.",
+    });
+    disconnectBtc.mockRejectedValueOnce(refusal);
+
+    await expect(result.current.disconnect("BTC")).rejects.toBe(refusal);
+
+    expect(displayError).toHaveBeenCalledWith(
+      expect.objectContaining({ title: "Wallets share one session", description: refusal.message }),
+    );
+    expect(displayChains).not.toHaveBeenCalled();
+    expect(disconnectEth).not.toHaveBeenCalled();
+    expect(reset).not.toHaveBeenCalled();
+
+    displayError.mock.calls[0][0].onCancel();
+
+    expect(displayChains).toHaveBeenCalled();
   });
 
   it("passes the chain scope when disconnecting a single chain", async () => {
@@ -183,7 +213,7 @@ describe("disconnect", () => {
 
     await result.current.disconnect("BTC");
 
-    expect(disconnectBtc).toHaveBeenCalledWith();
+    expect(disconnectBtc).toHaveBeenCalledWith("chain");
   });
 
   it("treats a click event as disconnect-all rather than as a chain", async () => {

--- a/packages/babylon-wallet-connector/src/hooks/__tests__/useWalletConnectors.sharedSessionDisconnect.test.tsx
+++ b/packages/babylon-wallet-connector/src/hooks/__tests__/useWalletConnectors.sharedSessionDisconnect.test.tsx
@@ -1,0 +1,148 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { HashMap, IWallet, Network } from "@/core/types";
+import { ERROR_CODES, WalletError } from "@/error";
+import { useWalletConnectors } from "@/hooks/useWalletConnectors";
+
+const TAPROOT_ADDRESS = "bc1p5cyxnuxmeuwuvkwfem96lqzszd02n6xdcjrs20cac6yqjjwudpxqkedrcr";
+const OTHER_COMPRESSED_PUBLIC_KEY = "0379be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798";
+
+type ConnectHandler = (wallet: IWallet) => void | Promise<void>;
+type ErrorHandler = (error: Error) => void;
+
+const harness = vi.hoisted(() => ({
+  connectHandler: null as ConnectHandler | null,
+  errorHandler: null as ErrorHandler | null,
+  disconnect: vi.fn(),
+  selectWallet: vi.fn(),
+  removeWallet: vi.fn(),
+  displayChains: vi.fn(),
+  displayError: vi.fn(),
+}));
+
+vi.mock("@/context/Chain.context", () => ({
+  useChainProviders: () => ({
+    BTC: {
+      id: "BTC",
+      config: { network: Network.MAINNET },
+      connectedWallet: null,
+      disconnect: harness.disconnect,
+      on: (event: string, handler: ConnectHandler | ErrorHandler) => {
+        if (event === "connect") harness.connectHandler = handler as ConnectHandler;
+        if (event === "error") harness.errorHandler = handler as ErrorHandler;
+        return () => {};
+      },
+    },
+  }),
+}));
+
+vi.mock("@/context/LifecycleHooks.context", () => ({
+  useLifeCycleHooks: () => ({}),
+}));
+
+vi.mock("@/hooks/useWidgetState", () => ({
+  useWidgetState: () => ({
+    visible: true,
+    selectWallet: harness.selectWallet,
+    removeWallet: harness.removeWallet,
+    displayLoader: vi.fn(),
+    displayChains: harness.displayChains,
+    displayError: harness.displayError,
+    confirm: vi.fn(),
+    close: vi.fn(),
+    reset: vi.fn(),
+    chains: {},
+  }),
+}));
+
+function fakeAccountStorage(): HashMap & { store: Map<string, string> } {
+  const store = new Map<string, string>();
+  return {
+    store,
+    get: (key: string) => store.get(key),
+    set: (key: string, value: string) => void store.set(key, value),
+    has: (key: string) => store.has(key),
+    delete: (key: string) => store.delete(key),
+  };
+}
+
+function connectedWalletWith(publicKeyHex: string): IWallet {
+  return {
+    id: "unisat",
+    name: "UniSat",
+    icon: "",
+    docs: "",
+    installed: true,
+    provider: null,
+    label: "",
+    account: { address: TAPROOT_ADDRESS, publicKeyHex },
+  } as IWallet;
+}
+
+function sharedSessionRefusal(): WalletError {
+  return new WalletError({
+    code: ERROR_CODES.SHARED_SESSION_DISCONNECT_REFUSED,
+    message: "Bitcoin and Ethereum share one wallet session.",
+    wallet: "AppKit",
+    chainId: "BTC",
+  });
+}
+
+beforeEach(() => {
+  harness.connectHandler = null;
+  harness.errorHandler = null;
+  vi.clearAllMocks();
+  harness.disconnect.mockResolvedValue(undefined);
+});
+
+describe("BTC validation failure with a refused shared-session disconnect", () => {
+  it("still removes the wallet locally and clears persisted storage", async () => {
+    const accountStorage = fakeAccountStorage();
+    accountStorage.store.set("BTC", "unisat");
+    harness.disconnect.mockRejectedValueOnce(sharedSessionRefusal());
+
+    renderHook(() => useWalletConnectors({ persistent: true, accountStorage }));
+    await waitFor(() => expect(harness.connectHandler).not.toBeNull());
+    await harness.connectHandler?.(connectedWalletWith(OTHER_COMPRESSED_PUBLIC_KEY));
+
+    await waitFor(() => expect(harness.displayError).toHaveBeenCalled());
+    const { onCancel } = harness.displayError.mock.calls[0][0];
+    await onCancel();
+
+    expect(harness.disconnect).toHaveBeenCalled();
+    expect(harness.removeWallet).toHaveBeenCalledWith("BTC");
+    expect(accountStorage.store.has("BTC")).toBe(false);
+  });
+});
+
+describe("SHARED_SESSION_DISCONNECT_REFUSED error event", () => {
+  it("shows the shared-session dialog and only calls displayChains once the dialog is dismissed", async () => {
+    const accountStorage = fakeAccountStorage();
+    renderHook(() => useWalletConnectors({ persistent: false, accountStorage }));
+    await waitFor(() => expect(harness.errorHandler).not.toBeNull());
+
+    const refusal = sharedSessionRefusal();
+    harness.errorHandler?.(refusal);
+
+    expect(harness.displayError).toHaveBeenCalledWith(
+      expect.objectContaining({ title: "Wallets share one session", description: refusal.message }),
+    );
+    expect(harness.displayChains).not.toHaveBeenCalled();
+
+    harness.displayError.mock.calls[0][0].onCancel();
+
+    expect(harness.displayChains).toHaveBeenCalled();
+  });
+
+  it("falls through to displayChains for a plain error", async () => {
+    const accountStorage = fakeAccountStorage();
+    renderHook(() => useWalletConnectors({ persistent: false, accountStorage }));
+    await waitFor(() => expect(harness.errorHandler).not.toBeNull());
+
+    harness.errorHandler?.(new Error("boom"));
+
+    expect(harness.displayError).not.toHaveBeenCalled();
+    expect(harness.displayChains).toHaveBeenCalled();
+  });
+});

--- a/packages/babylon-wallet-connector/src/hooks/__tests__/useWalletConnectors.sharedSessionDisconnect.test.tsx
+++ b/packages/babylon-wallet-connector/src/hooks/__tests__/useWalletConnectors.sharedSessionDisconnect.test.tsx
@@ -3,7 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { HashMap, IWallet, Network } from "@/core/types";
 import { ERROR_CODES, WalletError } from "@/error";
-import { useWalletConnectors } from "@/hooks/useWalletConnectors";
+import { useWalletConnectors, type BTCAddressValidation } from "@/hooks/useWalletConnectors";
 
 const TAPROOT_ADDRESS = "bc1p5cyxnuxmeuwuvkwfem96lqzszd02n6xdcjrs20cac6yqjjwudpxqkedrcr";
 const OTHER_COMPRESSED_PUBLIC_KEY = "0379be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798";
@@ -54,6 +54,13 @@ vi.mock("@/hooks/useWidgetState", () => ({
   }),
 }));
 
+// Rejects every key so the connect handler reaches the mismatch dialog without
+// a registered curve.
+const rejectEveryKey: BTCAddressValidation = {
+  validateAddress: () => {},
+  validateAddressWithPK: () => false,
+};
+
 function fakeAccountStorage(): HashMap & { store: Map<string, string> } {
   const store = new Map<string, string>();
   return {
@@ -91,53 +98,86 @@ beforeEach(() => {
 });
 
 describe("BTC validation failure with a refused shared-session disconnect", () => {
-  it("keeps the rejected wallet removed after the dialog closes and opens", async () => {
+  it("drops the rejected wallet locally and keeps it removed after the dialog closes and opens", async () => {
     const accountStorage = fakeAccountStorage();
-    harness.connectedWallet = connectedWalletWith(OTHER_COMPRESSED_PUBLIC_KEY);
-    harness.disconnect.mockRejectedValueOnce(sharedSessionRefusal());
-    const { rerender } = renderHook(() => useWalletConnectors({ persistent: true, accountStorage }));
-    await harness.connectHandler!(harness.connectedWallet);
+    const rejectedWallet = connectedWalletWith(OTHER_COMPRESSED_PUBLIC_KEY);
+    harness.connectedWallet = rejectedWallet;
+    // The connector stands in for the real one: a chain disconnect is refused
+    // for the shared session, and a local disconnect clears its wallet.
+    harness.disconnect.mockImplementation(async (scope: string) => {
+      if (scope === "chain") throw sharedSessionRefusal();
+      harness.connectedWallet = null;
+    });
+    const { rerender } = renderHook(() =>
+      useWalletConnectors({ persistent: true, accountStorage, btcValidation: rejectEveryKey }),
+    );
+    await harness.connectHandler!(rejectedWallet);
+    expect(harness.displayError).toHaveBeenCalledWith(expect.objectContaining({ title: "Public Key Mismatch" }));
+
     await harness.displayError.mock.calls[0][0].onCancel();
-    expect(harness.disconnect).toHaveBeenCalled();
+
+    await waitFor(() => expect(harness.disconnect.mock.calls).toEqual([["chain"], ["local"]]));
     expect(harness.removeWallet).toHaveBeenCalledWith("BTC");
     expect(accountStorage.store.has("BTC")).toBe(false);
-    expect(harness.connectedWallet.account).toBeNull();
     harness.selectWallet.mockClear();
     harness.visible = false;
     rerender();
     harness.visible = true;
     rerender();
-    expect(harness.selectWallet).not.toHaveBeenCalledWith("BTC", harness.connectedWallet);
+    expect(harness.selectWallet).not.toHaveBeenCalledWith("BTC", rejectedWallet);
+  });
+
+  it("does not re-select the rejected wallet while the chain disconnect is still in flight", async () => {
+    const accountStorage = fakeAccountStorage();
+    const rejectedWallet = connectedWalletWith(OTHER_COMPRESSED_PUBLIC_KEY);
+    harness.connectedWallet = rejectedWallet;
+    // The connector keeps its wallet until the remote chain disconnect settles.
+    let settleChainDisconnect!: () => void;
+    harness.disconnect.mockImplementation(async (scope: string) => {
+      if (scope === "chain") {
+        await new Promise<void>((resolve) => {
+          settleChainDisconnect = resolve;
+        });
+      }
+      harness.connectedWallet = null;
+    });
+    const { rerender } = renderHook(() =>
+      useWalletConnectors({ persistent: true, accountStorage, btcValidation: rejectEveryKey }),
+    );
+    await harness.connectHandler!(rejectedWallet);
+    harness.displayError.mock.calls[0][0].onCancel();
+    await waitFor(() => expect(harness.disconnect).toHaveBeenCalledWith("chain"));
+
+    harness.selectWallet.mockClear();
+    harness.visible = false;
+    rerender();
+    harness.visible = true;
+    rerender();
+
+    expect(harness.selectWallet).not.toHaveBeenCalledWith("BTC", rejectedWallet);
+    settleChainDisconnect();
+    await waitFor(() => expect(harness.connectedWallet).toBeNull());
   });
 });
 
-describe("SHARED_SESSION_DISCONNECT_REFUSED error event", () => {
-  it("shows the shared-session dialog and only calls displayChains once the dialog is dismissed", async () => {
+describe("BTC validation failure with a failed chain disconnect", () => {
+  it("logs the failure and still drops the rejected wallet locally", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
     const accountStorage = fakeAccountStorage();
-    renderHook(() => useWalletConnectors({ persistent: false, accountStorage }));
-    await waitFor(() => expect(harness.errorHandler).not.toBeNull());
+    const rejectedWallet = connectedWalletWith(OTHER_COMPRESSED_PUBLIC_KEY);
+    harness.connectedWallet = rejectedWallet;
+    harness.disconnect.mockImplementation(async (scope: string) => {
+      if (scope === "chain") throw new Error("relay down");
+      harness.connectedWallet = null;
+    });
+    renderHook(() => useWalletConnectors({ persistent: true, accountStorage, btcValidation: rejectEveryKey }));
+    await harness.connectHandler!(rejectedWallet);
+    await harness.displayError.mock.calls[0][0].onCancel();
 
-    const refusal = sharedSessionRefusal();
-    harness.errorHandler?.(refusal);
-
-    expect(harness.displayError).toHaveBeenCalledWith(
-      expect.objectContaining({ title: "Wallets share one session", description: refusal.message }),
-    );
-    expect(harness.displayChains).not.toHaveBeenCalled();
-
-    harness.displayError.mock.calls[0][0].onCancel();
-
-    expect(harness.displayChains).toHaveBeenCalled();
-  });
-
-  it("falls through to displayChains for a plain error", async () => {
-    const accountStorage = fakeAccountStorage();
-    renderHook(() => useWalletConnectors({ persistent: false, accountStorage }));
-    await waitFor(() => expect(harness.errorHandler).not.toBeNull());
-
-    harness.errorHandler?.(new Error("boom"));
-
-    expect(harness.displayError).not.toHaveBeenCalled();
-    expect(harness.displayChains).toHaveBeenCalled();
+    await waitFor(() => expect(harness.disconnect.mock.calls).toEqual([["chain"], ["local"]]));
+    expect(consoleError).toHaveBeenCalledWith("Failed to disconnect rejected wallet:", "relay down");
+    expect(harness.removeWallet).toHaveBeenCalledWith("BTC");
+    expect(accountStorage.store.has("BTC")).toBe(false);
+    consoleError.mockRestore();
   });
 });

--- a/packages/babylon-wallet-connector/src/hooks/__tests__/useWalletConnectors.sharedSessionDisconnect.test.tsx
+++ b/packages/babylon-wallet-connector/src/hooks/__tests__/useWalletConnectors.sharedSessionDisconnect.test.tsx
@@ -14,6 +14,8 @@ type ErrorHandler = (error: Error) => void;
 const harness = vi.hoisted(() => ({
   connectHandler: null as ConnectHandler | null,
   errorHandler: null as ErrorHandler | null,
+  connectedWallet: null as IWallet | null,
+  visible: true,
   disconnect: vi.fn(),
   selectWallet: vi.fn(),
   removeWallet: vi.fn(),
@@ -26,7 +28,7 @@ vi.mock("@/context/Chain.context", () => ({
     BTC: {
       id: "BTC",
       config: { network: Network.MAINNET },
-      connectedWallet: null,
+      connectedWallet: harness.connectedWallet,
       disconnect: harness.disconnect,
       on: (event: string, handler: ConnectHandler | ErrorHandler) => {
         if (event === "connect") harness.connectHandler = handler as ConnectHandler;
@@ -43,16 +45,12 @@ vi.mock("@/context/LifecycleHooks.context", () => ({
 
 vi.mock("@/hooks/useWidgetState", () => ({
   useWidgetState: () => ({
-    visible: true,
+    visible: harness.visible,
     selectWallet: harness.selectWallet,
     removeWallet: harness.removeWallet,
-    displayLoader: vi.fn(),
     displayChains: harness.displayChains,
     displayError: harness.displayError,
     confirm: vi.fn(),
-    close: vi.fn(),
-    reset: vi.fn(),
-    chains: {},
   }),
 }));
 
@@ -70,12 +68,6 @@ function fakeAccountStorage(): HashMap & { store: Map<string, string> } {
 function connectedWalletWith(publicKeyHex: string): IWallet {
   return {
     id: "unisat",
-    name: "UniSat",
-    icon: "",
-    docs: "",
-    installed: true,
-    provider: null,
-    label: "",
     account: { address: TAPROOT_ADDRESS, publicKeyHex },
   } as IWallet;
 }
@@ -92,27 +84,30 @@ function sharedSessionRefusal(): WalletError {
 beforeEach(() => {
   harness.connectHandler = null;
   harness.errorHandler = null;
+  harness.connectedWallet = null;
+  harness.visible = true;
   vi.clearAllMocks();
   harness.disconnect.mockResolvedValue(undefined);
 });
 
 describe("BTC validation failure with a refused shared-session disconnect", () => {
-  it("still removes the wallet locally and clears persisted storage", async () => {
+  it("keeps the rejected wallet removed after the dialog closes and opens", async () => {
     const accountStorage = fakeAccountStorage();
-    accountStorage.store.set("BTC", "unisat");
+    harness.connectedWallet = connectedWalletWith(OTHER_COMPRESSED_PUBLIC_KEY);
     harness.disconnect.mockRejectedValueOnce(sharedSessionRefusal());
-
-    renderHook(() => useWalletConnectors({ persistent: true, accountStorage }));
-    await waitFor(() => expect(harness.connectHandler).not.toBeNull());
-    await harness.connectHandler?.(connectedWalletWith(OTHER_COMPRESSED_PUBLIC_KEY));
-
-    await waitFor(() => expect(harness.displayError).toHaveBeenCalled());
-    const { onCancel } = harness.displayError.mock.calls[0][0];
-    await onCancel();
-
+    const { rerender } = renderHook(() => useWalletConnectors({ persistent: true, accountStorage }));
+    await harness.connectHandler!(harness.connectedWallet);
+    await harness.displayError.mock.calls[0][0].onCancel();
     expect(harness.disconnect).toHaveBeenCalled();
     expect(harness.removeWallet).toHaveBeenCalledWith("BTC");
     expect(accountStorage.store.has("BTC")).toBe(false);
+    expect(harness.connectedWallet.account).toBeNull();
+    harness.selectWallet.mockClear();
+    harness.visible = false;
+    rerender();
+    harness.visible = true;
+    rerender();
+    expect(harness.selectWallet).not.toHaveBeenCalledWith("BTC", harness.connectedWallet);
   });
 });
 

--- a/packages/babylon-wallet-connector/src/hooks/appkit/btc/__tests__/useAppKitBtcBridge.test.ts
+++ b/packages/babylon-wallet-connector/src/hooks/appkit/btc/__tests__/useAppKitBtcBridge.test.ts
@@ -1,0 +1,42 @@
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { APPKIT_BTC_CONNECTOR_ID } from "@/core/wallets/appkit/constants";
+
+import { useAppKitBtcBridge } from "../useAppKitBtcBridge";
+
+const harness = vi.hoisted(() => ({
+  connectedWalletId: "",
+  disconnect: vi.fn().mockResolvedValue(undefined),
+}));
+
+// AppKit already reports bip122 disconnected.
+vi.mock("@reown/appkit/react", () => ({
+  useAppKitAccount: () => ({ isConnected: false, address: undefined, allAccounts: [] }),
+}));
+vi.mock("@/hooks/useChainConnector", () => ({
+  useChainConnector: () => ({ connectedWallet: { id: harness.connectedWalletId }, disconnect: harness.disconnect }),
+}));
+
+beforeEach(() => {
+  harness.disconnect.mockClear();
+});
+
+describe("useAppKitBtcBridge", () => {
+  it("drops the connector's wallet locally once AppKit reports bitcoin disconnected", () => {
+    harness.connectedWalletId = APPKIT_BTC_CONNECTOR_ID;
+
+    renderHook(() => useAppKitBtcBridge());
+
+    expect(harness.disconnect).toHaveBeenCalledTimes(1);
+    expect(harness.disconnect).toHaveBeenCalledWith("local");
+  });
+
+  it("leaves a non-AppKit bitcoin wallet alone when AppKit reports bitcoin disconnected", () => {
+    harness.connectedWalletId = "unisat";
+
+    renderHook(() => useAppKitBtcBridge());
+
+    expect(harness.disconnect).not.toHaveBeenCalled();
+  });
+});

--- a/packages/babylon-wallet-connector/src/hooks/appkit/btc/useAppKitBtcBridge.ts
+++ b/packages/babylon-wallet-connector/src/hooks/appkit/btc/useAppKitBtcBridge.ts
@@ -1,11 +1,11 @@
 import { useAppKitAccount } from "@reown/appkit/react";
 import { useCallback, useEffect, useRef } from "react";
 
+import { APPKIT_OPEN_EVENT } from "@/core/wallets/appkit/constants";
 import { APPKIT_BTC_CONNECTOR_ID } from "@/core/wallets/btc/appkit";
 import { APPKIT_BTC_CONNECTED_EVENT } from "@/core/wallets/btc/appkit/constants";
 import { getCaipNetworkForNetwork } from "@/core/wallets/btc/appkit/network";
 import { getSharedBtcAppKitConfig } from "@/core/wallets/btc/appkit/sharedConfig";
-import { APPKIT_OPEN_EVENT } from "@/core/wallets/appkit/constants";
 import { useChainConnector } from "@/hooks/useChainConnector";
 
 interface UseAppKitBtcBridgeOptions {
@@ -61,7 +61,10 @@ export const useAppKitBtcBridge = ({ onError }: UseAppKitBtcBridgeOptions = {}) 
             console.warn("[AppKit BTC Bridge] Public key not available in current account");
           }
         } catch (pkError) {
-          console.error("[AppKit BTC Bridge] Error fetching public key:", pkError instanceof Error ? pkError.message : "Unknown error");
+          console.error(
+            "[AppKit BTC Bridge] Error fetching public key:",
+            pkError instanceof Error ? pkError.message : "Unknown error",
+          );
         }
 
         // Dispatch on the private EventTarget so AppKitBTCProvider can pick
@@ -77,7 +80,10 @@ export const useAppKitBtcBridge = ({ onError }: UseAppKitBtcBridgeOptions = {}) 
         // Mark this address as dispatched to prevent duplicate events
         lastDispatchedAddress.current = currentAddress;
       } catch (error) {
-        console.error("[AppKit BTC Bridge] Failed to process connection:", error instanceof Error ? error.message : "Unknown error");
+        console.error(
+          "[AppKit BTC Bridge] Failed to process connection:",
+          error instanceof Error ? error.message : "Unknown error",
+        );
         onError?.(error as Error);
         // Mark this address as "handled" so the effect at the bottom of
         // the hook does not re-fire `dispatchConnectionEvent` on every
@@ -124,8 +130,11 @@ export const useAppKitBtcBridge = ({ onError }: UseAppKitBtcBridgeOptions = {}) 
       // Reset the last dispatched address when disconnecting
       lastDispatchedAddress.current = null;
 
-      btcConnector.disconnect().catch((error) => {
-        console.error("Failed to disconnect from babylon-wallet-connector:", error instanceof Error ? error.message : "Unknown error");
+      btcConnector.disconnect("local").catch((error) => {
+        console.error(
+          "Failed to disconnect from babylon-wallet-connector:",
+          error instanceof Error ? error.message : "Unknown error",
+        );
       });
     }
   }, [isConnected, address, btcConnector, onError, dispatchConnectionEvent]);

--- a/packages/babylon-wallet-connector/src/hooks/useWalletConnect.ts
+++ b/packages/babylon-wallet-connector/src/hooks/useWalletConnect.ts
@@ -2,6 +2,7 @@ import { useCallback, useMemo } from "react";
 
 import { useChainProviders } from "@/context/Chain.context";
 import type { ChainId } from "@/core/types";
+import { isSharedSessionRefusal } from "@/error";
 
 import { useWidgetState } from "./useWidgetState";
 
@@ -13,6 +14,7 @@ export function useWalletConnect() {
     selectedWallets,
     open: openModal,
     displayChains,
+    displayError,
     displayWallets,
     reset,
   } = useWidgetState();
@@ -45,6 +47,10 @@ export function useWalletConnect() {
   /**
    * Disconnects a single chain, or every chain when called without one.
    *
+   * A single-chain disconnect the provider refuses (the chain shares its
+   * wallet session with another chain) is explained in the dialog and still
+   * rejects, so the caller knows nothing was disconnected.
+   *
    * Membership is tested rather than truthiness because React's bivariant
    * handler types let `onClick={disconnect}` pass a MouseEvent in here, which
    * must not be mistaken for a chain and silently skip the disconnect-all path.
@@ -52,7 +58,22 @@ export function useWalletConnect() {
   const disconnect = useCallback(
     async (chain?: ChainId) => {
       if (chain !== undefined && Object.prototype.hasOwnProperty.call(connectors, chain)) {
-        await connectors[chain]?.disconnect();
+        try {
+          await connectors[chain]?.disconnect("chain");
+        } catch (error) {
+          if (isSharedSessionRefusal(error)) {
+            displayError?.({
+              title: "Wallets share one session",
+              description: error.message,
+              submitButton: "",
+              cancelButton: "Done",
+              onCancel: () => {
+                displayChains?.();
+              },
+            });
+          }
+          throw error;
+        }
         return;
       }
 
@@ -64,7 +85,7 @@ export function useWalletConnect() {
 
       reset?.();
     },
-    [connectors, reset],
+    [connectors, displayChains, displayError, reset],
   );
 
   const selected = useMemo(

--- a/packages/babylon-wallet-connector/src/hooks/useWalletConnect.ts
+++ b/packages/babylon-wallet-connector/src/hooks/useWalletConnect.ts
@@ -59,7 +59,7 @@ export function useWalletConnect() {
       for (const connector of Object.values(connectors)) {
         if (!connector) continue;
 
-        await connector.disconnect();
+        await connector.disconnect("all");
       }
 
       reset?.();

--- a/packages/babylon-wallet-connector/src/hooks/useWalletConnectors.connect.test.tsx
+++ b/packages/babylon-wallet-connector/src/hooks/useWalletConnectors.connect.test.tsx
@@ -32,8 +32,7 @@ const TAPROOT_ADDRESS = "bc1p5cyxnuxmeuwuvkwfem96lqzszd02n6xdcjrs20cac6yqjjwudpx
 const COMPRESSED_PUBLIC_KEY = "03cc8a4bc64d897bddc5fbc2f670f7a8ba0b386779106cf1223c6fc5d7cd6fc115";
 
 /** A different valid key, so a mismatch is rejected on the address, not on parsing. */
-const OTHER_COMPRESSED_PUBLIC_KEY =
-  "0379be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798";
+const OTHER_COMPRESSED_PUBLIC_KEY = "0379be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798";
 
 const CONNECT_FAILED_TITLE = "Connection Failed";
 const PUBLIC_KEY_MISMATCH_TITLE = "Public Key Mismatch";
@@ -43,7 +42,7 @@ type ConnectHandler = (wallet: IWallet) => void | Promise<void>;
 const harness = vi.hoisted(() => ({
   connectHandler: null as ConnectHandler | null,
   visible: true,
-  disconnect: vi.fn(),
+  disconnect: vi.fn().mockResolvedValue(undefined),
   selectWallet: vi.fn(),
   removeWallet: vi.fn(),
   displayChains: vi.fn(),

--- a/packages/babylon-wallet-connector/src/hooks/useWalletConnectors.tsx
+++ b/packages/babylon-wallet-connector/src/hooks/useWalletConnectors.tsx
@@ -58,8 +58,6 @@ export interface BTCAddressValidation {
   validateAddressWithPK(address: string, publicKey: string, network: Network): boolean;
 }
 
-const ignoreReportedDisconnectError = () => {};
-
 interface Props {
   persistent: boolean;
   accountStorage: HashMap;
@@ -94,7 +92,10 @@ export function useWalletConnectors({ persistent, accountStorage, onError, btcVa
   );
 
   const dropRejectedWallet = (connector: Pick<IConnector, "id" | "disconnect">) => {
-    connector.disconnect().catch(ignoreReportedDisconnectError);
+    connector.disconnect().catch((error) => {
+      if (error instanceof WalletError && error.code === ERROR_CODES.SHARED_SESSION_DISCONNECT_REFUSED) return;
+      console.error("Failed to disconnect rejected wallet:", error instanceof Error ? error.message : "Unknown error");
+    });
     removeWallet?.(connector.id);
     if (persistent) {
       accountStorage.delete(connector.id);

--- a/packages/babylon-wallet-connector/src/hooks/useWalletConnectors.tsx
+++ b/packages/babylon-wallet-connector/src/hooks/useWalletConnectors.tsx
@@ -12,7 +12,7 @@ import {
 } from "@/core/confirmationReceipt";
 import { ChainId, HashMap, IChain, IConnector, IETHProvider, IWallet, Network } from "@/core/types";
 import { resolveFirstPartyIcon } from "@/core/wallets/firstPartyIcons";
-import { ERROR_CODES, WalletError } from "@/error";
+import { ERROR_CODES, isSharedSessionRefusal, WalletError } from "@/error";
 
 import { useWidgetState } from "./useWidgetState";
 
@@ -49,9 +49,7 @@ async function resolveEthDisplayWallet(wallet: IWallet): Promise<IWallet> {
  * silently bouncing back to chain selection would leave the user with no
  * idea why their wallet didn't connect.
  */
-const TERMINAL_CONNECT_ERROR_CODES: ReadonlySet<string> = new Set([
-  ERROR_CODES.INCOMPATIBLE_WALLET_VERSION,
-]);
+const TERMINAL_CONNECT_ERROR_CODES: ReadonlySet<string> = new Set([ERROR_CODES.INCOMPATIBLE_WALLET_VERSION]);
 
 export interface BTCAddressValidation {
   validateAddress(network: Network, address: string): void;
@@ -83,22 +81,34 @@ export function useWalletConnectors({ persistent, accountStorage, onError, btcVa
   const { verifyBTCAddress } = useLifeCycleHooks();
   const validationGenerationRef = useRef(0);
   const previousRequiredChainIdsRef = useRef(requiredChainIds);
-  const confirmationCandidate = confirmationReceipt ??
-    (persistent && !visible ? accountStorage.get(WALLET_CONFIRMATION_RECEIPT_KEY) : undefined);
+  const confirmationCandidate =
+    confirmationReceipt ?? (persistent && !visible ? accountStorage.get(WALLET_CONFIRMATION_RECEIPT_KEY) : undefined);
   const confirmationCandidateRef = useRef<string>();
   const dirtyOptionalChainsRef = useRef<Set<ChainId>>(new Set());
-  const requiredConnectorsReady = requiredChainIds.every(
-    (chainId) => connectors[chainId as ChainId]?.connectedWallet,
-  );
+  const requiredConnectorsReady = requiredChainIds.every((chainId) => connectors[chainId as ChainId]?.connectedWallet);
 
-  const dropRejectedWallet = (connector: Pick<IConnector, "id" | "disconnect">, wallet: IWallet) => {
-    wallet.account = null;
-    connector.disconnect().catch((error) => {
-      if (error instanceof WalletError && error.code === ERROR_CODES.SHARED_SESSION_DISCONNECT_REFUSED) return;
-      console.error("Failed to disconnect rejected wallet:", error instanceof Error ? error.message : "Unknown error");
-    });
+  // A wallet that failed post-connect validation is forgotten locally no matter
+  // what the provider does: the chain disconnect is attempted first so an
+  // AppKit wallet is released, and a refusal (shared session) or a failure
+  // falls back to the local teardown so the wallet cannot be selected again.
+  const droppingRef = useRef<Set<string>>(new Set());
+  const dropRejectedWallet = async (connector: Pick<IConnector, "id" | "disconnect">) => {
+    droppingRef.current.add(connector.id);
     removeWallet?.(connector.id);
     if (persistent) accountStorage.delete(connector.id);
+    try {
+      await connector.disconnect("chain");
+    } catch (error) {
+      if (!isSharedSessionRefusal(error)) {
+        console.error(
+          "Failed to disconnect rejected wallet:",
+          error instanceof Error ? error.message : "Unknown error",
+        );
+      }
+      await connector.disconnect("local");
+    } finally {
+      droppingRef.current.delete(connector.id);
+    }
   };
 
   // Connecting event
@@ -151,7 +161,7 @@ export function useWalletConnectors({ persistent, accountStorage, onError, btcVa
                 "The Bitcoin address and Public Key for this wallet do not match. Please contact your wallet provider for support.",
               onSubmit: goToNextScreen,
               onCancel: () => {
-                dropRejectedWallet(connector, connectedWallet);
+                void dropRejectedWallet(connector);
                 displayChains?.();
               },
             });
@@ -167,7 +177,7 @@ export function useWalletConnectors({ persistent, accountStorage, onError, btcVa
               submitButton: "",
               cancelButton: "Done",
               onCancel: async () => {
-                dropRejectedWallet(connector, connectedWallet);
+                void dropRejectedWallet(connector);
                 displayChains?.();
               },
             });
@@ -177,7 +187,7 @@ export function useWalletConnectors({ persistent, accountStorage, onError, btcVa
 
           goToNextScreen();
         } catch (e: any) {
-          dropRejectedWallet(connector, connectedWallet);
+          void dropRejectedWallet(connector);
           displayError?.({
             title: "Connection Failed",
             description: e.message,
@@ -218,7 +228,7 @@ export function useWalletConnectors({ persistent, accountStorage, onError, btcVa
     );
 
     connectorArr.forEach((connector) => {
-      const connectedWallet = connector.connectedWallet?.account ? connector.connectedWallet : null;
+      const connectedWallet = droppingRef.current.has(connector.id) ? null : connector.connectedWallet;
       if (connector.id === "ETH" && connectedWallet) {
         void resolveEthDisplayWallet(connectedWallet).then((wallet) => selectWallet?.(connector.id, wallet));
         return;
@@ -282,33 +292,11 @@ export function useWalletConnectors({ persistent, accountStorage, onError, btcVa
         // Guard on `displayError` directly so we still fall through to
         // `displayChains?.()` below if the dialog state isn't wired up;
         // otherwise the user could be stranded on the current screen.
-        if (
-          error instanceof WalletError &&
-          TERMINAL_CONNECT_ERROR_CODES.has(error.code) &&
-          displayError
-        ) {
+        if (error instanceof WalletError && TERMINAL_CONNECT_ERROR_CODES.has(error.code) && displayError) {
           const walletName = error.wallet ?? "your wallet";
           displayError({
             title: `Update ${walletName}`,
-            description:
-              error.message || `${walletName} needs to be updated before you can connect.`,
-            submitButton: "",
-            cancelButton: "Done",
-            onCancel: () => {
-              displayChains?.();
-            },
-          });
-          return;
-        }
-
-        if (
-          error instanceof WalletError &&
-          error.code === ERROR_CODES.SHARED_SESSION_DISCONNECT_REFUSED &&
-          displayError
-        ) {
-          displayError({
-            title: "Wallets share one session",
-            description: error.message,
+            description: error.message || `${walletName} needs to be updated before you can connect.`,
             submitButton: "",
             cancelButton: "Done",
             onCancel: () => {

--- a/packages/babylon-wallet-connector/src/hooks/useWalletConnectors.tsx
+++ b/packages/babylon-wallet-connector/src/hooks/useWalletConnectors.tsx
@@ -10,7 +10,7 @@ import {
   subscribeToConfirmationIdentityChanges,
   WALLET_CONFIRMATION_RECEIPT_KEY,
 } from "@/core/confirmationReceipt";
-import { ChainId, HashMap, IChain, IETHProvider, IWallet, Network } from "@/core/types";
+import { ChainId, HashMap, IChain, IConnector, IETHProvider, IWallet, Network } from "@/core/types";
 import { resolveFirstPartyIcon } from "@/core/wallets/firstPartyIcons";
 import { ERROR_CODES, WalletError } from "@/error";
 
@@ -58,6 +58,8 @@ export interface BTCAddressValidation {
   validateAddressWithPK(address: string, publicKey: string, network: Network): boolean;
 }
 
+const ignoreReportedDisconnectError = () => {};
+
 interface Props {
   persistent: boolean;
   accountStorage: HashMap;
@@ -90,6 +92,14 @@ export function useWalletConnectors({ persistent, accountStorage, onError, btcVa
   const requiredConnectorsReady = requiredChainIds.every(
     (chainId) => connectors[chainId as ChainId]?.connectedWallet,
   );
+
+  const dropRejectedWallet = (connector: Pick<IConnector, "id" | "disconnect">) => {
+    connector.disconnect().catch(ignoreReportedDisconnectError);
+    removeWallet?.(connector.id);
+    if (persistent) {
+      accountStorage.delete(connector.id);
+    }
+  };
 
   // Connecting event
   useEffect(() => {
@@ -141,8 +151,7 @@ export function useWalletConnectors({ persistent, accountStorage, onError, btcVa
                 "The Bitcoin address and Public Key for this wallet do not match. Please contact your wallet provider for support.",
               onSubmit: goToNextScreen,
               onCancel: () => {
-                connector.disconnect();
-                removeWallet?.(connector.id);
+                dropRejectedWallet(connector);
                 displayChains?.();
               },
             });
@@ -158,8 +167,7 @@ export function useWalletConnectors({ persistent, accountStorage, onError, btcVa
               submitButton: "",
               cancelButton: "Done",
               onCancel: async () => {
-                connector.disconnect();
-                removeWallet?.(connector.id);
+                dropRejectedWallet(connector);
                 displayChains?.();
               },
             });
@@ -169,8 +177,7 @@ export function useWalletConnectors({ persistent, accountStorage, onError, btcVa
 
           goToNextScreen();
         } catch (e: any) {
-          connector.disconnect();
-          removeWallet?.(connector.id);
+          dropRejectedWallet(connector);
           displayError?.({
             title: "Connection Failed",
             description: e.message,
@@ -285,6 +292,23 @@ export function useWalletConnectors({ persistent, accountStorage, onError, btcVa
             title: `Update ${walletName}`,
             description:
               error.message || `${walletName} needs to be updated before you can connect.`,
+            submitButton: "",
+            cancelButton: "Done",
+            onCancel: () => {
+              displayChains?.();
+            },
+          });
+          return;
+        }
+
+        if (
+          error instanceof WalletError &&
+          error.code === ERROR_CODES.SHARED_SESSION_DISCONNECT_REFUSED &&
+          displayError
+        ) {
+          displayError({
+            title: "Wallets share one session",
+            description: error.message,
             submitButton: "",
             cancelButton: "Done",
             onCancel: () => {

--- a/packages/babylon-wallet-connector/src/hooks/useWalletConnectors.tsx
+++ b/packages/babylon-wallet-connector/src/hooks/useWalletConnectors.tsx
@@ -91,15 +91,14 @@ export function useWalletConnectors({ persistent, accountStorage, onError, btcVa
     (chainId) => connectors[chainId as ChainId]?.connectedWallet,
   );
 
-  const dropRejectedWallet = (connector: Pick<IConnector, "id" | "disconnect">) => {
+  const dropRejectedWallet = (connector: Pick<IConnector, "id" | "disconnect">, wallet: IWallet) => {
+    wallet.account = null;
     connector.disconnect().catch((error) => {
       if (error instanceof WalletError && error.code === ERROR_CODES.SHARED_SESSION_DISCONNECT_REFUSED) return;
       console.error("Failed to disconnect rejected wallet:", error instanceof Error ? error.message : "Unknown error");
     });
     removeWallet?.(connector.id);
-    if (persistent) {
-      accountStorage.delete(connector.id);
-    }
+    if (persistent) accountStorage.delete(connector.id);
   };
 
   // Connecting event
@@ -152,7 +151,7 @@ export function useWalletConnectors({ persistent, accountStorage, onError, btcVa
                 "The Bitcoin address and Public Key for this wallet do not match. Please contact your wallet provider for support.",
               onSubmit: goToNextScreen,
               onCancel: () => {
-                dropRejectedWallet(connector);
+                dropRejectedWallet(connector, connectedWallet);
                 displayChains?.();
               },
             });
@@ -168,7 +167,7 @@ export function useWalletConnectors({ persistent, accountStorage, onError, btcVa
               submitButton: "",
               cancelButton: "Done",
               onCancel: async () => {
-                dropRejectedWallet(connector);
+                dropRejectedWallet(connector, connectedWallet);
                 displayChains?.();
               },
             });
@@ -178,7 +177,7 @@ export function useWalletConnectors({ persistent, accountStorage, onError, btcVa
 
           goToNextScreen();
         } catch (e: any) {
-          dropRejectedWallet(connector);
+          dropRejectedWallet(connector, connectedWallet);
           displayError?.({
             title: "Connection Failed",
             description: e.message,
@@ -219,7 +218,7 @@ export function useWalletConnectors({ persistent, accountStorage, onError, btcVa
     );
 
     connectorArr.forEach((connector) => {
-      const connectedWallet = connector.connectedWallet;
+      const connectedWallet = connector.connectedWallet?.account ? connector.connectedWallet : null;
       if (connector.id === "ETH" && connectedWallet) {
         void resolveEthDisplayWallet(connectedWallet).then((wallet) => selectWallet?.(connector.id, wallet));
         return;

--- a/packages/babylon-wallet-connector/src/index.tsx
+++ b/packages/babylon-wallet-connector/src/index.tsx
@@ -7,12 +7,12 @@ export type { WalletConfigOptions } from "@/utils/configBuilder";
 
 export * from "@/providers";
 
+export { useAppKitBtcBridge } from "@/hooks/appkit/btc/useAppKitBtcBridge";
+export { useAppKitOpenListener } from "@/hooks/appkit/useAppKitOpenListener";
 export { useChainConnector } from "@/hooks/useChainConnector";
 export { useVisibilityCheck } from "@/hooks/useVisibilityCheck";
 export { useWalletConnect } from "@/hooks/useWalletConnect";
 export { useWidgetState } from "@/hooks/useWidgetState";
-export { useAppKitBtcBridge } from "@/hooks/appkit/btc/useAppKitBtcBridge";
-export { useAppKitOpenListener } from "@/hooks/appkit/useAppKitOpenListener";
 
 export { type ChainConfigArr } from "@/context/Chain.context";
 export { useInscriptionProvider } from "@/context/Inscriptions.context";
@@ -23,60 +23,53 @@ export * from "@/core/types";
 export { type ETHTypedData } from "@/core/wallets/eth/appkit/types";
 
 // Export AppKit shared config helpers
-export { setSharedWagmiConfig, getSharedWagmiConfig, hasSharedWagmiConfig } from "@/core/wallets/eth/appkit/sharedConfig";
+export {
+  getSharedWagmiConfig,
+  hasSharedWagmiConfig,
+  setSharedWagmiConfig,
+} from "@/core/wallets/eth/appkit/sharedConfig";
 
 // Export AppKit connector IDs
-export { APPKIT_ETH_CONNECTOR_ID } from "@/core/wallets/eth/appkit";
 export { APPKIT_BTC_CONNECTOR_ID } from "@/core/wallets/btc/appkit";
+export { APPKIT_ETH_CONNECTOR_ID } from "@/core/wallets/eth/appkit";
 
 // Export unified AppKit modal utilities (supports both ETH and BTC)
-export {
-    initializeAppKitModal,
-    type AppKitModalConfig,
-} from "@/core/wallets/appkit/appKitModal";
+export { initializeAppKitModal, type AppKitModalConfig } from "@/core/wallets/appkit/appKitModal";
 
 // Export BTC AppKit shared config helpers
 export {
-    setSharedBtcAppKitConfig,
-    getSharedBtcAppKitConfig,
-    hasSharedBtcAppKitConfig,
+  getSharedBtcAppKitConfig,
+  hasSharedBtcAppKitConfig,
+  setSharedBtcAppKitConfig,
 } from "@/core/wallets/btc/appkit/sharedConfig";
 
 // Export UTXO filtering utilities
 export {
-    filterDust,
-    filterInscriptionUtxos,
-    getSpendableUtxos,
-    createInscriptionMap,
-    isInscriptionUtxo,
-    LOW_VALUE_UTXO_THRESHOLD,
-    type FilteredUtxos,
+  LOW_VALUE_UTXO_THRESHOLD,
+  createInscriptionMap,
+  filterDust,
+  filterInscriptionUtxos,
+  getSpendableUtxos,
+  isInscriptionUtxo,
+  type FilteredUtxos,
 } from "@/utils/utxoFiltering";
 
 // Export ordinals API and hook utilities
-export {
-    verifyUtxoOrdinals,
-    toInscriptionIdentifiers,
-    type UtxoOrdinalInfo,
-} from "@/api/ordinals";
+export { toInscriptionIdentifiers, verifyUtxoOrdinals, type UtxoOrdinalInfo } from "@/api/ordinals";
 
 export {
-    fetchOrdinals,
-    getOrdinalsQueryKey,
-    ORDINALS_QUERY_KEY,
-    OrdinalsClassifierUnavailableError,
-    type FetchOrdinalsOptions,
+  ORDINALS_QUERY_KEY,
+  OrdinalsClassifierUnavailableError,
+  fetchOrdinals,
+  getOrdinalsQueryKey,
+  type FetchOrdinalsOptions,
 } from "@/hooks/useOrdinals";
 
 // Export React hooks for ordinals
-export {
-    useOrdinals,
-    type UseOrdinalsOptions,
-    type UseOrdinalsResult,
-} from "@/hooks/useOrdinalsHook";
+export { useOrdinals, type UseOrdinalsOptions, type UseOrdinalsResult } from "@/hooks/useOrdinalsHook";
 
 // Export wallet event constants
 export { COSMOS_KEYSTORE_CHANGE_EVENTS } from "@/constants/walletEvents";
 
 // Export error types so consumers can match on typed error codes
-export { WalletError, ERROR_CODES, isUserRejectionMessage } from "@/error";
+export { ERROR_CODES, WalletError, isSharedSessionRefusal, isUserRejectionMessage } from "@/error";

--- a/packages/babylon-wallet-connector/src/providers/ETHWalletProvider.tsx
+++ b/packages/babylon-wallet-connector/src/providers/ETHWalletProvider.tsx
@@ -47,12 +47,12 @@ export const ETHWalletProvider = ({ children, callbacks }: ETHWalletProviderProp
   const [address, setAddress] = useState<string>();
   const [provider, setProvider] = useState<IETHProvider | null>(null);
 
-  const { open } = useWalletConnect();
+  const { open, disconnect: disconnectWallet } = useWalletConnect();
   const ethConnector = useChainConnector("ETH");
 
-  const disconnect = useCallback(async () => {
+  const disconnectLocally = useCallback(async () => {
     try {
-      await ethConnector?.disconnect();
+      await ethConnector?.disconnect("local");
     } catch (error) {
       console.error("Failed to disconnect ETH connector:", error instanceof Error ? error.message : "Unknown error");
     }
@@ -131,24 +131,11 @@ export const ETHWalletProvider = ({ children, callbacks }: ETHWalletProviderProp
       }
     });
 
-    // Bridge a late wagmi rehydrate into the connector "connect" flow.
-    // checkExistingConnection() above only sees the account wagmi has already
-    // restored by mount time. On reload wagmi often finishes reconnecting from
-    // cookieStorage *after* that: the provider then emits "accountsChanged"
-    // with the restored address, but nothing has called ethConnector.connect()
-    // yet, so connectedWallet / selectedWallets / the connect listener above
-    // never fire and ETH silently fails to re-wire (the AppKit modal shows the
-    // account while the app still shows "Connect"). Listen for that late
-    // address and route it through the connector — a silent no-op when wagmi is
-    // already connected, so it never reopens the modal — which then drives the
-    // connect listener above and the auto-confirm-on-reload effect.
+    // Restore connector state when wagmi restores the account after mount.
+    // The existing wagmi connection keeps this call from opening the modal.
     const bootstrapWallet = ethConnector.wallets[0];
     const bootstrapProvider = bootstrapWallet?.provider;
-    // wagmi can emit several `accountsChanged` while it rehydrates, before React
-    // re-renders with the new `address` — without this guard each one would see
-    // `address` empty and fire another `ethConnector.connect`. On success the
-    // address becomes truthy and the effect re-subscribes, so the flag only
-    // needs resetting on failure.
+    // Block duplicate events until React receives the restored address.
     let lateReconnectInFlight = false;
     const onLateReconnect = (accounts?: string[]) => {
       if (!accounts?.[0] || address || lateReconnectInFlight) return;
@@ -156,15 +143,11 @@ export const ETHWalletProvider = ({ children, callbacks }: ETHWalletProviderProp
       void ethConnector
         .connect(bootstrapWallet)
         .then((wallet) => {
-          // `connect` catches internally and resolves `null` on failure (it does
-          // not reject), so reset the guard here to allow a retry on the next
-          // accountsChanged. On success the address gets set and the effect
-          // re-subscribes, so the guard naturally stops further calls.
+          // A failed connection resolves null. Let the next event try again.
           if (!wallet) lateReconnectInFlight = false;
         })
         .catch((error) => {
-          // Defensive only — `connect` shouldn't reject, but reset on an
-          // unexpected synchronous throw so we don't wedge the guard.
+          // Also allow a retry after an unexpected error.
           lateReconnectInFlight = false;
           console.error("ETH late reconnect failed:", error instanceof Error ? error.message : "Unknown error");
         });
@@ -232,7 +215,7 @@ export const ETHWalletProvider = ({ children, callbacks }: ETHWalletProviderProp
           isProcessingChangeRef.current = false;
         }
       } else if (!newAddress && previousAddress) {
-        disconnect();
+        disconnectLocally();
       }
     };
 
@@ -245,17 +228,11 @@ export const ETHWalletProvider = ({ children, callbacks }: ETHWalletProviderProp
         provider.off("accountsChanged", onAccountsChanged);
       }
     };
-  }, [provider, callbacks, disconnect]);
+  }, [provider, callbacks, disconnectLocally]);
 
-  // NOTE: A previous version also subscribed to window.ethereum.accountsChanged
-  // as a fallback for injected providers. That listener was unscoped — it fired
-  // even when the session used WalletConnect, allowing unrelated wallets to
-  // overwrite the active ETH identity. Removed per audit finding #54.
-  // The provider-specific listener above (via wagmi watchAccount) already handles
-  // account changes for all connector types including injected providers.
+  // Use only the active provider. window.ethereum can report unrelated accounts.
 
-  // Check wallet connection when tab becomes visible
-  // This handles the case where user disconnects from extension while tab is in background
+  // Check for wallet changes when the user returns to the tab.
   const checkETHConnection = useCallback(async () => {
     if (!provider) return;
 
@@ -263,8 +240,7 @@ export const ETHWalletProvider = ({ children, callbacks }: ETHWalletProviderProp
       const currentAddress = await provider.getAddress();
 
       if (!currentAddress) {
-        // Wallet is disconnected
-        disconnect();
+        disconnectLocally();
       } else if (currentAddress.toLowerCase() !== address?.toLowerCase()) {
         // Account changed while tab was in background
         prevAddressRef.current = currentAddress;
@@ -272,11 +248,10 @@ export const ETHWalletProvider = ({ children, callbacks }: ETHWalletProviderProp
         await callbacks?.onAddressChange?.(currentAddress);
       }
     } catch (error) {
-      // Connection check failed - wallet likely disconnected
       console.error("ETH wallet connection check failed:", error instanceof Error ? error.message : "Unknown error");
-      disconnect();
+      disconnectLocally();
     }
-  }, [provider, address, callbacks, disconnect]);
+  }, [provider, address, callbacks, disconnectLocally]);
 
   useVisibilityCheck(checkETHConnection, {
     enabled: Boolean(provider && address),
@@ -290,7 +265,7 @@ export const ETHWalletProvider = ({ children, callbacks }: ETHWalletProviderProp
         loading,
         connected,
         address,
-        disconnect,
+        disconnect: () => disconnectWallet("ETH"),
         open,
       }}
     >

--- a/packages/babylon-wallet-connector/src/providers/ETHWalletProvider.tsx
+++ b/packages/babylon-wallet-connector/src/providers/ETHWalletProvider.tsx
@@ -10,10 +10,10 @@ import {
   type PropsWithChildren,
 } from "react";
 
+import type { IETHProvider } from "@/core/types";
 import { useChainConnector } from "@/hooks/useChainConnector";
 import { useVisibilityCheck } from "@/hooks/useVisibilityCheck";
 import { useWalletConnect } from "@/hooks/useWalletConnect";
-import type { IETHProvider } from "@/core/types";
 
 export interface ETHWalletLifecycleCallbacks {
   onConnect?: (address: string) => void | Promise<void>;
@@ -67,7 +67,9 @@ export const ETHWalletProvider = ({ children, callbacks }: ETHWalletProviderProp
         await callbacks?.onConnect?.(walletAddress);
       } catch (error: unknown) {
         setLoading(false);
-        callbacks?.onError?.(error instanceof Error ? error : new Error("ETH connection failed"), { address: walletAddress });
+        callbacks?.onError?.(error instanceof Error ? error : new Error("ETH connection failed"), {
+          address: walletAddress,
+        });
       }
     },
     [callbacks],
@@ -164,10 +166,7 @@ export const ETHWalletProvider = ({ children, callbacks }: ETHWalletProviderProp
           // Defensive only — `connect` shouldn't reject, but reset on an
           // unexpected synchronous throw so we don't wedge the guard.
           lateReconnectInFlight = false;
-          console.error(
-            "ETH late reconnect failed:",
-            error instanceof Error ? error.message : "Unknown error",
-          );
+          console.error("ETH late reconnect failed:", error instanceof Error ? error.message : "Unknown error");
         });
     };
     if (bootstrapProvider && typeof bootstrapProvider.on === "function") {
@@ -189,8 +188,7 @@ export const ETHWalletProvider = ({ children, callbacks }: ETHWalletProviderProp
       setAddress(undefined);
       setProvider(null);
       try {
-        // Let the connector clear its wallet before the callback runs.
-        await Promise.resolve().then(() => callbacks?.onDisconnect?.());
+        await callbacks?.onDisconnect?.();
       } catch (error) {
         console.error("Error in onDisconnect callback:", error instanceof Error ? error.message : "Unknown error");
       }
@@ -227,7 +225,9 @@ export const ETHWalletProvider = ({ children, callbacks }: ETHWalletProviderProp
         try {
           await callbacks?.onAddressChange?.(newAddress);
         } catch (error: unknown) {
-          callbacks?.onError?.(error instanceof Error ? error : new Error("ETH address change failed"), { address: newAddress });
+          callbacks?.onError?.(error instanceof Error ? error : new Error("ETH address change failed"), {
+            address: newAddress,
+          });
         } finally {
           isProcessingChangeRef.current = false;
         }
@@ -282,10 +282,7 @@ export const ETHWalletProvider = ({ children, callbacks }: ETHWalletProviderProp
     enabled: Boolean(provider && address),
   });
 
-  const connected = useMemo(
-    () => Boolean(address),
-    [address],
-  );
+  const connected = useMemo(() => Boolean(address), [address]);
 
   return (
     <ETHWalletContext.Provider

--- a/packages/babylon-wallet-connector/src/providers/ETHWalletProvider.tsx
+++ b/packages/babylon-wallet-connector/src/providers/ETHWalletProvider.tsx
@@ -53,7 +53,9 @@ export const ETHWalletProvider = ({ children, callbacks }: ETHWalletProviderProp
   const disconnect = useCallback(async () => {
     setAddress(undefined);
     setProvider(null);
-    ethConnector?.disconnect();
+    ethConnector?.disconnect().catch((error) => {
+      console.error("Failed to disconnect ETH connector:", error instanceof Error ? error.message : "Unknown error");
+    });
 
     try {
       await callbacks?.onDisconnect?.();

--- a/packages/babylon-wallet-connector/src/providers/ETHWalletProvider.tsx
+++ b/packages/babylon-wallet-connector/src/providers/ETHWalletProvider.tsx
@@ -51,18 +51,12 @@ export const ETHWalletProvider = ({ children, callbacks }: ETHWalletProviderProp
   const ethConnector = useChainConnector("ETH");
 
   const disconnect = useCallback(async () => {
-    setAddress(undefined);
-    setProvider(null);
-    ethConnector?.disconnect().catch((error) => {
-      console.error("Failed to disconnect ETH connector:", error instanceof Error ? error.message : "Unknown error");
-    });
-
     try {
-      await callbacks?.onDisconnect?.();
+      await ethConnector?.disconnect();
     } catch (error) {
-      console.error("Error in onDisconnect callback:", error instanceof Error ? error.message : "Unknown error");
+      console.error("Failed to disconnect ETH connector:", error instanceof Error ? error.message : "Unknown error");
     }
-  }, [ethConnector, callbacks]);
+  }, [ethConnector]);
 
   const connectETH = useCallback(
     async (walletAddress: string) => {
@@ -191,12 +185,17 @@ export const ETHWalletProvider = ({ children, callbacks }: ETHWalletProviderProp
   useEffect(() => {
     if (!ethConnector) return;
 
-    const unsubscribe = ethConnector.on("disconnect", () => {
-      disconnect();
+    return ethConnector.on("disconnect", async () => {
+      setAddress(undefined);
+      setProvider(null);
+      try {
+        // Let the connector clear its wallet before the callback runs.
+        await Promise.resolve().then(() => callbacks?.onDisconnect?.());
+      } catch (error) {
+        console.error("Error in onDisconnect callback:", error instanceof Error ? error.message : "Unknown error");
+      }
     });
-
-    return unsubscribe;
-  }, [ethConnector, disconnect]);
+  }, [ethConnector, callbacks]);
 
   // Track previous address to detect changes
   const prevAddressRef = useRef<string | undefined>(undefined);
@@ -304,4 +303,3 @@ export const ETHWalletProvider = ({ children, callbacks }: ETHWalletProviderProp
 };
 
 export const useETHWallet = () => useContext(ETHWalletContext);
-


### PR DESCRIPTION
## Outcome

A Bitcoin-only or Ethereum-only disconnect preserves the other wallet. A shared WalletConnect request is refused when it would end both sessions. The dialog explains the refusal. Explicit Disconnect All still ends both sessions.

The review fixes are pushed in `cbf3c6715d8da08a2fce22b5e1e0d059669d494a`. All 12 CI checks pass. Greptile gives this commit 5/5. Reviewer clearance remains.

## Change

- Add chain, all, and local disconnect scopes. Preserve connected state on a refused or failed chain disconnect.
- Use local cleanup when Ethereum reports lost accounts or a failed connection check. Keep the public Ethereum disconnect on the guarded path.
- Allow an independent Ethereum Auth session to disconnect. Keep the shared WalletConnect guard and the defensive Bitcoin Auth guard.
- Clear connector state before its disconnect event. An old disconnect cannot clear a later connection to the same wallet.
- Complete local cleanup for Disconnect All. Prevent a rejected wallet from returning when the dialog reopens.

## Safety

This includes the reverse disconnect change from #2480, under the decision in #2352. Tests cover independent wallets, shared sessions, refusals, failures, lost accounts, reconnect races, and Disconnect All.

The Ethereum-only entry keeps its dependency checks. The reconnect guard protects local connector state and events. It does not control remote wallet teardown. Full consumer session evidence remains in #2355.

## Verification

Checks for the code pushed in `cbf3c6715d8da08a2fce22b5e1e0d059669d494a`:

| Check | Result |
|---|---|
| Wallet unit tests | 358 pass |
| Package boundary tests | 23 pass |
| Nx build and four dependency tasks | Pass |
| Full package lint | No errors; 89 existing warnings |
| Commit authentication | Pass in CI |
| [Fresh Verify CI](https://github.com/babylonlabs-io/babylon-toolkit/actions/runs/34472259031) | Pass |
| [Visual CI](https://github.com/babylonlabs-io/babylon-toolkit/actions/runs/34472259138) | Pass; all 387 captures match; no missing or incomplete captures |
| Greptile review of this commit | 5/5 |

Three regression checks failed before the review fixes and pass now. The [current Greptile review](https://github.com/babylonlabs-io/babylon-toolkit/pull/2439#issuecomment-5582490820) has no new findings. All 15 inline review threads are resolved. The changes-requested review still needs reviewer clearance.

## Links

Closes #2352. #2438 is consolidated into #2352. Parent: #2230 and epic #2228.

- #2480: reverse disconnect implementation, included here.
- #2499: depends on this PR.
- #2355: full consumer session evidence.
- #2354: consent adoption.
- #2232: Vault session behavior.
