### PR TITLE
fix(vault): say the peg-in TVL cap is reached in deposit errors

### DIFF
--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -851,6 +851,10 @@ export const COPY = {
       // broadcast, so no funds are locked and the user can retry once it resumes.
       protocolPaused:
         "New deposits are temporarily disabled while the protocol is frozen or paused. No Bitcoin was sent — please try again once it resumes.",
+      capBelowMinimum: (remainingBtc: string, minBtc: string) =>
+        `Peg-in TVL cap reached — only ${remainingBtc} BTC remains, below the minimum deposit of ${minBtc} BTC`,
+      exceedsCap: (remainingBtc: string) =>
+        `Peg-in TVL cap reached — only ${remainingBtc} BTC remains`,
       cannotActivateInState: (state: string) =>
         `Cannot activate: BTCVault is in ${state} state. Activation is only valid when VERIFIED.`,
       // Deliberately worded without the token "broadcast". These are state

--- a/services/vault/src/hooks/deposit/__tests__/useDepositValidation.test.tsx
+++ b/services/vault/src/hooks/deposit/__tests__/useDepositValidation.test.tsx
@@ -146,7 +146,7 @@ describe("useDepositValidation", () => {
 
       expect(validationResult.valid).toBe(false);
       expect(validationResult.error).toBe(
-        "Remaining capacity (0.00005 BTC) is below the minimum deposit (0.0001 BTC)",
+        "Peg-in TVL cap reached — only 0.00005 BTC remains, below the minimum deposit of 0.0001 BTC",
       );
     });
 
@@ -316,7 +316,7 @@ describe("useDepositValidation", () => {
       const validationResult = result.current.validateAmount("0.001");
 
       expect(validationResult.valid).toBe(false);
-      expect(validationResult.error).toMatch(/exceeds remaining capacity/i);
+      expect(validationResult.error).toMatch(/Peg-in TVL cap reached/);
     });
 
     it("returns the supply-cap-reached error when remaining is zero", () => {

--- a/services/vault/src/services/deposit/__tests__/validations.test.ts
+++ b/services/vault/src/services/deposit/__tests__/validations.test.ts
@@ -4,6 +4,8 @@
 
 import { describe, expect, it } from "vitest";
 
+import { COPY } from "@/copy";
+
 import type { UTXO } from "../../vault/vaultTransactionService";
 import {
   type DepositCtaParams,
@@ -13,6 +15,7 @@ import {
   maxBelowMinimumLabel,
   validateMultiVaultDepositInputs,
   validateProviderSelection,
+  validateRemainingCapacity,
 } from "../validations";
 
 describe("Deposit Validations", () => {
@@ -662,7 +665,7 @@ describe("Deposit Validations", () => {
       });
       expect(result).toEqual({
         disabled: true,
-        label: "BTCVault size exceeds remaining capacity (0.005 BTC)",
+        label: "Peg-in TVL cap reached — only 0.005 BTC remains",
       });
     });
 
@@ -712,7 +715,7 @@ describe("Deposit Validations", () => {
       });
     });
 
-    it("returns 'BTCVault size exceeds remaining capacity' when amount > effectiveRemaining", () => {
+    it("returns 'Peg-in TVL cap reached' when amount > effectiveRemaining", () => {
       // Amount + fee + claim (806_000) still fits readyParams.btcBalance
       // (1_000_000), so this test isolates the cap branch from the balance
       // check. effectiveRemaining 500_000 sats = "0.005" via
@@ -724,7 +727,7 @@ describe("Deposit Validations", () => {
       });
       expect(result).toEqual({
         disabled: true,
-        label: "BTCVault size exceeds remaining capacity (0.005 BTC)",
+        label: "Peg-in TVL cap reached — only 0.005 BTC remains",
       });
     });
 
@@ -750,7 +753,7 @@ describe("Deposit Validations", () => {
       expect(result).toEqual({
         disabled: true,
         label:
-          "Remaining capacity (0.003 BTC) is below the minimum deposit (0.005 BTC)",
+          "Peg-in TVL cap reached — only 0.003 BTC remains, below the minimum deposit of 0.005 BTC",
       });
     });
 
@@ -764,7 +767,7 @@ describe("Deposit Validations", () => {
         amountSats: 0n,
       });
       expect(result.label).toBe(
-        "Remaining capacity (0.003 BTC) is below the minimum deposit (0.005 BTC)",
+        "Peg-in TVL cap reached — only 0.003 BTC remains, below the minimum deposit of 0.005 BTC",
       );
     });
 
@@ -809,7 +812,7 @@ describe("Deposit Validations", () => {
         amountSats: 100_000n,
       });
       expect(result.label).toBe(
-        "Remaining capacity (0.003 BTC) is below the minimum deposit (0.01 BTC)",
+        "Peg-in TVL cap reached — only 0.003 BTC remains, below the minimum deposit of 0.01 BTC",
       );
     });
 
@@ -912,6 +915,30 @@ describe("Deposit Validations", () => {
     it("names the minimum deposit", () => {
       const label = maxBelowMinimumLabel(1_000_000n);
       expect(label).toContain("Minimum deposit is 0.01");
+    });
+  });
+
+  describe("validateRemainingCapacity", () => {
+    it("rejects an amount above a positive remaining cap with the peg-in TVL cap copy", () => {
+      const result = validateRemainingCapacity({
+        amount: 800_000n,
+        effectiveRemaining: 500_000n,
+      });
+      expect(result).toEqual({
+        valid: false,
+        error: COPY.deposit.errors.exceedsCap("0.005"),
+      });
+    });
+
+    it("passes through the SDK's 'Supply cap reached' result when the cap is fully used", () => {
+      const result = validateRemainingCapacity({
+        amount: 100_000n,
+        effectiveRemaining: 0n,
+      });
+      expect(result).toEqual({
+        valid: false,
+        error: "Supply cap reached — deposits temporarily paused",
+      });
     });
   });
 });

