### PR TITLE
docs(packages): correct loader and module comments

### DIFF
--- a/packages/babylon-tbv-rust-wasm/src/index-node.ts
+++ b/packages/babylon-tbv-rust-wasm/src/index-node.ts
@@ -1,9 +1,8 @@
 // Node.js entry point for the WASM bindings.
 //
-// Loads the committed web WASM binary synchronously from disk using
-// readFileSync and initializes it via initSync. This avoids fetch()-based
-// loading, which does not work in Node.js environments, and does not require
-// a separate wasm-pack --target nodejs build step.
+// The loader reads the committed web WASM binary asynchronously on first use.
+// It initializes the binary with initSync. No fetch() or separate
+// wasm-pack --target nodejs build is needed.
 
 import {
   getWasmBindings,

--- a/packages/babylon-ts-sdk/eslint.config.mjs
+++ b/packages/babylon-ts-sdk/eslint.config.mjs
@@ -79,9 +79,7 @@ export default defineConfig([
       ],
     },
   },
-  // `import { type X } from "pkg"` leaves a side-effect import behind under
-  // verbatimModuleSyntax, which would defeat allowTypeImports above. Keep
-  // every type-only import in the top-level `import type` form.
+  // Keep every type-only import in the top-level `import type` form.
   {
     files: ["src/**/*.ts"],
     rules: {

--- a/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/status/index.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/vault-provider/status/index.ts
@@ -6,7 +6,7 @@
  * for unauthenticated status reads and polling that must remain usable in an
  * Ethereum-only application session.
  *
- * @module clients/vault-provider/status
+ * @module tbv/core/clients/vault-provider/status
  */
 
 export { VaultProviderRpcClient } from "../api";


### PR DESCRIPTION
## Outcome

The code comments match the current loading behavior and published module path. Local checks pass.

## Change

- Describe the Node loader's asynchronous read on first use.
- Keep the import-type style rule and remove its inaccurate explanation.
- Use the full published path in the status module tag.

## Safety

The emitted code is unchanged. The engine remains an optional peer, so that accurate comment stays. The required owner reviews still apply to the Node entry.

## Verification

- Nx SDK and engine lint checks passed.
- Nx engine build and lazy-entry check passed.
- Nx SDK API documentation check passed. Generated documentation is unchanged.
- The patch adds 5 lines and removes 8. Diff checks pass.

## Links

Tracks #2345. #2345 stays open until every remaining cleanup item is complete.

Covers the accepted stale comment and module name findings from #2307. The optional-peer contract changed in #2336.
