### PR TITLE
ci(workflows): run wallet and app browser checks

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -89,14 +89,52 @@ jobs:
       - name: Lint all
         run: pnpm run lint
 
-      - name: Install Chromium for browser tests
-        run: pnpm --filter @babylonlabs-io/ts-sdk exec playwright install --with-deps chromium
+      - name: Install browsers for browser tests
+        id: browsers
+        run: pnpm --filter @babylonlabs-io/ts-sdk exec playwright install --with-deps chromium firefox
 
       - name: Check packed wallet consumer
         run: pnpm exec nx run @babylonlabs-io/wallet-connector:check:packed-consumer
 
       - name: Test SDK in Chromium
         run: pnpm exec nx run @babylonlabs-io/ts-sdk:test-browser
+
+      - name: Test wallet connections in Chromium
+        if: ${{ !cancelled() && steps.browsers.outcome == 'success' }}
+        env:
+          PLAYWRIGHT_HTML_OPEN: never
+        run: xvfb-run -a pnpm exec nx run @babylonlabs-io/wallet-connector:test:e2e
+
+      - name: Test Vault browsers
+        if: ${{ !cancelled() && steps.browsers.outcome == 'success' }}
+        env:
+          PLAYWRIGHT_HTML_OPEN: never
+        run: pnpm exec nx run @services/vault:test:e2e
+
+      - name: Build staking for browser tests
+        id: staking-browser-build
+        if: ${{ !cancelled() && steps.browsers.outcome == 'success' }}
+        env:
+          NEXT_BUILD_E2E: 'true'
+          DISABLE_SENTRY: 'true'
+        run: pnpm exec nx run @services/simple-staking:build:e2e
+
+      - name: Test staking browsers
+        if: ${{ !cancelled() && steps.staking-browser-build.outcome == 'success' }}
+        env:
+          PLAYWRIGHT_HTML_OPEN: never
+        run: pnpm exec nx run @services/simple-staking:test:e2e
+
+      - name: Upload app browser results
+        if: ${{ !cancelled() && steps.browsers.outcome == 'success' }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2 https://github.com/actions/upload-artifact/releases/tag/v4.6.2
+        with:
+          name: app-browser-results
+          path: |
+            services/vault/playwright-report
+            services/vault/test-results
+            services/simple-staking/playwright-report
+            services/simple-staking/test-results
 
       - name: Test affected
         id: tests

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -109,7 +109,7 @@ jobs:
         if: ${{ !cancelled() && steps.browsers.outcome == 'success' }}
         env:
           PLAYWRIGHT_HTML_OPEN: never
-        run: pnpm exec nx run @services/vault:test:e2e
+        run: pnpm exec nx run @services/vault:test:e2e --retries=0
 
       - name: Build staking for browser tests
         id: staking-browser-build
@@ -123,7 +123,7 @@ jobs:
         if: ${{ !cancelled() && steps.staking-browser-build.outcome == 'success' }}
         env:
           PLAYWRIGHT_HTML_OPEN: never
-        run: pnpm exec nx run @services/simple-staking:test:e2e
+        run: pnpm exec nx run @services/simple-staking:test:e2e --retries=0
 
       - name: Upload app browser results
         if: ${{ !cancelled() && steps.browsers.outcome == 'success' }}

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -12,6 +12,7 @@ concurrency:
 jobs:
   verify:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
 
     steps:
       - name: Checkout code
@@ -137,6 +138,7 @@ jobs:
             services/simple-staking/test-results
 
       - name: Test affected
+        if: ${{ !cancelled() }}
         id: tests
         shell: bash
         run: |
@@ -166,6 +168,7 @@ jobs:
       # typedoc-plugin.mjs. MUST stay after "Build all": docs output depends on
       # the gitignored babylon-tbv-rust-wasm/dist.
       - name: Check generated API docs are current
+        if: ${{ !cancelled() }}
         shell: bash
         run: |
           set -o pipefail

--- a/packages/babylon-wallet-connector/.gitignore
+++ b/packages/babylon-wallet-connector/.gitignore
@@ -10,6 +10,7 @@ lerna-debug.log*
 node_modules
 dist
 dist-ssr
+storybook-static
 *.local
 
 # Editor directories and files

--- a/packages/babylon-wallet-connector/eslint.config.mjs
+++ b/packages/babylon-wallet-connector/eslint.config.mjs
@@ -4,7 +4,7 @@ import { defineConfig, globalIgnores } from "eslint/config";
 import tseslint from "typescript-eslint";
 
 export default defineConfig([
-  globalIgnores(["tests/e2e/fixtures/"]),
+  globalIgnores(["tests/e2e/fixtures/", "storybook-static/"]),
   ...reactConfig,
   {
     plugins: { import: importOrder, "@typescript-eslint": tseslint.plugin },

--- a/packages/babylon-wallet-connector/playwright.config.ts
+++ b/packages/babylon-wallet-connector/playwright.config.ts
@@ -35,8 +35,7 @@ export default defineConfig({
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
     baseURL,
-    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
-    trace: "on-first-retry",
+    trace: "off",
     locale: "en-US",
     launchOptions: {
       args: ["--lang=en-US", "--force-lang=en-US", "--accept-lang=en-US"],
@@ -76,9 +75,11 @@ export default defineConfig({
   ],
   /* Run your local dev server before starting the tests */
   webServer: {
-    command: "npm run dev",
-    url: baseURL,
-    timeout: 120 * 1000,
+    command: process.env.CI
+      ? "pnpm run build-storybook && pnpm exec vite preview --outDir storybook-static --port 6006 --strictPort"
+      : "npm run dev",
+    url: `${baseURL}/iframe.html`,
+    timeout: 300_000,
     reuseExistingServer: !process.env.CI,
   },
 });

--- a/packages/babylon-wallet-connector/playwright.config.ts
+++ b/packages/babylon-wallet-connector/playwright.config.ts
@@ -28,9 +28,9 @@ export default defineConfig({
   /* Retry on CI only */
   retries: 0,
   /* Opt out of parallel tests on CI. */
-  workers: 2,
+  workers: process.env.CI ? 1 : 2,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: "html",
+  reporter: "line",
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
@@ -60,6 +60,9 @@ export default defineConfig({
       testIgnore: "**/specs/wallets/**",
       use: {
         ...devices["Desktop Chrome"],
+        trace: "off",
+        screenshot: "off",
+        video: "off",
         locale: "en-US",
         launchOptions: {
           args: ["--lang=en-US", "--force-lang=en-US", "--accept-lang=en-US"],
@@ -76,6 +79,6 @@ export default defineConfig({
     command: "npm run dev",
     url: baseURL,
     timeout: 120 * 1000,
-    reuseExistingServer: true,
+    reuseExistingServer: !process.env.CI,
   },
 });

--- a/packages/babylon-wallet-connector/src/components/WalletProvider/index.stories.tsx
+++ b/packages/babylon-wallet-connector/src/components/WalletProvider/index.stories.tsx
@@ -59,21 +59,29 @@ export const WithDisabledWallets: Story = {
 };
 
 export const WithConnectedData: Story = {
+  argTypes: { requiredChains: { type: { name: "array", value: { name: "string" } } } },
   decorators: [
-    (Story) => (
+    (Story, { args }) => (
       <ScrollLocker>
-        <WalletProvider context={window.parent} config={config} onError={console.log}>
+        <WalletProvider
+          context={window.parent}
+          config={config}
+          requiredChains={args.requiredChains}
+          onError={console.log}
+        >
           <Story />
         </WalletProvider>
       </ScrollLocker>
     ),
   ],
   render: () => {
-    const { open, selectedWallets } = useWidgetState();
+    const { open, selectedWallets, confirmed } = useWidgetState();
 
     return (
       <div>
-        <Button onClick={open}>Connect Wallet</Button>
+        <Button onClick={open} data-confirmed={confirmed}>
+          Connect Wallet
+        </Button>
         <div className="flex flex-col gap-4">
           {Object.entries(selectedWallets).map(
             ([chainName, wallet]) =>

--- a/packages/babylon-wallet-connector/tests/e2e/fixtures/setupExtensions.ts
+++ b/packages/babylon-wallet-connector/tests/e2e/fixtures/setupExtensions.ts
@@ -1,84 +1,44 @@
-import { test as base, type BrowserContext, chromium } from "@playwright/test";
+import { test as base, type BrowserContext } from "@playwright/test";
+import { english, generateMnemonic, generatePrivateKey } from "viem/accounts";
 
-import { EXTENSION_CHROME_STORE_IDS, getExtensionPath } from "../setup/downloadExtensions";
-
+import { launchWalletContext, type SupportedWallet } from "./launch";
 import { setupKeplrWallet } from "./wallets/keplr";
 import { setupOKXWallet } from "./wallets/okx";
 
-type SupportedWallets = keyof typeof EXTENSION_CHROME_STORE_IDS;
-
 type ExtensionSetup = {
-  context: BrowserContext;
-  setupExtensions: (extensions: SupportedWallets[]) => Promise<{
+  setupExtensions: (extensions: SupportedWallet[]) => Promise<{
     context: BrowserContext;
   }>;
 };
 
 export const test = base.extend<ExtensionSetup>({
-  context: async ({}, use) => {
-    const context = await chromium.launchPersistentContext("", {
-      headless: false,
-      channel: "chromium",
-      locale: "en-US",
-      args: ["--lang=en-US", "--force-lang=en-US", "--accept-lang=en-US"],
-      permissions: ["clipboard-read", "clipboard-write"],
-    });
-    await use(context);
-    await context.close();
-  },
-
   setupExtensions: async ({}, use) => {
-    const setup = async (extensions: SupportedWallets[]) => {
-      // Create new context with all extensions loaded
-      const extensionPaths = extensions.map((ext) => getExtensionPath(EXTENSION_CHROME_STORE_IDS[ext]));
-      const newContext = await chromium.launchPersistentContext("", {
-        headless: false,
-        channel: "chromium",
-        locale: "en-US",
-        args: [
-          `--disable-extensions-except=${extensionPaths.join(",")}`,
-          `--load-extension=${extensionPaths.join(",")}`,
-          "--lang=en-US",
-          "--force-lang=en-US",
-          "--accept-lang=en-US",
-        ],
-        permissions: ["clipboard-read", "clipboard-write"],
-      });
-
-      // Open a blank page
-      const blankPage = await newContext.newPage();
-      await blankPage.goto("about:blank");
-
-      // Wait 5 seconds
-      await new Promise((resolve) => setTimeout(resolve, 5000));
-
-      // Close all other pages
-      for (const page of newContext.pages()) {
-        if (page !== blankPage) {
-          await page.close();
-        }
-      }
-
-      // Setup wallets one at a time
-      for (const ext of extensions) {
-        try {
-          if (ext === "OKX") {
-            await setupOKXWallet(newContext, process.env.E2E_WALLET_MNEMONIC!, process.env.E2E_WALLET_PASSWORD!);
-            console.log("OKX wallet setup completed");
-          } else if (ext === "KEPLR") {
-            await setupKeplrWallet(newContext, process.env.E2E_WALLET_MNEMONIC!, process.env.E2E_WALLET_PASSWORD!);
-            console.log("Keplr wallet setup completed");
+    const contexts: BrowserContext[] = [];
+    try {
+      await use(async (extensions) => {
+        const context = await launchWalletContext(extensions);
+        contexts.push(context);
+        const mnemonic = generateMnemonic(english);
+        const password = generatePrivateKey().slice(2, 34);
+        for (const ext of extensions) {
+          try {
+            if (ext === "OKX") {
+              await setupOKXWallet(context, mnemonic, password);
+            } else if (ext === "KEPLR") {
+              await setupKeplrWallet(context, mnemonic, password);
+            }
+          } catch (error) {
+            const reason = [mnemonic, password, ...mnemonic.split(" ")].reduce(
+              (message, secret) => message.replaceAll(secret, "[redacted]"),
+              error instanceof Error ? error.message : "Unknown setup error",
+            );
+            throw new Error(`${ext} wallet setup failed: ${reason}`);
           }
-        } catch (error) {
-          console.error(`Failed to setup ${ext} wallet:`, error);
-          await newContext.close();
-          throw error;
         }
-      }
-
-      return { context: newContext };
-    };
-
-    await use(setup);
+        return { context };
+      });
+    } finally {
+      await Promise.all(contexts.map((context) => context.close()));
+    }
   },
 });

--- a/packages/babylon-wallet-connector/tests/e2e/fixtures/setupExtensions.ts
+++ b/packages/babylon-wallet-connector/tests/e2e/fixtures/setupExtensions.ts
@@ -28,7 +28,7 @@ export const test = base.extend<ExtensionSetup>({
               await setupKeplrWallet(context, mnemonic, password);
             }
           } catch (error) {
-            const reason = [mnemonic, password, ...mnemonic.split(" ")].reduce(
+            const reason = [mnemonic, password].reduce(
               (message, secret) => message.replaceAll(secret, "[redacted]"),
               error instanceof Error ? error.message : "Unknown setup error",
             );

--- a/packages/babylon-wallet-connector/tests/e2e/fixtures/wallets/keplr.ts
+++ b/packages/babylon-wallet-connector/tests/e2e/fixtures/wallets/keplr.ts
@@ -4,6 +4,7 @@ import { EXTENSION_CHROME_STORE_IDS } from "../../setup/downloadExtensions";
 import { runtimeExtensionId } from "../../utils/extensionId";
 import { fillInputsByName } from "../../utils/fillInputs";
 import { findServiceWorkerForExtension } from "../../utils/findServiceWorkerForExtension";
+import { WAIT_FOR } from "../../utils/timing";
 
 export async function setupKeplrWallet(context: BrowserContext, mnemonic: string, password: string) {
   if (!mnemonic) throw new Error("Missing E2E_WALLET_MNEMONIC in environment variables");
@@ -23,7 +24,9 @@ export async function setupKeplrWallet(context: BrowserContext, mnemonic: string
   // Fill mnemonic
   const words = mnemonic.trim().split(" ");
   for (let i = 0; i < words.length; i++) {
-    await page.getByText("1.2.3.4.5.6.7.8.9.10.11.12.").locator("input").nth(i).fill(words[i]);
+    await page.locator('input[type="text"], input[type="password"]').nth(i).fill(words[i], { timeout: WAIT_FOR.ACTION_MS }).catch(() => {
+      throw new Error(`Keplr: seed word ${i + 1} input failed`);
+    });
   }
 
   // Import wallet
@@ -38,12 +41,7 @@ export async function setupKeplrWallet(context: BrowserContext, mnemonic: string
 
   await page.getByRole("button", { name: "Next" }).click();
 
-  // Deselect all networks
-  await page
-    .locator("div")
-    .filter({ hasText: /^Select All$/ })
-    .nth(2)
-    .click();
+  await page.getByText("All Native Chains", { exact: true }).click({ timeout: WAIT_FOR.ACTION_MS });
 
   // Complete setup
   for (const buttonName of ["Save", "Finish"]) {

--- a/packages/babylon-wallet-connector/tests/e2e/fixtures/wallets/keplr.ts
+++ b/packages/babylon-wallet-connector/tests/e2e/fixtures/wallets/keplr.ts
@@ -43,8 +43,8 @@ export async function setupKeplrWallet(context: BrowserContext, mnemonic: string
 
   await page.getByText("All Native Chains", { exact: true }).click({ timeout: WAIT_FOR.ACTION_MS });
 
-  // Complete setup
-  for (const buttonName of ["Save", "Finish"]) {
-    await page.getByRole("button", { name: buttonName }).click();
-  }
+  // Keplr 0.13.46's Finish button only closes the completed setup page.
+  await page.getByRole("button", { name: "Save" }).click();
+  await page.getByRole("button", { name: "Finish" }).waitFor({ state: "visible", timeout: WAIT_FOR.ACTION_MS });
+  await page.close();
 }

--- a/packages/babylon-wallet-connector/tests/e2e/fixtures/wallets/okx.ts
+++ b/packages/babylon-wallet-connector/tests/e2e/fixtures/wallets/okx.ts
@@ -55,8 +55,7 @@ async function clickByTestId(tab: Page, testid: string): Promise<void> {
 
 /** Click the last enabled <button> inside a frame (the primary "Next"/"Confirm" action). */
 async function clickPrimaryButton(frame: Frame): Promise<void> {
-  const btn = frame.locator("button:not([disabled])").last();
-  if ((await btn.count().catch(() => 0)) > 0) await btn.click({ force: true }).catch(() => {});
+  await frame.locator("button:not([disabled])").last().click({ force: true, timeout: WAIT_FOR.ACTION_MS });
 }
 
 /**
@@ -191,8 +190,8 @@ export async function setupOKXWallet(context: BrowserContext, mnemonic: string, 
 
   // Full-page onboarding tab (not the popup — the popup delegates seed entry to a modal window).
   const tab = await context.newPage();
-  await tab.goto(`${origin}/home.html#/initialize`).catch(() => {});
-  await tab.waitForLoadState("domcontentloaded").catch(() => {});
+  await tab.goto(`${origin}/home.html#/initialize`);
+  await tab.waitForLoadState("domcontentloaded");
   await sleep(SETTLE.MEDIUM);
   await closeForeignTabs(context, tab);
 
@@ -200,8 +199,8 @@ export async function setupOKXWallet(context: BrowserContext, mnemonic: string, 
   // a modal window); closeForeignTabs then kills that window if it appears.
   await clickByTestId(tab, "onboard-page-import-wallet-button");
   await sleep(SETTLE.MODAL);
-  await tab.goto(`${origin}/home.html#/import-with-seed-phrase-and-private-key?openFromThisPage=1`).catch(() => {});
-  await tab.waitForLoadState("domcontentloaded").catch(() => {});
+  await tab.goto(`${origin}/home.html#/import-with-seed-phrase-and-private-key?openFromThisPage=1`);
+  await tab.waitForLoadState("domcontentloaded");
   await sleep(SETTLE.MEDIUM);
   await closeForeignTabs(context, tab);
 
@@ -232,47 +231,47 @@ export async function setupOKXWallet(context: BrowserContext, mnemonic: string, 
   }
   await sleep(SETTLE.BRIEF);
   const confirmSeed = seedFrame.locator('button[data-testid="import-seed-phrase-or-private-key-page-confirm-button"]');
-  await confirmSeed.click({ force: true, timeout: WAIT_FOR.ACTION_MS }).catch(() => {});
+  await confirmSeed.click({ force: true, timeout: WAIT_FOR.ACTION_MS });
   await sleep(SETTLE.LONG);
   await closeForeignTabs(context, tab);
 
   // Password-type screen: choose Password (not biometric), then Next.
   const typeFrame = sesFrame(tab);
-  if (typeFrame) {
-    await typeFrame.locator('[data-testid="password-type-item"]').first().click({ force: true }).catch(() => {});
-    await sleep(SETTLE.SHORT);
-    await clickPrimaryButton(typeFrame);
-    await sleep(SETTLE.MODAL);
-  }
+  if (!typeFrame) throw new Error("OKX: password type iframe (ses.html) not found");
+  await typeFrame.getByTestId("password-type-item").first().click({ force: true, timeout: WAIT_FOR.ACTION_MS });
+  await sleep(SETTLE.SHORT);
+  await clickPrimaryButton(typeFrame);
+  await sleep(SETTLE.MODAL);
 
   // Password entry: fill both fields, confirm.
   const pwFrame = sesFrame(tab);
-  if (pwFrame) {
-    const pw = pwFrame.locator('input[type="password"]');
-    await pw.first().waitFor({ state: "visible", timeout: WAIT_FOR.ELEMENT_MS }).catch(() => {});
-    if ((await pw.count().catch(() => 0)) >= 2) {
-      await pw.nth(0).fill(password).catch(() => {});
-      await pw.nth(1).fill(password).catch(() => {});
-      await sleep(SETTLE.SHORT);
-      await clickPrimaryButton(pwFrame);
-      await sleep(SETTLE.LONG);
-    }
+  if (!pwFrame) throw new Error("OKX: password entry iframe (ses.html) not found");
+  const pw = pwFrame.locator('input[type="password"]');
+  await pw.first().waitFor({ state: "visible", timeout: WAIT_FOR.ELEMENT_MS });
+  try {
+    await pw.nth(0).fill(password, { timeout: WAIT_FOR.ACTION_MS });
+    await pw.nth(1).fill(password, { timeout: WAIT_FOR.ACTION_MS });
+  } catch {
+    throw new Error("OKX: password input failed");
   }
+  await sleep(SETTLE.SHORT);
+  await clickPrimaryButton(pwFrame);
+  await sleep(SETTLE.LONG);
   await closeForeignTabs(context, tab);
 
   // Welcome / supported-chains: content lives outside the ses frame. Uncheck "set OKX as default wallet"
   // (so it won't hijack the provider for other wallets), then click the bottom button — across all frames.
   for (const frame of tab.frames()) {
     const checked = frame.locator('input[type="checkbox"]:checked');
-    const n = await checked.count().catch(() => 0);
-    for (let i = 0; i < n; i++) await checked.nth(i).uncheck({ force: true }).catch(() => {});
-    await clickPrimaryButton(frame);
+    const n = await checked.count();
+    for (let i = n - 1; i >= 0; i--) await checked.nth(i).uncheck({ force: true });
+    if (await frame.locator("button:not([disabled])").count()) await clickPrimaryButton(frame);
   }
   await sleep(SETTLE.LONG);
   await closeForeignTabs(context, tab);
 
   // Wait for the wallet home, then apply English and switch to signet.
-  await tab.locator('[data-testid="home-page-home-root-element-id"]').waitFor({ state: "visible", timeout: WAIT_FOR.HOME_MS }).catch(() => {});
+  await tab.getByTestId("home-page-home-root-element-id").waitFor({ state: "visible", timeout: WAIT_FOR.HOME_MS });
   await dismissPromoDialog(tab); // OKX may pop a promo modal on the home that blocks the settings dropdown
   await switchToEnglish(tab);
   await switchToSignet(tab, origin);

--- a/packages/babylon-wallet-connector/tests/e2e/fixtures/wallets/okx.ts
+++ b/packages/babylon-wallet-connector/tests/e2e/fixtures/wallets/okx.ts
@@ -210,7 +210,9 @@ export async function setupOKXWallet(context: BrowserContext, mnemonic: string, 
   if (!seedFrame) throw new Error("OKX: seed-entry iframe (ses.html) not found");
   const words = mnemonic.trim().split(/\s+/).filter(Boolean);
   let boxes = seedFrame.locator('input[data-testid="import-seed-phrase-or-private-key-page-seed-phrase-input"]');
-  await boxes.first().waitFor({ state: "visible", timeout: WAIT_FOR.ELEMENT_SLOW_MS }).catch(() => {});
+  await boxes.first().waitFor({ state: "visible", timeout: WAIT_FOR.ELEMENT_SLOW_MS });
+  const reminder = seedFrame.getByTestId("security-reminder-got-it-button");
+  if (await reminder.isVisible()) await reminder.click({ timeout: WAIT_FOR.ACTION_MS });
   // The seed screen defaults to a 12-input grid with a phrase-length selector; a 24-word phrase needs
   // it switched first, or the extra words are dropped. OKX renders in the OS locale, so we NEVER match
   // the visible "N words" text — we drive the selector by its language-agnostic data attributes.
@@ -224,8 +226,9 @@ export async function setupOKXWallet(context: BrowserContext, mnemonic: string, 
       `OKX: seed grid shows ${boxCount} inputs but the phrase has ${words.length} words — the phrase-length selector (okd-select-text) did not switch. OKX's import UI likely changed; re-derive selectOkxSeedWordCount (okx.ts).`,
     );
   for (let i = 0; i < words.length; i++) {
-    await boxes.nth(i).click().catch(() => {});
-    await boxes.nth(i).fill(words[i]).catch(() => {});
+    await boxes.nth(i).fill(words[i], { timeout: WAIT_FOR.ACTION_MS }).catch(() => {
+      throw new Error(`OKX: seed word ${i + 1} input failed`);
+    });
   }
   await sleep(SETTLE.BRIEF);
   const confirmSeed = seedFrame.locator('button[data-testid="import-seed-phrase-or-private-key-page-confirm-button"]');

--- a/packages/babylon-wallet-connector/tests/e2e/specs/connectOKXKeplr.spec.ts
+++ b/packages/babylon-wallet-connector/tests/e2e/specs/connectOKXKeplr.spec.ts
@@ -1,16 +1,19 @@
-import { BrowserContext, expect, FrameLocator, Page } from "@playwright/test";
+import { BrowserContext, expect, Locator, Page } from "@playwright/test";
 
 import { test } from "../fixtures/setupExtensions";
 
-test("Connect OKX and Keplr wallets and verify addresses", async ({ setupExtensions }) => {
+test("Connect OKX and Keplr wallets and verify addresses", async ({ setupExtensions, baseURL }) => {
   // Setup and initial navigation
   const { context } = await setupExtensions(["OKX", "KEPLR"]);
-  const page = await context.newPage();
-  const storybook = page.locator('iframe[title="storybook-preview-iframe"]').contentFrame();
-  await page.goto("/?path=/docs/components-chainbutton--docs");
+  const storybook = await context.newPage();
+  await storybook.goto(
+    new URL(
+      "/iframe.html?id=components-walletprovider--with-connected-data&viewMode=story&args=requiredChains[0]:BTC;requiredChains[1]:BBN",
+      baseURL,
+    ).href,
+  );
 
-  // Accept terms and conditions
-  await setupStorybookEnvironment(page, storybook);
+  await storybook.getByRole("button", { name: "Connect Wallet" }).click();
 
   // Connect Bitcoin wallet (OKX)
   await connectBitcoinWallet(storybook, context);
@@ -18,40 +21,29 @@ test("Connect OKX and Keplr wallets and verify addresses", async ({ setupExtensi
   // Connect Babylon wallet (Keplr)
   await connectBabylonWallet(storybook, context);
 
-  // Verify wallet connections
-  const btcWalletInfo = await verifyWalletSection(storybook, "btc");
-  const bbnWalletInfo = await verifyWalletSection(storybook, "bbn");
-
-  // Log wallet information
-  console.log("BTC Wallet:", btcWalletInfo);
-  console.log("BBN Wallet:", bbnWalletInfo);
+  await verifyWalletSection(storybook, "btc");
+  await verifyWalletSection(storybook, "bbn");
 });
 
-async function setupStorybookEnvironment(page: Page, storybook: FrameLocator) {
-  await page.getByRole("button", { name: "WalletProvider" }).click();
-  await page.getByRole("link", { name: "With Connected Data" }).click();
-  await page.getByRole("button", { name: "Hide addons [⌥ A]" }).click();
-  await storybook.getByRole("button", { name: "Connect Wallet" }).click();
-}
-
-async function connectBitcoinWallet(storybook: FrameLocator, context: BrowserContext) {
+async function connectBitcoinWallet(storybook: Page, context: BrowserContext) {
   await storybook.getByRole("button", { name: "Bitcoin" }).click();
-  await storybook.getByRole("button", { name: "OKX" }).click();
-
-  await connectWalletViaPopup(context, "Connect");
+  await connectWalletViaPopup(context, storybook.getByTestId("wallet-option-okx"), "Connect");
 }
 
-async function connectBabylonWallet(storybook: FrameLocator, context: BrowserContext) {
+async function connectBabylonWallet(storybook: Page, context: BrowserContext) {
   await storybook.getByRole("button", { name: "Babylon" }).click();
-  await storybook.getByRole("button", { name: "Keplr" }).click();
+  await connectWalletViaPopup(context, storybook.getByTestId("wallet-option-keplr"), "Approve");
 
-  await connectWalletViaPopup(context, "Approve");
-
+  const walletButton = storybook.getByRole("button", { name: "Connect Wallet", exact: true });
+  await expect(walletButton).toHaveAttribute("data-confirmed", "false");
+  await expect(storybook.getByTestId("chains-connect-button")).toBeEnabled();
   await storybook.getByRole("button", { name: "Connect", exact: true }).click();
+  await expect(walletButton).toHaveAttribute("data-confirmed", "true");
+  await expect(storybook.locator(".bbn-dialog-fullscreen")).toBeHidden();
 }
 
-async function connectWalletViaPopup(context: BrowserContext, buttonName: string) {
-  const [popup] = await Promise.all([context.waitForEvent("page")]);
+async function connectWalletViaPopup(context: BrowserContext, walletButton: Locator, buttonName: string) {
+  const [popup] = await Promise.all([context.waitForEvent("page"), walletButton.click()]);
   await popup.waitForLoadState("domcontentloaded");
   await popup.bringToFront();
 
@@ -61,7 +53,7 @@ async function connectWalletViaPopup(context: BrowserContext, buttonName: string
   await popup.close();
 }
 
-async function verifyWalletSection(storybook: FrameLocator, walletType: "btc" | "bbn") {
+async function verifyWalletSection(storybook: Page, walletType: "btc" | "bbn") {
   const section = storybook.getByTestId(`${walletType}-wallet-section`);
   await expect(section).toBeVisible();
 
@@ -77,9 +69,4 @@ async function verifyWalletSection(storybook: FrameLocator, walletType: "btc" | 
   if (!address || !publicKey) {
     throw new Error("Address or public key not found");
   }
-
-  return {
-    address: addressText.split("Address: ")[1],
-    publicKey: pubkeyText.split("Public Key: ")[1],
-  };
 }

--- a/packages/babylon-wallet-connector/tests/e2e/specs/mnemonic.spec.ts
+++ b/packages/babylon-wallet-connector/tests/e2e/specs/mnemonic.spec.ts
@@ -1,6 +1,6 @@
 import { test } from "../fixtures/setupExtensions";
 
-test("Setup OKX and Keplr wallets", async ({ setupExtensions }) => {
+test("Setup OKX and Keplr wallets", async ({ setupExtensions, baseURL }) => {
   // Initialize browser context with required wallet extensions
   const { context } = await setupExtensions(["OKX", "KEPLR"]);
 
@@ -9,7 +9,7 @@ test("Setup OKX and Keplr wallets", async ({ setupExtensions }) => {
 
   // Navigate to root URL
   // This step could be updated to navigate to a specific testing page
-  await page.goto("/");
+  await page.goto(new URL("/", baseURL).href);
 
   // If anything goes wrong, the test will fail
 });

--- a/scripts/__tests__/visual-diff.test.mjs
+++ b/scripts/__tests__/visual-diff.test.mjs
@@ -117,55 +117,60 @@ test("compareOne reports a size change on its own terms", async () => {
   assert.equal(result.changedPixels, null);
 });
 
-// The silent-green path this manifest exists to close. Both sides of the
-// comparison run the same stashed harness against the same committed fixture,
-// so a capture failure takes the same screens out on BOTH sides - and a screen
-// absent from both never enters the union the diff iterates, so it can never
-// be reported as REMOVED. Without an expected set the run says "no visual
-// changes" for screens nobody photographed.
-test("a screen in the manifest but absent from both sides is reported as never captured", async () => {
-  const dir = await scratch();
-  await writePng(path.join(dir, "baseline", "kept.png"), 64, 64);
-  await writePng(path.join(dir, "candidate", "kept.png"), 64, 64);
-  for (const side of ["baseline", "candidate"]) {
-    await fs.writeFile(
-      path.join(dir, side, "expected-screens.txt"),
-      "kept.png\nwithheld.png\n",
+// A required screen can be missing from one side or both sides.
+// It must remain incomplete evidence even when the other side captured it.
+for (const capturedSide of [null, 'baseline', 'candidate']) {
+  test(`a required screen is incomplete when captured on ${capturedSide ?? 'neither side'}`, async () => {
+    const dir = await scratch();
+    await writePng(path.join(dir, 'baseline', 'kept.png'), 64, 64);
+    await writePng(path.join(dir, 'candidate', 'kept.png'), 64, 64);
+    for (const side of ['baseline', 'candidate']) {
+      await fs.writeFile(
+        path.join(dir, side, 'expected-screens.txt'),
+        'kept.png\nwithheld.png\n',
+      );
+    }
+
+    if (capturedSide) {
+      await fs.copyFile(
+        path.join(dir, capturedSide, 'kept.png'),
+        path.join(dir, capturedSide, 'withheld.png'),
+      );
+    }
+
+    const script = path.join(import.meta.dirname, '..', 'visual-diff.mjs');
+    const run = spawnSync(
+      process.execPath,
+      [
+        script,
+        '--baseline',
+        path.join(dir, 'baseline'),
+        '--candidate',
+        path.join(dir, 'candidate'),
+        '--out',
+        path.join(dir, 'report'),
+        '--expected-baseline',
+        path.join(dir, 'baseline', 'expected-screens.txt'),
+        '--expected-candidate',
+        path.join(dir, 'candidate', 'expected-screens.txt'),
+        '--fail-on-change',
+        'true',
+      ],
+      { encoding: 'utf8' },
     );
-  }
 
-  const script = path.join(import.meta.dirname, "..", "visual-diff.mjs");
-  const run = spawnSync(
-    process.execPath,
-    [
-      script,
-      "--baseline",
-      path.join(dir, "baseline"),
-      "--candidate",
-      path.join(dir, "candidate"),
-      "--out",
-      path.join(dir, "report"),
-      "--expected-baseline",
-      path.join(dir, "baseline", "expected-screens.txt"),
-      "--expected-candidate",
-      path.join(dir, "candidate", "expected-screens.txt"),
-      "--fail-on-change",
-      "true",
-    ],
-    { encoding: "utf8" },
-  );
+    const summary = JSON.parse(
+      await fs.readFile(path.join(dir, 'report', 'summary.json'), 'utf8'),
+    );
 
-  const summary = JSON.parse(
-    await fs.readFile(path.join(dir, "report", "summary.json"), "utf8"),
-  );
-
-  // The comparison itself is clean - that is exactly the trap.
-  assert.equal(summary.changedCount, 0);
-  assert.deepEqual(summary.absentScreens, ["withheld.png"]);
-  assert.equal(summary.expectedCount, 2);
-  assert.match(run.stdout, /Never captured on either side \(1 of 2/);
-  assert.equal(run.status, 1);
-});
+    // The comparison itself is clean - that is exactly the trap.
+    assert.equal(summary.changedCount, 0);
+    assert.deepEqual(summary.absentScreens, ['withheld.png']);
+    assert.equal(summary.expectedCount, 2);
+    assert.match(run.stdout, /Not captured on one or both sides \(1 of 2/);
+    assert.equal(run.status, 1);
+  });
+}
 
 test("a capture with no manifest is reported as unknown rather than complete", async () => {
   const dir = await scratch();
@@ -197,5 +202,5 @@ test("a capture with no manifest is reported as unknown rather than complete", a
 
   assert.equal(summary.expectedCount, null);
   assert.deepEqual(summary.absentScreens, []);
-  assert.match(run.stdout, /No expected-screens manifest on either side/);
+  assert.match(run.stdout, /At least one expected-screens manifest is missing/);
 });

--- a/scripts/visual-diff.mjs
+++ b/scripts/visual-diff.mjs
@@ -239,8 +239,8 @@ function renderReport(results, meta) {
   <h1>Visual diff</h1>
   <p class="summary">
     candidate <code>${escapeHtml(meta.candidateRef)}</code> vs baseline <code>${escapeHtml(meta.baselineRef)}</code><br />
-    ${meta.changedCount} of ${meta.totalCount} screens changed.
-    ${interesting.length === 0 ? "Showing all screens because nothing changed." : ""}
+    ${meta.expectedCount === null || meta.absentScreens.length > 0 ? 'Incomplete capture. ' : ''}${meta.changedCount} of ${meta.totalCount} screens changed.
+    ${interesting.length === 0 ? 'Showing all screens because nothing changed.' : ''}
   </p>
   ${rows}
 </body>
@@ -294,30 +294,29 @@ async function main() {
   const candidateNames = await listPngs(candidateDir);
   const allNames = [...new Set([...baselineNames, ...candidateNames])].sort();
 
-  // A screen absent from BOTH sides is invisible to everything below: it is
-  // never constructed, so it can never be ADDED, REMOVED or CHANGED, and the
-  // run reports "no visual changes" for a comparison that never looked at it.
-  // Because both sides are photographed by the same stashed harness against
-  // the same committed fixture, that symmetric shortfall is the DEFAULT
-  // failure mode here, not the rare one - a stale recording or a drifted
-  // testid takes the same screens out on both sides.
-  //
-  // Kept in `meta` rather than pushed into `results` as a fifth status:
-  // `visual-embed.mjs` composes an image for every non-UNCHANGED result, and
-  // there is no PNG on either side to compose from.
+  // Check each capture against its own manifest. A required screen that was
+  // not captured is incomplete evidence, not an added or removed screen.
+  // Keep it outside results so the image report uses only valid captures.
   const expectedLists = [
     await readExpected(args.get("expected-baseline")),
     await readExpected(args.get("expected-candidate")),
-  ].filter((list) => list !== null);
-  const expected =
-    expectedLists.length === 0
-      ? null
-      : [...new Set(expectedLists.flat())].sort();
-  const absentScreens =
-    expected?.filter((name) => !allNames.includes(name)) ?? [];
+  ];
+  const expected = expectedLists.includes(null)
+    ? null
+    : [...new Set(expectedLists.flat())].sort();
+  const absentScreens = [
+    ...new Set(
+      expectedLists.flatMap((list, side) =>
+        (list ?? []).filter(
+          (name) =>
+            !(side === 0 ? baselineNames : candidateNames).includes(name),
+        ),
+      ),
+    ),
+  ].sort();
 
   const results = [];
-  for (const name of allNames) {
+  for (const name of allNames.filter((name) => !absentScreens.includes(name))) {
     const inBaseline = baselineNames.includes(name);
     const inCandidate = candidateNames.includes(name);
 
@@ -351,9 +350,7 @@ async function main() {
     candidateRef: args.get("candidate-ref") ?? "HEAD",
     totalCount: results.length,
     changedCount: changed.length,
-    // null means no manifest was found on either side. The workflow treats
-    // that as a shortfall too: it can only happen when the capture that ran
-    // was not the stashed harness, which is not a state to report clean.
+    // Both manifests are required to confirm that the capture is complete.
     expectedCount: expected === null ? null : expected.length,
     absentScreens,
   };
@@ -390,12 +387,12 @@ async function main() {
   // on stdout so the workflow's `tee` carries it into the report comment.
   if (expected === null) {
     process.stdout.write(
-      `No expected-screens manifest on either side - cannot tell whether ` +
+      `At least one expected-screens manifest is missing - cannot tell whether ` +
         `every screen was captured. This run is not a full comparison.\n`,
     );
   } else if (absentScreens.length > 0) {
     process.stdout.write(
-      `Never captured on either side (${absentScreens.length} of ` +
+      `Not captured on one or both sides (${absentScreens.length} of ` +
         `${expected.length} expected screens):\n` +
         `${absentScreens.map((name) => `  ${name}`).join("\n")}\n`,
     );

--- a/services/simple-staking/e2e/constants/staking.ts
+++ b/services/simple-staking/e2e/constants/staking.ts
@@ -2,5 +2,3 @@ import { satoshiToBtc } from "@/ui/common/utils/btc";
 
 export const STAKING_AMOUNT_SAT = 50000;
 export const STAKING_AMOUNT_BTC = satoshiToBtc(STAKING_AMOUNT_SAT);
-export const STAKING_TX_HASH =
-  "47af61d63bcc6c513561d9a1198d082052cc07a81f50c6f130653f0a6ecc0fc1";

--- a/services/simple-staking/e2e/constants/staking.ts
+++ b/services/simple-staking/e2e/constants/staking.ts
@@ -1,4 +1,4 @@
-import { satoshiToBtc } from "@/ui/legacy/utils/btc";
+import { satoshiToBtc } from "@/ui/common/utils/btc";
 
 export const STAKING_AMOUNT_SAT = 50000;
 export const STAKING_AMOUNT_BTC = satoshiToBtc(STAKING_AMOUNT_SAT);

--- a/services/simple-staking/e2e/fixtures/wallet_connect.selectors.ts
+++ b/services/simple-staking/e2e/fixtures/wallet_connect.selectors.ts
@@ -2,24 +2,14 @@ export const CONNECT_BUTTON_SELECTOR =
   'button[data-testid="connect-wallets-button"]:enabled';
 
 export const DIALOG_SELECTORS = {
-  TERMS_DIALOG_HEADER: '[data-testid="dialog-header"]',
-  ANY_DIALOG: '[data-testid="dialog"], [role="dialog"]',
   ERROR_DIALOG: '[data-testid="error-dialog"]',
   ERROR_DIALOG_DONE_BUTTON:
     '[data-testid="error-dialog"] [data-testid="error-continue-button"]',
 };
 
 export const BUTTON_SELECTORS = {
-  NEXT: '[data-testid="terms-next-button"]',
-  ACCEPT: 'button:has-text("Accept")',
-  CONTINUE: '[data-testid="error-continue-button"]',
-  OK: 'button:has-text("OK")',
-  SAVE: 'button:has-text("Save")',
   DONE: '[data-testid="chains-connect-button"]',
-  CONTINUE_ANYWAY: '[data-testid="error-continue-button"]',
 };
-
-export const CHECKBOX_SELECTOR = '[data-testid="checkbox-input"]';
 
 export const WALLET_SELECTORS = {
   BITCOIN: '[data-testid="select-bitcoin-wallet-button"]',

--- a/services/simple-staking/e2e/fixtures/wallet_connect.selectors.ts
+++ b/services/simple-staking/e2e/fixtures/wallet_connect.selectors.ts
@@ -15,7 +15,7 @@ export const BUTTON_SELECTORS = {
   CONTINUE: '[data-testid="error-continue-button"]',
   OK: 'button:has-text("OK")',
   SAVE: 'button:has-text("Save")',
-  DONE: '[data-testid="chains-done-button"]',
+  DONE: '[data-testid="chains-connect-button"]',
   CONTINUE_ANYWAY: '[data-testid="error-continue-button"]',
 };
 

--- a/services/simple-staking/e2e/fixtures/wallet_connect.ts
+++ b/services/simple-staking/e2e/fixtures/wallet_connect.ts
@@ -1,8 +1,13 @@
 import type { Page } from "@playwright/test";
 
-import { injectBBNWallet, injectBTCWallet } from "../mocks/blockchain";
+import {
+  injectBBNWallet,
+  injectBTCWallet,
+  type TestWalletOptions,
+} from "../mocks/blockchain";
 import { mockVerifyBTCAddress } from "../mocks/handlers";
 
+import { PageNavigationActions } from "./page_navigation";
 import {
   BUTTON_SELECTORS,
   CHECKBOX_SELECTOR,
@@ -210,10 +215,11 @@ export class WalletConnectActions {
     }
   }
 
-  async setupWalletConnection() {
+  async setupWalletConnection(options?: TestWalletOptions) {
+    await new PageNavigationActions(this.page).waitForPageLoad();
     await this.setupMocks();
-    await injectBTCWallet(this.page);
-    await injectBBNWallet(this.page);
+    await injectBTCWallet(this.page, "OKX", options);
+    await injectBBNWallet(this.page, "Leap", options);
     await this.clickConnectButton();
     await this.acceptTermsAndConditions();
     await this.clickInjectableWalletButton();

--- a/services/simple-staking/e2e/fixtures/wallet_connect.ts
+++ b/services/simple-staking/e2e/fixtures/wallet_connect.ts
@@ -10,7 +10,6 @@ import { mockVerifyBTCAddress } from "../mocks/handlers";
 import { PageNavigationActions } from "./page_navigation";
 import {
   BUTTON_SELECTORS,
-  CHECKBOX_SELECTOR,
   CONNECT_BUTTON_SELECTOR,
   DIALOG_SELECTORS,
   WALLET_SELECTORS,
@@ -47,64 +46,6 @@ export class WalletConnectActions {
     }
   }
 
-  async acceptTermsAndConditions() {
-    const termsDialogVisible = await this.page
-      .locator(DIALOG_SELECTORS.TERMS_DIALOG_HEADER)
-      .isVisible()
-      .catch(() => false);
-
-    if (!termsDialogVisible) {
-      await this.handleAlternativeDialog();
-      return;
-    }
-
-    const checkboxes = this.page.locator(CHECKBOX_SELECTOR);
-    const count = await checkboxes.count();
-
-    for (let i = 0; i < count; i++) {
-      await checkboxes.nth(i).click();
-    }
-
-    await this.page.locator(BUTTON_SELECTORS.NEXT).click();
-  }
-
-  private async handleAlternativeDialog() {
-    const anyDialog = await this.page
-      .locator(DIALOG_SELECTORS.ANY_DIALOG)
-      .first()
-      .isVisible()
-      .catch(() => false);
-
-    if (!anyDialog) return;
-
-    const buttonSelectorsList = [
-      BUTTON_SELECTORS.NEXT,
-      BUTTON_SELECTORS.ACCEPT,
-      BUTTON_SELECTORS.CONTINUE,
-      BUTTON_SELECTORS.OK,
-      BUTTON_SELECTORS.CONTINUE_ANYWAY,
-    ];
-
-    for (const selector of buttonSelectorsList) {
-      const button = this.page.locator(selector).first();
-      if (await button.isVisible().catch(() => false)) {
-        await button
-          .click()
-          .catch((e) => console.error(`Error clicking ${selector}:`, e));
-        return;
-      }
-    }
-
-    const anyButton = this.page
-      .locator(`${DIALOG_SELECTORS.ANY_DIALOG} button`)
-      .first();
-    if (await anyButton.isVisible().catch(() => false)) {
-      await anyButton
-        .click()
-        .catch((e) => console.error("Error clicking dialog button:", e));
-    }
-  }
-
   async clickInjectableWalletButton() {
     const bitcoinWalletButton = this.page
       .locator(WALLET_SELECTORS.BITCOIN)
@@ -112,43 +53,6 @@ export class WalletConnectActions {
 
     await bitcoinWalletButton.waitFor({ state: "visible", timeout: 10_000 });
     await bitcoinWalletButton.click();
-  }
-
-  async clickConnectWalletButton() {
-    const saveButton = this.page.locator(BUTTON_SELECTORS.SAVE);
-    const continueAnywayButton = this.page.locator(
-      BUTTON_SELECTORS.CONTINUE_ANYWAY,
-    );
-
-    await Promise.race([
-      saveButton
-        .waitFor({ state: "visible", timeout: 5000 })
-        .then(() => "save")
-        .catch(() => 1),
-      continueAnywayButton
-        .waitFor({ state: "visible", timeout: 5000 })
-        .then(() => "continue")
-        .catch(() => 2),
-    ]);
-
-    if (await continueAnywayButton.isVisible().catch(() => false)) {
-      await continueAnywayButton.click();
-      await saveButton.waitFor({ state: "visible", timeout: 5000 });
-      await saveButton.click();
-      await this.page
-        .locator(DIALOG_SELECTORS.ANY_DIALOG)
-        .first()
-        .waitFor({ state: "hidden", timeout: 5000 })
-        .catch(() => {});
-      return;
-    }
-
-    if (await saveButton.isVisible().catch(() => false)) {
-      await saveButton.click();
-      return;
-    }
-
-    await this.handleAlternativeDialog();
   }
 
   async clickOKXWalletButton() {
@@ -160,7 +64,9 @@ export class WalletConnectActions {
       }
     }
 
-    await this.clickConnectWalletButton();
+    await this.page
+      .locator(WALLET_SELECTORS.BABYLON[0])
+      .waitFor({ state: "visible" });
   }
 
   async clickBabylonChainWalletButton() {
@@ -221,7 +127,6 @@ export class WalletConnectActions {
     await injectBTCWallet(this.page, "OKX", options);
     await injectBBNWallet(this.page, "Leap", options);
     await this.clickConnectButton();
-    await this.acceptTermsAndConditions();
     await this.clickInjectableWalletButton();
     await this.clickOKXWalletButton();
     await this.handleVerificationErrorIfPresent();

--- a/services/simple-staking/e2e/fixtures/wallet_connect.ts
+++ b/services/simple-staking/e2e/fixtures/wallet_connect.ts
@@ -124,8 +124,8 @@ export class WalletConnectActions {
   async setupWalletConnection(options?: TestWalletOptions) {
     await new PageNavigationActions(this.page).waitForPageLoad();
     await this.setupMocks();
-    await injectBTCWallet(this.page, "OKX", options);
     await injectBBNWallet(this.page, "Leap", options);
+    await injectBTCWallet(this.page, "OKX", options);
     await this.clickConnectButton();
     await this.clickInjectableWalletButton();
     await this.clickOKXWalletButton();

--- a/services/simple-staking/e2e/mock/tx/unbonding.ts
+++ b/services/simple-staking/e2e/mock/tx/unbonding.ts
@@ -1,4 +1,4 @@
-import { DelegationState } from "@/ui/legacy/types/delegations";
+import { DelegationState } from "@/ui/common/types/delegations";
 
 export const activeTX = {
   data: [

--- a/services/simple-staking/e2e/mock/tx/withdrawing.ts
+++ b/services/simple-staking/e2e/mock/tx/withdrawing.ts
@@ -1,32 +1,72 @@
-import { DelegationState } from "@/ui/legacy/types/delegations";
+import { initBTCCurve, Staking } from "@babylonlabs-io/btc-staking-ts";
+import * as ecc from "@bitcoin-js/tiny-secp256k1-asmjs";
+import { networks, payments } from "bitcoinjs-lib";
+
+import { DelegationState } from "@/ui/common/types/delegations";
+
+import { mockNetworkInfo } from "../../mocks/handlers/constants";
+import { activeTX } from "./unbonding";
+
+initBTCCurve();
+export const withdrawalPrivateKeyHex = "4".padStart(64, "0");
+const publicKey = Buffer.from(
+  ecc.pointFromScalar(Buffer.from(withdrawalPrivateKeyHex, "hex"), true)!,
+);
+export const withdrawalDestination = payments.p2wpkh({ pubkey: publicKey });
+const params = mockNetworkInfo.data.params.bbn[0];
+const original = activeTX.data[0];
+const staking = new Staking(
+  networks.bitcoin,
+  {
+    address: withdrawalDestination.address!,
+    publicKeyNoCoordHex: publicKey.subarray(1).toString("hex"),
+  },
+  {
+    covenantNoCoordPks: params.covenant_pks.map((pk) => pk.slice(2)),
+    covenantQuorum: params.covenant_quorum,
+    unbondingTime: params.unbonding_time_blocks,
+    unbondingFeeSat: params.unbonding_fee_sat,
+    minStakingAmountSat: params.min_staking_value_sat,
+    maxStakingAmountSat: params.max_staking_value_sat,
+    minStakingTimeBlocks: params.min_staking_time_blocks,
+    maxStakingTimeBlocks: params.max_staking_time_blocks,
+  },
+  [original.finality_provider_pk_hex],
+  original.staking_tx.timelock,
+);
+// These input transactions represent mined outputs in the local test.
+const { transaction: stakingTx } = staking.createStakingTransaction(
+  params.min_staking_value_sat,
+  [
+    {
+      txid: "11".repeat(32),
+      vout: 0,
+      value: params.max_staking_value_sat,
+      scriptPubKey: withdrawalDestination.output!.toString("hex"),
+    },
+  ],
+  1,
+);
+export const { transaction: unbondingTransaction } =
+  staking.createUnbondingTransaction(stakingTx);
+export const { fee: withdrawalFee } =
+  staking.createWithdrawEarlyUnbondedTransaction(unbondingTransaction, 1);
 
 export const unbondedTX = {
   data: [
     {
-      staking_tx_hash_hex:
-        "1547205e6e32aaeb4eba21788891f4f323ffee9fd824461300f71292fe33f67e",
-      staker_pk_hex:
-        "4c6e2954c75bcb53aa13b7cd5d8bcdb4c9a4dd0784d68b115bd4408813b45608",
-      finality_provider_pk_hex:
-        "094f5861be4128861d69ea4b66a5f974943f100f55400bf26f5cce124b4c9af7",
+      ...original,
+      staking_tx_hash_hex: stakingTx.getId(),
+      staker_pk_hex: publicKey.subarray(1).toString("hex"),
+      staking_value: params.min_staking_value_sat,
       state: DelegationState.UNBONDED,
-      staking_value: 50000,
-      staking_tx: {
-        tx_hex:
-          "02000000000102b497f79965a97f792dc604791cb97d76567660fdcff8d519cf993175de2880c00000000000fdffffff092b154d5edd66be91057390140898468a48df393ea52e52f6fe82fc895141ec0000000000fdffffff0350c3000000000000225120cf7c40c6fb1395430816dbb5e1ba9f172ef25573a3b609efa1723559cd82d5590000000000000000496a4762626234004c6e2954c75bcb53aa13b7cd5d8bcdb4c9a4dd0784d68b115bd4408813b45608094f5861be4128861d69ea4b66a5f974943f100f55400bf26f5cce124b4c9af70096cdb80000000000002251203a24123d844b4115ac87811ec3e9acfe8a307307a4d480f04bffcae35cb80f470140aefb4107e1a224ec95f5ef3482e594371d575b869b6ea95f985fd39d02f821549acd28c7c4a80e4d2af66e6d24f06f3e4be4e8f1e6778559c25ed4eca145fa960140242411eccc7853685dd04e7b2eb0ad337e6e8c0039026114cb2500566aa1e6d4288121ccec9535aaee697d0b4f0fd2588838d4d3a0055165aeeb59883fdd1716340e0d00",
-        output_index: 0,
-        start_timestamp: "2024-09-12T16:09:01Z",
-        start_height: 861031,
-        timelock: 150,
-      },
-      is_overflow: false,
+      staking_tx: { ...original.staking_tx, tx_hex: stakingTx.toHex() },
       unbonding_tx: {
-        tx_hex:
-          "020000000001017ef633fe9212f700134624d89feeff23f3f491887821ba4eebaa326e5e2047150000000000ffffffff019065000000000000225120f33fe22ce55a0d4f272d54d84ceb2d8b383784bd5bdad12cfc6e6ed38336148f0600406e6c2d481d4c77bf841c98e32b2dfcc86bb3267564752e03a34e67fdf70a9c2a7eddc15943f938b915518405dc6c80807971883f5206026ca609254ae401310040f53aa9e92f4d93ec92da58c6c7a379f18435f7ac877eda33105300115e942a403ae384ccfade0b690acd3bc4b6f2d946f1ef8a370f0d74fca346915dd2090caf40c73ffb9088349cb94b4d5a5f293394627d190437f47dc2275a1c67afd8f1200d594f8d86f4dd6bf248bd2f71f337eac094feafebe78ea68279c3e22609cf5b588a204c6e2954c75bcb53aa13b7cd5d8bcdb4c9a4dd0784d68b115bd4408813b45608ad206f13a6d104446520d1757caec13eaf6fbcf29f488c31e0107e7351d4994cd068ac20a10a06bb3bae360db3aef0326413b55b9e46bf20b9a96fc8a806a99e644fe277ba20a5e21514682b87e37fb5d3c9862055041d1e6f4cc4f3034ceaf3d90f86b230a6ba529c61c050929b74c1a04954b78b4b6035e97a5e078a5a0f28ec96d547bfee9ace803ac08cbd88238189c54c871cf32592ee6a4168ace71be7fa421fe0d115170c55fd872e3fc575e9845aca1bad807c7c409836824e21b47fcdc5ba259c787c17ff5fca00000000",
+        tx_hex: unbondingTransaction.toHex(),
         output_index: 0,
-        start_timestamp: "2024-09-12T16:32:26Z",
-        start_height: 861033,
-        timelock: 5,
+        start_timestamp: original.staking_tx.start_timestamp,
+        start_height: original.staking_tx.start_height,
+        timelock: params.unbonding_time_blocks,
       },
     },
   ],

--- a/services/simple-staking/e2e/mock/tx/withdrawing.ts
+++ b/services/simple-staking/e2e/mock/tx/withdrawing.ts
@@ -34,23 +34,23 @@ const staking = new Staking(
   [original.finality_provider_pk_hex],
   original.staking_tx.timelock,
 );
-// These input transactions represent mined outputs in the local test.
+const fundingOutpoint = { txid: "11".repeat(32), vout: 0 };
+const feeRate = 1; // Satoshis per virtual byte.
 const { transaction: stakingTx } = staking.createStakingTransaction(
   params.min_staking_value_sat,
   [
     {
-      txid: "11".repeat(32),
-      vout: 0,
+      ...fundingOutpoint,
       value: params.max_staking_value_sat,
       scriptPubKey: withdrawalDestination.output!.toString("hex"),
     },
   ],
-  1,
+  feeRate,
 );
 export const { transaction: unbondingTransaction } =
   staking.createUnbondingTransaction(stakingTx);
 export const { fee: withdrawalFee } =
-  staking.createWithdrawEarlyUnbondedTransaction(unbondingTransaction, 1);
+  staking.createWithdrawEarlyUnbondedTransaction(unbondingTransaction, feeRate);
 
 export const unbondedTX = {
   data: [

--- a/services/simple-staking/e2e/mocks/blockchain/bbnQueries.ts
+++ b/services/simple-staking/e2e/mocks/blockchain/bbnQueries.ts
@@ -1,4 +1,7 @@
-import { incentivequery } from "@babylonlabs-io/babylon-proto-ts";
+import {
+  incentivequery,
+  btclightclientquery,
+} from "@babylonlabs-io/babylon-proto-ts";
 import type { Page } from "@playwright/test";
 import { QueryBalanceResponse } from "cosmjs-types/cosmos/bank/v1beta1/query.js";
 
@@ -9,6 +12,100 @@ export const injectBBNQueries = async (
   rewardAmount: string = defaultData.bbnQueries.rewardAmount,
   mockData = defaultData,
 ) => {
+  await page.route("**/*", async (route, request) => {
+    const url = new URL(request.url());
+    // These fixtures do not include co-staking chain state.
+    if (
+      url.pathname === "/babylon/costaking/v1/params" ||
+      url.pathname.startsWith("/cosmos/staking/v1beta1/delegations/")
+    )
+      return route.abort();
+    if (["fetch", "xhr"].includes(request.resourceType())) {
+      await route.abort();
+      throw new Error(
+        `Unrouted ${request.method()} ${url.pathname}${url.search}`,
+      );
+    }
+    return route.continue();
+  });
+
+  await page.route("**/fees/recommended", (route) =>
+    route.fulfill({ json: mockData.btcWallet.networkFees }),
+  );
+
+  // Recorded from https://staking-api.testnet.babylonlabs.io/v2/apr on 2026-09-09.
+  // Keys are satoshis_staked. Each response has ubbn_staked=0.
+  const recordedAPRs = new Map([
+    [
+      "0",
+      {
+        data: {
+          current: {
+            btc_staking_apr: 0.11449292888869063,
+            baby_staking_apr: 1.336087451833286,
+            co_staking_apr: 0,
+            total_apr: 0.11449292888869063,
+          },
+          additional_baby_needed_for_boost: 0,
+          boost: {
+            btc_staking_apr: 0.11449292888869063,
+            baby_staking_apr: 1.336087451833286,
+            co_staking_apr: 0,
+            total_apr: 0.11449292888869063,
+          },
+        },
+      },
+    ],
+    [
+      "50000",
+      {
+        data: {
+          current: {
+            btc_staking_apr: 0.11449292888869063,
+            baby_staking_apr: 1.336087918077096,
+            co_staking_apr: 0,
+            total_apr: 0.11449292888869063,
+          },
+          additional_baby_needed_for_boost: 10,
+          boost: {
+            btc_staking_apr: 0.11449292888869063,
+            baby_staking_apr: 1.336087918077096,
+            co_staking_apr: 0.3275781446943151,
+            total_apr: 0.44207107358300574,
+          },
+        },
+      },
+    ],
+    [
+      "9876543",
+      {
+        data: {
+          current: {
+            btc_staking_apr: 0.11449292888869063,
+            baby_staking_apr: 1.3360881681088284,
+            co_staking_apr: 0,
+            total_apr: 0.11449292888869063,
+          },
+          additional_baby_needed_for_boost: 1975.3086,
+          boost: {
+            btc_staking_apr: 0.11449292888869063,
+            baby_staking_apr: 1.3360881681088284,
+            co_staking_apr: 0.3272640084086461,
+            total_apr: 0.4417569372973367,
+          },
+        },
+      },
+    ],
+  ]);
+  await page.route("**/v2/apr?*", (route) => {
+    const params = new URL(route.request().url()).searchParams;
+    const response =
+      params.get("ubbn_staked") === "0"
+        ? recordedAPRs.get(params.get("satoshis_staked") ?? "")
+        : undefined;
+    return response ? route.fulfill({ json: response }) : route.fallback();
+  });
+
   const rewardGaugeProto = incentivequery.QueryRewardGaugesResponse.fromPartial(
     {
       rewardGauges: {
@@ -155,7 +252,7 @@ export const injectBBNQueries = async (
     }
 
     try {
-      await route.continue();
+      await route.fallback();
     } catch (error) {
       console.error(
         "Failed to continue route, it may have been handled already:",
@@ -166,7 +263,7 @@ export const injectBBNQueries = async (
 
   await page.route("**", async (route, request) => {
     if (request.method() !== "POST" && request.method() !== "OPTIONS") {
-      return route.continue();
+      return route.fallback();
     }
 
     // For OPTIONS preflight, respond with basic CORS headers and 200
@@ -190,7 +287,7 @@ export const injectBBNQueries = async (
       parsed = postData ? JSON.parse(postData) : null;
     } catch (err) {
       console.error("Failed to parse POST data:", err);
-      return route.continue();
+      return route.fallback();
     }
 
     if (parsed && parsed.method === "status") {
@@ -240,31 +337,34 @@ export const injectBBNQueries = async (
       });
     }
 
-    if (!parsed) {
-      return route.fulfill({
-        status: 200,
-        contentType: "application/json",
-        body: JSON.stringify({ result: {} }),
-      });
-    }
-
-    if (parsed.method && !["abci_query", "status"].includes(parsed.method)) {
-      return route.fulfill({
-        status: 200,
-        contentType: "application/json",
-        body: JSON.stringify({
-          jsonrpc: "2.0",
-          id: parsed.id ?? -1,
-          result: {},
-        }),
-      });
-    }
+    if (!parsed || !["abci_query", "status"].includes(parsed.method))
+      return route.fallback();
 
     if (parsed.method !== "abci_query") {
-      return route.continue();
+      return route.fallback();
     }
 
     const pathParam = parsed.params?.path || "";
+    if (pathParam === "/babylon.btclightclient.v1.Query/Tip") {
+      const bytes = btclightclientquery.QueryTipResponse.encode(
+        btclightclientquery.QueryTipResponse.fromPartial({
+          header: { height: mockData.btcWallet.tipHeight },
+        }),
+      ).finish();
+      return route.fulfill({
+        json: {
+          jsonrpc: "2.0",
+          id: parsed.id,
+          result: {
+            response: {
+              code: 0,
+              value: Buffer.from(bytes).toString("base64"),
+              height: "1",
+            },
+          },
+        },
+      });
+    }
 
     const pathHandlers = {
       "babylon.incentive": async () => {
@@ -342,7 +442,7 @@ export const injectBBNQueries = async (
     }
 
     try {
-      await route.continue();
+      await route.fallback();
     } catch (error) {}
   });
 
@@ -691,7 +791,7 @@ export const injectBBNQueries = async (
 
   await page.route("**/api/address/*", async (route) => {
     if (route.request().url().includes("/utxo")) {
-      return route.continue();
+      return route.fallback();
     }
     await route.fulfill({
       status: 200,

--- a/services/simple-staking/e2e/mocks/blockchain/bbnQueries.ts
+++ b/services/simple-staking/e2e/mocks/blockchain/bbnQueries.ts
@@ -2,11 +2,12 @@ import { incentivequery } from "@babylonlabs-io/babylon-proto-ts";
 import type { Page } from "@playwright/test";
 import { QueryBalanceResponse } from "cosmjs-types/cosmos/bank/v1beta1/query.js";
 
-import mockData from "./constants";
+import defaultData from "./constants";
 
 export const injectBBNQueries = async (
   page: Page,
-  rewardAmount: string = mockData.bbnQueries.rewardAmount,
+  rewardAmount: string = defaultData.bbnQueries.rewardAmount,
+  mockData = defaultData,
 ) => {
   const rewardGaugeProto = incentivequery.QueryRewardGaugesResponse.fromPartial(
     {

--- a/services/simple-staking/e2e/mocks/blockchain/bbnQueries.ts
+++ b/services/simple-staking/e2e/mocks/blockchain/bbnQueries.ts
@@ -372,7 +372,7 @@ export const injectBBNQueries = async (
           pathParam.includes("Query/RewardGauges") ||
           pathParam.includes("v1.Query/RewardGauges")
         ) {
-          return route.fulfill({
+          await route.fulfill({
             status: 200,
             contentType: "application/json",
             body: JSON.stringify({
@@ -393,6 +393,7 @@ export const injectBBNQueries = async (
               },
             }),
           });
+          return true;
         }
         return false;
       },
@@ -441,9 +442,7 @@ export const injectBBNQueries = async (
       }
     }
 
-    try {
-      await route.fallback();
-    } catch (error) {}
+    await route.fallback();
   });
 
   await page.route("**/v2/delegations*", async (route) => {

--- a/services/simple-staking/e2e/mocks/blockchain/bbnWallet.ts
+++ b/services/simple-staking/e2e/mocks/blockchain/bbnWallet.ts
@@ -1,4 +1,6 @@
 import type { Page } from "@playwright/test";
+import { DirectSecp256k1Wallet } from "@cosmjs/proto-signing";
+import type { TestWalletOptions } from "./btcWallet";
 
 import mockData, { type MockData } from "./constants";
 import type { BBNWalletType } from "./types";
@@ -7,16 +9,53 @@ import { verifyBBNWalletInjected } from "./verification";
 type DataType = {
   walletType: BBNWalletType;
   mockData: MockData;
+  localSigner: boolean;
 };
 
 export const injectBBNWallet = async (
   page: Page,
   walletType: BBNWalletType = "Leap",
+  { data = mockData, privateKeyHex }: TestWalletOptions = {},
 ) => {
+  if (privateKeyHex) {
+    const signer = await DirectSecp256k1Wallet.fromKey(
+      Buffer.from(privateKeyHex, "hex"),
+      "bbn",
+    );
+    const [account] = await signer.getAccounts();
+    data = {
+      ...data,
+      bbnWallet: {
+        ...data.bbnWallet,
+        walletAddress: account.address,
+        pubkeyArray: Array.from(account.pubkey),
+      },
+    };
+    await page.exposeFunction(
+      "e2eSignDirect",
+      async (address: string, doc: any) => {
+        const result = await signer.signDirect(address, {
+          ...doc,
+          bodyBytes: Uint8Array.from(doc.bodyBytes),
+          authInfoBytes: Uint8Array.from(doc.authInfoBytes),
+          accountNumber: BigInt(doc.accountNumber),
+        });
+        return {
+          ...result,
+          signed: {
+            ...result.signed,
+            bodyBytes: Array.from(result.signed.bodyBytes),
+            authInfoBytes: Array.from(result.signed.authInfoBytes),
+            accountNumber: result.signed.accountNumber.toString(),
+          },
+        };
+      },
+    );
+  }
   try {
     await page.evaluate(
       (data: DataType) => {
-        const { walletType, mockData } = data;
+        const { walletType, mockData, localSigner } = data;
         const bbnData = mockData.bbnWallet;
 
         const bbnWallet = {
@@ -34,17 +73,26 @@ export const injectBBNWallet = async (
                 pubkey: new Uint8Array(bbnData.pubkeyArray),
               },
             ],
-            signDirect: async () => ({
-              signed: {
-                bodyBytes: new Uint8Array([]),
-                authInfoBytes: new Uint8Array([]),
-                chainId: "",
-                accountNumber: 0,
-              },
-              signature: {
-                signature: bbnData.signature,
-              },
-            }),
+            signDirect: async (address: string, doc: any) => {
+              if (localSigner) {
+                const result = await (window as any).e2eSignDirect(address, {
+                  ...doc,
+                  bodyBytes: Array.from(doc.bodyBytes),
+                  authInfoBytes: Array.from(doc.authInfoBytes),
+                  accountNumber: doc.accountNumber.toString(),
+                });
+                return {
+                  ...result,
+                  signed: {
+                    ...result.signed,
+                    bodyBytes: Uint8Array.from(result.signed.bodyBytes),
+                    authInfoBytes: Uint8Array.from(result.signed.authInfoBytes),
+                    accountNumber: BigInt(result.signed.accountNumber),
+                  },
+                };
+              }
+              throw new Error("No test signer configured");
+            },
           }),
           getOfflineSignerAuto: async () => bbnWallet.getOfflineSigner(),
           getAddress: async () => bbnData.walletAddress,
@@ -72,17 +120,7 @@ export const injectBBNWallet = async (
                 bech32Address: bbnData.walletAddress,
               };
             },
-            signDirect: async () => ({
-              signed: {
-                bodyBytes: new Uint8Array([]),
-                authInfoBytes: new Uint8Array([]),
-                chainId: "",
-                accountNumber: 0,
-              },
-              signature: {
-                signature: bbnData.signature,
-              },
-            }),
+            signDirect: bbnWallet.getOfflineSigner().signDirect,
           };
         } else if (walletType === "Leap") {
           // @ts-ignore - leap is defined in the window for the test
@@ -115,7 +153,7 @@ export const injectBBNWallet = async (
           };
         }
       },
-      { walletType, mockData },
+      { walletType, mockData: data, localSigner: Boolean(privateKeyHex) },
     );
 
     // Verify BBN wallet was properly injected

--- a/services/simple-staking/e2e/mocks/blockchain/bbnWallet.ts
+++ b/services/simple-staking/e2e/mocks/blockchain/bbnWallet.ts
@@ -1,5 +1,9 @@
 import type { Page } from "@playwright/test";
-import { DirectSecp256k1Wallet } from "@cosmjs/proto-signing";
+import {
+  DirectSecp256k1Wallet,
+  type DirectSignResponse,
+} from "@cosmjs/proto-signing";
+import type { SerializedSignDoc } from "../../types";
 import type { TestWalletOptions } from "./btcWallet";
 
 import mockData, { type MockData } from "./constants";
@@ -33,7 +37,7 @@ export const injectBBNWallet = async (
     };
     await page.exposeFunction(
       "e2eSignDirect",
-      async (address: string, doc: any) => {
+      async (address: string, doc: SerializedSignDoc) => {
         const result = await signer.signDirect(address, {
           ...doc,
           bodyBytes: Uint8Array.from(doc.bodyBytes),
@@ -73,9 +77,12 @@ export const injectBBNWallet = async (
                 pubkey: new Uint8Array(bbnData.pubkeyArray),
               },
             ],
-            signDirect: async (address: string, doc: any) => {
+            signDirect: async (
+              address: string,
+              doc: DirectSignResponse["signed"],
+            ): Promise<DirectSignResponse> => {
               if (localSigner) {
-                const result = await (window as any).e2eSignDirect(address, {
+                const result = await window.e2eSignDirect(address, {
                   ...doc,
                   bodyBytes: Array.from(doc.bodyBytes),
                   authInfoBytes: Array.from(doc.authInfoBytes),

--- a/services/simple-staking/e2e/mocks/blockchain/btcWallet.ts
+++ b/services/simple-staking/e2e/mocks/blockchain/btcWallet.ts
@@ -112,6 +112,7 @@ export const injectBTCWallet = async (
         const walletStrategies: Record<string, () => void> = {
           OKX: () => {
             (window as any).okxwallet = {
+              keplr: (window as Window & { leap?: unknown }).leap,
               bitcoin: {
                 ...btcWallet,
                 isOKXWallet: true,

--- a/services/simple-staking/e2e/mocks/blockchain/btcWallet.ts
+++ b/services/simple-staking/e2e/mocks/blockchain/btcWallet.ts
@@ -182,7 +182,7 @@ export const injectBTCWallet = async (
                 }
                 throw new Error(`Chain not supported: ${chain}`);
               },
-              request: async (params: { method: string; params?: any }) => {
+              request: async (params: { method: string; params?: unknown }) => {
                 const { method, params: methodParams } = params;
 
                 switch (method) {
@@ -198,7 +198,14 @@ export const injectBTCWallet = async (
                   case "btc_getBalance":
                     return btcData.balance;
                   case "btc_signPsbt":
-                    return btcWallet.signPsbt(methodParams?.psbt);
+                    if (
+                      typeof methodParams !== "object" ||
+                      methodParams === null ||
+                      !("psbt" in methodParams) ||
+                      typeof methodParams.psbt !== "string"
+                    )
+                      throw new Error("Invalid test signing request");
+                    return btcWallet.signPsbt(methodParams.psbt);
                   default:
                     return null;
                 }

--- a/services/simple-staking/e2e/mocks/blockchain/btcWallet.ts
+++ b/services/simple-staking/e2e/mocks/blockchain/btcWallet.ts
@@ -94,12 +94,12 @@ export const injectBTCWallet = async (
           getInscriptions: () => [],
           signPsbt: (_psbtHex: string) => {
             if (!localSigner) throw new Error("No test signer configured");
-            return (window as any).e2eSignPsbt(_psbtHex);
+            return window.e2eSignPsbt(_psbtHex);
           },
           ...(localSigner
             ? {
                 signMessage: (message: string, type: string) =>
-                  (window as any).e2eSignMessage(message, type),
+                  window.e2eSignMessage(message, type),
               }
             : {}),
           pushTx: (_txHex: string) => {

--- a/services/simple-staking/e2e/mocks/blockchain/btcWallet.ts
+++ b/services/simple-staking/e2e/mocks/blockchain/btcWallet.ts
@@ -1,22 +1,78 @@
 import type { Page } from "@playwright/test";
+import * as ecc from "@bitcoin-js/tiny-secp256k1-asmjs";
+import { initEccLib, networks, payments, Psbt } from "bitcoinjs-lib";
+import { ECPairFactory } from "ecpair";
+
+import { signBip322P2wpkhWitness } from "../../../../../packages/babylon-ts-sdk/src/testing/signBip322P2wpkhWitness";
 
 import mockData, { type MockData } from "./constants";
 import type { BTCWalletType } from "./types";
 import { verifyBTCWalletInjected } from "./verification";
 
+export interface TestWalletOptions {
+  data?: MockData;
+  privateKeyHex?: string;
+}
+
 type DataType = {
   walletType: BTCWalletType;
   mockData: MockData;
+  localSigner: boolean;
 };
 
 export const injectBTCWallet = async (
   page: Page,
   walletType: BTCWalletType = "OKX",
+  { data = mockData, privateKeyHex }: TestWalletOptions = {},
 ) => {
+  if (privateKeyHex) {
+    initEccLib(ecc);
+    const key = ECPairFactory(ecc).fromPrivateKey(
+      Buffer.from(privateKeyHex, "hex"),
+    );
+    data = {
+      ...data,
+      btcWallet: {
+        ...data.btcWallet,
+        publicKeyHex: key.publicKey.toString("hex"),
+        mainnetAddress: payments.p2wpkh({ pubkey: key.publicKey }).address!,
+        testnetAddress: payments.p2wpkh({
+          pubkey: key.publicKey,
+          network: networks.testnet,
+        }).address!,
+      },
+    };
+    await page.exposeFunction("e2eSignPsbt", (hex: string) => {
+      const psbt = Psbt.fromHex(hex).signAllInputs(key);
+      if (
+        !psbt.validateSignaturesOfAllInputs((pubkey, hash, signature) =>
+          signature.length === 64 && pubkey.length === 32
+            ? ecc.verifySchnorr(hash, pubkey, signature)
+            : ecc.verify(hash, pubkey, signature),
+        )
+      ) {
+        throw new Error("Invalid local test signature");
+      }
+      return psbt.finalizeAllInputs().toHex();
+    });
+    await page.exposeFunction(
+      "e2eSignMessage",
+      (message: string, type: string) => {
+        if (type !== "bip322-simple")
+          throw new Error("Unsupported test signature type");
+        return Buffer.from(
+          signBip322P2wpkhWitness(
+            new TextEncoder().encode(message),
+            key.privateKey!,
+          ),
+        ).toString("base64");
+      },
+    );
+  }
   try {
     await page.evaluate(
       (data: DataType) => {
-        const { walletType, mockData } = data;
+        const { walletType, mockData, localSigner } = data;
         const btcData = mockData.btcWallet;
 
         const btcWallet = {
@@ -37,8 +93,15 @@ export const injectBTCWallet = async (
           getNetworkFees: () => btcData.networkFees,
           getInscriptions: () => [],
           signPsbt: (_psbtHex: string) => {
-            return btcData.signedPsbt;
+            if (!localSigner) throw new Error("No test signer configured");
+            return (window as any).e2eSignPsbt(_psbtHex);
           },
+          ...(localSigner
+            ? {
+                signMessage: (message: string, type: string) =>
+                  (window as any).e2eSignMessage(message, type),
+              }
+            : {}),
           pushTx: (_txHex: string) => {
             return btcData.txHash;
           },
@@ -58,9 +121,6 @@ export const injectBTCWallet = async (
                 getAccounts: () => [btcData.mainnetAddress],
                 isAccountActive: () => true,
                 switchNetwork: (network: string) => Promise.resolve(true),
-                signPsbt: (psbtHex: string) => {
-                  return btcData.simplifiedPsbt;
-                },
                 connect: async () => {
                   return {
                     address: btcData.mainnetAddress,
@@ -138,7 +198,7 @@ export const injectBTCWallet = async (
                   case "btc_getBalance":
                     return btcData.balance;
                   case "btc_signPsbt":
-                    return methodParams?.psbt || btcData.simplifiedPsbt;
+                    return btcWallet.signPsbt(methodParams?.psbt);
                   default:
                     return null;
                 }
@@ -176,7 +236,7 @@ export const injectBTCWallet = async (
           strategy();
         }
       },
-      { walletType, mockData },
+      { walletType, mockData: data, localSigner: Boolean(privateKeyHex) },
     );
 
     const isInjected = await verifyBTCWalletInjected(page);

--- a/services/simple-staking/e2e/mocks/blockchain/constants.ts
+++ b/services/simple-staking/e2e/mocks/blockchain/constants.ts
@@ -6,16 +6,13 @@ export interface BBNWallet {
     keplr: string;
     leap: string;
   };
-  signature: string;
 }
 
 export interface BTCWallet {
   mainnetAddress: string;
   testnetAddress: string;
   publicKeyHex: string;
-  signedPsbt: string;
   txHash: string;
-  simplifiedPsbt: string;
   balance: {
     confirmed: number;
     unconfirmed: number;
@@ -71,7 +68,6 @@ const mockData: MockData = {
       keplr: "mock-keplr",
       leap: "mock-leap",
     },
-    signature: "signature",
   },
   btcWallet: {
     mainnetAddress:
@@ -80,10 +76,7 @@ const mockData: MockData = {
       "tb1p8gjpy0vyfdq3tty8sy0v86dvl69rquc85n2gpuztll9wxh9cparslrnj4m",
     publicKeyHex:
       "024c6e2954c75bcb53aa13b7cd5d8bcdb4c9a4dd0784d68b115bd4408813b45608",
-    signedPsbt:
-      "70736274ff0100fd040102000000028a12de07985b7d06d83d9683eb3c0a86284fa3cbb2df998aed61009d700748ba0200000000fdffffff4ca53ae433b535b660a2dca99724199b2219a617508eed2ccf88762683a622430200000000fdffffff0350c3000000000000225120cf7c40c6fb1395430816dbb5e1ba9f172ef25573a3b609efa1723559cd82d5590000000000000000496a4762626234004c6e2954c75bcb53aa13b7cd5d8bcdb4c9a4dd0784d68b115bd4408813b45608094f5861be4128861d69ea4b66a5f974943f100f55400bf26f5cce124b4c9af7009604450000000000002251203a24123d844b4115ac87811ec3e9acfe8a307307a4d480f04bffcae35cb80f47340e0d000001012b50ba0000000000002251203a24123d844b4115ac87811ec3e9acfe8a307307a4d480f04bffcae35cb80f470108420140f94b4114bf4c77c449fefb45d60a86831a73897e58b03ba8250e1bf877912cdcc48d106fa266e8aa4085a43e9ad348652fb7b1ad0d820b6455c06edd92cadfef00000000",
     txHash: "47af61d63bcc6c513561d9a1198d082052cc07a81f50c6f130653f0a6ecc0fc1",
-    simplifiedPsbt: "signed_psbt_hex_string",
     balance: {
       confirmed: 12345678,
       unconfirmed: 0,

--- a/services/simple-staking/e2e/specs/balanceAddress.spec.ts
+++ b/services/simple-staking/e2e/specs/balanceAddress.spec.ts
@@ -1,22 +1,22 @@
 import { expect, test } from "@playwright/test";
 
-import {
-  PageNavigationActions,
-  WalletBalanceActions,
-  WalletConnectActions,
-} from "../fixtures";
+import { WalletBalanceActions, WalletConnectActions } from "../fixtures";
+
+import { injectBBNQueries } from "../mocks/blockchain";
+import mockData from "../mocks/blockchain/constants";
 
 test.describe("Balance and address checks after connection", () => {
   let connectActions: WalletConnectActions;
   let balanceActions: WalletBalanceActions;
-  let navigationActions: PageNavigationActions;
 
   test.beforeEach(async ({ page }) => {
     connectActions = new WalletConnectActions(page);
     balanceActions = new WalletBalanceActions(page);
-    navigationActions = new PageNavigationActions(page);
 
-    await navigationActions.navigateToHomePage(page);
+    const data = structuredClone(mockData);
+    data.bbnQueries.stakableBtc = String(data.btcWallet.balance.confirmed);
+    await injectBBNQueries(page, undefined, data);
+    await page.goto("/");
     await connectActions.setupWalletConnection();
   });
 
@@ -28,7 +28,7 @@ test.describe("Balance and address checks after connection", () => {
     const babylonBalance = await balanceActions.getBabylonBalance();
 
     expect(stakedBalanceText).toContain("0.09876543 BTC");
-    expect(stakableBalance).toContain("<0.01 BTC");
+    expect(stakableBalance).toContain("0.12345678 BTC");
     expect(babylonBalance).toContain("1.00 BABY");
   });
 });

--- a/services/simple-staking/e2e/specs/balanceAddress.spec.ts
+++ b/services/simple-staking/e2e/specs/balanceAddress.spec.ts
@@ -27,8 +27,8 @@ test.describe("Balance and address checks after connection", () => {
     const stakableBalance = await balanceActions.getStakableBalance();
     const babylonBalance = await balanceActions.getBabylonBalance();
 
-    expect(stakedBalanceText).toContain("0.09876543 sBTC");
-    expect(stakableBalance).toContain("0.00074175 sBTC");
-    expect(babylonBalance).toContain("1 tBABY");
+    expect(stakedBalanceText).toContain("0.09876543 BTC");
+    expect(stakableBalance).toContain("<0.01 BTC");
+    expect(babylonBalance).toContain("1.00 BABY");
   });
 });

--- a/services/simple-staking/e2e/staking.spec.ts
+++ b/services/simple-staking/e2e/staking.spec.ts
@@ -1,8 +1,5 @@
 import { expect, test } from "@playwright/test";
-import {
-  btcstakingtx,
-  btclightclientquery,
-} from "@babylonlabs-io/babylon-proto-ts";
+import { btcstakingtx } from "@babylonlabs-io/babylon-proto-ts";
 import * as ecc from "@bitcoin-js/tiny-secp256k1-asmjs";
 import { DirectSecp256k1Wallet, makeSignBytes } from "@cosmjs/proto-signing";
 import { crypto, payments, script, Transaction } from "bitcoinjs-lib";
@@ -82,11 +79,6 @@ test("create a V2 stake with local wallet signatures", async ({ page }) => {
       unexpectedWrites.push(`${method} ${url.href}`);
       return route.abort();
     }
-    if (
-      url.pathname === "/babylon/costaking/v1/params" ||
-      url.pathname.startsWith("/cosmos/staking/v1beta1/delegations/")
-    )
-      return route.abort();
     if (url.pathname.endsWith("/fees/recommended"))
       return route.fulfill({ json: data.btcWallet.networkFees });
     if (url.pathname.endsWith("/utxo"))
@@ -119,19 +111,6 @@ test("create a V2 stake with local wallet signatures", async ({ page }) => {
       });
     if (url.pathname.endsWith("/api/tx") && method === "POST") {
       submittedBtc = Transaction.fromHex(request.postData()!);
-      expect(submittedBtc.ins).toHaveLength(1);
-      const [witnessSignature, witnessPublicKey] = submittedBtc.ins[0].witness;
-      expect(submittedBtc.ins[0].witness).toHaveLength(2);
-      expect(witnessPublicKey).toEqual(publicKey);
-      const { signature, hashType } = script.signature.decode(witnessSignature);
-      expect(hashType).toBe(Transaction.SIGHASH_ALL);
-      const hash = submittedBtc.hashForWitnessV0(
-        0,
-        payments.p2pkh({ pubkey: publicKey }).output!,
-        funding.outs[0].value,
-        hashType,
-      );
-      expect(ecc.verify(hash, publicKey, signature)).toBe(true);
       return route.fulfill({ body: submittedBtc.getId() });
     }
     if (["GET", "HEAD", "OPTIONS"].includes(method)) {
@@ -152,12 +131,6 @@ test("create a V2 stake with local wallet signatures", async ({ page }) => {
     if (rpc.method === "abci_query") {
       const path = rpc.params.path;
       let bytes;
-      if (path.endsWith("/Tip"))
-        bytes = btclightclientquery.QueryTipResponse.encode(
-          btclightclientquery.QueryTipResponse.fromPartial({
-            header: { height: data.btcWallet.tipHeight },
-          }),
-        ).finish();
       if (path.endsWith("/Account"))
         bytes = QueryAccountResponse.encode({
           account: {
@@ -183,39 +156,9 @@ test("create a V2 stake with local wallet signatures", async ({ page }) => {
       };
     } else if (rpc.method === "broadcast_tx_sync") {
       babylonTx = Buffer.from(rpc.params.tx, "base64");
-      const raw = TxRaw.decode(babylonTx);
-      expect(raw.signatures).toHaveLength(1);
-      const auth = AuthInfo.decode(raw.authInfoBytes);
-      expect(auth.signerInfos).toHaveLength(1);
-      const signer = auth.signerInfos[0];
-      expect(signer.sequence).toBe(0n);
-      expect(signer.modeInfo?.single?.mode).toBe(SignMode.SIGN_MODE_DIRECT);
-      expect(signer.publicKey?.typeUrl).toBe("/cosmos.crypto.secp256k1.PubKey");
-      expect(PubKey.decode(signer.publicKey!.value).key).toEqual(
-        account.pubkey,
-      );
-      const signBytes = makeSignBytes({
-        bodyBytes: raw.bodyBytes,
-        authInfoBytes: raw.authInfoBytes,
-        chainId: "bbn-test",
-        accountNumber: 0n,
-      });
-      expect(
-        ecc.verify(
-          crypto.sha256(Buffer.from(signBytes)),
-          account.pubkey,
-          raw.signatures[0],
-        ),
-      ).toBe(true);
-      const body = TxBody.decode(raw.bodyBytes);
-      expect(body.messages).toHaveLength(1);
-      expect(body.messages[0].typeUrl).toBe(
-        "/babylon.btcstaking.v1.MsgCreateBTCDelegation",
-      );
       registration = btcstakingtx.MsgCreateBTCDelegation.decode(
-        body.messages[0].value,
+        TxBody.decode(TxRaw.decode(babylonTx).bodyBytes).messages[0].value,
       );
-      expect(registration.stakerAddr).toBe(account.address);
       result = {
         code: 0,
         hash: crypto.sha256(babylonTx).toString("hex").toUpperCase(),
@@ -266,6 +209,47 @@ test("create a V2 stake with local wallet signatures", async ({ page }) => {
   await expect
     .poll(() => submittedBtc?.getId())
     .toBe(Transaction.fromBuffer(Buffer.from(registration!.stakingTx)).getId());
+  expect(submittedBtc!.ins).toHaveLength(1);
+  const [witnessSignature, witnessPublicKey] = submittedBtc!.ins[0].witness;
+  expect(submittedBtc!.ins[0].witness).toHaveLength(2);
+  expect(witnessPublicKey).toEqual(publicKey);
+  const { signature, hashType } = script.signature.decode(witnessSignature);
+  expect(hashType).toBe(Transaction.SIGHASH_ALL);
+  const hash = submittedBtc!.hashForWitnessV0(
+    0,
+    payments.p2pkh({ pubkey: publicKey }).output!,
+    funding.outs[0].value,
+    hashType,
+  );
+  expect(ecc.verify(hash, publicKey, signature)).toBe(true);
+  const raw = TxRaw.decode(babylonTx);
+  expect(raw.signatures).toHaveLength(1);
+  const auth = AuthInfo.decode(raw.authInfoBytes);
+  expect(auth.signerInfos).toHaveLength(1);
+  const signer = auth.signerInfos[0];
+  expect(signer.sequence).toBe(0n);
+  expect(signer.modeInfo?.single?.mode).toBe(SignMode.SIGN_MODE_DIRECT);
+  expect(signer.publicKey?.typeUrl).toBe("/cosmos.crypto.secp256k1.PubKey");
+  expect(PubKey.decode(signer.publicKey!.value).key).toEqual(account.pubkey);
+  const signBytes = makeSignBytes({
+    bodyBytes: raw.bodyBytes,
+    authInfoBytes: raw.authInfoBytes,
+    chainId: "bbn-test",
+    accountNumber: 0n,
+  });
+  expect(
+    ecc.verify(
+      crypto.sha256(Buffer.from(signBytes)),
+      account.pubkey,
+      raw.signatures[0],
+    ),
+  ).toBe(true);
+  const body = TxBody.decode(raw.bodyBytes);
+  expect(body.messages).toHaveLength(1);
+  expect(body.messages[0].typeUrl).toBe(
+    "/babylon.btcstaking.v1.MsgCreateBTCDelegation",
+  );
+  expect(registration!.stakerAddr).toBe(account.address);
   expect(submittedBtc!.ins[0].hash).toEqual(funding.getHash());
   expect(submittedBtc!.ins[0].index).toBe(0);
   expect(submittedBtc!.outs[0].value).toBe(STAKING_AMOUNT_SAT);

--- a/services/simple-staking/e2e/staking.spec.ts
+++ b/services/simple-staking/e2e/staking.spec.ts
@@ -1,50 +1,287 @@
 import { expect, test } from "@playwright/test";
-
 import {
-  STAKING_AMOUNT_BTC,
-  STAKING_AMOUNT_SAT,
-  STAKING_TX_HASH,
-} from "./constants/staking";
+  btcstakingtx,
+  btclightclientquery,
+} from "@babylonlabs-io/babylon-proto-ts";
+import * as ecc from "@bitcoin-js/tiny-secp256k1-asmjs";
+import { DirectSecp256k1Wallet, makeSignBytes } from "@cosmjs/proto-signing";
+import { crypto, payments, script, Transaction } from "bitcoinjs-lib";
+import { BaseAccount } from "cosmjs-types/cosmos/auth/v1beta1/auth.js";
+import { QueryAccountResponse } from "cosmjs-types/cosmos/auth/v1beta1/query.js";
+import { SimulateResponse } from "cosmjs-types/cosmos/tx/v1beta1/service.js";
+import { AuthInfo, TxBody, TxRaw } from "cosmjs-types/cosmos/tx/v1beta1/tx.js";
+import { PubKey } from "cosmjs-types/cosmos/crypto/secp256k1/keys.js";
+import { SignMode } from "cosmjs-types/cosmos/tx/signing/v1beta1/signing.js";
+
+import { STAKING_AMOUNT_BTC, STAKING_AMOUNT_SAT } from "./constants/staking";
 import { WalletConnectActions } from "./fixtures/wallet_connect";
+import { injectBBNQueries } from "./mocks/blockchain";
+import mockData from "./mocks/blockchain/constants";
 
-test.describe("Create staking transaction", () => {
-  let actions: WalletConnectActions;
+// Public test key 4. The funding output and chain responses exist only in this test.
+const privateKeyHex = "4".padStart(64, "0");
+const publicKey = Buffer.from(
+  ecc.pointFromScalar(Buffer.from(privateKeyHex, "hex"))!,
+);
+const fundingOutput = payments.p2wpkh({ pubkey: publicKey }).output!;
+const funding = new Transaction();
+funding.addInput(Buffer.alloc(32), 0xffffffff);
+funding.addOutput(fundingOutput, 200000);
 
-  test.beforeEach(async ({ page }) => {
-    await page.goto("/");
-    actions = new WalletConnectActions(page);
-    await actions.setupWalletConnection();
+test("create a V2 stake with local wallet signatures", async ({ page }) => {
+  const data = structuredClone(mockData);
+  data.bbnQueries.stakableBtc = String(funding.outs[0].value);
+  data.bbnQueries.networkInfo.min_staking_value_sat = STAKING_AMOUNT_SAT;
+  const [account] = await (
+    await DirectSecp256k1Wallet.fromKey(
+      Buffer.from(privateKeyHex, "hex"),
+      "bbn",
+    )
+  ).getAccounts();
+  let registration: btcstakingtx.MsgCreateBTCDelegation | undefined;
+  let babylonTx = Buffer.alloc(0);
+  let submittedBtc: Transaction | undefined;
+  const unexpectedWrites: string[] = [];
+  const toHex = (value: Uint8Array) => Buffer.from(value).toString("hex");
+  const verifiedDelegation = () => ({
+    finality_provider_btc_pks_hex: registration!.fpBtcPkList.map(toHex),
+    params_version: 0,
+    staker_btc_pk_hex: toHex(registration!.btcPk),
+    state: "VERIFIED",
+    delegation_staking: {
+      staking_tx_hex: toHex(registration!.stakingTx),
+      staking_tx_hash_hex: Transaction.fromBuffer(
+        Buffer.from(registration!.stakingTx),
+      ).getId(),
+      staking_timelock: registration!.stakingTime,
+      staking_amount: Number(registration!.stakingValue),
+      start_height: 0,
+      end_height: 0,
+      bbn_inception_height: 1,
+      bbn_inception_time: "2026-09-08T00:00:00Z",
+      slashing: {
+        slashing_tx_hex: toHex(registration!.slashingTx),
+        spending_height: 0,
+      },
+    },
+    delegation_unbonding: {
+      unbonding_timelock: registration!.unbondingTime,
+      unbonding_tx: toHex(registration!.unbondingTx),
+      slashing: {
+        unbonding_slashing_tx_hex: toHex(registration!.unbondingSlashingTx),
+        spending_height: 0,
+      },
+    },
   });
-
-  test("prepare the staking", async ({ page }) => {
-    const previewButton = page.locator("button").filter({ hasText: "Preview" });
-
-    // Selects the first finality provider in the list
-    await page.locator("#finality-providers>div>div").first().click();
-    expect(previewButton).toBeDisabled();
-
-    // Preview available after filling the amount
-    await page.getByPlaceholder("BTC").fill(`${STAKING_AMOUNT_BTC}`);
-    expect(previewButton).toBeEnabled();
-
-    await previewButton.click();
-    const stakeButton = page.locator("button").filter({ hasText: "Stake" });
-    await stakeButton.click();
-
-    // Check for local storage
-    const item = await page.evaluate(() =>
-      localStorage.getItem(
-        "bbn-staking-delegations-4c6e2954c75bcb53aa13b7cd5d8bcdb4c9a4dd0784d68b115bd4408813b45608",
+  await injectBBNQueries(page, undefined, data);
+  await page.route("**/*", async (route) => {
+    const request = route.request();
+    const url = new URL(request.url());
+    const method = request.method();
+    if (!["GET", "HEAD", "OPTIONS", "POST"].includes(method)) {
+      unexpectedWrites.push(`${method} ${url.href}`);
+      return route.abort();
+    }
+    if (
+      url.pathname === "/babylon/costaking/v1/params" ||
+      url.pathname.startsWith("/cosmos/staking/v1beta1/delegations/")
+    )
+      return route.abort();
+    if (url.pathname.endsWith("/fees/recommended"))
+      return route.fulfill({ json: data.btcWallet.networkFees });
+    if (url.pathname.endsWith("/utxo"))
+      return route.fulfill({
+        json: [
+          {
+            txid: funding.getId(),
+            vout: 0,
+            value: funding.outs[0].value,
+            status: { confirmed: true },
+          },
+        ],
+      });
+    if (url.pathname.includes("/validate-address/"))
+      return route.fulfill({
+        json: { isvalid: true, scriptPubKey: fundingOutput.toString("hex") },
+      });
+    if (url.pathname.endsWith(`/tx/${funding.getId()}/hex`))
+      return route.fulfill({ body: funding.toHex() });
+    if (url.pathname === "/v2/delegation")
+      return route.fulfill({
+        json: { data: registration ? verifiedDelegation() : null },
+      });
+    if (url.pathname === "/v2/delegations")
+      return route.fulfill({
+        json: {
+          data: registration ? [verifiedDelegation()] : [],
+          pagination: { next_key: "" },
+        },
+      });
+    if (url.pathname.endsWith("/api/tx") && method === "POST") {
+      submittedBtc = Transaction.fromHex(request.postData()!);
+      expect(submittedBtc.ins).toHaveLength(1);
+      const [witnessSignature, witnessPublicKey] = submittedBtc.ins[0].witness;
+      expect(submittedBtc.ins[0].witness).toHaveLength(2);
+      expect(witnessPublicKey).toEqual(publicKey);
+      const { signature, hashType } = script.signature.decode(witnessSignature);
+      expect(hashType).toBe(Transaction.SIGHASH_ALL);
+      const hash = submittedBtc.hashForWitnessV0(
+        0,
+        payments.p2pkh({ pubkey: publicKey }).output!,
+        funding.outs[0].value,
+        hashType,
+      );
+      expect(ecc.verify(hash, publicKey, signature)).toBe(true);
+      return route.fulfill({ body: submittedBtc.getId() });
+    }
+    if (["GET", "HEAD", "OPTIONS"].includes(method)) {
+      if (url.href.includes("broadcast_tx")) {
+        unexpectedWrites.push(url.href);
+        return route.abort();
+      }
+      return route.fallback();
+    }
+    let rpc;
+    try {
+      rpc = request.postDataJSON();
+    } catch {
+      unexpectedWrites.push(url.href);
+      return route.abort();
+    }
+    let result;
+    if (rpc.method === "abci_query") {
+      const path = rpc.params.path;
+      let bytes;
+      if (path.endsWith("/Tip"))
+        bytes = btclightclientquery.QueryTipResponse.encode(
+          btclightclientquery.QueryTipResponse.fromPartial({
+            header: { height: data.btcWallet.tipHeight },
+          }),
+        ).finish();
+      if (path.endsWith("/Account"))
+        bytes = QueryAccountResponse.encode({
+          account: {
+            typeUrl: "/cosmos.auth.v1beta1.BaseAccount",
+            value: BaseAccount.encode(
+              BaseAccount.fromPartial({ address: account.address }),
+            ).finish(),
+          },
+        }).finish();
+      if (path.endsWith("/Simulate"))
+        bytes = SimulateResponse.encode(
+          SimulateResponse.fromPartial({
+            gasInfo: { gasUsed: 100000n, gasWanted: 100000n },
+          }),
+        ).finish();
+      if (!bytes) return route.fallback();
+      result = {
+        response: {
+          code: 0,
+          value: Buffer.from(bytes).toString("base64"),
+          height: "1",
+        },
+      };
+    } else if (rpc.method === "broadcast_tx_sync") {
+      babylonTx = Buffer.from(rpc.params.tx, "base64");
+      const raw = TxRaw.decode(babylonTx);
+      expect(raw.signatures).toHaveLength(1);
+      const auth = AuthInfo.decode(raw.authInfoBytes);
+      expect(auth.signerInfos).toHaveLength(1);
+      const signer = auth.signerInfos[0];
+      expect(signer.sequence).toBe(0n);
+      expect(signer.modeInfo?.single?.mode).toBe(SignMode.SIGN_MODE_DIRECT);
+      expect(signer.publicKey?.typeUrl).toBe("/cosmos.crypto.secp256k1.PubKey");
+      expect(PubKey.decode(signer.publicKey!.value).key).toEqual(
+        account.pubkey,
+      );
+      const signBytes = makeSignBytes({
+        bodyBytes: raw.bodyBytes,
+        authInfoBytes: raw.authInfoBytes,
+        chainId: "bbn-test",
+        accountNumber: 0n,
+      });
+      expect(
+        ecc.verify(
+          crypto.sha256(Buffer.from(signBytes)),
+          account.pubkey,
+          raw.signatures[0],
+        ),
+      ).toBe(true);
+      const body = TxBody.decode(raw.bodyBytes);
+      expect(body.messages).toHaveLength(1);
+      expect(body.messages[0].typeUrl).toBe(
+        "/babylon.btcstaking.v1.MsgCreateBTCDelegation",
+      );
+      registration = btcstakingtx.MsgCreateBTCDelegation.decode(
+        body.messages[0].value,
+      );
+      expect(registration.stakerAddr).toBe(account.address);
+      result = {
+        code: 0,
+        hash: crypto.sha256(babylonTx).toString("hex").toUpperCase(),
+      };
+    } else if (rpc.method === "tx_search") {
+      result = {
+        total_count: "1",
+        txs: [
+          {
+            hash: crypto.sha256(babylonTx).toString("hex").toUpperCase(),
+            height: "1",
+            index: 0,
+            tx: babylonTx.toString("base64"),
+            tx_result: {
+              code: 0,
+              gas_wanted: "100000",
+              gas_used: "100000",
+              events: [],
+            },
+          },
+        ],
+      };
+    } else if (rpc.method === "status") return route.fallback();
+    else {
+      unexpectedWrites.push(`${url.href} ${rpc.method}`);
+      return route.abort();
+    }
+    return route.fulfill({ json: { jsonrpc: "2.0", id: rpc.id, result } });
+  });
+  await page.goto("/");
+  await new WalletConnectActions(page).setupWalletConnection({
+    data,
+    privateKeyHex,
+  });
+  await page
+    .getByText("Add Finality Provider", { exact: true })
+    .first()
+    .locator("..")
+    .locator("svg")
+    .click();
+  await page.getByRole("row").filter({ hasText: "PRO Delegators" }).click();
+  await page.getByPlaceholder("Enter Amount").fill(String(STAKING_AMOUNT_BTC));
+  await page.getByRole("button", { name: "Preview", exact: true }).click();
+  await page
+    .getByRole("button", { name: "Proceed to Signing", exact: true })
+    .click();
+  await page.getByRole("button", { name: "Stake BTC", exact: true }).click();
+  await expect
+    .poll(() => submittedBtc?.getId())
+    .toBe(Transaction.fromBuffer(Buffer.from(registration!.stakingTx)).getId());
+  expect(submittedBtc!.ins[0].hash).toEqual(funding.getHash());
+  expect(submittedBtc!.ins[0].index).toBe(0);
+  expect(submittedBtc!.outs[0].value).toBe(STAKING_AMOUNT_SAT);
+  expect(registration!.stakingValue.toString()).toBe(
+    String(STAKING_AMOUNT_SAT),
+  );
+  const key = `bbn-staking-delegations-v2-${publicKey.subarray(1).toString("hex")}_statuses`;
+  await expect
+    .poll(() =>
+      page.evaluate(
+        (key) => JSON.parse(localStorage.getItem(key) ?? "{}"),
+        key,
       ),
-    );
-    expect(item).not.toBeNull();
-
-    const parsed = JSON.parse(item as string);
-    expect(parsed).toHaveLength(1);
-
-    // Check the staking delegation tx hash and staking value
-    const [delegation] = parsed;
-    expect(delegation.stakingValueSat).toBe(STAKING_AMOUNT_SAT);
-    expect(delegation.stakingTxHashHex).toBe(STAKING_TX_HASH);
-  });
+    )
+    .toEqual({
+      [submittedBtc!.getId()]: "INTERMEDIATE_PENDING_BTC_CONFIRMATION",
+    });
+  expect(unexpectedWrites).toEqual([]);
 });

--- a/services/simple-staking/e2e/types.d.ts
+++ b/services/simple-staking/e2e/types.d.ts
@@ -1,5 +1,23 @@
+import type { DirectSignResponse } from "@cosmjs/proto-signing";
+
+export interface SerializedSignDoc {
+  bodyBytes: number[];
+  authInfoBytes: number[];
+  chainId: string;
+  accountNumber: string;
+}
+
 declare global {
   interface Window {
+    e2eSignDirect: (
+      address: string,
+      doc: SerializedSignDoc,
+    ) => Promise<{
+      signed: SerializedSignDoc;
+      signature: DirectSignResponse["signature"];
+    }>;
+    e2eSignPsbt: (hex: string) => Promise<string>;
+    e2eSignMessage: (message: string, type: string) => Promise<string>;
     // From balanceAddress.spec.ts
     mockCosmJSBankBalance: (
       address: string,
@@ -34,7 +52,7 @@ declare global {
         minimumFee: number;
       };
       getInscriptions: () => any[];
-      signPsbt: (psbtHex: string) => string;
+      signPsbt: (psbtHex: string) => string | Promise<string>;
       pushTx: (txHex: string) => string;
       isConnected?: boolean;
     };

--- a/services/simple-staking/e2e/unbonding.spec.ts
+++ b/services/simple-staking/e2e/unbonding.spec.ts
@@ -1,36 +1,91 @@
 import { expect, test } from "@playwright/test";
+import { Psbt, Transaction, opcodes, script } from "bitcoinjs-lib";
+import { witnessStackToScriptWitness } from "bitcoinjs-lib/src/psbt/psbtutils.js";
 
-import { DelegationState } from "@/ui/legacy/types/delegations";
-import { getState } from "@/ui/legacy/utils/getState";
+import { DelegationState } from "@/ui/common/types/delegations";
 
 import { WalletConnectActions } from "./fixtures/wallet_connect";
 import { interceptRequest } from "./helper/interceptRequest";
-import { activeTX, unbondingTX } from "./mock/tx/unbonding";
+import { activeTX, unbondingPOST, unbondingTX } from "./mock/tx/unbonding";
+import { injectBBNQueries } from "./mocks/blockchain";
+import { mockNetworkInfo } from "./mocks/handlers/constants";
 
 test.describe("Create unbonding transaction", () => {
   let actions: WalletConnectActions;
 
+  test.beforeEach(({ page }) => injectBBNQueries(page));
+
   test("prepare the unbonding", async ({ page }) => {
-    // Intercept the GET request for delegations
+    const recordedTx = Transaction.fromHex(unbondingPOST.unbonding_tx_hex);
+    const witness = recordedTx.ins[0].witness;
+    const chunks = script.decompile(witness[1])!;
+    const unsignedTx = recordedTx.clone();
+    unsignedTx.setWitness(0, []);
+    await interceptRequest(page, "**/v2/network-info*", 200, {
+      data: {
+        params: {
+          btc: [mockNetworkInfo.data.params.btc[0]],
+          bbn: [
+            {
+              ...mockNetworkInfo.data.params.bbn[0],
+              covenant_pks: chunks
+                .filter(Buffer.isBuffer)
+                .slice(1)
+                .map((key) => key.toString("hex")),
+              covenant_quorum: Number(chunks.at(-2)) - opcodes.OP_RESERVED,
+              unbonding_time_blocks: unbondingTX.timelock,
+              unbonding_fee_sat:
+                activeTX.data[0].staking_value - recordedTx.outs[0].value,
+            },
+          ],
+        },
+      },
+    });
+    await page.exposeFunction("signRecordedUnbonding", (hex: string) => {
+      const psbt = Psbt.fromHex(hex);
+      expect(psbt.data.globalMap.unsignedTx.toBuffer().toString("hex")).toBe(
+        unsignedTx.toHex(),
+      );
+      psbt.updateInput(0, {
+        finalScriptWitness: witnessStackToScriptWitness(witness),
+      });
+      return psbt.toHex();
+    });
     await interceptRequest(page, "**/v1/staker/delegations**", 200, activeTX);
-    // Intercept the GET request for unbonding eligibility
     await interceptRequest(page, "**/v1/unbonding/eligibility**", 200);
-    // Intercept the POST request for unbonding
     await interceptRequest(page, "**/v1/unbonding", 202, {
       message: "Request accepted",
     });
     await page.goto("/");
     actions = new WalletConnectActions(page);
     await actions.setupWalletConnection();
+    await page.evaluate(() => {
+      const injected = window as unknown as {
+        okxwallet: { bitcoin: { signPsbt: (hex: string) => Promise<string> } };
+        signRecordedUnbonding: (hex: string) => Promise<string>;
+      };
+      injected.okxwallet.bitcoin.signPsbt = injected.signRecordedUnbonding;
+    });
 
-    // unbond -> proceed
+    await page.getByRole("tab", { name: "Activity", exact: true }).click();
+    await page
+      .getByRole("row")
+      .filter({
+        has: page.getByRole("button", { name: "Register", exact: true }),
+      })
+      .getByRole("button", { name: "", exact: true })
+      .click();
     await page.getByRole("button", { name: "Unbond" }).click();
+    const submitted = page.waitForRequest(
+      (request) =>
+        request.method() === "POST" &&
+        new URL(request.url()).pathname === "/v1/unbonding",
+    );
     await page.getByRole("button", { name: "Proceed" }).click();
+    expect((await submitted).postDataJSON()).toEqual(unbondingPOST);
 
     // expect the unbonding state text instead of a button
-    await expect(
-      page.getByText(getState(DelegationState.INTERMEDIATE_UNBONDING)),
-    ).toBeVisible();
+    await expect(page.getByText("Requesting Unbonding")).toBeVisible();
 
     // check for local storage
     const item = await page.evaluate(() =>
@@ -59,6 +114,7 @@ test.describe("Create unbonding transaction", () => {
     await page.goto("/");
     actions = new WalletConnectActions(page);
     await actions.setupWalletConnection();
+    await page.getByRole("tab", { name: "Activity", exact: true }).click();
     await expect(page.getByText("Unbonding Requested")).toBeVisible();
 
     // check for local storage
@@ -88,6 +144,7 @@ test.describe("Create unbonding transaction", () => {
     await page.goto("/");
     actions = new WalletConnectActions(page);
     await actions.setupWalletConnection();
+    await page.getByRole("tab", { name: "Activity", exact: true }).click();
     await expect(page.getByText("Unbonded", { exact: true })).toBeVisible();
   });
 });

--- a/services/simple-staking/e2e/withdrawing.spec.ts
+++ b/services/simple-staking/e2e/withdrawing.spec.ts
@@ -1,40 +1,99 @@
 import { expect, test } from "@playwright/test";
+import * as ecc from "@bitcoin-js/tiny-secp256k1-asmjs";
+import { payments, Transaction } from "bitcoinjs-lib";
+import { tapleafHash } from "bitcoinjs-lib/src/payments/bip341.js";
 
-import { DelegationState } from "@/ui/legacy/types/delegations";
-import { getState } from "@/ui/legacy/utils/getState";
+import { DelegationState } from "@/ui/common/types/delegations";
 
 import { WalletConnectActions } from "./fixtures/wallet_connect";
 import { interceptRequest } from "./helper/interceptRequest";
-import { unbondedTX } from "./mock/tx/withdrawing";
+import {
+  unbondedTX,
+  unbondingTransaction,
+  withdrawalDestination,
+  withdrawalFee,
+  withdrawalPrivateKeyHex,
+} from "./mock/tx/withdrawing";
+import { injectBBNQueries } from "./mocks/blockchain";
+import mockData from "./mocks/blockchain/constants";
 
 test.describe("Create withdrawing transaction", () => {
   let actions: WalletConnectActions;
 
+  test.beforeEach(({ page }) => injectBBNQueries(page));
+
   test("prepare the withdrawing", async ({ page }) => {
-    // Intercept the GET request for delegations
+    await interceptRequest(
+      page,
+      "**/fees/recommended",
+      200,
+      mockData.btcWallet.networkFees,
+    );
     await interceptRequest(page, "**/v1/staker/delegations**", 200, unbondedTX);
-    // Intercept the Mempool POST request for withdrawing
-    await interceptRequest(page, "**/api/tx", 200, {
-      tx: "536af306eac15c7d87d852c601f52a23c2242f53c8c5f803c11befce090c3616",
+    let submissions = 0;
+    await page.route("**/api/tx", async (route) => {
+      expect(route.request().method()).toBe("POST");
+      const tx = Transaction.fromHex(route.request().postData()!);
+      expect(tx.ins).toHaveLength(1);
+      expect(tx.ins[0]).toMatchObject({
+        hash: unbondingTransaction.getHash(),
+        index: 0,
+        sequence: unbondedTX.data[0].unbonding_tx.timelock,
+      });
+      expect(tx.outs).toEqual([
+        {
+          script: withdrawalDestination.output,
+          value: unbondingTransaction.outs[0].value - withdrawalFee,
+        },
+      ]);
+      expect(tx.ins[0].witness).toHaveLength(3);
+      expect(() =>
+        payments.p2tr({
+          output: unbondingTransaction.outs[0].script,
+          witness: tx.ins[0].witness,
+        }),
+      ).not.toThrow();
+      const [signature, script, controlBlock] = tx.ins[0].witness;
+      const hash = tx.hashForWitnessV1(
+        0,
+        [unbondingTransaction.outs[0].script],
+        [unbondingTransaction.outs[0].value],
+        Transaction.SIGHASH_DEFAULT,
+        tapleafHash({ output: script, version: controlBlock[0] & 0xfe }),
+      );
+      expect(
+        ecc.verifySchnorr(
+          hash,
+          Buffer.from(unbondedTX.data[0].staker_pk_hex, "hex"),
+          signature,
+        ),
+      ).toBe(true);
+      submissions++;
+      await route.fulfill({
+        status: 200,
+        contentType: "text/plain",
+        body: tx.getId(),
+      });
     });
     await page.goto("/");
     actions = new WalletConnectActions(page);
-    await actions.setupWalletConnection();
+    await actions.setupWalletConnection({
+      privateKeyHex: withdrawalPrivateKeyHex,
+    });
 
-    // withdraw -> proceed
+    await page.getByRole("tab", { name: "Activity", exact: true }).click();
     await page.getByRole("button", { name: "Withdraw" }).click();
     await page.getByRole("button", { name: "Proceed" }).click();
 
     // expect the withdrawal state text instead of a button
-    await expect(
-      page.getByText(getState(DelegationState.INTERMEDIATE_WITHDRAWAL)),
-    ).toBeVisible();
+    await expect(page.getByText("Withdrawal Submitted")).toBeVisible();
+    expect(submissions).toBe(1);
 
     // check for local storage
-    const item = await page.evaluate(() =>
-      localStorage.getItem(
-        "bbn-staking-intermediate-delegations-4c6e2954c75bcb53aa13b7cd5d8bcdb4c9a4dd0784d68b115bd4408813b45608",
-      ),
+    const item = await page.evaluate(
+      (pk) =>
+        localStorage.getItem(`bbn-staking-intermediate-delegations-${pk}`),
+      unbondedTX.data[0].staker_pk_hex,
     );
     expect(item).not.toBeNull();
     const parsed = JSON.parse(item as string);
@@ -56,14 +115,17 @@ test.describe("Create withdrawing transaction", () => {
     await interceptRequest(page, "**/v1/staker/delegations**", 200, updatedTX);
     await page.goto("/");
     actions = new WalletConnectActions(page);
-    await actions.setupWalletConnection();
+    await actions.setupWalletConnection({
+      privateKeyHex: withdrawalPrivateKeyHex,
+    });
+    await page.getByRole("tab", { name: "Activity", exact: true }).click();
     await expect(page.getByText("Withdrawn")).toBeVisible();
 
     // check for local storage
-    const item = await page.evaluate(() =>
-      localStorage.getItem(
-        "bbn-staking-intermediate-delegations-4c6e2954c75bcb53aa13b7cd5d8bcdb4c9a4dd0784d68b115bd4408813b45608",
-      ),
+    const item = await page.evaluate(
+      (pk) =>
+        localStorage.getItem(`bbn-staking-intermediate-delegations-${pk}`),
+      unbondedTX.data[0].staker_pk_hex,
     );
     expect(item).toBe("[]");
     const parsed = JSON.parse(item as string);

--- a/services/simple-staking/package.json
+++ b/services/simple-staking/package.json
@@ -19,7 +19,7 @@
     "sort-imports": "eslint --fix .",
     "test": "jest",
     "test:watch": "jest --watch",
-    "test:e2e": "playwright test e2e/specs/",
+    "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:headed": "playwright test --headed",
     "test:e2e:report": "playwright show-report",

--- a/services/simple-staking/playwright.config.ts
+++ b/services/simple-staking/playwright.config.ts
@@ -29,7 +29,7 @@ export default defineConfig({
   use: {
     baseURL,
     headless: true,
-    trace: "on-first-retry",
+    trace: "retain-on-failure",
   },
 
   projects: [

--- a/services/simple-staking/playwright.config.ts
+++ b/services/simple-staking/playwright.config.ts
@@ -20,7 +20,7 @@ const effectiveEnv = {
 export default defineConfig({
   testDir: path.join(__dirname, "e2e"),
   fullyParallel: true,
-  forbidOnly: false,
+  forbidOnly: !!process.env.CI,
   retries: 2,
   timeout: 90_000,
   workers: 1,
@@ -41,7 +41,7 @@ export default defineConfig({
     command: `sh -c 'NODE_OPTIONS="--max-http-header-size=65536" PORT=${PORT} pnpm exec vite preview --host 0.0.0.0 --port ${PORT}'`,
     url: baseURL,
     timeout: 120_000,
-    reuseExistingServer: true,
+    reuseExistingServer: !process.env.CI,
     env: effectiveEnv,
   },
 });

--- a/services/vault/e2e/catastrophic-errors.spec.ts
+++ b/services/vault/e2e/catastrophic-errors.spec.ts
@@ -1,13 +1,17 @@
 import type { Page } from "@playwright/test";
 import { expect, test } from "@playwright/test";
+import {
+  decodeFunctionData,
+  encodeAbiParameters,
+  encodeFunctionResult,
+  multicall3Abi,
+  toFunctionSelector,
+} from "viem";
 
 import { SentryInterceptor } from "./helpers/sentry-interceptor";
 
 const PORT_MISSING_ENV = 5173;
 const PORT_FULL_ENV = 5175;
-
-const ABI_ENCODED_TRUE =
-  "0x0000000000000000000000000000000000000000000000000000000000000001";
 
 async function assertBlockingModal(
   page: Page,
@@ -130,8 +134,8 @@ test.describe("Catastrophic Error Handling", () => {
     });
   });
 
-  test.describe("Application Paused", () => {
-    test("should show blocking error modal when application is paused by admin", async ({
+  test.describe("Protocol Paused", () => {
+    test("should show the full pause banner when the protocol is paused", async ({
       page,
     }) => {
       await page.route("**/graphql", async (route) => {
@@ -142,32 +146,52 @@ test.describe("Catastrophic Error Handling", () => {
         });
       });
 
-      await page.route(/.*eth.*|.*rpc.*/, async (route) => {
+      let pauseReadCount = 0;
+      await page.route("http://localhost:9997/rpc", async (route) => {
         const postData = route.request().postDataJSON();
-
-        if (postData?.method === "eth_call") {
-          await route.fulfill({
-            status: 200,
-            contentType: "application/json",
-            body: JSON.stringify({
-              jsonrpc: "2.0",
-              id: postData.id,
-              result: ABI_ENCODED_TRUE,
+        const data = postData?.params?.[0]?.data;
+        if (
+          postData?.method !== "eth_call" ||
+          data?.slice(0, 10) !==
+            toFunctionSelector("aggregate3((address,bool,bytes)[])")
+        )
+          return route.abort();
+        const { functionName, args } = decodeFunctionData({
+          abi: multicall3Abi,
+          data,
+        });
+        if (functionName !== "aggregate3") return route.abort();
+        const result = args[0].map(({ callData }) => {
+          const success = callData === toFunctionSelector("pauseState()");
+          if (success) pauseReadCount += 1;
+          return {
+            success,
+            returnData: success
+              ? encodeAbiParameters([{ type: "uint8" }], [2])
+              : ("0x" as const),
+          };
+        });
+        await route.fulfill({
+          json: {
+            jsonrpc: "2.0",
+            id: postData.id,
+            result: encodeFunctionResult({
+              abi: multicall3Abi,
+              functionName: "aggregate3",
+              result,
             }),
-          });
-          return;
-        }
-
-        await route.continue();
+          },
+        });
       });
 
       await page.goto(`http://localhost:${PORT_FULL_ENV}/`);
 
-      await assertBlockingModal(
-        page,
-        "Application Paused",
-        /currently paused for maintenance/i,
-      );
+      const banner = page.getByTestId("protocol-status-banner");
+      await expect(banner).toBeVisible();
+      await expect(banner).toHaveAttribute("role", "alert");
+      await expect(banner).toContainText("Protocol is fully paused");
+      await expect(banner).toContainText("Debt continues accruing interest");
+      expect(pauseReadCount).toBeGreaterThan(0);
     });
   });
 });

--- a/services/vault/e2e/high-severity-errors.spec.ts
+++ b/services/vault/e2e/high-severity-errors.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "@playwright/test";
 
 import { installRecordedBackend } from "./fixtures/replay";
+import { SentryInterceptor } from "./helpers/sentry-interceptor";
 
 test("app loads without error UI or unhandled errors with the recorded backend", async ({
   page,
@@ -17,7 +18,9 @@ test("app loads without error UI or unhandled errors with the recorded backend",
   ).toBeVisible({ timeout: 30_000 });
 
   await expect(
-    page.getByRole("heading", { name: /Configuration Error|Service Unavailable/i }),
+    page.getByRole("heading", {
+      name: /Configuration Error|Service Unavailable/i,
+    }),
   ).not.toBeVisible();
   await expect(
     page.getByText(/Protocol is (soft-paused|fully paused)/),
@@ -26,4 +29,32 @@ test("app loads without error UI or unhandled errors with the recorded backend",
   expect(backend.served["eth-rpc"]).toBeGreaterThan(0);
   expect(backend.misses).toEqual([]);
   expect(pageErrors).toEqual([]);
+});
+
+test("shows a failed application configuration query and reports it to Sentry", async ({
+  page,
+}) => {
+  await installRecordedBackend(page);
+  const sentry = new SentryInterceptor();
+  await sentry.setup(page);
+  let failures = 0;
+  await page.route("**/graphql", (route) => {
+    if (route.request().postDataJSON().query.includes("GetAaveAppConfig")) {
+      failures++;
+      return route.abort("connectionfailed");
+    }
+    return route.fallback();
+  });
+
+  await page.goto("/vaults");
+  await expect(page.getByTestId("app-error-state")).toBeVisible({
+    timeout: 30_000,
+  });
+  await expect(
+    page.getByRole("button", { name: "Retry", exact: true }),
+  ).toBeVisible();
+  await expect
+    .poll(() => sentry.hasEventWithMessage(/fetch|network/i))
+    .toBe(true);
+  expect(failures).toBeGreaterThan(0);
 });

--- a/services/vault/e2e/high-severity-errors.spec.ts
+++ b/services/vault/e2e/high-severity-errors.spec.ts
@@ -1,229 +1,29 @@
 import { expect, test } from "@playwright/test";
 
-import { SentryInterceptor } from "./helpers/sentry-interceptor";
+import { installRecordedBackend } from "./fixtures/replay";
 
-const PORT = 5175;
-const BASE_URL = `http://localhost:${PORT}`;
+test("app loads without error UI or unhandled errors with the recorded backend", async ({
+  page,
+}) => {
+  const pageErrors: Error[] = [];
+  page.on("pageerror", (error) => pageErrors.push(error));
+  const backend = await installRecordedBackend(page);
 
-test.describe("High Severity Error Handling", () => {
-  test.describe("Baseline Health Check", () => {
-    test("app loads without error modals when GraphQL and RPC are healthy", async ({
-      page,
-    }) => {
-      await page.route("**/graphql", async (route) => {
-        await route.fulfill({
-          status: 200,
-          contentType: "application/json",
-          body: JSON.stringify({ data: { __typename: "Query" } }),
-        });
-      });
+  await page.goto("/");
+  await expect(
+    page.getByRole("heading", {
+      name: "Borrow against native Bitcoin, trustlessly.",
+    }),
+  ).toBeVisible({ timeout: 30_000 });
 
-      await page.route(/.*eth.*|.*rpc.*/, async (route) => {
-        const postData = route.request().postDataJSON();
-
-        if (postData?.method === "eth_call") {
-          const data = postData.params?.[0]?.data || "";
-
-          if (data.startsWith("0x5c975abb")) {
-            await route.fulfill({
-              status: 200,
-              contentType: "application/json",
-              body: JSON.stringify({
-                jsonrpc: "2.0",
-                id: postData.id,
-                result:
-                  "0x0000000000000000000000000000000000000000000000000000000000000000",
-              }),
-            });
-            return;
-          }
-        }
-
-        await route.continue();
-      });
-
-      await page.goto(`${BASE_URL}/`);
-
-      await expect(
-        page.getByRole("heading", { name: /Configuration Error/i }),
-      ).not.toBeVisible({ timeout: 10000 });
-      await expect(
-        page.getByRole("heading", { name: /Service Unavailable/i }),
-      ).not.toBeVisible();
-      await expect(
-        page.getByRole("heading", { name: /Application Paused/i }),
-      ).not.toBeVisible();
-      await expect(
-        page.getByText(/Failed to load applications/i),
-      ).not.toBeVisible();
-    });
-
-    test("app does not throw unhandled errors on healthy load", async ({
-      page,
-    }) => {
-      let hasUnhandledError = false;
-
-      page.on("pageerror", () => {
-        hasUnhandledError = true;
-      });
-
-      await page.route("**/graphql", async (route) => {
-        await route.fulfill({
-          status: 200,
-          contentType: "application/json",
-          body: JSON.stringify({ data: { __typename: "Query" } }),
-        });
-      });
-
-      await page.route(/.*eth.*|.*rpc.*/, async (route) => {
-        const postData = route.request().postDataJSON();
-
-        if (postData?.method === "eth_call") {
-          const data = postData.params?.[0]?.data || "";
-
-          if (data.startsWith("0x5c975abb")) {
-            await route.fulfill({
-              status: 200,
-              contentType: "application/json",
-              body: JSON.stringify({
-                jsonrpc: "2.0",
-                id: postData.id,
-                result:
-                  "0x0000000000000000000000000000000000000000000000000000000000000000",
-              }),
-            });
-            return;
-          }
-        }
-
-        await route.continue();
-      });
-
-      await page.goto(`${BASE_URL}/`);
-      await page.waitForTimeout(3000);
-
-      expect(hasUnhandledError).toBe(false);
-    });
-  });
-
-  test.describe("Data Fetch Errors", () => {
-    let sentryInterceptor: SentryInterceptor;
-
-    test.beforeEach(async ({ page }) => {
-      sentryInterceptor = new SentryInterceptor();
-      await sentryInterceptor.setup(page);
-    });
-
-    test("should show error UI when applications query fails", async ({
-      page,
-    }) => {
-      await page.route("**/graphql", async (route) => {
-        const postData = route.request().postDataJSON();
-        const query = postData?.query || "";
-
-        if (query.includes("applications")) {
-          await route.fulfill({
-            status: 200,
-            contentType: "application/json",
-            body: JSON.stringify({
-              errors: [{ message: "Failed to fetch applications" }],
-            }),
-          });
-          return;
-        }
-
-        await route.fulfill({
-          status: 200,
-          contentType: "application/json",
-          body: JSON.stringify({ data: { __typename: "Query" } }),
-        });
-      });
-
-      await page.route(/.*eth.*|.*rpc.*/, async (route) => {
-        const postData = route.request().postDataJSON();
-
-        if (postData?.method === "eth_call") {
-          const data = postData.params?.[0]?.data || "";
-          if (data.startsWith("0x5c975abb")) {
-            await route.fulfill({
-              status: 200,
-              contentType: "application/json",
-              body: JSON.stringify({
-                jsonrpc: "2.0",
-                id: postData.id,
-                result:
-                  "0x0000000000000000000000000000000000000000000000000000000000000000",
-              }),
-            });
-            return;
-          }
-        }
-
-        await route.continue();
-      });
-
-      await page.goto(`${BASE_URL}/`);
-
-      const errorText = page.getByText(/Failed to load applications/i);
-      await expect(errorText).toBeVisible({ timeout: 15000 });
-
-      const tryAgainButton = page.getByRole("button", { name: /Try Again/i });
-      await expect(tryAgainButton).toBeVisible();
-    });
-
-    test("should send Sentry event when applications query fails", async ({
-      page,
-    }) => {
-      await page.route("**/graphql", async (route) => {
-        const postData = route.request().postDataJSON();
-        const query = postData?.query || "";
-
-        if (query.includes("applications")) {
-          await route.fulfill({
-            status: 200,
-            contentType: "application/json",
-            body: JSON.stringify({
-              errors: [{ message: "Failed to fetch applications" }],
-            }),
-          });
-          return;
-        }
-
-        await route.fulfill({
-          status: 200,
-          contentType: "application/json",
-          body: JSON.stringify({ data: { __typename: "Query" } }),
-        });
-      });
-
-      await page.route(/.*eth.*|.*rpc.*/, async (route) => {
-        const postData = route.request().postDataJSON();
-
-        if (postData?.method === "eth_call") {
-          const data = postData.params?.[0]?.data || "";
-          if (data.startsWith("0x5c975abb")) {
-            await route.fulfill({
-              status: 200,
-              contentType: "application/json",
-              body: JSON.stringify({
-                jsonrpc: "2.0",
-                id: postData.id,
-                result:
-                  "0x0000000000000000000000000000000000000000000000000000000000000000",
-              }),
-            });
-            return;
-          }
-        }
-
-        await route.continue();
-      });
-
-      await page.goto(`${BASE_URL}/`);
-      await sentryInterceptor.waitForEvent(page, { timeout: 15000 });
-
-      const sentryRequests = sentryInterceptor.getRequests();
-      expect(sentryRequests.length).toBeGreaterThan(0);
-    });
-  });
+  await expect(
+    page.getByRole("heading", { name: /Configuration Error|Service Unavailable/i }),
+  ).not.toBeVisible();
+  await expect(
+    page.getByText(/Protocol is (soft-paused|fully paused)/),
+  ).not.toBeVisible();
+  expect(backend.served.graphql).toBeGreaterThan(0);
+  expect(backend.served["eth-rpc"]).toBeGreaterThan(0);
+  expect(backend.misses).toEqual([]);
+  expect(pageErrors).toEqual([]);
 });

--- a/services/vault/e2e/network-failures.spec.ts
+++ b/services/vault/e2e/network-failures.spec.ts
@@ -6,9 +6,8 @@
  * unhandled `pageerror` and the document still renders (title set,
  * shell paints text). That is the entirety of what this spec verifies.
  *
- * Catastrophic surfaces (GraphQL unreachable, GraphQL 5xx, missing env,
- * app paused) DO have user-visible blocking modals and are covered in
- * `catastrophic-errors.spec.ts`.
+ * `catastrophic-errors.spec.ts` covers blocking configuration/backend
+ * errors and the protocol pause banner.
  *
  * What this spec deliberately does NOT verify - and why
  * -----------------------------------------------------
@@ -36,6 +35,8 @@
 
 import { type Page, expect, test } from "@playwright/test";
 
+import { installRecordedBackend } from "./fixtures/replay";
+
 // Sentinel URLs - must match MOCK_ENV_VARS in playwright.config.ts.
 // Pinning these here means the intercept matches the exact URL the app
 // fetches, independent of whichever .env file vite happens to load.
@@ -60,18 +61,6 @@ const SLOW_RPC_DELAY_MS = 5_000;
 const GRAPHQL_HEALTHY_BODY = JSON.stringify({
   data: { __typename: "Query" },
 });
-
-const PAUSED_FALSE_RESULT =
-  "0x0000000000000000000000000000000000000000000000000000000000000000";
-const PAUSED_SELECTOR_PREFIX = "0x5c975abb";
-
-function buildPausedFalseResponseBody(id: unknown): string {
-  return JSON.stringify({
-    jsonrpc: "2.0",
-    id,
-    result: PAUSED_FALSE_RESULT,
-  });
-}
 
 async function stubGraphqlHealthy(page: Page) {
   await page.route("**/graphql", async (route) => {
@@ -112,22 +101,9 @@ test.describe("Network failure mode coverage", () => {
     test("RPC timeout does not throw unhandled errors", async ({ page }) => {
       await stubGraphqlHealthy(page);
 
-      // After the paused-check shortcut, every other RPC call aborts
-      // immediately. This simulates an unreachable RPC.
+      // Abort every RPC call to simulate an unreachable endpoint.
       let abortCount = 0;
       await page.route(ETH_RPC_URL, async (route) => {
-        const postData = route.request().postDataJSON();
-        if (postData?.method === "eth_call") {
-          const data = postData.params?.[0]?.data ?? "";
-          if (data.startsWith(PAUSED_SELECTOR_PREFIX)) {
-            await route.fulfill({
-              status: 200,
-              contentType: "application/json",
-              body: buildPausedFalseResponseBody(postData.id),
-            });
-            return;
-          }
-        }
         abortCount += 1;
         await route.abort("timedout");
       });
@@ -150,18 +126,6 @@ test.describe("Network failure mode coverage", () => {
 
       let errorResponseCount = 0;
       await page.route(ETH_RPC_URL, async (route) => {
-        const postData = route.request().postDataJSON();
-        if (postData?.method === "eth_call") {
-          const data = postData.params?.[0]?.data ?? "";
-          if (data.startsWith(PAUSED_SELECTOR_PREFIX)) {
-            await route.fulfill({
-              status: 200,
-              contentType: "application/json",
-              body: buildPausedFalseResponseBody(postData.id),
-            });
-            return;
-          }
-        }
         errorResponseCount += 1;
         await route.fulfill({
           status: 500,
@@ -180,25 +144,7 @@ test.describe("Network failure mode coverage", () => {
 
   test.describe("Vault Provider proxy failures", () => {
     test("VP proxy 5xx does not crash the app", async ({ page }) => {
-      await stubGraphqlHealthy(page);
-
-      // Let the paused-check pass so the app proceeds far enough to
-      // call the VP health endpoint.
-      await page.route(ETH_RPC_URL, async (route) => {
-        const postData = route.request().postDataJSON();
-        if (postData?.method === "eth_call") {
-          const data = postData.params?.[0]?.data ?? "";
-          if (data.startsWith(PAUSED_SELECTOR_PREFIX)) {
-            await route.fulfill({
-              status: 200,
-              contentType: "application/json",
-              body: buildPausedFalseResponseBody(postData.id),
-            });
-            return;
-          }
-        }
-        await route.abort("timedout");
-      });
+      await installRecordedBackend(page);
 
       let vpHealthHitCount = 0;
       await page.route(VP_HEALTH_URL, async (route) => {
@@ -227,17 +173,6 @@ test.describe("Network failure mode coverage", () => {
       let slowResponseCount = 0;
       await page.route(ETH_RPC_URL, async (route) => {
         const postData = route.request().postDataJSON();
-        if (postData?.method === "eth_call") {
-          const data = postData.params?.[0]?.data ?? "";
-          if (data.startsWith(PAUSED_SELECTOR_PREFIX)) {
-            await route.fulfill({
-              status: 200,
-              contentType: "application/json",
-              body: buildPausedFalseResponseBody(postData.id),
-            });
-            return;
-          }
-        }
         slowResponseCount += 1;
         // Hold the request for SLOW_RPC_DELAY_MS, then return a
         // JSON-RPC error. Crucially, the handler never forwards to

--- a/services/vault/e2e/visual/capture.ts
+++ b/services/vault/e2e/visual/capture.ts
@@ -197,30 +197,12 @@ export async function assertNoErrorSurface(
 }
 
 /**
- * Refuse to photograph the mobile layout at a desktop width.
- *
- * A category gate, not a fix for one bug. `installVisualDeterminism` freezes
- * `Date.now()` for the life of the page, and that is load-bearing for
- * clock-derived copy - `stabilize.ts` explains why `clock.install()` is not an
- * option instead. The cost is that any throttled or debounced listener in app
- * code is reduced to a single leading-edge call for the whole capture run: it
- * takes whatever the first event carried and never revises it. A resize
- * listener that reads one spurious width therefore keeps it forever.
- *
- * That is exactly what happened. A full-page screenshot of a page taller than
- * the viewport briefly emulates a 1x1 viewport, core-ui's `useIsMobile` took
- * the 1x1 resize on its leading edge, and five 1280px-wide screens were
- * photographed as the mobile tree. `stabilize.ts` no longer fires that event,
- * which closes the instance; this closes the category, because the next
- * listener to arrive will not have that history to warn it.
- *
- * Checked here rather than by the poll for the same reason as
- * {@link assertNoErrorSurface}: the wrong layout is stable, so no amount of
- * waiting can see it. Only a claim about what the frame must CONTAIN can.
- *
- * Below {@link DESKTOP_LAYOUT_MIN_WIDTH_PX} the gate does nothing - the mobile
- * layout is the correct answer there, and the spurious width 1 lands on the
- * same side of the breakpoint as the real one.
+ * Reject the mobile layout at a desktop width, even when its pixels are stable.
+ * Chromium can emit a temporary 1x1 resize during a full-page screenshot.
+ * The fixed clock lets a throttled listener keep that size after restoration.
+ * Check before and after each screenshot. The capture filter handles only
+ * that temporary event; this guard still catches other wrong-layout causes.
+ * Mobile viewports correctly retain their mobile layout.
  */
 async function assertLayoutMatchesViewport(
   page: Page,
@@ -231,14 +213,8 @@ async function assertLayoutMatchesViewport(
 
   await expect(
     page.locator(MOBILE_MENU_BUTTON),
-    `${label} captured the mobile layout at a ${viewport.width}px viewport. ` +
-      `The app decided it is mobile and never revised that decision, which is ` +
-      `what a resize listener does when it takes a spurious width on its ` +
-      `leading edge and the frozen capture clock stops its trailing edge from ` +
-      `ever firing. The result is a desktop-width photograph of the mobile ` +
-      `tree, and it is perfectly static, so it diffs clean against itself ` +
-      `forever. Find what resized the page during the capture rather than ` +
-      `accepting this as a baseline.`,
+    `${label} shows the mobile menu at a ${viewport.width}px viewport. ` +
+      `Check screenshot resize events and the fixed capture clock.`,
   ).toHaveCount(0);
 }
 
@@ -331,32 +307,55 @@ export interface StagedShot {
 }
 
 /**
- * Settle the page and photograph it, WITHOUT writing it to disk.
- *
- * Staged rather than written because the CI capture step is
- * `continue-on-error` (`.github/workflows/visual-regression.yml`), and that is
- * only safe while a fired gate leaves no file behind. A missing surface is
- * what makes the diff step report "missing" and the summary refuse to say "no
- * visual changes"; a screenshot already on disk would hand the diff a
- * complete, comparable set on both sides and let a failed gate report success.
- * So nothing reaches disk until the gates have passed - see
- * {@link writeCaptures}.
- *
- * Full-page rather than viewport-sized: a change below the fold is still a
- * change, and cropping would hide it.
+ * Capture the full page after content and layout guards pass.
+ * Stage bytes until the whole walk passes; a failure withholds every image.
+ * Keep offscreen pixels and filter temporary 1x1 resizes during capture.
+ * Check the restored viewport and layout before staging the image.
  */
 export async function capture(
   page: Page,
   fileName: string,
 ): Promise<StagedShot> {
   await waitForVisualStability(page);
-  // Per photograph, not per walk - see {@link assertNoErrorSurface}. Settled
-  // is not the same as rendered: an error fallback is perfectly stable.
+  // Reject stable error screens before each screenshot.
   await assertNoErrorSurface(page, fileName);
   // Nor is settled the same as correct: a latched mobile layout is stable too.
   await assertLayoutMatchesViewport(page, fileName);
   await assertNoDevChrome(page, fileName);
-  const buffer = await page.screenshot({ fullPage: true });
+  const viewport = page.viewportSize();
+  if (!viewport || viewport.width <= 1 || viewport.height <= 1) {
+    throw new Error(`${fileName} needs a known viewport larger than 1x1.`);
+  }
+  await page.evaluate(() =>
+    document.documentElement.setAttribute("data-visual-capture", ""),
+  );
+  let buffer: Buffer;
+  let captureFailed = false;
+  try {
+    buffer = await page.screenshot({ fullPage: true });
+    await expect
+      .poll(() =>
+        page.evaluate(() => ({
+          width: innerWidth,
+          height: innerHeight,
+        })),
+      )
+      .toEqual(viewport);
+  } catch (error) {
+    captureFailed = true;
+    throw error;
+  } finally {
+    await page
+      .evaluate(() =>
+        document.documentElement.removeAttribute("data-visual-capture"),
+      )
+      .catch((error) => {
+        if (!captureFailed) throw error;
+        // eslint-disable-next-line no-console -- Keep the secondary browser failure in the test log.
+        console.error("Full-page capture cleanup also failed:", error);
+      });
+  }
+  await assertLayoutMatchesViewport(page, fileName);
   expect(
     buffer.byteLength,
     `${fileName} is ${buffer.byteLength} bytes - the screen never painted.`,
@@ -364,11 +363,7 @@ export async function capture(
   return { fileName, buffer };
 }
 
-/**
- * Write staged photographs to disk. Call only after {@link assertAppRendered}
- * has passed - reaching here is the test's statement that what it photographed
- * is worth diffing against.
- */
+/** Write staged images only after the whole walk passes its guards. */
 export async function writeCaptures(
   shots: readonly StagedShot[],
 ): Promise<void> {
@@ -381,23 +376,10 @@ export async function writeCaptures(
 }
 
 /**
- * Create the output directory and declare which screens it should end up
- * holding. Call from `test.beforeAll`.
- *
- * The manifest is what closes the last silent-green path. A fired gate
- * withholds a PNG, which the diff step is meant to read as "missing" - but it
- * only checks that each surface DIRECTORY is non-empty, and `visual-diff.mjs`
- * builds its name set from the union of the two sides, so a screen absent from
- * BOTH never enters the comparison at all. Both sides run the same stashed
- * harness against the same committed fixture, so every fixture- or
- * harness-caused failure is symmetric BY CONSTRUCTION: the ten deposit-flow
- * shots vanish from both sides, the twelve route shots still land, and the run
- * reports "No visual changes" for a comparison that never looked at 10 of 58
- * screens.
- *
- * Written at collection time rather than derived at diff time on purpose: it
- * is a statement of intent made before anything can fail, so a spec that never
- * ran at all still leaves its screens accounted for.
+ * Declare expected screens before tests run, including walks that may fail.
+ * The report uses this manifest to find screens absent from both sides.
+ * A screen present on only one side needs separate capture-failure handling.
+ * Call from `test.beforeAll`; every spec writes the same target list.
  */
 export async function ensureOutputDir(): Promise<void> {
   await fs.mkdir(VISUAL_OUTPUT_DIR, { recursive: true });

--- a/services/vault/e2e/visual/stabilize.ts
+++ b/services/vault/e2e/visual/stabilize.ts
@@ -14,10 +14,8 @@
  *   deliberately keeps running (`.bbn-loader`, see docs/motion-system.md).
  *   A functional spinner is exactly what a screenshot catches mid-frame,
  *   so `FREEZE_SPINNER_CSS` stops it at a fixed angle.
- * - **Clock-derived copy** (relative timestamps, countdowns, expiry) is
- *   pinned with `setFixedTime`. Deliberately NOT `clock.install()`:
- *   full fake timers stall React Query's retry/refetch scheduling and
- *   the app never reaches a settled frame.
+ * - **Clock-derived copy** stays pinned with `setFixedTime`. Timers
+ *   keep React Query's retry and refetch scheduling active.
  * - **Web fonts** are self-hosted woff2 (`src/globals.css`), so there is
  *   no CDN race - but the first paint can still land before Px-Grotesk
  *   swaps in, so we await `document.fonts.ready`.
@@ -108,6 +106,20 @@ const MIN_RENDERED_TEXT_LENGTH = 20;
  */
 export async function installVisualDeterminism(page: Page): Promise<void> {
   await page.clock.setFixedTime(VISUAL_FIXED_TIME);
+  await page.addInitScript(() => {
+    window.addEventListener(
+      "resize",
+      (event) => {
+        if (
+          innerWidth === 1 &&
+          innerHeight === 1 &&
+          document.documentElement?.hasAttribute("data-visual-capture")
+        )
+          event.stopImmediatePropagation();
+      },
+      true,
+    );
+  });
 }
 
 /**

--- a/services/vault/playwright.config.ts
+++ b/services/vault/playwright.config.ts
@@ -30,11 +30,10 @@ const BEHAVIOURAL_TEST_IGNORE = ["**/visual/**", GOD_MODE_SPEC];
  * different app than the one under test.
  */
 export const MOCK_ENV_VARS = {
-  NEXT_PUBLIC_TBV_BTC_VAULT_REGISTRY:
-    "0x0000000000000000000000000000000000000001",
-  NEXT_PUBLIC_TBV_AAVE_ADAPTER: "0x0000000000000000000000000000000000000002",
-  NEXT_PUBLIC_TBV_AAVE_ADAPTER_CONFIG:
-    "0x0000000000000000000000000000000000000003",
+  NEXT_PUBLIC_TBV_BTC_VAULT_REGISTRY: RECORDED_DEPLOYMENT.BTC_VAULT_REGISTRY,
+  NEXT_PUBLIC_TBV_AAVE_ADAPTER: RECORDED_DEPLOYMENT.AAVE_ADAPTER,
+  NEXT_PUBLIC_TBV_AAVE_ADAPTER_CONFIG: RECORDED_DEPLOYMENT.AAVE_ADAPTER_CONFIG,
+  NEXT_PUBLIC_TBV_BTC_PRICE_FEED: RECORDED_DEPLOYMENT.BTC_PRICE_FEED,
   NEXT_PUBLIC_TBV_GRAPHQL_ENDPOINT: "http://localhost:9999/graphql",
   NEXT_PUBLIC_TBV_VP_PROXY_URL: "http://localhost:9998",
   NEXT_PUBLIC_ETH_RPC_URL: "http://localhost:9997/rpc",
@@ -68,13 +67,8 @@ export const MOCK_ENV_VARS = {
 };
 
 /**
- * Point the app at the deployment the replayed recording was captured
- * against. `MOCK_ENV_VARS` uses 0x…0001/2/3 placeholders, which are fine for
- * the behavioural suite (it asserts on what the app DOES with a response) and
- * useless against the recording: a replayed read is answered by the address it
- * was aimed at, so a placeholder matches nothing and every screen falls back
- * to the error boundary. See `e2e/fixtures/replay/contracts.ts`. Shared by
- * the god-mode server below and `playwright.visual.config.ts`.
+ * Keep the recorded deployment available to the god-mode and visual servers.
+ * Visual captures also use these values when testing baseline code.
  */
 export const RECORDED_DEPLOYMENT_ENV = {
   NEXT_PUBLIC_TBV_BTC_VAULT_REGISTRY: RECORDED_DEPLOYMENT.BTC_VAULT_REGISTRY,
@@ -100,7 +94,7 @@ export default defineConfig({
   // chases live animations for its full timeout and then retries twice.
   testIgnore: "**/visual/**",
   fullyParallel: false,
-  forbidOnly: false,
+  forbidOnly: !!process.env.CI,
   retries: 2,
   timeout: 90_000,
   workers: 1,
@@ -132,35 +126,36 @@ export default defineConfig({
 
   webServer: [
     {
-      command: `pnpm exec vite --port ${PORT_MISSING_ENV}`,
+      command: `pnpm exec vite --port ${PORT_MISSING_ENV} --strictPort`,
       url: `http://localhost:${PORT_MISSING_ENV}`,
       timeout: 120_000,
-      reuseExistingServer: true,
-      // This "missing configuration" server inherits the parent shell. Force the Sentry DSN
-      // empty so a developer's exported NEXT_PUBLIC_SENTRY_DSN can't enable Sentry here and
-      // transmit to a real project — the enable gate is DSN-only.
+      reuseExistingServer: !process.env.CI,
+      // Disable Sentry on the server with missing configuration.
       env: {
         NEXT_PUBLIC_SENTRY_DSN: "",
+        PLAYWRIGHT_VITE_CACHE_DIR: "node_modules/.vite-e2e-missing",
       },
     },
     {
-      command: `pnpm exec vite --port ${PORT_FULL_ENV}`,
+      command: `pnpm exec vite --port ${PORT_FULL_ENV} --strictPort`,
       url: `http://localhost:${PORT_FULL_ENV}`,
       timeout: 120_000,
-      reuseExistingServer: true,
+      reuseExistingServer: !process.env.CI,
       env: {
         ...MOCK_ENV_VARS,
+        PLAYWRIGHT_VITE_CACHE_DIR: "node_modules/.vite-e2e-full",
       },
     },
     {
-      command: `pnpm exec vite --port ${PORT_GOD_MODE}`,
+      command: `pnpm exec vite --port ${PORT_GOD_MODE} --strictPort`,
       url: `http://localhost:${PORT_GOD_MODE}`,
       timeout: 120_000,
-      reuseExistingServer: true,
+      reuseExistingServer: !process.env.CI,
       env: {
         ...MOCK_ENV_VARS,
         ...RECORDED_DEPLOYMENT_ENV,
         NEXT_PUBLIC_FF_GOD_MODE_PANEL: "true",
+        PLAYWRIGHT_VITE_CACHE_DIR: "node_modules/.vite-e2e-god-mode",
       },
     },
   ],

--- a/services/vault/playwright.config.ts
+++ b/services/vault/playwright.config.ts
@@ -102,7 +102,7 @@ export default defineConfig({
 
   use: {
     headless: true,
-    trace: "on-first-retry",
+    trace: "retain-on-failure",
   },
 
   projects: [

--- a/services/vault/vite.config.ts
+++ b/services/vault/vite.config.ts
@@ -92,8 +92,9 @@ const enableSentryPlugin =
       process.env.SENTRY_PROJECT,
   );
 
-export default defineConfig(({ mode }) => ({
-  cacheDir: process.env.PLAYWRIGHT_VITE_CACHE_DIR,
+export default defineConfig(({ mode, command }) => ({
+  cacheDir:
+    command === "serve" ? process.env.PLAYWRIGHT_VITE_CACHE_DIR : undefined,
   server: {
     headers: SECURITY_HEADERS,
     proxy: resolveSidecarProxy(mode),

--- a/services/vault/vite.config.ts
+++ b/services/vault/vite.config.ts
@@ -92,8 +92,8 @@ const enableSentryPlugin =
       process.env.SENTRY_PROJECT,
   );
 
-// https://vite.dev/config/
 export default defineConfig(({ mode }) => ({
+  cacheDir: process.env.PLAYWRIGHT_VITE_CACHE_DIR,
   server: {
     headers: SECURITY_HEADERS,
     proxy: resolveSidecarProxy(mode),


### PR DESCRIPTION
## Outcome

PR verification runs wallet connector, Vault, and staking browser checks. A browser failure no longer skips unit tests or API documentation checks.

## Change

Build the wallet test page before CI opens it. Complete staking responses with real recordings and existing chain responses. Validate signer inputs and the Bitcoin balance. Restore query-error, Retry, and error-reporting coverage. Mark fulfilled reward requests as handled. Name the withdrawal fixture input and fee rate without changing its data.

Supply the existing Cosmos signer before OKX detection. Report required OKX setup failures with safe password errors. Wait for Keplr's completed setup screen, then close its tab.

During full-page screenshots, filter Chromium's temporary 1x1 resize until the viewport is restored. Keep the fixed clock and all content and layout checks. Check each capture against its own screen list so missing images are reported as incomplete.

## Safety

Wallet tests use fresh, unfunded wallets. Submissions are intercepted and checked. No real transactions are sent. Wallet traces, screenshots, and video are disabled. Seed and password input errors use safe messages without the original cause. App failure traces remain available.

The visual repair changes test and report code only. Screenshots retain all content below the viewport. Other resize events still reach the app. Failed screenshots clear the filter and preserve the original error. Pixel differences remain advisory.

## Verification

- [CI passes at ea328745](https://github.com/babylonlabs-io/babylon-toolkit/actions/runs/34387375632). Both clean package consumers, all browser gates, affected unit tests, and generated API documentation pass.
- [Visual regression passes](https://github.com/babylonlabs-io/babylon-toolkit/actions/runs/34387375577). Both sides have all 58 Vault images, including 42 deposit images, and all 329 Storybook images. No missing images or reported visual changes. Small raw pixel differences remain below the existing comparison threshold.
- [Greptile gives 5/5](https://github.com/babylonlabs-io/babylon-toolkit/pull/2463#issuecomment-5593131191) for this commit. All review conversations are resolved. The PR is approved.
- The fixture clarification preserves all exported data and transaction bytes. Four withdrawal browser cases and 371 unit tests pass locally, with one existing skip. It adds no net lines.

These checks cover the current flows. Final Ethereum-first release evidence remains in #2233.

## Links

Closes #2453.

Parent: #2233. Epic: #2228.
