### PR TITLE
fix(vault): drop the duplicated confirmation count from the ETH step header

### DIFF
--- a/services/vault/src/components/simple/DepositProgressView/DepositProgressView.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/DepositProgressView.tsx
@@ -385,13 +385,8 @@ export function DepositProgressView(props: DepositProgressViewProps) {
   const showCompletedGroupsPill = completedGroups >= 1;
 
   const steps = useMemo(
-    () =>
-      buildStepItems(
-        payoutSigningProgress,
-        peginSigningProgress,
-        ethConfirmationDetail,
-      ),
-    [payoutSigningProgress, peginSigningProgress, ethConfirmationDetail],
+    () => buildStepItems(payoutSigningProgress, peginSigningProgress),
+    [payoutSigningProgress, peginSigningProgress],
   );
 
   const activeStepDetail = resolveActiveStepDetail({

--- a/services/vault/src/components/simple/DepositProgressView/__tests__/steps.test.ts
+++ b/services/vault/src/components/simple/DepositProgressView/__tests__/steps.test.ts
@@ -126,48 +126,12 @@ describe("buildStepItems payout-signing counters", () => {
   });
 });
 
-describe("buildStepItems Ethereum confirmation counter", () => {
-  const ethStep = (items: ReturnType<typeof buildStepItems>) =>
-    items[getVisualStep(DepositFlowStep.SUBMIT_PEGIN) - 1];
-
-  it("puts the confirmation counter on the ETH registration step while the gate holds", () => {
-    const items = buildStepItems(null, null, {
-      confirmations: 3,
-      required: 8,
-    });
-    expect(ethStep(items).description).toBe(
-      COPY.deposit.steps.signingCounter(3, 8),
-    );
-  });
-
-  it("leaves the ETH registration step bare outside the gate's window", () => {
-    // Step 4 also covers the wallet popup and the receipt wait, where there is
-    // nothing to count yet.
-    expect(ethStep(buildStepItems(null)).description).toBeUndefined();
-  });
-
-  it("does not add the counter to any other step", () => {
-    const items = buildStepItems(null, null, {
-      confirmations: 3,
-      required: 8,
-    });
-    const withDescription = items
-      .map((item, index) => ({ index, description: item.description }))
-      .filter((entry) => entry.description !== undefined);
-    expect(withDescription).toEqual([
-      {
-        index: getVisualStep(DepositFlowStep.SUBMIT_PEGIN) - 1,
-        description: COPY.deposit.steps.signingCounter(3, 8),
-      },
-    ]);
-  });
-
-  it("keeps the visual step count unchanged", () => {
-    // The counter is a sub-state of an existing step; adding a 16th step would
-    // renumber every consumer of getVisualStep, including the e2e step machine.
-    expect(
-      buildStepItems(null, null, { confirmations: 3, required: 8 }),
-    ).toHaveLength(TOTAL_VISUAL_STEPS);
+describe("buildStepItems Ethereum registration step", () => {
+  it("has no description — the confirmation count lives only in the detail panel", () => {
+    const items = buildStepItems(null);
+    const ethStep = items[getVisualStep(DepositFlowStep.SUBMIT_PEGIN) - 1];
+    expect(ethStep.label).toBe(COPY.deposit.steps.signAndBroadcastEth);
+    expect(ethStep.description).toBeUndefined();
   });
 });
 

--- a/services/vault/src/components/simple/DepositProgressView/steps.ts
+++ b/services/vault/src/components/simple/DepositProgressView/steps.ts
@@ -2,14 +2,12 @@ import type { StepperItem } from "@babylonlabs-io/core-ui";
 
 import { COPY } from "@/copy";
 import { DepositFlowStep } from "@/hooks/deposit/depositFlowSteps/types";
-import type { RegistrationDepthProgress } from "@/services/vault/ethConfirmationGate";
 import type { PayoutSigningProgress } from "@/services/vault/vaultPayoutSignatureService";
 import type { PeginSigningProgress } from "@/services/vault/vaultTransactionService";
 
 export function buildStepItems(
   progress: PayoutSigningProgress | null,
   peginProgress: PeginSigningProgress | null = null,
-  ethConfirmationProgress: RegistrationDepthProgress | null = null,
 ): StepperItem[] {
   const payoutCounter =
     progress?.phase === "claimers" && progress.total > 0
@@ -31,15 +29,6 @@ export function buildStepItems(
         )
       : undefined;
 
-  // Ethereum finality gate depth. Absent outside the gate's window, so the
-  // step reads normally during the wallet popup and the receipt wait.
-  const ethConfirmationCounter = ethConfirmationProgress
-    ? COPY.deposit.steps.signingCounter(
-        ethConfirmationProgress.confirmations,
-        ethConfirmationProgress.required,
-      )
-    : undefined;
-
   return [
     {
       label: COPY.deposit.steps.generateSecret,
@@ -53,7 +42,6 @@ export function buildStepItems(
     },
     {
       label: COPY.deposit.steps.signAndBroadcastEth,
-      description: ethConfirmationCounter,
     },
     {
       label: COPY.deposit.steps.signAndBroadcastPrePegin,


### PR DESCRIPTION
## Outcome

The ETH registration step in the Deposit Progress modal no longer shows "(4 of 8)" next to its label. The confirmation count appears once, in the detail panel.

## Change

`buildStepItems` drops its Ethereum confirmation parameter and the step `description` it produced. `DepositProgressView` stops passing `ethConfirmationDetail` to the step builder. The detail panel still renders "Confirmations: 4 of 8".

## Safety

Removal only. The visual step count and every other step description are unchanged. Net 53 lines removed.

## Verification

| Gate | Result |
|---|---|
| `tsc --noEmit -p tsconfig.lib.json` (vault) | clean |
| `eslint` on changed files | 0 errors |
| `vitest` for `DepositProgressView` | 13 files, 172 tests pass |

## Links

Closes #2420.
