### PR TITLE
fix(wasm): explain lazy build check failures

### DIFF
--- a/packages/babylon-tbv-rust-wasm/scripts/check-lazy-entries.js
+++ b/packages/babylon-tbv-rust-wasm/scripts/check-lazy-entries.js
@@ -2,15 +2,31 @@ import { cpSync, readFileSync, rmSync, mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, extname, join, resolve } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
+import ts from 'typescript';
 
 const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const packageManifest = JSON.parse(
   readFileSync(resolve(packageRoot, 'package.json'), 'utf8'),
 );
-const { compilerOptions } = JSON.parse(
-  readFileSync(resolve(packageRoot, 'tsconfig.lib.json'), 'utf8'),
+function failConfig(diagnostic) {
+  throw new Error(
+    `Cannot read tsconfig.lib.json or its extends chain: ${ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n')}`,
+  );
+}
+const config = ts.getParsedCommandLineOfConfigFile(
+  resolve(packageRoot, 'tsconfig.lib.json'),
+  undefined,
+  { ...ts.sys, onUnRecoverableConfigFileDiagnostic: failConfig },
 );
-const outputDirectory = resolve(packageRoot, compilerOptions.outDir);
+const configError =
+  config.options.configFile.parseDiagnostics[0] ?? config.errors[0];
+if (configError) failConfig(configError);
+const outputDirectory = config.options.outDir;
+if (outputDirectory !== resolve(packageRoot, 'dist')) {
+  throw new Error(
+    'tsconfig.lib.json and its extends chain must resolve compilerOptions.outDir to dist to match package exports',
+  );
+}
 if (
   JSON.stringify(Object.keys(packageManifest.exports).sort()) !==
   JSON.stringify(['.', './raw'])
@@ -128,20 +144,31 @@ for (const loaderName of ['wasm-loader.ts', 'wasm-loader-node.ts']) {
   }
 }
 
-// Each emitted loader must resolve its generated type import.
-// Use the configured output directory to check changes to the build layout.
+// Check generated imports that TypeScript and skipLibCheck consumers can miss.
 for (const loaderName of ['wasm-loader.d.ts', 'wasm-loader-node.d.ts']) {
   const emitted = resolve(outputDirectory, loaderName);
+  let declaration;
   try {
-    const match = readFileSync(emitted, 'utf8').match(
-      /from ['"]([^'"]*generated\/vault_wasm\.js)['"]/,
+    declaration = readFileSync(emitted, 'utf8');
+  } catch (cause) {
+    throw new Error(
+      `Missing dist/${loaderName}. Check compilerOptions.outDir and rebuild the package.`,
+      { cause },
     );
-    if (!match) throw new Error(`${loaderName} must import generated types`);
+  }
+  const match = declaration.match(
+    /from ['"]([^'"]*generated\/vault_wasm\.js)['"]/,
+  );
+  if (!match) {
+    throw new Error(
+      `${loaderName} no longer pins its bindings to the generated declarations`,
+    );
+  }
+  try {
     readFileSync(resolve(dirname(emitted), match[1].replace(/\.js$/, '.d.ts')));
   } catch (cause) {
     throw new Error(
-      `${loaderName} must resolve its generated declarations from ${outputDirectory}. ` +
-        `Check compilerOptions.outDir and the generated import path.`,
+      `${loaderName} emits '${match[1]}', which resolves to no declaration from dist. The emit directory and src must stay siblings one level under the package root.`,
       { cause },
     );
   }
@@ -164,8 +191,7 @@ for (const [rawName, loaderName] of [
   }
 }
 
-// Remove generated code from a copy of the build. Both facade entries must
-// import before the first call fails. Raw entries must fail during import.
+// Without generated code, facade entries must import and raw entries must fail.
 const isolatedPackage = mkdtempSync(join(tmpdir(), 'tbv-wasm-lazy-'));
 try {
   cpSync(

--- a/packages/babylon-tbv-rust-wasm/scripts/check-lazy-entries.js
+++ b/packages/babylon-tbv-rust-wasm/scripts/check-lazy-entries.js
@@ -7,6 +7,10 @@ const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const packageManifest = JSON.parse(
   readFileSync(resolve(packageRoot, 'package.json'), 'utf8'),
 );
+const { compilerOptions } = JSON.parse(
+  readFileSync(resolve(packageRoot, 'tsconfig.lib.json'), 'utf8'),
+);
+const outputDirectory = resolve(packageRoot, compilerOptions.outDir);
 if (
   JSON.stringify(Object.keys(packageManifest.exports).sort()) !==
   JSON.stringify(['.', './raw'])
@@ -124,31 +128,21 @@ for (const loaderName of ['wasm-loader.ts', 'wasm-loader-node.ts']) {
   }
 }
 
-// Each loader's type-only import is copied into its emitted declaration
-// verbatim, so it has to resolve from dist too. Nothing reports it when it
-// stops resolving: tsc is silent here, and every consumer inherits
-// skipLibCheck, which drops the error inside the emitted declaration.
+// Each emitted loader must resolve its generated type import.
+// Use the configured output directory to check changes to the build layout.
 for (const loaderName of ['wasm-loader.d.ts', 'wasm-loader-node.d.ts']) {
-  const emitted = resolve(packageRoot, 'dist', loaderName);
-  const match = readFileSync(emitted, 'utf8').match(
-    /from ['"]([^'"]*generated\/vault_wasm\.js)['"]/,
-  );
-  if (!match) {
-    throw new Error(
-      `${loaderName} no longer pins its bindings to the generated declarations`,
-    );
-  }
-  const [, specifier] = match;
+  const emitted = resolve(outputDirectory, loaderName);
   try {
-    readFileSync(
-      resolve(dirname(emitted), specifier.replace(/\.js$/, '.d.ts')),
+    const match = readFileSync(emitted, 'utf8').match(
+      /from ['"]([^'"]*generated\/vault_wasm\.js)['"]/,
     );
-  } catch {
+    if (!match) throw new Error(`${loaderName} must import generated types`);
+    readFileSync(resolve(dirname(emitted), match[1].replace(/\.js$/, '.d.ts')));
+  } catch (cause) {
     throw new Error(
-      `${loaderName} emits '${specifier}', which resolves to no declaration ` +
-        `from dist. The emitted specifier reaches the generated surface only ` +
-        `while the emit directory and src stay siblings one level under the ` +
-        `package root.`,
+      `${loaderName} must resolve its generated declarations from ${outputDirectory}. ` +
+        `Check compilerOptions.outDir and the generated import path.`,
+      { cause },
     );
   }
 }
@@ -170,17 +164,15 @@ for (const [rawName, loaderName] of [
   }
 }
 
-// Runtime proof against the compiled artifacts: remove generated glue from an
-// isolated package copy. Lazy browser/Node roots must still import, then fail
-// only when the first facade call attempts the dynamic import. The explicit
-// raw entries must fail during import because their generated import is eager.
+// Remove generated code from a copy of the build. Both facade entries must
+// import before the first call fails. Raw entries must fail during import.
 const isolatedPackage = mkdtempSync(join(tmpdir(), 'tbv-wasm-lazy-'));
 try {
   cpSync(
     resolve(packageRoot, 'package.json'),
     join(isolatedPackage, 'package.json'),
   );
-  cpSync(resolve(packageRoot, 'dist'), join(isolatedPackage, 'dist'), {
+  cpSync(outputDirectory, join(isolatedPackage, 'dist'), {
     recursive: true,
   });
   rmSync(join(isolatedPackage, 'dist', 'generated'), {
@@ -190,7 +182,14 @@ try {
 
   for (const entryName of ['index.js', 'index-node.js']) {
     const url = pathToFileURL(join(isolatedPackage, 'dist', entryName)).href;
-    const facade = await import(`${url}?lazy-root=${entryName}`);
+    const facade = await import(`${url}?lazy-root=${entryName}`).catch(
+      (cause) => {
+        throw new Error(
+          `${entryName} must import without generated WASM glue. Check the compiled entry and its imports.`,
+          { cause },
+        );
+      },
+    );
     try {
       await facade.initWasm();
       throw new Error(`${entryName} first call unexpectedly found WASM glue`);
@@ -254,7 +253,7 @@ try {
     resolve(packageRoot, 'package.json'),
     join(browserRacePackage, 'package.json'),
   );
-  cpSync(resolve(packageRoot, 'dist'), join(browserRacePackage, 'dist'), {
+  cpSync(outputDirectory, join(browserRacePackage, 'dist'), {
     recursive: true,
   });
   const wasmBytes = readFileSync(
@@ -320,7 +319,7 @@ try {
 // their own complete result. That is what per-call connector ownership buys:
 // neither call can free or overwrite the object the other is reading.
 const concurrentWasmBytes = readFileSync(
-  resolve(packageRoot, 'dist', 'generated', 'vault_wasm_bg.wasm'),
+  resolve(outputDirectory, 'generated', 'vault_wasm_bg.wasm'),
 );
 try {
   globalThis.fetch = async () =>
@@ -329,7 +328,7 @@ try {
     });
 
   const browserFacadeUrl = pathToFileURL(
-    resolve(packageRoot, 'dist', 'index.js'),
+    resolve(outputDirectory, 'index.js'),
   ).href;
   const browserFacade = await import(
     `${browserFacadeUrl}?concurrent-connector-facade`


### PR DESCRIPTION
## Outcome

The lazy-build check explains missing declarations and eager import failures. It rejects a build output directory that differs from the published package layout. Local checks pass.

## Change

Read JSONC and inherited settings with TypeScript. Require the resolved output directory to match `dist`. Give missing emitted files, removed generated imports, and unresolved declarations separate messages. Keep the original file-read errors as causes.

## Safety

An eager facade import still fails the check. Only the first WASM call may report missing generated code. A relocated build fails before a temporary copy can hide missing or stale published files. Declaration errors include the import path and explain the required sibling layout.

## Verification

- Nx build, lint, and all 10 existing tests pass.
- Eleven temporary checks against real build files pass. They cover normal builds, JSONC, inherited output, absent output, relocated output with stale or missing files, malformed or missing configuration, missing emitted declarations, removed generated imports, and unresolved declaration paths.

## Links

Tracks #2345. #2345 stays open.

This covers the diagnostic error item accepted in [the #2307 review](https://github.com/babylonlabs-io/babylon-toolkit/pull/2307#discussion_r3865457140). Epic: #2228.
