### PR TITLE
docs(wasm): correct the Node loader comment

### DIFF
--- a/packages/babylon-tbv-rust-wasm/scripts/build-wasm.js
+++ b/packages/babylon-tbv-rust-wasm/scripts/build-wasm.js
@@ -243,9 +243,9 @@ const buildWasm = async () => {
       process.exit(1);
     }
 
-    // Copy generated files to dist/generated. The node entrypoint
-    // (src/index-node.ts) loads this same web artifact via readFileSync +
-    // initSync, so no separate nodejs-target build is needed.
+    // Copy generated files to dist/generated. The Node loader
+    // (src/wasm-loader-node.ts) uses readFile, then initSync.
+    // No separate nodejs-target build is needed.
     console.log('Copying generated files...');
     const name = 'vault_wasm';
 


### PR DESCRIPTION
## Outcome

The build script comment matches the current Node loader. Local checks pass.

## Change

Name `src/wasm-loader-node.ts` and its `readFile` call before `initSync`. This corrects the remaining review finding from merged #2469.

## Safety

Only three comment lines change. Executable code and the WASM commit pin are unchanged. The two code-owner reviews and line review required by `CLAUDE.md` still apply.

## Verification

- Nx engine lint, build, and lazy-entry checks pass.
- All 10 loader tests pass.
- Node syntax and diff checks pass.
- The script emits identical code with comments removed.

## Links

Tracks #2345. #2345 stays open.

Follow-up to #2469.