--- a/services/vault/src/services/deposit/validations.ts
+++ b/services/vault/src/services/deposit/validations.ts
@@ -8,9 +8,11 @@ import { formatSatoshisToBtc } from "@babylonlabs-io/ts-sdk/tbv/core";
 import {
   validateMultiVaultDepositInputs as sdkValidateMultiVaultDepositInputs,
   validateProviderSelection as sdkValidateProviderSelection,
+  validateRemainingCapacity as sdkValidateRemainingCapacity,
   validateVaultAmounts as sdkValidateVaultAmounts,
   type DepositFormValidityParams,
   type MultiVaultDepositFlowInputs,
+  type RemainingCapacityParams,
   type ValidationResult,
 } from "@babylonlabs-io/ts-sdk/tbv/core/services";
 
@@ -20,7 +22,6 @@ import { getBtcSymbol } from "@/utils/formatting";
 export {
   isDepositAmountValid,
   validateDepositAmount,
-  validateRemainingCapacity,
   validateVaultProviderPubkey,
 } from "@babylonlabs-io/ts-sdk/tbv/core/services";
 
@@ -226,7 +227,10 @@ export function capBelowMinimumLabel(
   effectiveRemaining: bigint,
   minDeposit: bigint,
 ): string {
-  return `Remaining capacity (${formatSatoshisToBtc(effectiveRemaining)} BTC) is below the minimum deposit (${formatSatoshisToBtc(minDeposit)} BTC)`;
+  return COPY.deposit.errors.capBelowMinimum(
+    formatSatoshisToBtc(effectiveRemaining),
+    formatSatoshisToBtc(minDeposit),
+  );
 }
 
 /**
@@ -250,6 +254,25 @@ export function maxBelowMinimum(
 
 export function maxBelowMinimumLabel(minDeposit: bigint): string {
   return `Minimum deposit is ${formatSatoshisToBtc(minDeposit)} ${getBtcSymbol()}`;
+}
+
+export function validateRemainingCapacity(
+  params: RemainingCapacityParams,
+): ValidationResult {
+  const result = sdkValidateRemainingCapacity(params);
+  if (
+    result.valid ||
+    params.effectiveRemaining === null ||
+    params.effectiveRemaining === 0n
+  ) {
+    return result;
+  }
+  return {
+    valid: false,
+    error: COPY.deposit.errors.exceedsCap(
+      formatSatoshisToBtc(params.effectiveRemaining),
+    ),
+  };
 }
 
 export function getDepositButtonLabel(
@@ -326,13 +349,12 @@ export function getDepositCtaState(params: DepositCtaParams): DepositCtaState {
     };
   }
 
-  // Mirror `validateRemainingCapacity` from the SDK. The message strings must
-  // match exactly so users see the same wording whether the block surfaces via
-  // the CTA or via a future inline error. These run before the generic
-  // `amountExceedsMax` check below: `maxDepositSats` is itself clamped to the
-  // supply cap, so a cap-bound amount also trips `amountExceedsMax` — and
-  // "Insufficient balance" would be wrong when the wallet has ample balance but
-  // the supply cap is the real limiter.
+  // Mirrors `validateRemainingCapacity` from the SDK's cap-exhaustion logic.
+  // These run before the generic `amountExceedsMax` check below:
+  // `maxDepositSats` is itself clamped to the supply cap, so a cap-bound
+  // amount also trips `amountExceedsMax` — and "Insufficient balance" would
+  // be wrong when the wallet has ample balance but the supply cap is the
+  // real limiter.
   if (params.effectiveRemaining === 0n) {
     return {
       disabled: true,
@@ -371,7 +393,9 @@ export function getDepositCtaState(params: DepositCtaParams): DepositCtaState {
   ) {
     return {
       disabled: true,
-      label: `BTCVault size exceeds remaining capacity (${formatSatoshisToBtc(params.effectiveRemaining)} BTC)`,
+      label: COPY.deposit.errors.exceedsCap(
+        formatSatoshisToBtc(params.effectiveRemaining),
+      ),
     };
   }
 


### PR DESCRIPTION
## Outcome

Deposit errors caused by the peg-in TVL cap say so. "Peg-in TVL cap reached — only 0.005 BTC remains" replaces "BTCVault size exceeds remaining capacity", and the below-minimum case reads "Peg-in TVL cap reached — only 0.003 BTC remains, below the minimum deposit of 0.005 BTC".

## Change

- Both strings live in `COPY.deposit.errors` as `exceedsCap` and `capBelowMinimum`.
- `validateRemainingCapacity` in the vault wraps the SDK validator and replaces its message for the positive-remainder case. The fully exhausted case still returns the SDK's "Supply cap reached — deposits temporarily paused".
- The submit-gate CTA and the inline validation use the same copy.

## Safety

Copy only. Validation outcomes, thresholds, and the SDK are unchanged. The old comment claiming the strings must match the SDK exactly is replaced, since the vault now owns the wording deliberately.

## Verification

| Gate | Result |
|---|---|
| `tsc --noEmit -p tsconfig.lib.json` (vault) | clean |
| `eslint` on changed files | 0 errors |
| `vitest` for `services/deposit` and `hooks/deposit` | 27 files, 450 tests pass |

Two new tests pin the wrapper: positive remainder gets the new copy, zero remainder passes the SDK result through.

## Links

Closes #2433.
