### PR TITLE
test(ts-sdk): state the loader cache reset behavior

### DIFF
--- a/packages/babylon-ts-sdk/src/tbv/core/wasm/__tests__/loader.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/wasm/__tests__/loader.test.ts
@@ -105,7 +105,7 @@ describe("loadRawTbvWasm", () => {
   });
 
   it("clears the SDK cache after an initWasm rejection", async () => {
-    // This mock proves that the SDK clears its cache after a rejection.
+    // Without the SDK cache reset, later calls would repeat this rejection.
     // The real engine keeps generated initialization failures latched.
     let initCalls = 0;
     vi.doMock(RAW, () => ({

--- a/packages/babylon-ts-sdk/src/tbv/core/wasm/__tests__/loader.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/wasm/__tests__/loader.test.ts
@@ -104,9 +104,9 @@ describe("loadRawTbvWasm", () => {
     expect(causeMessages(error)).toContain("wasm instantiation failed");
   });
 
-  it("clears the cache after an initWasm failure so a retry re-initializes", async () => {
-    // initWasm runs inside the cached promise, so a failure there has to clear
-    // the cache too or the engine is unusable for the rest of the session.
+  it("clears the SDK cache after an initWasm rejection", async () => {
+    // This mock proves that the SDK clears its cache after a rejection.
+    // The real engine keeps generated initialization failures latched.
     let initCalls = 0;
     vi.doMock(RAW, () => ({
       initWasm: async () => {


### PR DESCRIPTION
## Outcome

The loader test states that it proves SDK cache reset. Its comment explains why a rejected promise must leave the cache.

## Change

Correct the test name and comments. Keep all assertions.

## Safety

Generated engine initialization failures remain latched. The test does not claim that those failures recover. #2367 covers browser download and compile retries.

## Verification

At `b61802c78f4c61bc51acfbdb2c7125c1103ac937`, 1,966 SDK unit tests and 7 built-package tests pass. Dependent builds, lint, and diff checks pass. Only wording changes; emitted code is identical.

## Links

Tracks #2345. #2345 stays open until every remaining cleanup item is complete.

Covers [the loader test wording finding](https://github.com/babylonlabs-io/babylon-toolkit/pull/2307#discussion_r3865457120).
