### PR TITLE
feat(vault): prompt for Bitcoin before wallet actions

### DIFF
--- a/services/vault/src/components/Wallet/BtcActionGate.tsx
+++ b/services/vault/src/components/Wallet/BtcActionGate.tsx
@@ -1,4 +1,4 @@
-import { Button, Heading } from "@babylonlabs-io/core-ui";
+import { Button, Heading, Loader } from "@babylonlabs-io/core-ui";
 import { useState, type PropsWithChildren } from "react";
 
 import { COPY } from "@/copy";
@@ -8,17 +8,45 @@ export function BtcActionGate({
   children,
   onClose,
 }: PropsWithChildren<{ onClose: () => void }>) {
-  const { connected, requireBtcWallet } = useBtcAction();
+  const {
+    connected,
+    btcConnected,
+    sessionConfirmed,
+    loading,
+    requireBtcWallet,
+  } = useBtcAction();
   const [started, setStarted] = useState(connected);
 
   // Keep an active flow mounted during a temporary wallet disconnect.
   if (started) return <>{children}</>;
 
+  // A saved session is still restoring, so neither prompt is right yet. The
+  // children stay unmounted: every resume branch auto-runs on mount.
+  if (loading) {
+    return (
+      <div className="mx-auto flex max-w-[564px] flex-col items-center gap-4">
+        <Loader />
+        <p className="text-accent-secondary">
+          {COPY.wallet.btcAction.resolving}
+        </p>
+      </div>
+    );
+  }
+
   return (
     <div className="mx-auto flex max-w-[564px] flex-col gap-4">
       <Heading variant="h5">{COPY.wallet.btcAction.heading}</Heading>
-      <p className="text-accent-secondary">{COPY.wallet.btcAction.body}</p>
+      <p className="text-accent-secondary">
+        {btcConnected && !sessionConfirmed
+          ? COPY.wallet.btcAction.confirmBody
+          : COPY.wallet.btcAction.body}
+      </p>
+      {/* These data-testids exist so the real-wallet E2E
+          (e2e/real/actions/stepMachine.ts) can disambiguate these controls
+          from the progress view's Retry, which shares this gate's "Retry"
+          label. Carry them over if you move or rename the controls. */}
       <Button
+        data-testid={connected ? "btc-action-retry" : "btc-action-connect"}
         onClick={() => {
           if (requireBtcWallet()) setStarted(true);
         }}
@@ -27,7 +55,11 @@ export function BtcActionGate({
           ? COPY.wallet.btcAction.retry
           : COPY.wallet.btcAction.connect}
       </Button>
-      <Button variant="outlined" onClick={onClose}>
+      <Button
+        data-testid="btc-action-cancel"
+        variant="outlined"
+        onClick={onClose}
+      >
         {COPY.wallet.btcAction.cancel}
       </Button>
     </div>

--- a/services/vault/src/components/Wallet/BtcActionGate.tsx
+++ b/services/vault/src/components/Wallet/BtcActionGate.tsx
@@ -1,0 +1,35 @@
+import { Button, Heading } from "@babylonlabs-io/core-ui";
+import { useState, type PropsWithChildren } from "react";
+
+import { COPY } from "@/copy";
+import { useBtcAction } from "@/hooks/useBtcAction";
+
+export function BtcActionGate({
+  children,
+  onClose,
+}: PropsWithChildren<{ onClose: () => void }>) {
+  const { connected, requireBtcWallet } = useBtcAction();
+  const [started, setStarted] = useState(connected);
+
+  // Keep an active flow mounted during a temporary wallet disconnect.
+  if (started) return <>{children}</>;
+
+  return (
+    <div className="mx-auto flex max-w-[564px] flex-col gap-4">
+      <Heading variant="h5">{COPY.wallet.btcAction.heading}</Heading>
+      <p className="text-accent-secondary">{COPY.wallet.btcAction.body}</p>
+      <Button
+        onClick={() => {
+          if (requireBtcWallet()) setStarted(true);
+        }}
+      >
+        {connected
+          ? COPY.wallet.btcAction.retry
+          : COPY.wallet.btcAction.connect}
+      </Button>
+      <Button variant="outlined" onClick={onClose}>
+        {COPY.wallet.btcAction.cancel}
+      </Button>
+    </div>
+  );
+}

--- a/services/vault/src/components/Wallet/__tests__/BtcActionGate.test.tsx
+++ b/services/vault/src/components/Wallet/__tests__/BtcActionGate.test.tsx
@@ -1,0 +1,26 @@
+import { render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { COPY } from "@/copy";
+
+import { BtcActionGate } from "../BtcActionGate";
+
+vi.mock("@babylonlabs-io/wallet-connector", () => ({
+  useBTCWallet: () => ({ connected: false, loading: true }),
+  useWalletConnect: () => ({ connected: false, open: vi.fn() }),
+}));
+
+describe("BtcActionGate", () => {
+  it("shows the resolving loader and mounts nothing while the wallet is still loading", () => {
+    const { getByText, queryByText, queryByTestId, queryAllByRole } = render(
+      <BtcActionGate onClose={vi.fn()}>
+        <div data-testid="gated-child" />
+      </BtcActionGate>,
+    );
+
+    expect(getByText(COPY.wallet.btcAction.resolving)).toBeInTheDocument();
+    expect(queryByTestId("gated-child")).not.toBeInTheDocument();
+    expect(queryByText(COPY.wallet.btcAction.heading)).not.toBeInTheDocument();
+    expect(queryAllByRole("button")).toHaveLength(0);
+  });
+});

--- a/services/vault/src/components/deposit/EmergencyWithdrawModal/__tests__/EmergencyWithdrawModal.test.tsx
+++ b/services/vault/src/components/deposit/EmergencyWithdrawModal/__tests__/EmergencyWithdrawModal.test.tsx
@@ -1,13 +1,4 @@
-/**
- * Tests for the click-time application-status gate on the escape hatch.
- *
- * The confirm screen's own check reads the cache as of paint, so it is
- * `undefined` — button enabled — for the whole first round-trip after the modal
- * mounts. These cover what happens when the answer lands only after the click:
- * a CONFIRMED inactive application must stop before the BTC wallet is ever
- * opened, and anything else must let the withdrawal through, because this is
- * the only recovery left for a swept peg-in.
- */
+/** Check application status before a wallet prompt or recovery transaction. */
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
@@ -129,18 +120,20 @@ beforeEach(() => {
 });
 
 describe("EmergencyWithdrawModal — application status before the reveal", () => {
-  it("requests Bitcoin without deriving or submitting the withdrawal", () => {
+  it("requests Bitcoin without deriving or submitting the withdrawal", async () => {
     btcActionWallet.connected = false;
+    vi.mocked(isVaultApplicationActive).mockResolvedValue(true);
     renderModal();
-    expect(btcActionWallet.open).toHaveBeenCalledWith("BTC");
+    await waitFor(() => {
+      expect(btcActionWallet.open).toHaveBeenCalledWith("BTC");
+    });
     expect(deriveHtlcSecretHex).not.toHaveBeenCalled();
     expect(handleActivation).not.toHaveBeenCalled();
     expect(isVaultApplicationActive).toHaveBeenCalledTimes(1);
   });
 
-  it("never opens the BTC wallet when the application resolves inactive after the click", async () => {
-    // Resolve only after the click, reproducing a click inside the first
-    // round-trip — the window the render-time gate cannot cover.
+  it("blocks a connected wallet when the application resolves inactive after the click", async () => {
+    // Resolve after the click to check the first request window.
     let resolveStatus: (active: boolean) => void = () => {};
     vi.mocked(isVaultApplicationActive).mockReturnValue(
       new Promise<boolean>((resolve) => {
@@ -159,6 +152,17 @@ describe("EmergencyWithdrawModal — application status before the reveal", () =
     ).toBeInTheDocument();
     expect(deriveHtlcSecretHex).not.toHaveBeenCalled();
     expect(handleActivation).not.toHaveBeenCalled();
+    expect(btcActionWallet.open).not.toHaveBeenCalled();
+  });
+
+  it("does not request Bitcoin when the application is inactive", async () => {
+    btcActionWallet.connected = false;
+    vi.mocked(isVaultApplicationActive).mockResolvedValue(false);
+    renderModal();
+    await screen.findByText(COPY.deposit.emergencyWithdraw.applicationInactive);
+    expect(deriveHtlcSecretHex).not.toHaveBeenCalled();
+    expect(handleActivation).not.toHaveBeenCalled();
+    expect(btcActionWallet.open).not.toHaveBeenCalled();
   });
 
   it("derives the secret and submits when the application is active", async () => {
@@ -173,13 +177,10 @@ describe("EmergencyWithdrawModal — application status before the reveal", () =
   });
 
   it("re-reads a stale cached status instead of trusting it", async () => {
-    // Modal reopened within gcTime: the cache still holds the answer from the
-    // previous open, so the button paints enabled off a value minutes old. A
-    // click must not ride that — the application was paused in between.
+    // A paused application must override the saved active status on reopen.
     const client = makeQueryClient();
     client.setQueryData(
-      // Key literal on purpose: if it drifts from the hook, this test should
-      // stop seeding the cache and fail loudly rather than pass vacuously.
+      // Keep the key literal to detect a change to the query key.
       ["vaultApplicationStatus", ACTIVITY.id],
       true,
       { updatedAt: Date.now() - 60_000 },
@@ -196,9 +197,7 @@ describe("EmergencyWithdrawModal — application status before the reveal", () =
   });
 
   it("still submits when the application status read fails", async () => {
-    // Fail OPEN: an RPC blip must not strand a depositor whose peg-in is
-    // already swept. The pre-broadcast simulation refuses to sign into a
-    // genuinely inactive application.
+    // A failed read permits recovery. The transaction simulation checks again.
     vi.mocked(isVaultApplicationActive).mockRejectedValue(
       new Error("rpc unavailable"),
     );

--- a/services/vault/src/components/deposit/EmergencyWithdrawModal/__tests__/EmergencyWithdrawModal.test.tsx
+++ b/services/vault/src/components/deposit/EmergencyWithdrawModal/__tests__/EmergencyWithdrawModal.test.tsx
@@ -51,7 +51,11 @@ vi.mock("@/hooks/useProtocolGate", () => ({
   useProtocolGateState: () => ({ protocol: null, aave: null }),
 }));
 
+const btcActionWallet = vi.hoisted(() => ({ connected: true, open: vi.fn() }));
+
 vi.mock("@babylonlabs-io/wallet-connector", () => ({
+  useBTCWallet: () => ({ connected: btcActionWallet.connected }),
+  useWalletConnect: () => ({ connected: true, open: btcActionWallet.open }),
   useChainConnector: () => ({
     connectedWallet: {
       id: "test-btc-wallet",
@@ -120,10 +124,20 @@ function renderModal(client?: QueryClient) {
 }
 
 beforeEach(() => {
+  btcActionWallet.connected = true;
   vi.clearAllMocks();
 });
 
 describe("EmergencyWithdrawModal — application status before the reveal", () => {
+  it("requests Bitcoin without deriving or submitting the withdrawal", () => {
+    btcActionWallet.connected = false;
+    renderModal();
+    expect(btcActionWallet.open).toHaveBeenCalledWith("BTC");
+    expect(deriveHtlcSecretHex).not.toHaveBeenCalled();
+    expect(handleActivation).not.toHaveBeenCalled();
+    expect(isVaultApplicationActive).toHaveBeenCalledTimes(1);
+  });
+
   it("never opens the BTC wallet when the application resolves inactive after the click", async () => {
     // Resolve only after the click, reproducing a click inside the first
     // round-trip — the window the render-time gate cannot cover.

--- a/services/vault/src/components/deposit/EmergencyWithdrawModal/index.tsx
+++ b/services/vault/src/components/deposit/EmergencyWithdrawModal/index.tsx
@@ -26,6 +26,7 @@ import { V3ModalShell } from "@/components/shared/V3ModalShell";
 import { useETHWallet } from "@/context/wallet";
 import { COPY } from "@/copy";
 import { useActivationState } from "@/hooks/deposit/useActivationState";
+import { useBtcAction } from "@/hooks/useBtcAction";
 import { useEnsureVaultApplicationActive } from "@/hooks/useVaultApplicationActive";
 import {
   captureFunnelFailure,
@@ -53,6 +54,7 @@ export function EmergencyWithdrawModal({
   onClose,
   onSuccess,
 }: EmergencyWithdrawModalProps) {
+  const { requireBtcWallet } = useBtcAction();
   const btcConnector = useChainConnector("BTC");
   const btcWalletProvider =
     (btcConnector?.connectedWallet?.provider as BitcoinWallet | undefined) ??
@@ -92,6 +94,10 @@ export function EmergencyWithdrawModal({
 
   const handleConfirm = useCallback(async () => {
     if (withdrawing) return;
+    if (!requireBtcWallet()) {
+      setLocalError(COPY.wallet.btcAction.body);
+      return;
+    }
     if (!btcWalletProvider || !connectedBtcAddress) {
       setLocalError(
         COPY.deposit.emergencyWithdraw.errors.btcWalletNotConnected,
@@ -149,6 +155,7 @@ export function EmergencyWithdrawModal({
       if (mountedRef.current) setDeriving(false);
     }
   }, [
+    requireBtcWallet,
     withdrawing,
     activity,
     btcWalletProvider,

--- a/services/vault/src/components/deposit/EmergencyWithdrawModal/index.tsx
+++ b/services/vault/src/components/deposit/EmergencyWithdrawModal/index.tsx
@@ -94,16 +94,6 @@ export function EmergencyWithdrawModal({
 
   const handleConfirm = useCallback(async () => {
     if (withdrawing) return;
-    if (!requireBtcWallet()) {
-      setLocalError(COPY.wallet.btcAction.body);
-      return;
-    }
-    if (!btcWalletProvider || !connectedBtcAddress) {
-      setLocalError(
-        COPY.deposit.emergencyWithdraw.errors.btcWalletNotConnected,
-      );
-      return;
-    }
     if (!depositorEthAddress) {
       setLocalError(
         COPY.deposit.emergencyWithdraw.errors.ethWalletNotConnected,
@@ -126,6 +116,16 @@ export function EmergencyWithdrawModal({
       // confirm screen reads, so that gate re-renders with the explanation and
       // the button disabled. Setting `localError` would print it twice.
       if ((await ensureApplicationActive(activity.id)) === false) return;
+      if (!requireBtcWallet()) {
+        setLocalError(COPY.wallet.btcAction.body);
+        return;
+      }
+      if (!btcWalletProvider || !connectedBtcAddress) {
+        setLocalError(
+          COPY.deposit.emergencyWithdraw.errors.btcWalletNotConnected,
+        );
+        return;
+      }
 
       const secretHex = await deriveHtlcSecretHex({
         activity,

--- a/services/vault/src/components/deposit/EmergencyWithdrawModal/index.tsx
+++ b/services/vault/src/components/deposit/EmergencyWithdrawModal/index.tsx
@@ -117,7 +117,7 @@ export function EmergencyWithdrawModal({
       // the button disabled. Setting `localError` would print it twice.
       if ((await ensureApplicationActive(activity.id)) === false) return;
       if (!requireBtcWallet()) {
-        setLocalError(COPY.wallet.btcAction.body);
+        setLocalError(COPY.wallet.btcAction.error);
         return;
       }
       if (!btcWalletProvider || !connectedBtcAddress) {

--- a/services/vault/src/components/deposit/PayoutSignModal/__tests__/usePayoutSigningState.test.tsx
+++ b/services/vault/src/components/deposit/PayoutSignModal/__tests__/usePayoutSigningState.test.tsx
@@ -69,7 +69,9 @@ let mockBtcConnector: {
   };
 } | null = null;
 vi.mock("@babylonlabs-io/wallet-connector", () => ({
-  useBTCWallet: () => ({ connected: true }),
+  useBTCWallet: () => ({
+    connected: Boolean(mockBtcConnector?.connectedWallet),
+  }),
   useWalletConnect: () => ({ connected: true, open: vi.fn() }),
   useChainConnector: vi.fn(() => mockBtcConnector),
 }));
@@ -1277,14 +1279,12 @@ describe("usePayoutSigningState", () => {
       });
       expect(result.current.errorTerminal).toBe(true);
 
-      // Wallet disconnects before the retry — a guard error, recoverable.
-      // Re-render so the handler closes over the new connector state.
       mockBtcConnector = { connectedWallet: undefined };
       rerender();
       await act(async () => {
         await result.current.handleSign();
       });
-      expect(result.current.error?.title).toBe("Wallet address unavailable");
+      expect(result.current.error?.title).toBe("Wallet not connected");
       expect(result.current.errorTerminal).toBe(false);
     });
 

--- a/services/vault/src/components/deposit/PayoutSignModal/__tests__/usePayoutSigningState.test.tsx
+++ b/services/vault/src/components/deposit/PayoutSignModal/__tests__/usePayoutSigningState.test.tsx
@@ -69,6 +69,8 @@ let mockBtcConnector: {
   };
 } | null = null;
 vi.mock("@babylonlabs-io/wallet-connector", () => ({
+  useBTCWallet: () => ({ connected: true }),
+  useWalletConnect: () => ({ connected: true, open: vi.fn() }),
   useChainConnector: vi.fn(() => mockBtcConnector),
 }));
 

--- a/services/vault/src/components/deposit/PayoutSignModal/usePayoutSigningState.ts
+++ b/services/vault/src/components/deposit/PayoutSignModal/usePayoutSigningState.ts
@@ -172,14 +172,13 @@ export function usePayoutSigningState({
 
   const handleSign = useCallback(async () => {
     if (inFlightRef.current || signing) return;
+    // A new attempt must allow a retry after a recoverable guard error.
+    setErrorTerminal(false);
     if (!requireBtcWallet()) {
       setError(COPY.deposit.payoutSigningGuards.walletNotConnected);
       return;
     }
     inFlightRef.current = true;
-    // A new attempt starts non-terminal: a guard error after a terminal
-    // refusal is a fresh, recoverable error and must get its Retry back.
-    setErrorTerminal(false);
 
     // Single outer try/finally so the reentrancy lock is always cleared —
     // including on synchronous throws from the guards (e.g.

--- a/services/vault/src/components/deposit/PayoutSignModal/usePayoutSigningState.ts
+++ b/services/vault/src/components/deposit/PayoutSignModal/usePayoutSigningState.ts
@@ -20,6 +20,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import type { Hex } from "viem";
 
 import { COPY } from "@/copy";
+import { useBtcAction } from "@/hooks/useBtcAction";
 import {
   captureFunnelFailure,
   shortId,
@@ -129,6 +130,7 @@ export function usePayoutSigningState({
   const cancelRequestedRef = useRef(false);
 
   const { findProvider } = useVaultProviders(activity.applicationEntryPoint);
+  const { requireBtcWallet } = useBtcAction();
   const btcConnector = useChainConnector("BTC");
   const { setOptimisticStatus } = usePeginPolling();
 
@@ -170,6 +172,10 @@ export function usePayoutSigningState({
 
   const handleSign = useCallback(async () => {
     if (inFlightRef.current || signing) return;
+    if (!requireBtcWallet()) {
+      setError(COPY.deposit.payoutSigningGuards.walletNotConnected);
+      return;
+    }
     inFlightRef.current = true;
     // A new attempt starts non-terminal: a guard error after a terminal
     // refusal is a fresh, recoverable error and must get its Retry back.
@@ -473,6 +479,7 @@ export function usePayoutSigningState({
       setCancelRequested(false);
     }
   }, [
+    requireBtcWallet,
     signing,
     activity.providers,
     activity.peginTxHash,

--- a/services/vault/src/components/pages/RootLayout.tsx
+++ b/services/vault/src/components/pages/RootLayout.tsx
@@ -34,6 +34,7 @@ import { useAddressType } from "@/context/addressType";
 import { AppPeginPollingProvider } from "@/context/deposit/AppPeginPollingProvider";
 import { useGeoFencing } from "@/context/geofencing";
 import { COPY } from "@/copy";
+import { useBtcAction } from "@/hooks/useBtcAction";
 import { usePageTitle } from "@/hooks/usePageTitle";
 import { useProtocolGateState } from "@/hooks/useProtocolGate";
 import { useProtocolStatusOverride } from "@/overrides/protocolStatus";
@@ -147,14 +148,19 @@ export default function RootLayout() {
     string | undefined
   >();
 
+  const { requireBtcWallet } = useBtcAction();
   // Reject a click event reaching `initialAmountBtc`: TypeScript allows this
   // where an `onClick` handler is expected, and it crashes the deposit dialog.
-  const openDeposit = useCallback((initialAmountBtc?: string) => {
-    setInitialDepositAmountBtc(
-      typeof initialAmountBtc === "string" ? initialAmountBtc : undefined,
-    );
-    setIsDepositOpen(true);
-  }, []);
+  const openDeposit = useCallback(
+    (initialAmountBtc?: string) => {
+      if (!requireBtcWallet()) return;
+      setInitialDepositAmountBtc(
+        typeof initialAmountBtc === "string" ? initialAmountBtc : undefined,
+      );
+      setIsDepositOpen(true);
+    },
+    [requireBtcWallet],
+  );
 
   const closeDeposit = useCallback(() => {
     setIsDepositOpen(false);

--- a/services/vault/src/components/pages/__tests__/RootLayout.test.tsx
+++ b/services/vault/src/components/pages/__tests__/RootLayout.test.tsx
@@ -83,6 +83,11 @@ vi.mock("@/components/Wallet", () => ({
 // `Network` is the only export RootLayout's real tree needs here because
 // NetworkBadge imports it directly.
 vi.mock("@babylonlabs-io/wallet-connector", () => ({
+  useBTCWallet: () => ({ connected: walletMock.btcConnected }),
+  useWalletConnect: () => ({
+    connected: walletMock.btcConnected && walletMock.ethConnected,
+    open: vi.fn(),
+  }),
   Network: { MAINNET: "mainnet", SIGNET: "signet" },
 }));
 

--- a/services/vault/src/components/simple/DepositSignContent.tsx
+++ b/services/vault/src/components/simple/DepositSignContent.tsx
@@ -17,6 +17,7 @@ import { useSigningNotificationOptional } from "@/context/SigningNotificationCon
 import { COPY } from "@/copy";
 import { useDepositFlow } from "@/hooks/deposit/useDepositFlow";
 import { useDepositSigningNotification } from "@/hooks/deposit/useDepositSigningNotification";
+import { useBtcAction } from "@/hooks/useBtcAction";
 
 import { DepositProgressView } from "./DepositProgressView";
 import { FeeRateSelector } from "./DepositProgressView/FeeRateSelector";
@@ -124,8 +125,10 @@ export function DepositSignContent({
   // This ref restores the exactly-once guarantee regardless of click cadence.
   const hasStartedRef = useRef(false);
 
+  const { requireBtcWallet } = useBtcAction();
   const handleSign = useCallback(() => {
     if (hasStartedRef.current) return;
+    if (!requireBtcWallet()) return;
     hasStartedRef.current = true;
     // The Sign click is a user gesture - the right moment to ask for OS
     // notification permission so we can later ping the depositor when a
@@ -137,7 +140,7 @@ export function DepositSignContent({
     }
     setStarted(true);
     void startFlow();
-  }, [startFlow, signingNotifier]);
+  }, [startFlow, signingNotifier, requireBtcWallet]);
 
   // Derived state
   const { isComplete, canClose, isProcessing, canContinueInBackground } =

--- a/services/vault/src/components/simple/PostDepositContinuationView.tsx
+++ b/services/vault/src/components/simple/PostDepositContinuationView.tsx
@@ -151,9 +151,15 @@ export function PostDepositContinuationView({
     onClose();
   }, [navigate, onClose]);
 
+  // Actionability keys on the vault's on-chain depositor key, not the wallet
+  // key, so the payout branch mounts while Bitcoin is disconnected and its
+  // BtcActionGate can prompt for the wallet instead of a wait state hiding it.
   const isActionable = (id: string): boolean => {
-    const state = getPollingResult(id)?.peginState;
-    return isCandidateVault(state) && hasActionableStep(state, btcPublicKey);
+    const result = getPollingResult(id);
+    return (
+      isCandidateVault(result?.peginState) &&
+      hasActionableStep(result?.peginState, result?.depositorBtcPubkey)
+    );
   };
 
   // Which vault drives the rendered action branch. Two rules:
@@ -406,9 +412,11 @@ export function PostDepositContinuationView({
     );
   }
 
+  // Same on-chain key as `isActionable`: a payout-ready vault with an unknown
+  // depositor key is not selected, and must not mount from the wait fallback.
   if (
     activity &&
-    btcPublicKey &&
+    pollingResult?.depositorBtcPubkey &&
     actions.includes(PeginAction.SIGN_PAYOUT_TRANSACTIONS)
   ) {
     return (

--- a/services/vault/src/components/simple/ResumeDepositContent.tsx
+++ b/services/vault/src/components/simple/ResumeDepositContent.tsx
@@ -87,7 +87,12 @@ interface CaughtError {
 
 export interface ResumeSignContentProps {
   activity: VaultActivity;
-  btcPublicKey: string;
+  /**
+   * The connected wallet's key. `undefined` while Bitcoin is disconnected or
+   * the key is still being read after a connect; the branch mounts either
+   * way so BtcActionGate can prompt, and signing waits for the key.
+   */
+  btcPublicKey: string | undefined;
   depositorEthAddress: Hex;
   /**
    * Every vault ID sharing this deposit's Pre-PegIn (the split-pegin
@@ -103,8 +108,53 @@ export interface ResumeSignContentProps {
 export function ResumeSignContent(props: ResumeSignContentProps) {
   return (
     <BtcActionGate onClose={props.onClose}>
-      <ResumeSignContentConnected {...props} />
+      {props.btcPublicKey === undefined ? (
+        <ResumeSignContentAwaitingKey
+          activity={props.activity}
+          siblingVaultIds={props.siblingVaultIds}
+          onClose={props.onClose}
+        />
+      ) : (
+        <ResumeSignContentConnected
+          {...props}
+          btcPublicKey={props.btcPublicKey}
+        />
+      )}
     </BtcActionGate>
+  );
+}
+
+// The wait state the continuation view used to render for a payout-ready
+// vault without a wallet key: the deposit rests on the auth-anchor step (see
+// getPeginDisplayStep) until the key read settles and the ceremony can start.
+function ResumeSignContentAwaitingKey({
+  activity,
+  siblingVaultIds,
+  onClose,
+}: Pick<ResumeSignContentProps, "activity" | "siblingVaultIds" | "onClose">) {
+  const { vaultCount, currentVaultIndex, perVaultSteps } =
+    useSplitVaultProgress(
+      siblingVaultIds,
+      activity.id,
+      DepositFlowStep.SIGN_AUTH_ANCHOR,
+    );
+
+  return (
+    <DepositProgressView
+      currentStep={DepositFlowStep.SIGN_AUTH_ANCHOR}
+      offchainParamsVersion={activity.offchainParamsVersion}
+      error={null}
+      isComplete={false}
+      isProcessing
+      canClose
+      canContinueInBackground
+      payoutSigningProgress={null}
+      peginSigningProgress={null}
+      vaultCount={vaultCount}
+      currentVaultIndex={currentVaultIndex}
+      perVaultSteps={perVaultSteps}
+      onClose={onClose}
+    />
   );
 }
 
@@ -115,7 +165,7 @@ function ResumeSignContentConnected({
   siblingVaultIds,
   onClose,
   onSuccess,
-}: ResumeSignContentProps) {
+}: ResumeSignContentProps & { btcPublicKey: string }) {
   const {
     signing,
     progress,

--- a/services/vault/src/components/simple/ResumeDepositContent.tsx
+++ b/services/vault/src/components/simple/ResumeDepositContent.tsx
@@ -28,6 +28,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import type { Address, Hex } from "viem";
 
 import { getVaultRegistryReader } from "@/clients/eth-contract/sdk-readers";
+import { BtcActionGate } from "@/components/Wallet/BtcActionGate";
 import { computeDepositDerivedState } from "@/components/deposit/DepositSignModal/depositStepHelpers";
 import { usePayoutSigningState } from "@/components/deposit/PayoutSignModal/usePayoutSigningState";
 import { useDepositPollingResult } from "@/context/deposit/PeginPollingContext";
@@ -47,6 +48,7 @@ import { useBroadcastState } from "@/hooks/deposit/useBroadcastState";
 import { useReleaseVpTokenOnUnmount } from "@/hooks/deposit/useReleaseVpTokenOnUnmount";
 import { useRequiredPrePeginDepth } from "@/hooks/deposit/useRequiredPrePeginDepth";
 import { useSplitVaultProgress } from "@/hooks/deposit/useSplitVaultProgress";
+import { useBtcAction } from "@/hooks/useBtcAction";
 import { useRunOnce } from "@/hooks/useRunOnce";
 import { logger } from "@/infrastructure";
 import {
@@ -98,7 +100,15 @@ export interface ResumeSignContentProps {
   onSuccess: () => void;
 }
 
-export function ResumeSignContent({
+export function ResumeSignContent(props: ResumeSignContentProps) {
+  return (
+    <BtcActionGate onClose={props.onClose}>
+      <ResumeSignContentConnected {...props} />
+    </BtcActionGate>
+  );
+}
+
+function ResumeSignContentConnected({
   activity,
   btcPublicKey,
   depositorEthAddress,
@@ -252,7 +262,15 @@ export interface ResumeBroadcastContentProps {
   onSuccess: () => void;
 }
 
-export function ResumeBroadcastContent({
+export function ResumeBroadcastContent(props: ResumeBroadcastContentProps) {
+  return (
+    <BtcActionGate onClose={props.onClose}>
+      <ResumeBroadcastContentConnected {...props} />
+    </BtcActionGate>
+  );
+}
+
+function ResumeBroadcastContentConnected({
   activity,
   batchVaultIds,
   depositorEthAddress,
@@ -335,12 +353,21 @@ export interface ResumeWotsContentProps {
   onSuccess: () => void;
 }
 
-export function ResumeWotsContent({
+export function ResumeWotsContent(props: ResumeWotsContentProps) {
+  return (
+    <BtcActionGate onClose={props.onClose}>
+      <ResumeWotsContentConnected {...props} />
+    </BtcActionGate>
+  );
+}
+
+function ResumeWotsContentConnected({
   activity,
   siblingVaultIds,
   onClose,
   onSuccess,
 }: ResumeWotsContentProps) {
+  const { requireBtcWallet } = useBtcAction();
   const btcConnector = useChainConnector("BTC");
   const btcWalletProvider =
     (btcConnector?.connectedWallet?.provider as BitcoinWallet | undefined) ??
@@ -394,7 +421,7 @@ export function ResumeWotsContent({
   const trackPrimedTxid = useReleaseVpTokenOnUnmount();
 
   const handleSubmit = useCallback(async () => {
-    if (!btcWalletProvider || !connectedBtcAddress) {
+    if (!requireBtcWallet() || !btcWalletProvider || !connectedBtcAddress) {
       setError({ raw: COPY.deposit.resume.walletNotConnected });
       setLoading(false);
       return;
@@ -553,6 +580,7 @@ export function ResumeWotsContent({
     }
   }, [
     activity,
+    requireBtcWallet,
     btcWalletProvider,
     connectedBtcAddress,
     btcConnector?.connectedWallet?.id,
@@ -678,13 +706,22 @@ export interface ResumeActivationContentProps {
   onGoToDashboard: () => void;
 }
 
-export function ResumeActivationContent({
+export function ResumeActivationContent(props: ResumeActivationContentProps) {
+  return (
+    <BtcActionGate onClose={props.onClose}>
+      <ResumeActivationContentConnected {...props} />
+    </BtcActionGate>
+  );
+}
+
+function ResumeActivationContentConnected({
   activity,
   depositorEthAddress,
   siblingVaultIds,
   onClose,
   onGoToDashboard,
 }: ResumeActivationContentProps) {
+  const { requireBtcWallet } = useBtcAction();
   const btcConnector = useChainConnector("BTC");
   const btcWalletProvider =
     (btcConnector?.connectedWallet?.provider as BitcoinWallet | undefined) ??
@@ -720,7 +757,7 @@ export function ResumeActivationContent({
   });
 
   const handleSubmit = useCallback(async () => {
-    if (!btcWalletProvider || !connectedBtcAddress) {
+    if (!requireBtcWallet() || !btcWalletProvider || !connectedBtcAddress) {
       setLocalError({
         raw: COPY.deposit.resume.walletNotConnected,
       });
@@ -763,6 +800,7 @@ export function ResumeActivationContent({
     }
   }, [
     activity,
+    requireBtcWallet,
     btcWalletProvider,
     connectedBtcAddress,
     btcConnector?.connectedWallet?.id,

--- a/services/vault/src/components/simple/SimpleDeposit.tsx
+++ b/services/vault/src/components/simple/SimpleDeposit.tsx
@@ -19,6 +19,7 @@ import { useBtcWalletState } from "@/hooks/deposit/useBtcWalletState";
 import { useDepositPeginFee } from "@/hooks/deposit/useDepositPeginFee";
 import { useDialogStep } from "@/hooks/deposit/useDialogStep";
 import { usePendingVaultOverlapCheck } from "@/hooks/deposit/usePendingVaultOverlapCheck";
+import { useBtcAction } from "@/hooks/useBtcAction";
 import { useProtocolFeeRows } from "@/hooks/useProtocolFeeRows";
 import { useProtocolGateState } from "@/hooks/useProtocolGate";
 import { useVaultCountCap } from "@/hooks/useVaultCountCap";
@@ -84,6 +85,7 @@ function SimpleDepositContent({
   initialAmountBtc,
 }: SimpleDepositBaseProps) {
   const gate = useProtocolGateState();
+  const { requireBtcWallet } = useBtcAction();
   const { isGeoBlocked, isLoading: isGeoLoading } = useGeoFencing();
   const { isBlocked: isAddressBlocked, isLoading: isScreeningLoading } =
     useAddressScreening();
@@ -356,6 +358,7 @@ function SimpleDepositContent({
     // position past the on-chain cap, or when the cap couldn't be read (fail
     // closed) — defense-in-depth behind the disabled CTA.
     if (isVaultCapReached || vaultCountCapUnavailable) return;
+    if (!requireBtcWallet()) return;
 
     // The CTA doubles as the recovery action when the wallet-liveness probe
     // has failed OR the proactive lock poll has flagged a silently-locked

--- a/services/vault/src/components/simple/__tests__/DepositSignContent.test.tsx
+++ b/services/vault/src/components/simple/__tests__/DepositSignContent.test.tsx
@@ -9,6 +9,17 @@ import type { DepositErrorContent } from "@/utils/errors";
 import type { DepositProgressViewProps } from "../DepositProgressView";
 import { DepositSignContent } from "../DepositSignContent";
 
+const btcActionWallet = vi.hoisted(() => ({ connected: true, open: vi.fn() }));
+vi.mock("@babylonlabs-io/wallet-connector", () => ({
+  useBTCWallet: () => ({ connected: btcActionWallet.connected }),
+  useWalletConnect: () => ({ connected: true, open: btcActionWallet.open }),
+}));
+
+beforeEach(() => {
+  btcActionWallet.connected = true;
+  btcActionWallet.open.mockClear();
+});
+
 const mockExecuteDeposit = vi.hoisted(() => vi.fn());
 const mockCancelDeviceSign = vi.hoisted(() => vi.fn());
 // Mutable so tests can drive the flow's cancel seam through the static mock.
@@ -146,6 +157,22 @@ describe("DepositSignContent", () => {
     deviceCancelState.requested = false;
     flowErrorState.error = null;
     flowErrorState.resumableVaultIds = null;
+  });
+
+  it("keeps a deposit unstarted until the user retries after connection", async () => {
+    btcActionWallet.connected = false;
+    mockExecuteDeposit.mockResolvedValue(null);
+    const first = renderContent();
+    fireEvent.click(first.getByTestId("summary-sign"));
+    expect(btcActionWallet.open).toHaveBeenCalledWith("BTC");
+    expect(mockExecuteDeposit).not.toHaveBeenCalled();
+    expect(first.queryByTestId("progress")).toBeNull();
+    first.unmount();
+    btcActionWallet.connected = true;
+    const next = renderContent();
+    expect(mockExecuteDeposit).not.toHaveBeenCalled();
+    fireEvent.click(next.getByTestId("summary-sign"));
+    expect(mockExecuteDeposit).toHaveBeenCalledOnce();
   });
 
   it("renders Retry and switches to the continuation view after a post-registration device error", async () => {

--- a/services/vault/src/components/simple/__tests__/DepositSignContent.test.tsx
+++ b/services/vault/src/components/simple/__tests__/DepositSignContent.test.tsx
@@ -1,5 +1,6 @@
 import type { BitcoinWallet } from "@babylonlabs-io/ts-sdk/shared";
 import { act, fireEvent, render } from "@testing-library/react";
+import { cloneElement } from "react";
 import type { Address, Hex } from "viem";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -119,13 +120,13 @@ vi.mock("../DepositProgressView", () => ({
   },
 }));
 
-function renderContent(
+function contentElement(
   overrides: {
     onRefetchActivities?: () => Promise<void>;
     depositorEthAddress?: Address | undefined;
   } = {},
 ) {
-  return render(
+  return (
     <DepositSignContent
       vaultAmounts={[100000n]}
       mempoolFeeRate={1}
@@ -144,8 +145,12 @@ function renderContent(
       onClose={vi.fn()}
       onRefetchActivities={overrides.onRefetchActivities}
       onFeeRateChange={vi.fn()}
-    />,
+    />
   );
+}
+
+function renderContent(overrides: Parameters<typeof contentElement>[0] = {}) {
+  return render(contentElement(overrides));
 }
 
 describe("DepositSignContent", () => {
@@ -159,19 +164,20 @@ describe("DepositSignContent", () => {
     flowErrorState.resumableVaultIds = null;
   });
 
-  it("keeps a deposit unstarted until the user retries after connection", async () => {
+  it("keeps a deposit unstarted until the user retries after connection", () => {
     btcActionWallet.connected = false;
     mockExecuteDeposit.mockResolvedValue(null);
-    const first = renderContent();
-    fireEvent.click(first.getByTestId("summary-sign"));
+    const content = contentElement();
+    const view = render(content);
+    fireEvent.click(view.getByTestId("summary-sign"));
     expect(btcActionWallet.open).toHaveBeenCalledWith("BTC");
     expect(mockExecuteDeposit).not.toHaveBeenCalled();
-    expect(first.queryByTestId("progress")).toBeNull();
-    first.unmount();
+    expect(view.queryByTestId("progress")).toBeNull();
     btcActionWallet.connected = true;
-    const next = renderContent();
+    view.rerender(cloneElement(content));
     expect(mockExecuteDeposit).not.toHaveBeenCalled();
-    fireEvent.click(next.getByTestId("summary-sign"));
+    expect(view.queryByTestId("progress")).toBeNull();
+    fireEvent.click(view.getByTestId("summary-sign"));
     expect(mockExecuteDeposit).toHaveBeenCalledOnce();
   });
 

--- a/services/vault/src/components/simple/__tests__/PostDepositContinuationView.test.tsx
+++ b/services/vault/src/components/simple/__tests__/PostDepositContinuationView.test.tsx
@@ -297,6 +297,7 @@ function resultWith(opts: {
   localStatus?: string;
   displayVariant?: "pending" | "active" | "inactive" | "warning";
   message?: string;
+  depositorBtcPubkey?: string;
 }) {
   return {
     depositId: "x",
@@ -311,7 +312,10 @@ function resultWith(opts: {
       message: opts.message,
     },
     isOwnedByCurrentWallet: true,
-    depositorBtcPubkey: undefined,
+    // The on-chain depositor key that decides payout actionability. Pass
+    // `undefined` explicitly for a vault whose key is unknown.
+    depositorBtcPubkey:
+      "depositorBtcPubkey" in opts ? opts.depositorBtcPubkey : "0xdepositorpk",
   };
 }
 
@@ -410,13 +414,25 @@ describe("PostDepositContinuationView", () => {
     expect(renderView().getByTestId("payout")).toBeTruthy();
   });
 
-  it("waits (no payout) when the BTC public key is unavailable", () => {
+  it("mounts payout signing without the wallet key so its Bitcoin prompt can render", () => {
     mockGetPollingResult.mockReturnValue(
       resultWith({ availableActions: [PeginAction.SIGN_PAYOUT_TRANSACTIONS] }),
     );
     const { queryByTestId, getByTestId } = renderView({
       btcPublicKey: undefined,
     });
+    expect(getByTestId("payout")).toBeTruthy();
+    expect(queryByTestId("progress-view")).toBeNull();
+  });
+
+  it("waits (no payout) when the vault's depositor BTC public key is unknown", () => {
+    mockGetPollingResult.mockReturnValue(
+      resultWith({
+        availableActions: [PeginAction.SIGN_PAYOUT_TRANSACTIONS],
+        depositorBtcPubkey: undefined,
+      }),
+    );
+    const { queryByTestId, getByTestId } = renderView();
     expect(queryByTestId("payout")).toBeNull();
     expect(getByTestId("progress-view")).toBeTruthy();
   });
@@ -826,15 +842,16 @@ describe("PostDepositContinuationView", () => {
     expect(getByTestId("wots").getAttribute("data-vault")).toBe("0xvault1");
   });
 
-  it("skips a payout-only vault when btcPublicKey is unavailable and picks the next actionable sibling", () => {
+  it("skips a payout-only vault when its on-chain depositor BTC public key is unknown and picks the next actionable sibling", () => {
     const states = new Map<string, ReturnType<typeof resultWith>>([
       [
         "0xvault0",
         resultWith({
-          // Payout signing is available, but the prereq btcPublicKey is missing,
-          // so this vault must not win actionableIndex.
+          // Payout signing is available, but the vault's depositor BTC public
+          // key is unknown, so this vault must not win actionableIndex.
           availableActions: [PeginAction.SIGN_PAYOUT_TRANSACTIONS],
           contractStatus: 0,
+          depositorBtcPubkey: undefined,
         }),
       ],
       [

--- a/services/vault/src/components/simple/__tests__/ResumeDepositContent.test.tsx
+++ b/services/vault/src/components/simple/__tests__/ResumeDepositContent.test.tsx
@@ -7,6 +7,7 @@
  */
 
 import { fireEvent, render, waitFor } from "@testing-library/react";
+import { cloneElement } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { getVaultRegistryReader } from "@/clients/eth-contract/sdk-readers";
@@ -19,11 +20,13 @@ import {
 } from "@/context/deposit/optimisticDepositState";
 import { COPY } from "@/copy";
 import { useActivationState } from "@/hooks/deposit/useActivationState";
+import { useBroadcastState } from "@/hooks/deposit/useBroadcastState";
 import { shortId } from "@/infrastructure/telemetryEvents";
 import type { VaultActivity } from "@/types/activity";
 
 import {
   ResumeActivationContent,
+  ResumeBroadcastContent,
   ResumeSignContent,
   ResumeWotsContent,
 } from "../ResumeDepositContent";
@@ -71,7 +74,24 @@ vi.mock("@babylonlabs-io/ts-sdk/tbv/core/utils", () => ({
   calculateBtcTxHash: mockCalculateBtcTxHash,
 }));
 
+const btcActionWallet = vi.hoisted(() => ({
+  connected: true,
+  confirmed: true,
+  open: vi.fn(),
+}));
+
+beforeEach(() => {
+  btcActionWallet.connected = true;
+  btcActionWallet.confirmed = true;
+  btcActionWallet.open.mockClear();
+});
+
 vi.mock("@babylonlabs-io/wallet-connector", () => ({
+  useBTCWallet: () => ({ connected: btcActionWallet.connected }),
+  useWalletConnect: () => ({
+    connected: btcActionWallet.confirmed,
+    open: btcActionWallet.open,
+  }),
   useChainConnector: vi.fn(() => ({
     connectedWallet: {
       account: { address: "tb1test" },
@@ -1060,5 +1080,174 @@ describe("ResumeActivationContent — activated success terminal", () => {
     expect(getByTestId("error").textContent).toBe(
       COPY.deposit.errors.signingRejected.body,
     );
+  });
+});
+
+describe("Bitcoin action prompt", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    btcActionWallet.connected = false;
+    mockCalculateBtcTxHash.mockReturnValue(ON_CHAIN_HASH);
+    mockGetVaultRegistryReader.mockReturnValue(readerWith(ON_CHAIN_HASH));
+  });
+
+  it("requires an explicit retry before WOTS work starts after connection", async () => {
+    const content = (
+      <ResumeWotsContent
+        activity={baseActivity}
+        onClose={vi.fn()}
+        onSuccess={vi.fn()}
+      />
+    );
+    const view = render(content);
+    expect(mockGetVaultRegistryReader).not.toHaveBeenCalled();
+    fireEvent.click(
+      view.getByRole("button", { name: COPY.wallet.btcAction.connect }),
+    );
+    expect(btcActionWallet.open).toHaveBeenCalledWith("BTC");
+    btcActionWallet.connected = true;
+    view.rerender(cloneElement(content));
+    expect(mockGetVaultRegistryReader).not.toHaveBeenCalled();
+    expect(mockDeriveVaultRoot).not.toHaveBeenCalled();
+    fireEvent.click(
+      view.getByRole("button", { name: COPY.wallet.btcAction.retry }),
+    );
+    await waitFor(() => expect(mockGetVaultRegistryReader).toHaveBeenCalled());
+  });
+
+  it("leaves WOTS work unstarted when the user cancels the prompt", () => {
+    const onClose = vi.fn();
+    const view = render(
+      <ResumeWotsContent
+        activity={baseActivity}
+        onClose={onClose}
+        onSuccess={vi.fn()}
+      />,
+    );
+    fireEvent.click(
+      view.getByRole("button", { name: COPY.wallet.btcAction.connect }),
+    );
+    fireEvent.click(
+      view.getByRole("button", { name: COPY.wallet.btcAction.cancel }),
+    );
+    expect(onClose).toHaveBeenCalledOnce();
+    view.unmount();
+    btcActionWallet.connected = true;
+    expect(mockGetVaultRegistryReader).not.toHaveBeenCalled();
+    expect(mockDeriveVaultRoot).not.toHaveBeenCalled();
+    expect(mockSubmitWotsPublicKey).not.toHaveBeenCalled();
+  });
+
+  it("does not mount broadcast work when Bitcoin connects", () => {
+    const content = (
+      <ResumeBroadcastContent
+        activity={baseActivity}
+        batchVaultIds={[baseActivity.id]}
+        depositorEthAddress="0xdepositor"
+        onClose={vi.fn()}
+        onSuccess={vi.fn()}
+      />
+    );
+    const view = render(content);
+    expect(useBroadcastState).not.toHaveBeenCalled();
+    btcActionWallet.connected = true;
+    view.rerender(cloneElement(content));
+    expect(useBroadcastState).not.toHaveBeenCalled();
+    fireEvent.click(
+      view.getByRole("button", { name: COPY.wallet.btcAction.retry }),
+    );
+    expect(useBroadcastState).toHaveBeenCalled();
+  });
+
+  it("does not mount activation work when Bitcoin connects", () => {
+    const content = (
+      <ResumeActivationContent
+        activity={baseActivity}
+        depositorEthAddress="0xdepositor"
+        onClose={vi.fn()}
+        onGoToDashboard={vi.fn()}
+      />
+    );
+    const view = render(content);
+    expect(useActivationState).not.toHaveBeenCalled();
+    btcActionWallet.connected = true;
+    view.rerender(cloneElement(content));
+    expect(useActivationState).not.toHaveBeenCalled();
+    expect(mockHandleActivation).not.toHaveBeenCalled();
+    fireEvent.click(
+      view.getByRole("button", { name: COPY.wallet.btcAction.retry }),
+    );
+    expect(useActivationState).toHaveBeenCalled();
+  });
+
+  it("keeps a recorded payout cancellation after connection and retry", () => {
+    markPayoutSignCanceled(baseActivity.id);
+    const content = (
+      <ResumeSignContent
+        activity={baseActivity}
+        btcPublicKey="0xbtcpub"
+        depositorEthAddress="0xdepositor"
+        onClose={vi.fn()}
+        onSuccess={vi.fn()}
+      />
+    );
+    const view = render(content);
+    expect(usePayoutSigningState).not.toHaveBeenCalled();
+    btcActionWallet.connected = true;
+    view.rerender(cloneElement(content));
+    expect(usePayoutSigningState).not.toHaveBeenCalled();
+    fireEvent.click(
+      view.getByRole("button", { name: COPY.wallet.btcAction.retry }),
+    );
+    expect(usePayoutSigningState).toHaveBeenCalled();
+    const state = vi.mocked(usePayoutSigningState).mock.results.at(-1)?.value;
+    expect(state.handleSign).not.toHaveBeenCalled();
+    expect(view.getByTestId("started").textContent).toBe("false");
+  });
+
+  it("requires wallet confirmation before the explicit retry", () => {
+    btcActionWallet.connected = true;
+    btcActionWallet.confirmed = false;
+    const content = (
+      <ResumeBroadcastContent
+        activity={baseActivity}
+        batchVaultIds={[baseActivity.id]}
+        depositorEthAddress="0xdepositor"
+        onClose={vi.fn()}
+        onSuccess={vi.fn()}
+      />
+    );
+    const view = render(content);
+    expect(useBroadcastState).not.toHaveBeenCalled();
+    fireEvent.click(
+      view.getByRole("button", { name: COPY.wallet.btcAction.connect }),
+    );
+    expect(btcActionWallet.open).toHaveBeenCalledWith("BTC");
+    btcActionWallet.confirmed = true;
+    view.rerender(cloneElement(content));
+    expect(useBroadcastState).not.toHaveBeenCalled();
+    fireEvent.click(
+      view.getByRole("button", { name: COPY.wallet.btcAction.retry }),
+    );
+    expect(useBroadcastState).toHaveBeenCalled();
+  });
+
+  it("keeps an active broadcast mounted during a temporary disconnect", () => {
+    btcActionWallet.connected = true;
+    const content = (
+      <ResumeBroadcastContent
+        activity={baseActivity}
+        batchVaultIds={[baseActivity.id]}
+        depositorEthAddress="0xdepositor"
+        onClose={vi.fn()}
+        onSuccess={vi.fn()}
+      />
+    );
+    const view = render(content);
+    const progress = view.getByTestId("progress-view");
+    btcActionWallet.connected = false;
+    view.rerender(cloneElement(content));
+    expect(view.getByTestId("progress-view")).toBe(progress);
+    expect(view.queryByText(COPY.wallet.btcAction.heading)).toBeNull();
   });
 });

--- a/services/vault/src/components/simple/__tests__/ResumeDepositContent.test.tsx
+++ b/services/vault/src/components/simple/__tests__/ResumeDepositContent.test.tsx
@@ -1117,13 +1117,14 @@ describe("Bitcoin action prompt", () => {
 
   it("leaves WOTS work unstarted when the user cancels the prompt", () => {
     const onClose = vi.fn();
-    const view = render(
+    const content = (
       <ResumeWotsContent
         activity={baseActivity}
         onClose={onClose}
         onSuccess={vi.fn()}
-      />,
+      />
     );
+    const view = render(content);
     fireEvent.click(
       view.getByRole("button", { name: COPY.wallet.btcAction.connect }),
     );
@@ -1131,11 +1132,45 @@ describe("Bitcoin action prompt", () => {
       view.getByRole("button", { name: COPY.wallet.btcAction.cancel }),
     );
     expect(onClose).toHaveBeenCalledOnce();
-    view.unmount();
     btcActionWallet.connected = true;
+    view.rerender(cloneElement(content));
+    expect(
+      view.getByRole("button", { name: COPY.wallet.btcAction.retry }),
+    ).toBeTruthy();
     expect(mockGetVaultRegistryReader).not.toHaveBeenCalled();
     expect(mockDeriveVaultRoot).not.toHaveBeenCalled();
     expect(mockSubmitWotsPublicKey).not.toHaveBeenCalled();
+  });
+
+  it("holds the payout wait state after retry until the wallet key resolves", () => {
+    const withKey = (btcPublicKey: string | undefined) => (
+      <ResumeSignContent
+        activity={baseActivity}
+        btcPublicKey={btcPublicKey}
+        depositorEthAddress="0xdepositor"
+        onClose={vi.fn()}
+        onSuccess={vi.fn()}
+      />
+    );
+    const view = render(withKey(undefined));
+    expect(view.queryByTestId("progress-view")).toBeNull();
+    fireEvent.click(
+      view.getByRole("button", { name: COPY.wallet.btcAction.connect }),
+    );
+    expect(btcActionWallet.open).toHaveBeenCalledWith("BTC");
+    btcActionWallet.connected = true;
+    view.rerender(withKey(undefined));
+    expect(usePayoutSigningState).not.toHaveBeenCalled();
+    fireEvent.click(
+      view.getByRole("button", { name: COPY.wallet.btcAction.retry }),
+    );
+    expect(view.getByTestId("processing").textContent).toBe("true");
+    expect(usePayoutSigningState).not.toHaveBeenCalled();
+    view.rerender(withKey("0xbtcpub"));
+    expect(usePayoutSigningState).toHaveBeenCalled();
+    // The ceremony auto-runs on the first mount with a key, after the retry.
+    const state = vi.mocked(usePayoutSigningState).mock.results[0]?.value;
+    expect(state.handleSign).toHaveBeenCalledOnce();
   });
 
   it("does not mount broadcast work when Bitcoin connects", () => {
@@ -1219,10 +1254,13 @@ describe("Bitcoin action prompt", () => {
     );
     const view = render(content);
     expect(useBroadcastState).not.toHaveBeenCalled();
+    expect(view.getByText(COPY.wallet.btcAction.confirmBody)).toBeTruthy();
     fireEvent.click(
       view.getByRole("button", { name: COPY.wallet.btcAction.connect }),
     );
-    expect(btcActionWallet.open).toHaveBeenCalledWith("BTC");
+    // Bitcoin is already connected, so the dialog opens on the chain list
+    // that carries the confirm step, not on the Bitcoin wallet list.
+    expect(btcActionWallet.open).toHaveBeenCalledWith(undefined);
     btcActionWallet.confirmed = true;
     view.rerender(cloneElement(content));
     expect(useBroadcastState).not.toHaveBeenCalled();

--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -1284,6 +1284,13 @@ export const COPY = {
     },
   },
   wallet: {
+    btcAction: {
+      heading: "Connect your Bitcoin wallet",
+      body: "This action needs your Bitcoin wallet. Connect it, then try the action again.",
+      connect: "Connect Bitcoin wallet",
+      retry: "Retry",
+      cancel: "Cancel",
+    },
     geoBlockedTooltip: "Not available in your region",
     walletNotEligibleTooltip: "Wallet not eligible",
     addressScreeningBannerBody:

--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -513,6 +513,14 @@ export const COPY = {
         `Network fee exceeds the ${percent}% refund safety cap. Lower the fee rate to continue.`,
       retryButton: "Retry",
       confirmButton: "Confirm",
+      // Failures surfaced on the review screen's error callout. Kept here
+      // rather than inline in the execution hook, like `reclaim.errors`.
+      errors: {
+        walletNotConnected: "BTC wallet not connected",
+        missingVaultId: "Missing BTCVault ID",
+        ethWalletNotConnected: "ETH wallet not connected",
+        invalidFeeRate: "Fee rate must be a positive number",
+      },
     },
     // The tier hints are static: they name the confirmation target of the
     // mempool.space field each tile reads (hourFee / halfHourFee / fastestFee),
@@ -1287,6 +1295,14 @@ export const COPY = {
     btcAction: {
       heading: "Connect your Bitcoin wallet",
       body: "This action needs your Bitcoin wallet. Connect it, then try the action again.",
+      // The wallet is connected, but the session dialog still waits for the
+      // depositor to confirm it.
+      confirmBody:
+        "This action needs your Bitcoin wallet. Confirm the wallet connection, then try the action again.",
+      // Shown while a saved wallet session is still being restored.
+      resolving: "Checking your Bitcoin wallet…",
+      // The inline error for handlers that run outside the prompt panel.
+      error: "Bitcoin wallet not connected.",
       connect: "Connect Bitcoin wallet",
       retry: "Retry",
       cancel: "Cancel",

--- a/services/vault/src/hooks/__tests__/useBtcAction.test.tsx
+++ b/services/vault/src/hooks/__tests__/useBtcAction.test.tsx
@@ -1,0 +1,61 @@
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useBtcAction } from "../useBtcAction";
+
+const wallet = vi.hoisted(() => ({
+  btcConnected: true,
+  confirmed: true,
+  loading: false,
+  open: vi.fn(),
+}));
+
+vi.mock("@babylonlabs-io/wallet-connector", () => ({
+  useBTCWallet: () => ({
+    connected: wallet.btcConnected,
+    loading: wallet.loading,
+  }),
+  useWalletConnect: () => ({ connected: wallet.confirmed, open: wallet.open }),
+}));
+
+describe("useBtcAction", () => {
+  beforeEach(() => {
+    wallet.btcConnected = true;
+    wallet.confirmed = true;
+    wallet.loading = false;
+    wallet.open.mockClear();
+  });
+
+  it("passes without opening the dialog when Bitcoin is connected and the session is confirmed", () => {
+    const { result } = renderHook(() => useBtcAction());
+    expect(result.current.connected).toBe(true);
+    expect(result.current.requireBtcWallet()).toBe(true);
+    expect(wallet.open).not.toHaveBeenCalled();
+  });
+
+  it("opens the Bitcoin wallet list when no Bitcoin wallet is connected", () => {
+    wallet.btcConnected = false;
+    const { result } = renderHook(() => useBtcAction());
+    expect(result.current.btcConnected).toBe(false);
+    expect(result.current.requireBtcWallet()).toBe(false);
+    expect(wallet.open).toHaveBeenCalledWith("BTC");
+  });
+
+  it("opens the confirm step when Bitcoin is connected but the session is unconfirmed", () => {
+    wallet.confirmed = false;
+    const { result } = renderHook(() => useBtcAction());
+    expect(result.current.btcConnected).toBe(true);
+    expect(result.current.sessionConfirmed).toBe(false);
+    expect(result.current.connected).toBe(false);
+    expect(result.current.requireBtcWallet()).toBe(false);
+    expect(wallet.open).toHaveBeenCalledWith(undefined);
+  });
+
+  it("reports the wallet as still loading while a saved session restores", () => {
+    wallet.btcConnected = false;
+    wallet.loading = true;
+    const { result } = renderHook(() => useBtcAction());
+    expect(result.current.loading).toBe(true);
+    expect(result.current.connected).toBe(false);
+  });
+});

--- a/services/vault/src/hooks/deposit/__tests__/useArtifactDownload.test.tsx
+++ b/services/vault/src/hooks/deposit/__tests__/useArtifactDownload.test.tsx
@@ -8,6 +8,26 @@ import {
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+const btcActionWallet = vi.hoisted(() => ({
+  connected: true,
+  confirmed: true,
+  open: vi.fn(),
+}));
+
+beforeEach(() => {
+  btcActionWallet.connected = true;
+  btcActionWallet.confirmed = true;
+  btcActionWallet.open.mockClear();
+});
+
+vi.mock("@babylonlabs-io/wallet-connector", () => ({
+  useBTCWallet: () => ({ connected: btcActionWallet.connected }),
+  useWalletConnect: () => ({
+    connected: btcActionWallet.confirmed,
+    open: btcActionWallet.open,
+  }),
+}));
+
 const featureFlagsMock = vi.hoisted(() => ({
   // The artifact-download override is itself gated on this flag; the
   // god-mode test flips it on to exercise the gated path.
@@ -141,6 +161,68 @@ describe("useArtifactDownload — prime then fetch", () => {
     vi.restoreAllMocks();
     featureFlagsMock.isGodModePanelEnabled = false;
     setArtifactDownloadOverride(null);
+  });
+
+  it("waits for an explicit download retry after Bitcoin connects", async () => {
+    btcActionWallet.connected = false;
+    const { result, rerender } = renderHook(() =>
+      useArtifactDownload({ primeContext }),
+    );
+    await act(() =>
+      result.current.download(PROVIDER_ADDRESS, PEGIN_TXID, DEPOSITOR_PK),
+    );
+    expect(btcActionWallet.open).toHaveBeenCalledWith("BTC");
+    expect(openTargetMock).not.toHaveBeenCalled();
+    expect(ensureAuthMock).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+    btcActionWallet.connected = true;
+    rerender();
+    expect(openTargetMock).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+    fetchMock.mockResolvedValueOnce(OUTCOME);
+    await act(() =>
+      result.current.download(PROVIDER_ADDRESS, PEGIN_TXID, DEPOSITOR_PK),
+    );
+    expect(openTargetMock).toHaveBeenCalledOnce();
+    expect(ensureAuthMock).toHaveBeenCalledOnce();
+    expect(fetchMock).toHaveBeenCalledOnce();
+  });
+
+  it("downloads with a cached token while Bitcoin is disconnected", async () => {
+    btcActionWallet.connected = false;
+    seedHotCache();
+    fetchMock.mockResolvedValueOnce(OUTCOME);
+    const { result } = renderHook(() =>
+      useArtifactDownload({ primeContext: null }),
+    );
+    await act(() =>
+      result.current.download(PROVIDER_ADDRESS, PEGIN_TXID, DEPOSITOR_PK),
+    );
+    expect(btcActionWallet.open).not.toHaveBeenCalled();
+    expect(ensureAuthMock).not.toHaveBeenCalled();
+    expect(result.current.downloaded).toBe(true);
+  });
+
+  it("stops on an expired token when Bitcoin is disconnected", async () => {
+    btcActionWallet.connected = false;
+    seedHotCache();
+    fetchMock.mockRejectedValueOnce(
+      new JsonRpcError(-32001, "missing or malformed Bearer token", "wire"),
+    );
+    const { result, rerender } = renderHook(() =>
+      useArtifactDownload({ primeContext }),
+    );
+    await act(() =>
+      result.current.download(PROVIDER_ADDRESS, PEGIN_TXID, DEPOSITOR_PK),
+    );
+    expect(btcActionWallet.open).toHaveBeenCalledWith("BTC");
+    expect(ensureAuthMock).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(result.current.loading).toBe(false);
+    btcActionWallet.connected = true;
+    rerender();
+    expect(ensureAuthMock).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledOnce();
   });
 
   it("primes the bearer upfront when the registry is cold, then fetches once", async () => {

--- a/services/vault/src/hooks/deposit/__tests__/useVaultActions.test.ts
+++ b/services/vault/src/hooks/deposit/__tests__/useVaultActions.test.ts
@@ -140,7 +140,15 @@ vi.mock("@/clients/eth-contract/pause-state/query", () => ({
   getOnChainPauseState: () => Promise.resolve(onChainPauseMock.value),
 }));
 
+const btcActionWallet = vi.hoisted(() => ({ connected: true, open: vi.fn() }));
+beforeEach(() => {
+  btcActionWallet.connected = true;
+  btcActionWallet.open.mockClear();
+});
+
 vi.mock("@babylonlabs-io/wallet-connector", () => ({
+  useBTCWallet: () => ({ connected: btcActionWallet.connected }),
+  useWalletConnect: () => ({ connected: true, open: btcActionWallet.open }),
   getSharedWagmiConfig: vi.fn(() => ({})),
   useChainConnector: vi.fn(makeDefaultChainConnector),
 }));
@@ -361,6 +369,7 @@ describe("useVaultActions — handleBroadcast transaction integrity", () => {
   });
 
   it("requires an explicit broadcast retry after BTC reconnects", async () => {
+    btcActionWallet.connected = false;
     mockFetchVaultById.mockResolvedValue(baseVault as never);
     vi.mocked(useChainConnector).mockReturnValue(null);
     const { result, rerender } = renderHook(() => useVaultActions());
@@ -375,6 +384,9 @@ describe("useVaultActions — handleBroadcast transaction integrity", () => {
     expect(mockSignPsbt).not.toHaveBeenCalled();
     expect(baseBroadcastParams.onShowSuccessModal).not.toHaveBeenCalled();
 
+    expect(btcActionWallet.open).toHaveBeenCalledWith("BTC");
+    expect(mockFetchVaultById).not.toHaveBeenCalled();
+    btcActionWallet.connected = true;
     vi.mocked(useChainConnector).mockImplementation(
       makeDefaultChainConnector as never,
     );

--- a/services/vault/src/hooks/deposit/useArtifactDownload.ts
+++ b/services/vault/src/hooks/deposit/useArtifactDownload.ts
@@ -143,12 +143,16 @@ export function useArtifactDownload(options?: {
       // god-mode panel's "Mock artifact download" toggle; off in production
       // builds, where the god-mode gate is compile-time false.
       const demoDownload = getArtifactDownloadOverride();
+      const normalizedPeginTxid = stripHexPrefix(peginTxid);
       if (
         !demoDownload &&
-        !vpTokenRegistry.peek(stripHexPrefix(peginTxid)) &&
+        !vpTokenRegistry.peek(normalizedPeginTxid) &&
         !requireBtcWallet()
       ) {
-        setState({ ...INITIAL_STATE, error: COPY.wallet.btcAction.body });
+        // Mark any in-flight download stale, as `cancel` does, so it settles
+        // silently instead of overwriting this error.
+        abortControllerRef.current?.abort();
+        setState({ ...INITIAL_STATE, error: COPY.wallet.btcAction.error });
         return;
       }
 
@@ -179,8 +183,6 @@ export function useArtifactDownload(options?: {
         // the user sees names it rather than the fetch behind it.
         progress: COPY.deposit.recoveryArtifacts.choosingSaveLocation,
       });
-
-      const normalizedPeginTxid = stripHexPrefix(peginTxid);
 
       // Per-vault join key for telemetry. The collateral re-download path
       // mounts the hook without a vaultId; the pegin txid identifies the same
@@ -458,9 +460,11 @@ export function useArtifactDownload(options?: {
           // retry the stream.
           if (!primeAttempted && isAuthRejectedError(err)) {
             primeAttempted = true;
+            // Drop any cached token so the next acquire goes back to the server.
+            // Covers the hot-but-stale case (auth_expired); harmless on cold cache.
             vpTokenRegistry.peek(normalizedPeginTxid)?.invalidate();
             if (!requireBtcWallet()) {
-              setError(COPY.wallet.btcAction.body);
+              setError(COPY.wallet.btcAction.error);
               return;
             }
             try {

--- a/services/vault/src/hooks/deposit/useArtifactDownload.ts
+++ b/services/vault/src/hooks/deposit/useArtifactDownload.ts
@@ -9,6 +9,7 @@ import type { Hex } from "viem";
 
 import { COPY } from "@/copy";
 import { ensureAuthenticatedVpClient } from "@/hooks/deposit/depositFlowSteps/ensureAuthenticatedVpClient";
+import { useBtcAction } from "@/hooks/useBtcAction";
 import { logger } from "@/infrastructure";
 import {
   captureFunnelFailure,
@@ -91,6 +92,7 @@ export function useArtifactDownload(options?: {
   vaultId?: Hex;
   primeContext?: PrimeContext | null;
 }) {
+  const { requireBtcWallet } = useBtcAction();
   const vaultId = options?.vaultId;
   const primeContext = options?.primeContext ?? null;
 
@@ -141,6 +143,14 @@ export function useArtifactDownload(options?: {
       // god-mode panel's "Mock artifact download" toggle; off in production
       // builds, where the god-mode gate is compile-time false.
       const demoDownload = getArtifactDownloadOverride();
+      if (
+        !demoDownload &&
+        !vpTokenRegistry.peek(stripHexPrefix(peginTxid)) &&
+        !requireBtcWallet()
+      ) {
+        setState({ ...INITIAL_STATE, error: COPY.wallet.btcAction.body });
+        return;
+      }
 
       // DO NOT REORDER: showSaveFilePicker() requires transient user
       // activation, which any preceding `await` destroys. Opening the save
@@ -325,10 +335,6 @@ export function useArtifactDownload(options?: {
           totalBytes: 0,
         }));
 
-        // Drop any cached token so the next acquire goes back to the server.
-        // Covers the hot-but-stale case (auth_expired); harmless on cold cache.
-        vpTokenRegistry.peek(normalizedPeginTxid)?.invalidate();
-
         await ensureAuthenticatedVpClient({
           btcWallet: primeContext.btcWallet,
           vaultId: primeContext.vaultId,
@@ -452,6 +458,11 @@ export function useArtifactDownload(options?: {
           // retry the stream.
           if (!primeAttempted && isAuthRejectedError(err)) {
             primeAttempted = true;
+            vpTokenRegistry.peek(normalizedPeginTxid)?.invalidate();
+            if (!requireBtcWallet()) {
+              setError(COPY.wallet.btcAction.body);
+              return;
+            }
             try {
               const primed = await tryPrimeAndRetry();
               if (primed && !isStale()) {
@@ -497,7 +508,7 @@ export function useArtifactDownload(options?: {
         }
       }
     },
-    [vaultId, primeContext, persistReceipt],
+    [vaultId, primeContext, persistReceipt, requireBtcWallet],
   );
 
   const cancel = useCallback(() => {

--- a/services/vault/src/hooks/deposit/useReclaimState.ts
+++ b/services/vault/src/hooks/deposit/useReclaimState.ts
@@ -75,7 +75,7 @@ export function useReclaimState({
     async (feeRate: number) => {
       if (inFlightRef.current || reclaiming) return;
       if (!requireBtcWallet()) {
-        setError(COPY.wallet.btcAction.body);
+        setError(COPY.wallet.btcAction.error);
         return;
       }
       inFlightRef.current = true;

--- a/services/vault/src/hooks/deposit/useReclaimState.ts
+++ b/services/vault/src/hooks/deposit/useReclaimState.ts
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import type { Hex } from "viem";
 
 import { COPY } from "@/copy";
+import { useBtcAction } from "@/hooks/useBtcAction";
 import { logger } from "@/infrastructure";
 import {
   ReclaimAlreadySettledError,
@@ -37,6 +38,7 @@ export interface UseReclaimStateResult {
 export function useReclaimState({
   activity,
 }: UseReclaimStateProps): UseReclaimStateResult {
+  const { requireBtcWallet } = useBtcAction();
   const btcConnector = useChainConnector("BTC");
   const btcWalletProvider = btcConnector?.connectedWallet?.provider;
   const connectedBtcAddress = btcConnector?.connectedWallet?.account?.address;
@@ -72,6 +74,10 @@ export function useReclaimState({
   const handleReclaim = useCallback(
     async (feeRate: number) => {
       if (inFlightRef.current || reclaiming) return;
+      if (!requireBtcWallet()) {
+        setError(COPY.wallet.btcAction.body);
+        return;
+      }
       inFlightRef.current = true;
 
       try {
@@ -155,6 +161,7 @@ export function useReclaimState({
       }
     },
     [
+      requireBtcWallet,
       reclaiming,
       vaultId,
       btcWalletProvider,

--- a/services/vault/src/hooks/deposit/useRefundState.ts
+++ b/services/vault/src/hooks/deposit/useRefundState.ts
@@ -87,18 +87,18 @@ export function useRefundState({
     async (feeRate: number) => {
       if (inFlightRef.current || refunding) return;
       if (!requireBtcWallet()) {
-        setError(COPY.wallet.btcAction.body);
+        setError(COPY.wallet.btcAction.error);
         return;
       }
       inFlightRef.current = true;
 
       try {
         if (!btcWalletProvider || !connectedBtcAddress) {
-          setError("BTC wallet not connected");
+          setError(COPY.deposit.refundReview.errors.walletNotConnected);
           return;
         }
         if (!vaultId) {
-          setError("Missing BTC Vault ID");
+          setError(COPY.deposit.refundReview.errors.missingVaultId);
           return;
         }
         if (!ethAddress) {
@@ -106,11 +106,11 @@ export function useRefundState({
           // sibling vaults (batched Pre-PegIn refunds). Without it we
           // can't reconstruct the full HTLC vector even for single-vault
           // refunds, so fail closed.
-          setError("ETH wallet not connected");
+          setError(COPY.deposit.refundReview.errors.ethWalletNotConnected);
           return;
         }
         if (!Number.isFinite(feeRate) || feeRate <= 0) {
-          setError("Fee rate must be a positive number");
+          setError(COPY.deposit.refundReview.errors.invalidFeeRate);
           return;
         }
 

--- a/services/vault/src/hooks/deposit/useRefundState.ts
+++ b/services/vault/src/hooks/deposit/useRefundState.ts
@@ -4,6 +4,8 @@ import type { Address } from "viem";
 
 import { usePeginPolling } from "@/context/deposit/PeginPollingContext";
 import { useETHWallet } from "@/context/wallet";
+import { COPY } from "@/copy";
+import { useBtcAction } from "@/hooks/useBtcAction";
 import { logger } from "@/infrastructure";
 import { LocalStorageStatus } from "@/models/peginStateMachine";
 import {
@@ -33,6 +35,7 @@ const EMPTY_CONFIRMED: VaultActivity[] = [];
 export function useRefundState({
   activity,
 }: UseRefundStateProps): UseRefundStateResult {
+  const { requireBtcWallet } = useBtcAction();
   const btcConnector = useChainConnector("BTC");
   const btcWalletProvider = btcConnector?.connectedWallet?.provider;
   const connectedBtcAddress = btcConnector?.connectedWallet?.account?.address;
@@ -83,6 +86,10 @@ export function useRefundState({
   const handleRefund = useCallback(
     async (feeRate: number) => {
       if (inFlightRef.current || refunding) return;
+      if (!requireBtcWallet()) {
+        setError(COPY.wallet.btcAction.body);
+        return;
+      }
       inFlightRef.current = true;
 
       try {
@@ -197,6 +204,7 @@ export function useRefundState({
       }
     },
     [
+      requireBtcWallet,
       refunding,
       vaultId,
       btcWalletProvider,

--- a/services/vault/src/hooks/deposit/useVaultActions.ts
+++ b/services/vault/src/hooks/deposit/useVaultActions.ts
@@ -33,6 +33,7 @@ import {
 import FeatureFlags from "@/config/featureFlags";
 import { getETHChain } from "@/config/network";
 import { COPY } from "@/copy";
+import { useBtcAction } from "@/hooks/useBtcAction";
 import { useProtocolGateState } from "@/hooks/useProtocolGate";
 import { logger } from "@/infrastructure";
 import {
@@ -215,6 +216,7 @@ export function useVaultActions(): UseVaultActionsReturn {
   }, []);
 
   // Connectors
+  const { requireBtcWallet } = useBtcAction();
   const btcConnector = useChainConnector("BTC");
 
   /**
@@ -230,6 +232,11 @@ export function useVaultActions(): UseVaultActionsReturn {
       onRefetchActivities,
       onShowSuccessModal,
     } = params;
+
+    if (!requireBtcWallet()) {
+      setBroadcastError(COPY.deposit.errors.walletNotConnected);
+      return;
+    }
 
     setBroadcasting(true);
     setBroadcastError(null);

--- a/services/vault/src/hooks/useBtcAction.ts
+++ b/services/vault/src/hooks/useBtcAction.ts
@@ -1,0 +1,19 @@
+import {
+  useBTCWallet,
+  useWalletConnect,
+} from "@babylonlabs-io/wallet-connector";
+import { useCallback } from "react";
+
+export function useBtcAction() {
+  const { connected: btcConnected } = useBTCWallet();
+  const { connected: sessionConfirmed, open } = useWalletConnect();
+  const connected = btcConnected && sessionConfirmed;
+
+  const requireBtcWallet = useCallback(() => {
+    if (connected) return true;
+    open("BTC");
+    return false;
+  }, [connected, open]);
+
+  return { connected, requireBtcWallet };
+}

--- a/services/vault/src/hooks/useBtcAction.ts
+++ b/services/vault/src/hooks/useBtcAction.ts
@@ -5,15 +5,21 @@ import {
 import { useCallback } from "react";
 
 export function useBtcAction() {
-  const { connected: btcConnected } = useBTCWallet();
+  const { connected: btcConnected, loading } = useBTCWallet();
   const { connected: sessionConfirmed, open } = useWalletConnect();
   const connected = btcConnected && sessionConfirmed;
 
   const requireBtcWallet = useCallback(() => {
     if (connected) return true;
-    open("BTC");
+    open(btcConnected ? undefined : "BTC");
     return false;
-  }, [connected, open]);
+  }, [connected, btcConnected, open]);
 
-  return { connected, requireBtcWallet };
+  return {
+    connected,
+    btcConnected,
+    sessionConfirmed,
+    loading,
+    requireBtcWallet,
+  };
 }


### PR DESCRIPTION
## Outcome

Vault asks for Bitcoin before a Bitcoin action. An already connected user can resume after the first key read. Wallet loss stops active payout work. Reconnect requires a separate Retry.

Status: The branch includes the latest main changes. Commit `312622fd6` uses the approved security key. Fresh CI and Greptile review are pending for this commit. All review threads are resolved. Jeremy's earlier change request is dismissed. A fresh code-owner approval is still required.

## Change

- Preserve the opening action while the first key read and status polling finish.
- Revoke that action after wallet, consent, or key loss. Delayed payout, WOTS, and broadcast status cannot start work after reconnect.
- Stop active payout polling and signing when the required session changes. Cancel the original Ledger provider and reject late results.
- Keep Cancel visible until the active call settles. Then show a recoverable error with Retry when the current key is available. If the parent closes the payout view, cancel the original device request.
- Show a loader and Cancel while the connected wallet key is unavailable. Use the shared deposit content width.
- Remove duplicate test properties introduced by the main branch update.

## Safety

Cancel leaves a pending action unstarted. Connection alone does not start it. The payout-address and signing checks remain in place. This PR does not enable Ethereum-first mode.

The cached-token rejection case remains deferred in #2507 under #2228. Required human reviews and applicable Bitcoin safety checks remain.

## Verification

- Before the main update: 3,814 Vault tests pass; six existing tests are skipped.
- After the main update and follow-up fixes: 138 targeted tests pass. These cover payout cancellation, wallet prompts, continuation, and page layout.
- Production build and full lint pass. The changed files have no lint errors or warnings.
- Regression coverage includes the real first key read, delayed status, reconnect, consent loss, key loss, early asynchronous checks, Ledger cancellation, late signing results, and Retry after immediate cancellation.
- Real-wallet release evidence remains in #2355 and #2233.

## Links

Closes #2505. Tracks #2232. #2232 stays open.

Epic: #2228. Wallet dependency: #2230. Final integration: #2501.
