### PR TITLE
docs(ts-sdk): consolidate frozen expander comments

### DIFF
--- a/packages/babylon-ts-sdk/src/tbv/core/wasm/index.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/wasm/index.ts
@@ -348,7 +348,7 @@ export async function expandAuthAnchor(root: Uint8Array): Promise<Uint8Array> {
 /**
  * Derive 32-byte `hashlockSecret` for HTLC `htlcVout` (preimage → `activateVaultWithSecret`).
  * @stability frozen - btc-vault Rust owns this API.
- * Changing the derived bytes prevents affected vaults from activating. See CLAUDE.md §4.
+ * Changing the derived bytes means affected vaults can never activate. See CLAUDE.md §4.
  */
 export async function expandHashlockSecret(
   root: Uint8Array,
@@ -360,7 +360,7 @@ export async function expandHashlockSecret(
 /**
  * Derive 64-byte `wotsSeed` for HTLC `htlcVout` (→ WOTS keys, hashed as `depositorWotsPkHash`).
  * @stability frozen - btc-vault Rust owns this API.
- * Changing the derived bytes breaks existing `depositorWotsPkHash` values and prevents claims. See CLAUDE.md §4.
+ * Changing the derived bytes breaks existing `depositorWotsPkHash` values. No claim path remains. See CLAUDE.md §4.
  */
 export async function expandWotsSeed(
   root: Uint8Array,

--- a/packages/babylon-ts-sdk/src/tbv/core/wasm/index.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/wasm/index.ts
@@ -338,11 +338,8 @@ export async function getChallengeAssertScriptInfo(
 
 /**
  * Derive 32-byte `authAnchor` (OP_RETURN preimage → VP bearer token).
- * @stability frozen — forwards the frozen expander in `@babylonlabs-io/babylon-tbv-rust-wasm`; see CLAUDE.md §4.
- */
-/**
- * Derive 32-byte `authAnchor` (OP_RETURN preimage → VP bearer token).
- * @stability frozen — owned by btc-vault Rust via the vault-wasm pin (`VAULT_WASM_COMMIT`); rotation breaks VP auth for existing deposits.
+ * @stability frozen - btc-vault Rust owns this API through the vault-wasm pin (`VAULT_WASM_COMMIT`).
+ * Changing the derived bytes breaks VP auth for existing deposits. See CLAUDE.md §4.
  */
 export async function expandAuthAnchor(root: Uint8Array): Promise<Uint8Array> {
   return (await loadTbvWasm()).expandAuthAnchor(root);
@@ -350,11 +347,8 @@ export async function expandAuthAnchor(root: Uint8Array): Promise<Uint8Array> {
 
 /**
  * Derive 32-byte `hashlockSecret` for HTLC `htlcVout` (preimage → `activateVaultWithSecret`).
- * @stability frozen — forwards the frozen expander in `@babylonlabs-io/babylon-tbv-rust-wasm`; see CLAUDE.md §4.
- */
-/**
- * Derive 32-byte `hashlockSecret` for HTLC `htlcVout` (preimage → `activateVaultWithSecret`).
- * @stability frozen — owned by btc-vault Rust; rotation means affected vaults can never activate.
+ * @stability frozen - btc-vault Rust owns this API.
+ * Changing the derived bytes prevents affected vaults from activating. See CLAUDE.md §4.
  */
 export async function expandHashlockSecret(
   root: Uint8Array,
@@ -365,11 +359,8 @@ export async function expandHashlockSecret(
 
 /**
  * Derive 64-byte `wotsSeed` for HTLC `htlcVout` (→ WOTS keys, hashed as `depositorWotsPkHash`).
- * @stability frozen — forwards the frozen expander in `@babylonlabs-io/babylon-tbv-rust-wasm`; see CLAUDE.md §4.
- */
-/**
- * Derive 64-byte `wotsSeed` for HTLC `htlcVout` (→ WOTS keys, hashed as `depositorWotsPkHash`).
- * @stability frozen — owned by btc-vault Rust; rotation breaks existing `depositorWotsPkHash` → no claim path.
+ * @stability frozen - btc-vault Rust owns this API.
+ * Changing the derived bytes breaks existing `depositorWotsPkHash` values and prevents claims. See CLAUDE.md §4.
  */
 export async function expandWotsSeed(
   root: Uint8Array,


### PR DESCRIPTION
## Outcome

Each frozen expander has one attached stability comment. The comments retain the permanent effect of changing derived bytes.

## Change

Remove duplicate comments. Keep Rust ownership, the effect of byte changes, and the reference to CLAUDE.md section 4. Use the required regular hyphens.

## Safety

Emitted code is unchanged. The required owner reviews apply to this registered critical path.

## Verification

At `ce1f46848670c1bbea71e00ae5aed607d5be46fb`, 1,966 SDK unit tests and 7 built-package tests pass. Lint and API documentation checks pass. Generated documentation is unchanged. Emitted code matches the previous commit.

## Links

Tracks #2345. #2345 stays open until every remaining cleanup item is complete.

Covers [the duplicate stability comment finding](https://github.com/babylonlabs-io/babylon-toolkit/pull/2307#discussion_r3865457104).
