### PR TITLE
fix(vault): centralize deposit error messages

### DIFF
--- a/services/vault/src/components/simple/ResumeDepositContent.tsx
+++ b/services/vault/src/components/simple/ResumeDepositContent.tsx
@@ -445,9 +445,10 @@ export function ResumeWotsContent({
         computedTxHash.toLowerCase() !== onChainPrePeginTxHash.toLowerCase()
       ) {
         throw new Error(
-          `Pre-PegIn transaction hash mismatch: computed ${computedTxHash} from indexer tx, ` +
-            `but on-chain contract has ${onChainPrePeginTxHash}. ` +
-            `Aborting to prevent potential attack.`,
+          COPY.deposit.errors.hashMismatch(
+            computedTxHash,
+            onChainPrePeginTxHash,
+          ),
         );
       }
 

--- a/services/vault/src/components/simple/__tests__/ResumeDepositContent.test.tsx
+++ b/services/vault/src/components/simple/__tests__/ResumeDepositContent.test.tsx
@@ -333,7 +333,7 @@ describe("ResumeWotsContent — Pre-PegIn tx hash trust boundary", () => {
 
     await waitFor(() => {
       expect(getByTestId("progress-view").textContent).toContain(
-        "Pre-PegIn transaction hash mismatch",
+        "Pre-Pegin transaction hash mismatch",
       );
     });
 
@@ -635,7 +635,7 @@ describe("ResumeActivationContent — Pre-PegIn tx hash trust boundary", () => {
 
     await waitFor(() => {
       expect(getByTestId("progress-view").textContent).toContain(
-        "Pre-PegIn transaction hash mismatch",
+        "Pre-Pegin transaction hash mismatch",
       );
     });
 

--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -962,13 +962,19 @@ export const COPY = {
         body: "We couldn't broadcast your Bitcoin transaction to the network. Please try again.",
       },
       hashMismatch: (computedHash: string, chainHash: string) =>
-        `Pre-PegIn transaction hash mismatch: computed ${computedHash} from indexer tx, but on-chain contract has ${chainHash}. Aborting to prevent potential attack.`,
+        `Pre-Pegin transaction hash mismatch: computed ${computedHash} from indexer tx, but on-chain contract has ${chainHash}. Aborting to prevent potential attack.`,
+      refundHashMismatch: (computedHash: string, chainHash: string) =>
+        `Pre-Pegin transaction hash mismatch: computed ${computedHash} from indexer tx, but on-chain contract has ${chainHash}. Aborting refund to prevent potential attack.`,
+      vaultNotFound: "BTCVault not found. Please try again.",
+      prePeginIndexerTxMismatch:
+        "Transaction mismatch: the indexer returned a transaction that differs from the locally stored copy. Aborting to prevent a potential attack.",
       prePeginIntegrityMismatch:
-        "Transaction integrity check failed: the Pre-PegIn transaction does not match the hash stored on-chain. Aborting to prevent a potential attack.",
+        "Transaction integrity check failed: the Pre-Pegin transaction does not match the hash stored on-chain. Aborting to prevent a potential attack.",
       prePeginSigningCanceled:
-        "Signing canceled — the signed Pre-PegIn was not broadcast",
+        "Signing canceled - the signed Pre-Pegin was not broadcast",
+      // depositErrors.ts matches "broadcast" to select the failure callout.
       prePeginBroadcastFailed: (error: unknown) =>
-        `Failed to broadcast batch Pre-PegIn transaction: ${error instanceof Error ? error.message : String(error)}`,
+        `Failed to broadcast batch Pre-Pegin transaction: ${error instanceof Error ? error.message : String(error)}`,
       providerNotFound: {
         title: "Vault provider not found",
         body: "The selected vault provider could not be found. Please refresh and try again.",

--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -961,6 +961,14 @@ export const COPY = {
         title: "Broadcast failed",
         body: "We couldn't broadcast your Bitcoin transaction to the network. Please try again.",
       },
+      hashMismatch: (computedHash: string, chainHash: string) =>
+        `Pre-PegIn transaction hash mismatch: computed ${computedHash} from indexer tx, but on-chain contract has ${chainHash}. Aborting to prevent potential attack.`,
+      prePeginIntegrityMismatch:
+        "Transaction integrity check failed: the Pre-PegIn transaction does not match the hash stored on-chain. Aborting to prevent a potential attack.",
+      prePeginSigningCanceled:
+        "Signing canceled — the signed Pre-PegIn was not broadcast",
+      prePeginBroadcastFailed: (error: unknown) =>
+        `Failed to broadcast batch Pre-PegIn transaction: ${error instanceof Error ? error.message : String(error)}`,
       providerNotFound: {
         title: "Vault provider not found",
         body: "The selected vault provider could not be found. Please refresh and try again.",

--- a/services/vault/src/hooks/deposit/depositFlowSteps/__tests__/ensureAuthenticatedVpClient.test.ts
+++ b/services/vault/src/hooks/deposit/depositFlowSteps/__tests__/ensureAuthenticatedVpClient.test.ts
@@ -109,7 +109,7 @@ describe("ensureAuthenticatedVpClient", () => {
         providerAddress: PROVIDER_ADDRESS,
         depositorBtcPubkey: "ab".repeat(32),
       }),
-    ).rejects.toThrow(/Pre-PegIn transaction hash mismatch/);
+    ).rejects.toThrow(/Pre-Pegin transaction hash mismatch/);
 
     expect(mockGetVaultProtocolInfo).toHaveBeenCalledOnce();
     expect(deriveVaultRoot).not.toHaveBeenCalled();

--- a/services/vault/src/hooks/deposit/depositFlowSteps/ensureAuthenticatedVpClient.ts
+++ b/services/vault/src/hooks/deposit/depositFlowSteps/ensureAuthenticatedVpClient.ts
@@ -29,6 +29,7 @@ import { calculateBtcTxHash } from "@babylonlabs-io/ts-sdk/tbv/core/utils";
 import type { Address, Hex } from "viem";
 
 import { getVaultRegistryReader } from "@/clients/eth-contract/sdk-readers";
+import { COPY } from "@/copy";
 import { resolveVpAuthPinnedPubkey } from "@/services/vault/vpAuthPinnedPubkey";
 import { getVpProxyUrl } from "@/utils/rpc";
 
@@ -86,9 +87,7 @@ export async function ensureAuthenticatedVpClient(
   const computedTxHash = calculateBtcTxHash(params.unsignedPrePeginTxHex);
   if (computedTxHash.toLowerCase() !== protocol.prePeginTxHash.toLowerCase()) {
     throw new Error(
-      `Pre-PegIn transaction hash mismatch: computed ${computedTxHash} from indexer tx, ` +
-        `but on-chain contract has ${protocol.prePeginTxHash}. ` +
-        `Aborting to prevent potential attack.`,
+      COPY.deposit.errors.hashMismatch(computedTxHash, protocol.prePeginTxHash),
     );
   }
 

--- a/services/vault/src/hooks/deposit/useDepositFlow.ts
+++ b/services/vault/src/hooks/deposit/useDepositFlow.ts
@@ -1072,9 +1072,7 @@ export function useDepositFlow(
                 if (lastSignSettledWithCancelPendingRef.current) {
                   deviceCancelSettledRef.current = true;
                   throw Object.assign(
-                    new Error(
-                      "Signing canceled — the signed Pre-PegIn was not broadcast",
-                    ),
+                    new Error(COPY.deposit.errors.prePeginSigningCanceled),
                     { code: WALLET_CONNECTION_REJECTED_CODE },
                   );
                 }
@@ -1096,15 +1094,12 @@ export function useDepositFlow(
           if (isDepositTermsRejectedError(error)) {
             throw error;
           }
-          const errorMsg =
-            error instanceof Error ? error.message : String(error);
           // `cause` keeps the typed inner error visible to the cause-walking
           // classifiers (user cancellation, method-not-supported) in the
           // mappers.
-          throw new Error(
-            `Failed to broadcast batch Pre-PegIn transaction: ${errorMsg}`,
-            { cause: error },
-          );
+          throw new Error(COPY.deposit.errors.prePeginBroadcastFailed(error), {
+            cause: error,
+          });
         }
 
         // Broadcast succeeded — update pending pegins from PENDING to CONFIRMING

--- a/services/vault/src/hooks/deposit/useVaultActions.ts
+++ b/services/vault/src/hooks/deposit/useVaultActions.ts
@@ -287,10 +287,7 @@ export function useVaultActions(): UseVaultActionsReturn {
       if (
         computedHash.toLowerCase() !== onChainVault.prePeginTxHash.toLowerCase()
       ) {
-        throw new Error(
-          "Transaction integrity check failed: the Pre-PegIn transaction " +
-            "does not match the hash stored on-chain. Aborting to prevent a potential attack.",
-        );
+        throw new Error(COPY.deposit.errors.prePeginIntegrityMismatch);
       }
 
       // Gate on a fresh on-chain status read. The GraphQL pre-check above is

--- a/services/vault/src/hooks/deposit/useVaultActions.ts
+++ b/services/vault/src/hooks/deposit/useVaultActions.ts
@@ -243,7 +243,7 @@ export function useVaultActions(): UseVaultActionsReturn {
       const vault = await fetchVaultById(vaultId);
 
       if (!vault) {
-        throw new Error("BTCVault not found. Please try again.");
+        throw new Error(COPY.deposit.errors.vaultNotFound);
       }
 
       if (vault.status !== ContractStatus.PENDING) {
@@ -264,9 +264,7 @@ export function useVaultActions(): UseVaultActionsReturn {
         stripHexPrefix(localUnsignedTxHex).toLowerCase() !==
           stripHexPrefix(graphqlUnsignedTxHex).toLowerCase()
       ) {
-        throw new Error(
-          "Transaction mismatch: the indexer returned a transaction that differs from the locally stored copy. Aborting to prevent a potential attack.",
-        );
+        throw new Error(COPY.deposit.errors.prePeginIndexerTxMismatch);
       }
 
       const unsignedTxHex = localUnsignedTxHex || graphqlUnsignedTxHex;

--- a/services/vault/src/services/vault/__tests__/vaultRefundService.test.ts
+++ b/services/vault/src/services/vault/__tests__/vaultRefundService.test.ts
@@ -404,7 +404,7 @@ describe("vaultRefundService - adapter wiring", () => {
         depositorBtcPubkey: DEPOSITOR_PUBKEY,
         feeRate: 10,
       }),
-    ).rejects.toThrow("Pre-PegIn transaction hash mismatch");
+    ).rejects.toThrow("Pre-Pegin transaction hash mismatch");
   });
 
   it("throws when vault is not found in indexer", async () => {

--- a/services/vault/src/services/vault/htlcSecretDerivation.ts
+++ b/services/vault/src/services/vault/htlcSecretDerivation.ts
@@ -28,6 +28,7 @@ import { calculateBtcTxHash } from "@babylonlabs-io/ts-sdk/tbv/core/utils";
 import type { Hex } from "viem";
 
 import { getVaultRegistryReader } from "@/clients/eth-contract/sdk-readers";
+import { COPY } from "@/copy";
 import type { VaultActivity } from "@/types/activity";
 import {
   shouldProbeWalletLiveness,
@@ -64,9 +65,7 @@ export async function deriveHtlcSecretHex(params: {
     const computedTxHash = calculateBtcTxHash(activity.unsignedPrePeginTx);
     if (computedTxHash.toLowerCase() !== onChainPrePeginTxHash.toLowerCase()) {
       throw new Error(
-        `Pre-PegIn transaction hash mismatch: computed ${computedTxHash} from indexer tx, ` +
-          `but on-chain contract has ${onChainPrePeginTxHash}. ` +
-          `Aborting to prevent potential attack.`,
+        COPY.deposit.errors.hashMismatch(computedTxHash, onChainPrePeginTxHash),
       );
     }
 

--- a/services/vault/src/services/vault/vaultRefundService.ts
+++ b/services/vault/src/services/vault/vaultRefundService.ts
@@ -240,9 +240,10 @@ async function readTargetVault(vaultId: Hex): Promise<TargetVaultData> {
     computedTxHash.toLowerCase() !== onChainVault.prePeginTxHash.toLowerCase()
   ) {
     throw new Error(
-      `Pre-PegIn transaction hash mismatch: computed ${computedTxHash} from indexer tx, ` +
-        `but on-chain contract has ${onChainVault.prePeginTxHash}. ` +
-        `Aborting refund to prevent potential attack.`,
+      COPY.deposit.errors.refundHashMismatch(
+        computedTxHash,
+        onChainVault.prePeginTxHash,
+      ),
     );
   }
 

--- a/services/vault/src/utils/errors/__tests__/depositErrors.test.ts
+++ b/services/vault/src/utils/errors/__tests__/depositErrors.test.ts
@@ -252,9 +252,7 @@ describe("mapDepositError", () => {
 
   it("maps a broadcast failure to the broadcast callout", () => {
     expect(
-      mapDepositError(
-        new Error("Failed to broadcast batch Pre-PegIn transaction: timeout"),
-      ),
+      mapDepositError(new Error(ERRORS.prePeginBroadcastFailed("timeout"))),
     ).toEqual(ERRORS.broadcastFailed);
   });
 
@@ -263,9 +261,7 @@ describe("mapDepositError", () => {
     // funds" (BTC-side) — that must not be read as an ETH gas shortfall.
     expect(
       mapDepositError(
-        new Error(
-          "Failed to broadcast batch Pre-PegIn transaction: insufficient funds",
-        ),
+        new Error(ERRORS.prePeginBroadcastFailed("insufficient funds")),
       ),
     ).toEqual(ERRORS.broadcastFailed);
   });
@@ -275,9 +271,7 @@ describe("mapDepositError", () => {
     // wallet code), so a rejection there must still be matched by phrasing.
     expect(
       mapDepositError(
-        new Error(
-          "Failed to broadcast batch Pre-PegIn transaction: User rejected the request",
-        ),
+        new Error(ERRORS.prePeginBroadcastFailed("User rejected the request")),
       ),
     ).toEqual(ERRORS.signingRejected);
   });
@@ -540,15 +534,12 @@ describe("mapDepositError", () => {
     // rejection whose message carries no cancellation wording used to flatten
     // into the wrapper and read as a broadcast failure.
     const rejection = new FakeWalletError("CONNECTION_REJECTED", "nope");
-    const withCause = new Error(
-      "Failed to broadcast batch Pre-PegIn transaction: nope",
-      { cause: rejection },
-    );
+    const withCause = new Error(ERRORS.prePeginBroadcastFailed("nope"), {
+      cause: rejection,
+    });
     expect(mapDepositError(withCause)).toEqual(ERRORS.signingRejected);
 
-    const withoutCause = new Error(
-      "Failed to broadcast batch Pre-PegIn transaction: nope",
-    );
+    const withoutCause = new Error(ERRORS.prePeginBroadcastFailed("nope"));
     expect(mapDepositError(withoutCause)).toEqual(ERRORS.broadcastFailed);
   });
 });

--- a/services/vault/src/utils/errors/depositErrors.ts
+++ b/services/vault/src/utils/errors/depositErrors.ts
@@ -362,7 +362,7 @@ export function mapDepositError(err: unknown): DepositErrorContent {
   }
 
   // 7. Pre-PegIn broadcast failure. Checked before the ETH-gas/UTXO buckets:
-  // the flow wraps broadcast errors as "Failed to broadcast batch Pre-PegIn
+  // the flow wraps broadcast errors as "Failed to broadcast batch Pre-Pegin
   // transaction: <inner>", and that inner text can contain BTC-side
   // "insufficient funds" — a broadcast wrapper must win over the ETH-gas
   // classification.


### PR DESCRIPTION
## Outcome

Deposit and refund error messages now share one source. The affected messages use the documented Pre-Pegin spelling.

## Change

- Move repeated hash, missing-vault, integrity, signing, and broadcast messages into `COPY.deposit.errors`.
- Keep the refund-specific hash-mismatch message.
- Document the broadcast substring match. Use the real formatter in the existing error classification tests.

## Safety

Transaction checks, cancellation codes, and error causes stay the same. Wording changes are limited to Pre-Pegin spelling and a regular hyphen. All existing test assertions remain.

## Verification

- Full Vault suite: 3,756 passed, 6 existing skips.
- Focused deposit, resume, refund, and error tests: 273 passed.
- Vault build and lint passed. Lint has 136 existing warnings.
- Formatting and diff checks passed. The review fix adds 30 lines and removes 35.

## Links

[Original copy finding on #2348](https://github.com/babylonlabs-io/babylon-toolkit/pull/2348#discussion_r3871047445).
