### PR TITLE
feat(wallet-connector): preserve Bitcoin on Ethereum disconnect

### DIFF
--- a/packages/babylon-wallet-connector/src/components/Chains/__tests__/container.test.tsx
+++ b/packages/babylon-wallet-connector/src/components/Chains/__tests__/container.test.tsx
@@ -2,7 +2,8 @@ import { render } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from "vitest";
 
 import type { IChain } from "@/core/types";
-import { APPKIT_BTC_CONNECTOR_ID, APPKIT_OPEN_EVENT } from "@/core/wallets/appkit/constants";
+import { APPKIT_BTC_CONNECTOR_ID, APPKIT_ETH_CONNECTOR_ID, APPKIT_OPEN_EVENT } from "@/core/wallets/appkit/constants";
+import { __resetSharedBtcAppKitConfigForTests, setSharedBtcAppKitConfig } from "@/core/wallets/btc/appkit/sharedConfig";
 import { ERROR_CODES, WalletError } from "@/error";
 
 import { ChainsContainer } from "../container";
@@ -38,9 +39,25 @@ let connect: ReturnType<typeof vi.fn>;
 let displayWallets: ReturnType<typeof vi.fn>;
 let appKitOpened: Mock<(event: Event) => void>;
 
-function selectBtc() {
+function selectChain(id: "BTC" | "ETH") {
   render(<ChainsContainer />);
-  return harness.onSelectChain!(BTC_CHAIN);
+  return harness.onSelectChain!({ id } as IChain);
+}
+
+function configureEthereum(providerType: string, btcConnected = true) {
+  harness.connectors.ETH = {
+    wallets: [{ id: APPKIT_ETH_CONNECTOR_ID }],
+    connectedWallet: { id: APPKIT_ETH_CONNECTOR_ID },
+    connect,
+  };
+  setSharedBtcAppKitConfig({
+    modal: {
+      getProviderType: (namespace: string) => (namespace === "eip155" ? providerType : "ANNOUNCED"),
+      getAccount: (namespace: string) => (namespace === "bip122" ? { isConnected: btcConnected } : undefined),
+    } as never,
+    adapter: {} as never,
+    network: "signet",
+  });
 }
 
 beforeEach(() => {
@@ -68,14 +85,31 @@ beforeEach(() => {
 
 afterEach(() => {
   window.removeEventListener(APPKIT_OPEN_EVENT, appKitOpened);
+  __resetSharedBtcAppKitConfigForTests();
 });
 
-describe("selecting an already-connected AppKit Bitcoin row", () => {
-  it("disconnects bitcoin through the connector instead of opening the AppKit modal", async () => {
-    await selectBtc();
+it.each(["BTC", "ETH"] as const)("connects the selected %s wallet when disconnected", async (chain) => {
+  if (chain === "ETH") configureEthereum("WALLET_CONNECT");
+  const connector = harness.connectors[chain] as { connectedWallet?: unknown };
+  connector.connectedWallet = undefined;
+
+  await selectChain(chain);
+
+  expect(connect).toHaveBeenCalledWith(chain === "ETH" ? APPKIT_ETH_CONNECTOR_ID : APPKIT_BTC_CONNECTOR_ID);
+  expect(harness.disconnect).not.toHaveBeenCalled();
+  expect(appKitOpened).not.toHaveBeenCalled();
+});
+
+describe.each(["BTC", "ETH"] as const)("selecting a connected AppKit %s row in a shared session", (chain) => {
+  beforeEach(() => {
+    if (chain === "ETH") configureEthereum("WALLET_CONNECT");
+  });
+
+  it("uses the guarded disconnect without opening the AppKit modal", async () => {
+    await selectChain(chain);
 
     expect(harness.disconnect).toHaveBeenCalledTimes(1);
-    expect(harness.disconnect).toHaveBeenCalledWith("BTC");
+    expect(harness.disconnect).toHaveBeenCalledWith(chain);
     expect(appKitOpened).not.toHaveBeenCalled();
     expect(connect).not.toHaveBeenCalled();
   });
@@ -83,10 +117,10 @@ describe("selecting an already-connected AppKit Bitcoin row", () => {
   it("settles quietly when the disconnect is refused for a shared session", async () => {
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
     harness.disconnect.mockRejectedValue(
-      new WalletError({ code: ERROR_CODES.SHARED_SESSION_DISCONNECT_REFUSED, message: "shared", chainId: "BTC" }),
+      new WalletError({ code: ERROR_CODES.SHARED_SESSION_DISCONNECT_REFUSED, message: "shared", chainId: chain }),
     );
 
-    await expect(selectBtc()).resolves.toBeUndefined();
+    await expect(selectChain(chain)).resolves.toBeUndefined();
 
     expect(consoleError).not.toHaveBeenCalled();
     expect(appKitOpened).not.toHaveBeenCalled();
@@ -97,10 +131,35 @@ describe("selecting an already-connected AppKit Bitcoin row", () => {
     const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
     harness.disconnect.mockRejectedValue(new Error("relay down"));
 
-    await expect(selectBtc()).resolves.toBeUndefined();
+    await expect(selectChain(chain)).resolves.toBeUndefined();
 
-    expect(consoleError).toHaveBeenCalledWith("Failed to disconnect AppKit BTC:", "relay down");
+    expect(consoleError).toHaveBeenCalledWith(`Failed to disconnect AppKit ${chain}:`, "relay down");
     expect(appKitOpened).not.toHaveBeenCalled();
     consoleError.mockRestore();
   });
 });
+
+it("guards the connected Ethereum row for an Auth session", async () => {
+  configureEthereum("AUTH");
+
+  await selectChain("ETH");
+
+  expect(harness.disconnect).toHaveBeenCalledWith("ETH");
+  expect(appKitOpened).not.toHaveBeenCalled();
+});
+
+it.each([
+  ["ANNOUNCED", true],
+  ["WALLET_CONNECT", false],
+] as const)(
+  "allows the Ethereum account modal for %s with Bitcoin connected=%s",
+  async (providerType, btcConnected) => {
+    configureEthereum(providerType, btcConnected);
+
+    await selectChain("ETH");
+
+    expect(harness.disconnect).not.toHaveBeenCalled();
+    expect(appKitOpened).toHaveBeenCalledTimes(1);
+    expect(connect).not.toHaveBeenCalled();
+  },
+);

--- a/packages/babylon-wallet-connector/src/components/Chains/container.tsx
+++ b/packages/babylon-wallet-connector/src/components/Chains/container.tsx
@@ -6,6 +6,7 @@ import type { IChain } from "@/core/types";
 // adapter into the `./eth` graph, since this screen is part of the dialog.
 import { useChainProviders } from "@/context/Chain.context";
 import { APPKIT_BTC_CONNECTOR_ID, APPKIT_ETH_CONNECTOR_ID, APPKIT_OPEN_EVENT } from "@/core/wallets/appkit/constants";
+import { ethDisconnectWouldDropBitcoin } from "@/core/wallets/eth/appkit/sharedConfig";
 import { isSharedSessionRefusal } from "@/error";
 import { useWalletConnect } from "@/hooks/useWalletConnect";
 import { useWidgetState } from "@/hooks/useWidgetState";
@@ -36,59 +37,27 @@ export function ChainsContainer(props: ContainerProps) {
 
   const handleSelectChain = useCallback(
     async (chain: IChain) => {
-      // Special handling for ETH chain with only AppKit wallet
-      if (chain.id === "ETH") {
-        const ethConnector = connectors.ETH;
-        const appkitWallet = ethConnector?.wallets.find((w) => w.id === APPKIT_ETH_CONNECTOR_ID);
-
-        if (appkitWallet && ethConnector?.wallets.length === 1) {
-          // Already connected: reopen the AppKit modal so the user can switch/disconnect.
-          if (ethConnector.connectedWallet) {
-            openAppKitModal();
-            return;
-          }
-
-          // Only AppKit available, connect it directly
-          // This will trigger the AppKitProvider.connectWallet() which dispatches the event
+      if (chain.id === "ETH" || chain.id === "BTC") {
+        const connector = connectors[chain.id];
+        const appkitId = chain.id === "ETH" ? APPKIT_ETH_CONNECTOR_ID : APPKIT_BTC_CONNECTOR_ID;
+        const wallet = connector?.wallets.find((candidate) => candidate.id === appkitId);
+        if (wallet && connector?.wallets.length === 1) {
+          const connected = Boolean(connector.connectedWallet);
           try {
-            await ethConnector.connect(appkitWallet);
-          } catch (error) {
-            console.error("Failed to connect AppKit:", error);
-          }
-          return;
-        }
-      }
-
-      // Special handling for BTC chain with only AppKit wallet
-      if (chain.id === "BTC") {
-        const btcConnector = connectors.BTC;
-        const appkitBtcWallet = btcConnector?.wallets.find((w) => w.id === APPKIT_BTC_CONNECTOR_ID);
-
-        if (appkitBtcWallet && btcConnector?.wallets.length === 1) {
-          // Already connected: disconnect through the connector rather than
-          // reopening Reown, whose own Disconnect control drops a shared
-          // session for every chain. A shared session is refused and the
-          // dialog explains why; the row can be clicked again to connect.
-          if (btcConnector.connectedWallet) {
-            try {
-              await disconnect("BTC");
-            } catch (error) {
-              if (!isSharedSessionRefusal(error)) {
-                console.error(
-                  "Failed to disconnect AppKit BTC:",
-                  error instanceof Error ? error.message : "Unknown error",
-                );
-              }
+            if (!connected) {
+              await connector.connect(wallet.id);
+            } else if (chain.id === "ETH" && !ethDisconnectWouldDropBitcoin()) {
+              openAppKitModal();
+            } else {
+              await disconnect(chain.id);
             }
-            return;
-          }
-
-          // Only AppKit available, connect it directly
-          // This will trigger the AppKitBTCProvider.connectWallet() which dispatches the event
-          try {
-            await btcConnector.connect(appkitBtcWallet);
           } catch (error) {
-            console.error("Failed to connect AppKit BTC:", error);
+            if (!isSharedSessionRefusal(error)) {
+              console.error(
+                `Failed to ${connected ? "disconnect" : "connect"} AppKit ${chain.id}:`,
+                error instanceof Error ? error.message : "Unknown error",
+              );
+            }
           }
           return;
         }

--- a/packages/babylon-wallet-connector/src/core/wallets/appkit/state.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/appkit/state.ts
@@ -96,6 +96,7 @@ export function createAppKitCapabilities({
  * the Bitcoin adapter through its sibling.
  */
 let appKitState: AppKitState | null = null;
+let manualAppKitModal: AppKitModal | null = null;
 const manualAppKitCapabilities = new Set<"Ethereum" | "Bitcoin">();
 
 export function failInitialization(message: string, chainId?: string): never {
@@ -107,10 +108,10 @@ export function getAppKitState(): AppKitState | null {
 }
 
 export function getAppKitModal(): AppKitModal | null {
-  return appKitState?.modal ?? null;
+  return appKitState?.modal ?? manualAppKitModal;
 }
 
-export function registerManualAppKitConfig(capability: "Ethereum" | "Bitcoin"): void {
+export function registerManualAppKitConfig(capability: "Ethereum" | "Bitcoin", modal?: AppKitModal): void {
   if (appKitState) {
     failInitialization(
       `Cannot set a manual ${capability} AppKit configuration after AppKit initialization. Use the canonical AppKit state.`,
@@ -118,11 +119,13 @@ export function registerManualAppKitConfig(capability: "Ethereum" | "Bitcoin"): 
   }
 
   manualAppKitCapabilities.add(capability);
+  if (modal) manualAppKitModal = modal;
 }
 
 /** @internal */
 export function __resetManualAppKitConfigForTests(capability: "Ethereum" | "Bitcoin"): void {
   manualAppKitCapabilities.delete(capability);
+  if (capability === "Bitcoin") manualAppKitModal = null;
 }
 
 export function validateAppKitInitialization(projectId?: string): projectId is string {

--- a/packages/babylon-wallet-connector/src/core/wallets/btc/appkit/__tests__/sharedConfig.test.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/appkit/__tests__/sharedConfig.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+import { ethDisconnectWouldDropBitcoin } from "@/core/wallets/eth/appkit/sharedConfig";
+
 import {
   __resetSharedBtcAppKitConfigForTests,
   btcDisconnectWouldDropEthereum,
@@ -26,55 +28,58 @@ function setModal(session: {
   return modal;
 }
 
-describe("btcDisconnectWouldDropEthereum", () => {
-  it("reports true when bitcoin runs over walletconnect and ethereum is connected", () => {
+describe.each([
+  ["Bitcoin", "bip122", "eip155", btcDisconnectWouldDropEthereum],
+  ["Ethereum", "eip155", "bip122", ethDisconnectWouldDropBitcoin],
+] as const)("%s shared disconnect", (_chain, namespace, otherNamespace, wouldDropOther) => {
+  it("refuses WalletConnect while the other chain is connected", () => {
     const modal = setModal({
-      providerTypes: { bip122: "WALLET_CONNECT", eip155: "ANNOUNCED" },
-      accounts: { bip122: { isConnected: false }, eip155: { isConnected: true } },
+      providerTypes: { [namespace]: "WALLET_CONNECT", [otherNamespace]: "ANNOUNCED" },
+      accounts: { [namespace]: { isConnected: false }, [otherNamespace]: { isConnected: true } },
     });
 
-    expect(btcDisconnectWouldDropEthereum()).toBe(true);
-    expect(modal.getProviderType).toHaveBeenCalledWith("bip122");
-    expect(modal.getAccount).toHaveBeenCalledWith("eip155");
+    expect(wouldDropOther()).toBe(true);
+    expect(modal.getProviderType).toHaveBeenCalledWith(namespace);
+    expect(modal.getAccount).toHaveBeenCalledWith(otherNamespace);
   });
 
-  it("reports true when bitcoin runs over auth and ethereum is connected", () => {
+  it("refuses Auth while the other chain is connected", () => {
     setModal({
-      providerTypes: { bip122: "AUTH", eip155: "ANNOUNCED" },
-      accounts: { bip122: { isConnected: false }, eip155: { isConnected: true } },
+      providerTypes: { [namespace]: "AUTH", [otherNamespace]: "ANNOUNCED" },
+      accounts: { [namespace]: { isConnected: false }, [otherNamespace]: { isConnected: true } },
     });
 
-    expect(btcDisconnectWouldDropEthereum()).toBe(true);
+    expect(wouldDropOther()).toBe(true);
   });
 
-  it("reports false for an announced bitcoin extension even while ethereum is connected over walletconnect", () => {
+  it("allows an announced extension while the other chain uses WalletConnect", () => {
     setModal({
-      providerTypes: { bip122: "ANNOUNCED", eip155: "WALLET_CONNECT" },
+      providerTypes: { [namespace]: "ANNOUNCED", [otherNamespace]: "WALLET_CONNECT" },
       accounts: { bip122: { isConnected: true }, eip155: { isConnected: true } },
     });
 
-    expect(btcDisconnectWouldDropEthereum()).toBe(false);
+    expect(wouldDropOther()).toBe(false);
   });
 
-  it("reports false over walletconnect when there is no ethereum account", () => {
+  it("allows WalletConnect when the other account is absent", () => {
     setModal({
-      providerTypes: { bip122: "WALLET_CONNECT" },
-      accounts: { bip122: { isConnected: true } },
+      providerTypes: { [namespace]: "WALLET_CONNECT" },
+      accounts: { [namespace]: { isConnected: true } },
     });
 
-    expect(btcDisconnectWouldDropEthereum()).toBe(false);
+    expect(wouldDropOther()).toBe(false);
   });
 
-  it("reports false over walletconnect when the ethereum account is disconnected", () => {
+  it("allows WalletConnect when the other account is disconnected", () => {
     setModal({
       providerTypes: { bip122: "WALLET_CONNECT", eip155: "WALLET_CONNECT" },
-      accounts: { bip122: { isConnected: true }, eip155: { isConnected: false } },
+      accounts: { [namespace]: { isConnected: true }, [otherNamespace]: { isConnected: false } },
     });
 
-    expect(btcDisconnectWouldDropEthereum()).toBe(false);
+    expect(wouldDropOther()).toBe(false);
   });
 
-  it("reports false when no shared bitcoin config is registered", () => {
-    expect(btcDisconnectWouldDropEthereum()).toBe(false);
+  it("reports no shared session before initialization", () => {
+    expect(wouldDropOther()).toBe(false);
   });
 });

--- a/packages/babylon-wallet-connector/src/core/wallets/btc/appkit/sharedConfig.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/btc/appkit/sharedConfig.ts
@@ -76,7 +76,7 @@ export function setSharedBtcAppKitConfig(config: SharedBtcAppKitConfigInput): vo
     connectionEvents: config.connectionEvents ?? sharedBtcAppKitConfig?.connectionEvents ?? new EventTarget(),
   };
 
-  registerManualAppKitConfig(BITCOIN_CAPABILITY);
+  registerManualAppKitConfig(BITCOIN_CAPABILITY, config.modal);
   sharedBtcAppKitConfig = resolvedConfig;
 }
 

--- a/packages/babylon-wallet-connector/src/core/wallets/eth/appkit/__tests__/provider.test.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/eth/appkit/__tests__/provider.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { Config } from "wagmi";
 
 import type { ETHConfig } from "@/core/types";
+import { ERROR_CODES } from "@/error";
 
 // `createWallet` constructs the provider before AppKit initialization.
 // The mocks show whether the constructor attached the watchers.
@@ -51,6 +52,11 @@ const ethConfig: ETHConfig = {
   nativeCurrency: { name: "Ether", symbol: "ETH", decimals: 18 },
 };
 
+afterEach(async () => {
+  const { getAppKitModal } = await import("@/core/wallets/appkit/state");
+  vi.mocked(getAppKitModal).mockReturnValue(null);
+});
+
 // The shared-config singleton has no reset hook, so each test resets the
 // module registry and imports a fresh provider + sharedConfig pair. The
 // mocked wagmi functions above survive the reset (`vi.hoisted`), so call
@@ -91,6 +97,52 @@ describe("AppKitProvider — constructed after AppKit init (shared wagmi config 
   afterEach(() => {
     vi.clearAllMocks();
   });
+
+  it.each([
+    ["ANNOUNCED", true, "chain", false],
+    ["WALLET_CONNECT", true, "chain", true],
+    ["AUTH", true, "chain", true],
+    ["WALLET_CONNECT", false, "chain", false],
+    ["WALLET_CONNECT", undefined, "chain", false],
+    ["WALLET_CONNECT", true, "all", false],
+    ["AUTH", true, "all", false],
+    ["WALLET_CONNECT", true, "local", false],
+  ] as const)(
+    "handles %s with Bitcoin connected=%s for scope=%s",
+    async (providerType, btcConnected, scope, refused) => {
+      vi.resetModules();
+      const { getAppKitModal } = await import("@/core/wallets/appkit/state");
+      const { setSharedWagmiConfig } = await import("../sharedConfig");
+      const { AppKitProvider } = await import("../provider");
+      vi.mocked(getAppKitModal).mockReturnValue({
+        getProviderType: (namespace: string) => (namespace === "eip155" ? providerType : "ANNOUNCED"),
+        getAccount: (namespace: string) =>
+          namespace === "bip122" && btcConnected !== undefined ? { isConnected: btcConnected } : undefined,
+      } as never);
+      const sharedConfig = {} as Config;
+      setSharedWagmiConfig(sharedConfig);
+      const provider = new AppKitProvider(ethConfig);
+      wagmiActions.getAccount.mockReturnValueOnce({ address: "0xabc", chainId: 1, status: "connected" });
+      await provider.connectWallet();
+
+      if (refused) {
+        await expect(provider.disconnect(scope)).rejects.toMatchObject({
+          code: ERROR_CODES.SHARED_SESSION_DISCONNECT_REFUSED,
+          chainId: "ETH",
+        });
+        expect(wagmiActions.disconnect).not.toHaveBeenCalled();
+        await expect(provider.getAddress()).resolves.toBe("0xabc");
+        await expect(provider.getChainId()).resolves.toBe(1);
+      } else {
+        await provider.disconnect(scope);
+        if (scope === "local") expect(wagmiActions.disconnect).not.toHaveBeenCalled();
+        else expect(wagmiActions.disconnect).toHaveBeenCalledWith(sharedConfig);
+        await expect(provider.getAddress()).rejects.toThrow("Wallet not connected");
+        await expect(provider.getChainId()).rejects.toThrow("Wallet not connected");
+      }
+      provider.destroy();
+    },
+  );
 
   it("starts the account and chain watchers against the shared config on construction", async () => {
     vi.resetModules();

--- a/packages/babylon-wallet-connector/src/core/wallets/eth/appkit/provider.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/eth/appkit/provider.ts
@@ -27,8 +27,9 @@ import { APPKIT_OPEN_EVENT } from "@/core/wallets/appkit/constants";
 // Read the modal from the shared singleton rather than from `appKitModal`,
 // which pulls the Bitcoin adapter in with it.
 import { getAppKitModal } from "@/core/wallets/appkit/state";
+import { ERROR_CODES, WalletError } from "@/error";
 
-import { getSharedWagmiConfig, hasSharedWagmiConfig } from "./sharedConfig";
+import { ethDisconnectWouldDropBitcoin, getSharedWagmiConfig, hasSharedWagmiConfig } from "./sharedConfig";
 
 // Grace period after modal close before rejecting as cancelled, to allow
 // async handoffs (WalletConnect deep-link, mobile wallet return) to publish
@@ -254,6 +255,15 @@ export class AppKitProvider implements IETHProvider {
   }
 
   async disconnect(scope: DisconnectScope): Promise<void> {
+    if (scope === "chain" && ethDisconnectWouldDropBitcoin()) {
+      throw new WalletError({
+        code: ERROR_CODES.SHARED_SESSION_DISCONNECT_REFUSED,
+        message:
+          "Ethereum and Bitcoin share one wallet session. Disconnecting Ethereum alone would also disconnect Bitcoin. Disconnect all wallets instead.",
+        wallet: "AppKit",
+        chainId: "ETH",
+      });
+    }
     if (scope !== "local") await wagmiDisconnect(this.getWagmiConfig());
     this.address = undefined;
     this.chainId = undefined;

--- a/packages/babylon-wallet-connector/src/core/wallets/eth/appkit/sharedConfig.ts
+++ b/packages/babylon-wallet-connector/src/core/wallets/eth/appkit/sharedConfig.ts
@@ -1,6 +1,11 @@
 import type { Config } from "wagmi";
 
-import { failInitialization, getAppKitState, registerManualAppKitConfig } from "@/core/wallets/appkit/state";
+import {
+  failInitialization,
+  getAppKitModal,
+  getAppKitState,
+  registerManualAppKitConfig,
+} from "@/core/wallets/appkit/state";
 
 const ETHEREUM_CAPABILITY = "Ethereum";
 const SHARED_WAGMI_REPLACEMENT_WARNING =
@@ -33,7 +38,10 @@ export function getSharedWagmiConfig(): Config {
   const initializedState = getAppKitState();
   if (initializedState) {
     if (!initializedState.wagmiConfig) {
-      failInitialization("AppKit was initialized without Ethereum support. Initialize it with Ethereum support.", "ETH");
+      failInitialization(
+        "AppKit was initialized without Ethereum support. Initialize it with Ethereum support.",
+        "ETH",
+      );
     }
 
     return initializedState.wagmiConfig;
@@ -51,4 +59,11 @@ export function getSharedWagmiConfig(): Config {
 export function hasSharedWagmiConfig(): boolean {
   const initializedState = getAppKitState();
   return initializedState ? initializedState.wagmiConfig !== undefined : sharedWagmiConfig !== null;
+}
+
+export function ethDisconnectWouldDropBitcoin(): boolean {
+  const modal = getAppKitModal();
+  const providerType = modal?.getProviderType("eip155");
+  const sharesSession = providerType === "WALLET_CONNECT" || providerType === "AUTH";
+  return sharesSession && modal?.getAccount("bip122")?.isConnected === true;
 }

--- a/packages/babylon-wallet-connector/src/hooks/__tests__/useWalletConnect.optionalChains.test.tsx
+++ b/packages/babylon-wallet-connector/src/hooks/__tests__/useWalletConnect.optionalChains.test.tsx
@@ -178,31 +178,36 @@ describe("disconnect", () => {
     expect(reset).not.toHaveBeenCalled();
   });
 
-  it("explains a refused single-chain disconnect in the dialog and still rejects", async () => {
-    const { result } = setup({
-      requiredChainIds: ["ETH"],
-      selectedWallets: { BTC: btcWallet, ETH: ethWallet },
-      confirmed: true,
-    });
-    const refusal = new WalletError({
-      code: ERROR_CODES.SHARED_SESSION_DISCONNECT_REFUSED,
-      message: "Bitcoin and Ethereum share one wallet session.",
-    });
-    disconnectBtc.mockRejectedValueOnce(refusal);
+  it.each(["BTC", "ETH"] as const)(
+    "explains a refused %s disconnect in the dialog and still rejects",
+    async (chain) => {
+      const { result } = setup({
+        requiredChainIds: ["ETH"],
+        selectedWallets: { BTC: btcWallet, ETH: ethWallet },
+        confirmed: true,
+      });
+      const refusal = new WalletError({
+        code: ERROR_CODES.SHARED_SESSION_DISCONNECT_REFUSED,
+        message: "Bitcoin and Ethereum share one wallet session.",
+      });
+      const [disconnect, otherDisconnect] =
+        chain === "BTC" ? [disconnectBtc, disconnectEth] : [disconnectEth, disconnectBtc];
+      disconnect.mockRejectedValueOnce(refusal);
 
-    await expect(result.current.disconnect("BTC")).rejects.toBe(refusal);
+      await expect(result.current.disconnect(chain)).rejects.toBe(refusal);
 
-    expect(displayError).toHaveBeenCalledWith(
-      expect.objectContaining({ title: "Wallets share one session", description: refusal.message }),
-    );
-    expect(displayChains).not.toHaveBeenCalled();
-    expect(disconnectEth).not.toHaveBeenCalled();
-    expect(reset).not.toHaveBeenCalled();
+      expect(displayError).toHaveBeenCalledWith(
+        expect.objectContaining({ title: "Wallets share one session", description: refusal.message }),
+      );
+      expect(displayChains).not.toHaveBeenCalled();
+      expect(otherDisconnect).not.toHaveBeenCalled();
+      expect(reset).not.toHaveBeenCalled();
 
-    displayError.mock.calls[0][0].onCancel();
+      displayError.mock.calls[0][0].onCancel();
 
-    expect(displayChains).toHaveBeenCalled();
-  });
+      expect(displayChains).toHaveBeenCalled();
+    },
+  );
 
   it("passes the chain scope when disconnecting a single chain", async () => {
     const { result } = setup({


### PR DESCRIPTION
## Outcome

An Ethereum-only disconnect keeps Bitcoin connected. Shared WalletConnect and Auth sessions refuse the request and keep both wallets connected.

## Change

- Mirror the Bitcoin disconnect rule for Ethereum. Return the same refusal code with Ethereum-specific text.
- Keep the connected Ethereum row out of the AppKit account modal when its Disconnect button would end both sessions.
- Make the shared modal available to the guard for canonical and manual AppKit setup.

## Safety

Refusal preserves wallet state and emits no disconnect event. Disconnect All still ends both sessions. Independent Ethereum sessions keep their existing account controls. The Ethereum package entry still excludes Bitcoin dependencies.

jonybur approved the reverse disconnect rule during implementation. This PR builds on #2439 and targets its branch.

## Verification

- 358 wallet unit tests and 23 package boundary tests pass.
- Package build and lint pass. Lint reports 89 existing warnings.
- Tests cover injected, WalletConnect, Auth, mixed sessions, missing Bitcoin, local cleanup, Disconnect All, refusal display, and the connected wallet row.

## Links

Closes #2438. Depends on #2439. Tracks #2230. #2230 stays open. Epic: #2228.
