### PR TITLE
fix(vault): keep pending deposits under the Deposit activity filter

### DIFF
--- a/services/vault/src/components/Activity/ActivityList.tsx
+++ b/services/vault/src/components/Activity/ActivityList.tsx
@@ -5,7 +5,11 @@ import { twJoin } from "tailwind-merge";
 import { ListRowCard } from "@/components/shared/ListRow";
 import { COPY } from "@/copy";
 import { useMidnightTick } from "@/hooks/useMidnightTick";
-import type { ActivityRow, ActivityType } from "@/types/activityLog";
+import {
+  PENDING_DEPOSIT_TYPE,
+  type ActivityRow,
+  type ActivityType,
+} from "@/types/activityLog";
 import { formatActivityDateGroup } from "@/utils/formatting";
 import { useDebounce } from "@/utils/hooks";
 
@@ -53,9 +57,11 @@ function groupByDate(
 }
 
 // Only the ActivityTypes that appear as filter options in the Figma menu.
-// `Redeem` and `Pending Deposit` rows still render in the list but are not
-// directly filterable. `claim_expired` is remapped to a refunded Deposit
-// upstream, so it falls under the `Deposit` filter automatically.
+// `Redeem` rows still render in the list but are not directly filterable.
+// `Pending Deposit` rows aren't a separate option here either — they fall
+// under the `Deposit` filter, matching how they render (see typeLabels).
+// `claim_expired` is remapped to a refunded Deposit upstream, so it falls
+// under the `Deposit` filter automatically.
 const FILTER_OPTIONS = (
   Object.entries(COPY.activity.filterTypes) as Array<[ActivityType, string]>
 ).map(([value, label]) => ({ value, label }));
@@ -110,7 +116,9 @@ export function ActivityList({
     () =>
       activities.filter(
         (row) =>
-          (filter === null || row.type === filter) &&
+          (filter === null ||
+            row.type === filter ||
+            (filter === "Deposit" && row.type === PENDING_DEPOSIT_TYPE)) &&
           activityRowMatchesSearch(row, normalizedQuery),
       ),
     [activities, filter, normalizedQuery],

--- a/services/vault/src/components/Activity/__tests__/ActivityList.test.tsx
+++ b/services/vault/src/components/Activity/__tests__/ActivityList.test.tsx
@@ -120,6 +120,27 @@ describe("ActivityList", () => {
     expect(within(items[0]).getByText("Borrow")).toBeInTheDocument();
   });
 
+  it("includes Pending Deposit rows when filtering by Deposit", () => {
+    const rows = [
+      makeRow({ id: "a", type: "Deposit" }),
+      makeRow({ id: "b", type: "Pending Deposit", isPending: true }),
+      makeRow({
+        id: "c",
+        type: "Borrow",
+        amount: { value: "100", symbol: "USDC" },
+      }),
+    ];
+    renderList({ activities: rows, isConnected: true });
+
+    fireEvent.click(screen.getByRole("button", { name: /show all/i }));
+    fireEvent.click(screen.getByRole("option", { name: "Deposits" }));
+
+    const items = screen.getAllByRole("listitem");
+    expect(items).toHaveLength(2);
+    expect(within(items[0]).getByText("Deposit")).toBeInTheDocument();
+    expect(within(items[1]).getByText("Deposit")).toBeInTheDocument();
+  });
+
   it("shows a minimal empty state without the deposit CTA when a filter hides all rows", () => {
     const rows = [makeRow({ id: "a", type: "Deposit" })];
     renderList({ activities: rows, isConnected: true });


### PR DESCRIPTION
## Outcome

Filtering the Activity list by Deposit keeps pending deposits, which already render with the label "Deposit".

## Change

The filter in `ActivityList` treats a `"Pending Deposit"` row as a match for the `"Deposit"` filter. The filter menu options are unchanged.

## Safety

One condition added to the existing filter. Other filters and the search behave as before.

## Verification

| Gate | Result |
|---|---|
| `tsc --noEmit -p tsconfig.lib.json` (vault) | clean |
| `eslint` on changed files | 0 errors |
| `vitest` for `components/Activity` | 6 files, 61 tests pass |

New test filters a Deposit, a Pending Deposit, and a Borrow row by Deposit and expects both deposit rows.

## Links

Closes #2426.
