### PR TITLE
fix(vault): capitalise Overview captions and separate the page background

### DIFF
--- a/services/vault/src/components/pages/RootLayout.tsx
+++ b/services/vault/src/components/pages/RootLayout.tsx
@@ -185,7 +185,7 @@ export default function RootLayout() {
 
   return (
     <div
-      className="relative flex min-h-svh w-full flex-col bg-surface"
+      className="relative flex min-h-svh w-full flex-col bg-background-contrast"
       style={
         { "--tbv-top-banner-height": `${topBannerHeight}px` } as CSSProperties
       }

--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -1860,10 +1860,9 @@ export const COPY = {
   overview: {
     heading: "Overview",
     positionTitle: "Position",
-    healthFactorLabel: "Health factor",
-    totalCollateralValueLabel: "Total collateral value",
-    totalBorrowedLabel: "Total borrowed",
-    availableToBorrowLabel: "Available to borrow",
+    totalCollateralValueLabel: "Total Collateral Value",
+    totalBorrowedLabel: "Total Borrowed",
+    availableToBorrowLabel: "Available to Borrow",
     depositAction: "Deposit",
     borrowAction: "Borrow",
     repayAction: "Repay",

--- a/services/vault/src/globals.css
+++ b/services/vault/src/globals.css
@@ -8,7 +8,7 @@
 @tailwind utilities;
 
 html {
-  @apply bg-surface;
+  @apply bg-background-contrast;
   -webkit-font-smoothing: antialiased;
 }
 


### PR DESCRIPTION
## Outcome

The Overview position captions read in Title Case, and the page background is `#F2F2F2` while the sidebar stays `#FFFFFF`.

## Change

- `copy.ts` Overview labels: "Total Collateral Value", "Total Borrowed", "Available to Borrow". The unused `overview.healthFactorLabel` key is deleted.
- Page ground moves from `bg-surface` to `bg-background-contrast` in `globals.css` and on the root layout wrapper. The sidebar keeps `bg-surface`.

## Safety

Copy and token changes only. No layout or logic changes. The Health factor "Very Safe" and infinity display named in the issue is already implemented and was verified, not changed.

## Verification

| Gate | Result |
|---|---|
| `tsc --noEmit -p tsconfig.lib.json` (vault) | clean |
| `eslint` on changed files | 0 errors |
| `vitest` for `components/simple` and `components/pages` | 60 files, 621 tests pass |

## Links

Closes #2415.
