### PR TITLE
fix(vault): wait for offscreen visual changes

### DIFF
--- a/services/vault/e2e/visual/stabilize.ts
+++ b/services/vault/e2e/visual/stabilize.ts
@@ -71,6 +71,9 @@ const HIDE_GOD_MODE_LAUNCHER_CSS = `
   }
 `;
 
+/** Overlap captures so fixed headers do not hide the same document pixels. */
+const STABILITY_SCROLL_STEP_RATIO = 0.5;
+
 /** How long the frame must stay byte-identical before we trust it. */
 const STABILITY_QUIET_MS = 300;
 /** Consecutive identical frames required. */
@@ -120,10 +123,11 @@ async function readFrameSignature(page: Page): Promise<FrameSignature> {
   if (maxX === 0 && maxY === 0) {
     return { pixels: await page.screenshot(), documentWidth, documentHeight };
   }
+  const stepX = viewportWidth * STABILITY_SCROLL_STEP_RATIO;
+  const stepY = viewportHeight * STABILITY_SCROLL_STEP_RATIO;
   try {
-    // Overlap captures so fixed headers do not hide the same document pixels.
-    for (let top = 0; ; top = Math.min(top + viewportHeight / 2, maxY)) {
-      for (let left = 0; ; left = Math.min(left + viewportWidth / 2, maxX)) {
+    for (let top = 0; ; top = Math.min(top + stepY, maxY)) {
+      for (let left = 0; ; left = Math.min(left + stepX, maxX)) {
         await page.evaluate(
           ([left, top]) => window.scrollTo({ left, top, behavior: "instant" }),
           [left, top],

--- a/services/vault/e2e/visual/stabilize.ts
+++ b/services/vault/e2e/visual/stabilize.ts
@@ -71,7 +71,10 @@ const HIDE_GOD_MODE_LAUNCHER_CSS = `
   }
 `;
 
-/** Overlap captures so fixed headers do not hide the same document pixels. */
+/**
+ * The half-viewport overlap (400px desktop, 422px mobile) must exceed the fixed
+ * header height so each document pixel appears in at least one capture.
+ */
 const STABILITY_SCROLL_STEP_RATIO = 0.5;
 
 /** How long the frame must stay byte-identical before we trust it. */
@@ -103,11 +106,14 @@ interface FrameSignature {
   readonly pixels: Buffer;
   readonly documentWidth: number;
   readonly documentHeight: number;
+  readonly frameCount: number;
+  readonly durationMs: number;
 }
 
 /** Compare overlapping captures. Restore the scroll position after each poll. */
 async function readFrameSignature(page: Page): Promise<FrameSignature> {
-  // Read the document size first to settle layout before capture.
+  const startedAt = performance.now();
+  // Measuring the document first settles layout and prevents unstable deposit card images.
   const { documentWidth, documentHeight, viewportWidth, viewportHeight, x, y } =
     await page.evaluate(() => ({
       documentWidth: document.documentElement.scrollWidth,
@@ -121,10 +127,17 @@ async function readFrameSignature(page: Page): Promise<FrameSignature> {
   const maxX = Math.max(0, documentWidth - viewportWidth);
   const maxY = Math.max(0, documentHeight - viewportHeight);
   if (maxX === 0 && maxY === 0) {
-    return { pixels: await page.screenshot(), documentWidth, documentHeight };
+    return {
+      pixels: await page.screenshot(),
+      documentWidth,
+      documentHeight,
+      frameCount: 1,
+      durationMs: Math.round(performance.now() - startedAt),
+    };
   }
   const stepX = viewportWidth * STABILITY_SCROLL_STEP_RATIO;
   const stepY = viewportHeight * STABILITY_SCROLL_STEP_RATIO;
+  let scanFailed = false;
   try {
     for (let top = 0; ; top = Math.min(top + stepY, maxY)) {
       for (let left = 0; ; left = Math.min(left + stepX, maxX)) {
@@ -137,16 +150,34 @@ async function readFrameSignature(page: Page): Promise<FrameSignature> {
       }
       if (top === maxY) break;
     }
+  } catch (error) {
+    scanFailed = true;
+    throw error;
   } finally {
-    await page.evaluate(
-      ([left, top]) => window.scrollTo({ left, top, behavior: "instant" }),
-      [x, y],
-    );
+    await page
+      .evaluate(
+        ([left, top]) => window.scrollTo({ left, top, behavior: "instant" }),
+        [x, y],
+      )
+      .catch((error) => {
+        if (!scanFailed) throw error;
+        // eslint-disable-next-line no-console -- Keep the secondary browser failure in the test log.
+        console.error(
+          "Scroll restoration also failed after the visual scan:",
+          error,
+        );
+      });
   }
-  return { pixels: Buffer.concat(frames), documentWidth, documentHeight };
+  return {
+    pixels: Buffer.concat(frames),
+    documentWidth,
+    documentHeight,
+    frameCount: frames.length,
+    durationMs: Math.round(performance.now() - startedAt),
+  };
 }
 
-/** True only when both halves of the signal are unchanged. */
+/** Dimensions detect document growth; pixels detect paint changes at the same size. */
 function isSameFrame(a: FrameSignature, b: FrameSignature): boolean {
   return (
     a.documentWidth === b.documentWidth &&
@@ -207,7 +238,8 @@ export async function waitForVisualStability(page: Page): Promise<void> {
 
   throw new Error(
     `Page did not reach a stable frame within ${STABILITY_TIMEOUT_MS}ms. ` +
-      `Something on this screen animates or refetches indefinitely - freeze it ` +
-      `in stabilize.ts rather than accepting a flaky baseline.`,
+      `Last scan: ${previous.frameCount} captures in ${previous.durationMs}ms ` +
+      `for a ${previous.documentWidth}x${previous.documentHeight}px document. ` +
+      `Check scan cost, animations, and refetches before changing the timeout.`,
   );
 }

--- a/services/vault/e2e/visual/stabilize.ts
+++ b/services/vault/e2e/visual/stabilize.ts
@@ -25,24 +25,10 @@
  *   covered by `waitForVisualStability`, which polls until the rendered
  *   frame stops changing rather than guessing a fixed delay.
  *
- * The stability poll photographs the VIEWPORT, never the full page. A
- * full-page screenshot of a page taller than the viewport makes Playwright
- * take Chromium's `captureBeyondViewport` path, and Chromium emulates a
- * 1x1 viewport for a moment while it does. The page gets a real `resize`
- * event with `window.innerWidth === 1`, then a restore ~10-250ms later.
- * Any throttled or debounced resize listener in app code takes the 1x1
- * edge and keeps it: `setFixedTime` above freezes `Date.now()` for the
- * life of the page, lodash.throttle derives its window from `Date.now()`,
- * so the trailing edge never fires and the restore is discarded. That is
- * how core-ui's `useIsMobile` latched to `true` and five desktop routes
- * were photographed as the mobile tree. The wrong layout is then perfectly
- * static, so a pixel poll cannot tell it from a correct one.
- *
- * A viewport screenshot fires no resize event, so the poll stops causing
- * the defect it is meant to detect. It also stops seeing below the fold,
- * which two screens genuinely need, so the poll folds the document size
- * into the signal as well - see {@link readFrameSignature}. The capture
- * itself stays full-page; it is taken once, after the page has settled.
+ * The stability poll scrolls through overlapping viewport captures. This
+ * includes pixels below the fold without changing the viewport dimensions.
+ * Full-page polling triggers Chromium's temporary 1x1 viewport. With the
+ * fixed clock, throttled resize listeners can keep that incorrect size.
  */
 
 import type { Page } from "@playwright/test";
@@ -110,45 +96,50 @@ export async function installVisualDeterminism(page: Page): Promise<void> {
   await page.clock.setFixedTime(VISUAL_FIXED_TIME);
 }
 
-/**
- * What one poll iteration compares. Two parts, because neither alone is
- * enough:
- *
- * - `pixels` is the viewport only. It sees everything above the fold and
- *   nothing below it, and it is the half that must not be full-page (see
- *   the header comment).
- * - `documentWidth` / `documentHeight` cover what the crop hides. A list
- *   that grows below the fold, a lazy chunk that lands off-screen and a
- *   collapsing skeleton all move the document box, so growth the pixels
- *   cannot show still reads as "not settled".
- *
- * A change to EITHER part means the screen is still moving.
- */
 interface FrameSignature {
   readonly pixels: Buffer;
   readonly documentWidth: number;
   readonly documentHeight: number;
 }
 
-/**
- * Read one {@link FrameSignature} from the live page.
- *
- * The document box is measured BEFORE the pixels, and the order is not a
- * style choice. Reading `scrollWidth` forces a synchronous style and
- * layout flush. Ask for it right after a screenshot and the flush lands
- * between that raster and the next one, which moves the antialiasing of a
- * rounded corner by one grey level: the deposit dialog's amount card came
- * out two different ways across 12 runs of the same commit. Measure
- * first, photograph the layout that measurement settled, and every run
- * agrees again.
- */
+/** Compare overlapping captures. Restore the scroll position after each poll. */
 async function readFrameSignature(page: Page): Promise<FrameSignature> {
-  const { documentWidth, documentHeight } = await page.evaluate(() => ({
-    documentWidth: document.documentElement.scrollWidth,
-    documentHeight: document.documentElement.scrollHeight,
-  }));
-  const pixels = await page.screenshot();
-  return { pixels, documentWidth, documentHeight };
+  // Read the document size first to settle layout before capture.
+  const { documentWidth, documentHeight, viewportWidth, viewportHeight, x, y } =
+    await page.evaluate(() => ({
+      documentWidth: document.documentElement.scrollWidth,
+      documentHeight: document.documentElement.scrollHeight,
+      viewportWidth: window.innerWidth,
+      viewportHeight: window.innerHeight,
+      x: window.scrollX,
+      y: window.scrollY,
+    }));
+  const frames: Buffer[] = [];
+  const maxX = Math.max(0, documentWidth - viewportWidth);
+  const maxY = Math.max(0, documentHeight - viewportHeight);
+  if (maxX === 0 && maxY === 0) {
+    return { pixels: await page.screenshot(), documentWidth, documentHeight };
+  }
+  try {
+    // Overlap captures so fixed headers do not hide the same document pixels.
+    for (let top = 0; ; top = Math.min(top + viewportHeight / 2, maxY)) {
+      for (let left = 0; ; left = Math.min(left + viewportWidth / 2, maxX)) {
+        await page.evaluate(
+          ([left, top]) => window.scrollTo({ left, top, behavior: "instant" }),
+          [left, top],
+        );
+        frames.push(await page.screenshot());
+        if (left === maxX) break;
+      }
+      if (top === maxY) break;
+    }
+  } finally {
+    await page.evaluate(
+      ([left, top]) => window.scrollTo({ left, top, behavior: "instant" }),
+      [x, y],
+    );
+  }
+  return { pixels: Buffer.concat(frames), documentWidth, documentHeight };
 }
 
 /** True only when both halves of the signal are unchanged. */


### PR DESCRIPTION
## Outcome

Vault visual checks wait for pixel changes below the viewport. Scan failures now retain the useful error and report the measured scan cost.

## Change

Compare overlapping viewport captures across the full document, including one-pixel overflow. Restore the original scroll position after each scan. Keep the original capture path when the document fits the viewport.

Report the last scan's capture count, duration, and document dimensions on timeout. Preserve the scan error if restoration also fails, and log the restore error. A standalone restore failure still rejects the capture.

## Safety

The viewport dimensions stay fixed. The existing layout and error checks run before the final image is written. This change is limited to the visual test helper.

## Verification

- Final visual suite: 18 tests passed and all 58 expected images produced.
- Five checks on existing recorded screens passed: both restore-error paths, measured timeout details, one-pixel overflow with exact scroll restoration, and the fitted-page fast path without scrolling or resizing.
- Full Vault tests: 3,756 passed, 6 existing skips. Build, lint, helper type checking, formatting, and diff checks passed. Lint reports 136 existing warnings.
- Earlier offscreen-change check: a three-second change at fixed document dimensions made the old check return after 667ms; the fixed check waited 3,901ms. Earlier 6x and 20x CPU slowdown checks kept the viewport and desktop layout intact.
- Earlier repeat-image checks found a pre-existing variation: one deposit image differed at three pixels by one color level. The unchanged helper reproduced it. Final and control runs produced the same two image hashes. This did not prevent the complete visual runs from passing.

## Links

Follow-up to [the Greptile finding on #2308](https://github.com/babylonlabs-io/babylon-toolkit/pull/2308#discussion_r3847745871).
