### PR TITLE
fix(ledger-vault): match the device's unmasked refund sequence check

### DIFF
--- a/packages/babylon-ledger-vault-signer/src/__tests__/envelope.test.ts
+++ b/packages/babylon-ledger-vault-signer/src/__tests__/envelope.test.ts
@@ -253,6 +253,13 @@ describe("assertDepositTermsDeviceCompatible", () => {
     expect(() => assertDepositTermsDeviceCompatible(makeTerms({ protocolFeeRate: 10_001n }))).toThrow(/protocolFeeRate/);
   });
 
+  it("accepts the device prepegin max-fee ceiling and rejects one sat above it", () => {
+    expect(() => assertDepositTermsDeviceCompatible(makeTerms({ prepeginMaxFee: 100_000_000n }))).not.toThrow();
+    expect(() => assertDepositTermsDeviceCompatible(makeTerms({ prepeginMaxFee: 100_000_001n }))).toThrow(
+      /prepeginMaxFee/,
+    );
+  });
+
   it("rejects a commission or claim value below the device dust floor", () => {
     const vault = makeTerms().vaults[0];
     expect(() =>

--- a/packages/babylon-ledger-vault-signer/src/__tests__/envelope.test.ts
+++ b/packages/babylon-ledger-vault-signer/src/__tests__/envelope.test.ts
@@ -248,10 +248,9 @@ describe("assertDepositTermsDeviceCompatible", () => {
     expect(() => assertDepositTermsDeviceCompatible(makeTerms({ timelockRefund: 4321 }))).toThrow(/timelockRefund/);
   });
 
-  it("rejects a protocolFeeRate above the device u32 ceiling", () => {
-    expect(() => assertDepositTermsDeviceCompatible(makeTerms({ protocolFeeRate: 0x1_0000_0000n }))).toThrow(
-      /protocolFeeRate/,
-    );
+  it("accepts the device fee-rate ceiling and rejects one sat/vB above it", () => {
+    expect(() => assertDepositTermsDeviceCompatible(makeTerms({ protocolFeeRate: 10_000n }))).not.toThrow();
+    expect(() => assertDepositTermsDeviceCompatible(makeTerms({ protocolFeeRate: 10_001n }))).toThrow(/protocolFeeRate/);
   });
 
   it("rejects a commission or claim value below the device dust floor", () => {

--- a/packages/babylon-ledger-vault-signer/src/__tests__/refundPsbt.test.ts
+++ b/packages/babylon-ledger-vault-signer/src/__tests__/refundPsbt.test.ts
@@ -2,8 +2,8 @@
  * Refund-PSBT classification and augmentation (#2371).
  *
  * The leaf grammar mirrors the firmware's own parser byte-for-byte —
- * `fw:sign_psbt_validate_helpers.c:77-148` (`parse_refund_leaf_script`) @
- * `ff1e1ce17` — so every accept/reject vector here is a firmware-grammar pin,
+ * `fw:sign_psbt_validate_helpers.c:77-156` (`parse_refund_leaf_script`) @
+ * `b0c0ac4d` — so every accept/reject vector here is a firmware-grammar pin,
  * including the shapes the firmware is deliberately loose about (OP_PUSHDATA1,
  * a non-minimal positive CScriptNum).
  */
@@ -158,10 +158,17 @@ describe("parseRefundLeafScript (firmware-grammar mirror)", () => {
     });
   });
 
-  it("parses the maximum 4-byte CScriptNum the firmware admits", () => {
-    expect(parseRefundLeafScript(refundLeaf(DEPOSITOR_XONLY, Buffer.from([0x04, 0xff, 0xff, 0xff, 0x7f])))).toEqual({
+  it("parses the maximum CSV the firmware admits — the BIP-68 block-count field (0xffff)", () => {
+    expect(parseRefundLeafScript(refundLeaf(DEPOSITOR_XONLY, Buffer.from([0x03, 0xff, 0xff, 0x00])))).toEqual({
       leafKeyHex: DEPOSITOR_XONLY,
-      csv: 0x7fffffff,
+      csv: 0xffff,
+    });
+  });
+
+  it("parses a 4-byte CScriptNum push — the firmware's length cap — when its value fits the field", () => {
+    expect(parseRefundLeafScript(refundLeaf(DEPOSITOR_XONLY, Buffer.from([0x04, 0xff, 0xff, 0x00, 0x00])))).toEqual({
+      leafKeyHex: DEPOSITOR_XONLY,
+      csv: 0xffff,
     });
   });
 
@@ -170,6 +177,8 @@ describe("parseRefundLeafScript (firmware-grammar mirror)", () => {
     ["OP_1NEGATE push", Buffer.from([0x4f])],
     ["negative CScriptNum (sign bit set)", Buffer.from([0x01, 0x80])],
     ["zero CScriptNum", Buffer.from([0x01, 0x00])],
+    ["CSV one above the BIP-68 block-count field (0x10000)", Buffer.from([0x03, 0x00, 0x00, 0x01])],
+    ["CSV 0x7fffffff — the 4-byte maximum the firmware accepted before V-005", Buffer.from([0x04, 0xff, 0xff, 0xff, 0x7f])],
     ["5-byte CScriptNum", Buffer.from([0x05, 0x01, 0x00, 0x00, 0x00, 0x00])],
     ["OP_PUSHDATA1 with a 5-byte length", Buffer.from([0x4c, 0x05, 0x01, 0x00, 0x00, 0x00, 0x00])],
     ["push extending past the script end", Buffer.from([0x04, 0x01])],
@@ -290,6 +299,11 @@ describe("assertRefundPsbtSignable", () => {
     expect(() => assertRefundPsbtSignable(classified({ sequence: 144 }))).toThrow(/sequence/);
   });
 
+  it("rejects a sequence with a bit above the block-count field even though the low 16 bits match the CSV", () => {
+    // A masked compare accepted this; the device compares unmasked (V-005).
+    expect(() => assertRefundPsbtSignable(classified({ sequence: 0x00010000 + CSV_2016 }))).toThrow(/sequence/);
+  });
+
   it("rejects an input without a witnessUtxo", () => {
     expect(() => assertRefundPsbtSignable(classified({ dropWitnessUtxo: true }))).toThrow(/witnessUtxo/);
   });
@@ -327,7 +341,7 @@ describe("augmentPsbtForRefund", () => {
     expect(inputDeriv![0].path).toBe("m/86'/1'/0'/0/0");
     expect(inputDeriv![0].leafHashes).toEqual([]);
 
-    // The asymmetry the device demands (`fw:sign_psbt_validate.c:1005-1057`):
+    // The asymmetry the device demands (`fw:sign_psbt_validate.c:1025-1069`):
     // the output entry is keyed by the scriptPubKey's witness program, which
     // is the BIP-86 TWEAK of the depositor key — never the depositor key itself.
     const outputDeriv = augmented.data.outputs[0].tapBip32Derivation;

--- a/packages/babylon-ledger-vault-signer/src/__tests__/refundPsbt.test.ts
+++ b/packages/babylon-ledger-vault-signer/src/__tests__/refundPsbt.test.ts
@@ -77,6 +77,7 @@ function buildRefundShapedPsbt(
     version?: number;
     locktime?: number;
     sequence?: number;
+    sighashType?: number;
   } = {},
 ): string {
   const leaf = overrides.leaf ?? refundLeaf(DEPOSITOR_XONLY, PUSH_2016);
@@ -107,6 +108,9 @@ function buildRefundShapedPsbt(
         }),
     tapInternalKey: Buffer.from(NUMS_XONLY, "hex"),
   });
+  // Assigned directly: bip174's addInput `canAdd` treats a sighashType of 0 as
+  // falsy and refuses it, while `fromHex` decodes an explicit 0 like any other.
+  if (overrides.sighashType !== undefined) psbt.data.inputs[0].sighashType = overrides.sighashType;
   if (overrides.extraInput) {
     psbt.addInput({
       hash: Buffer.alloc(32, 0x33),
@@ -176,9 +180,10 @@ describe("parseRefundLeafScript (firmware-grammar mirror)", () => {
     ["OP_0 push", Buffer.from([0x00])],
     ["OP_1NEGATE push", Buffer.from([0x4f])],
     ["negative CScriptNum (sign bit set)", Buffer.from([0x01, 0x80])],
+    ["negative 4-byte CScriptNum (sign bit in the top byte)", Buffer.from([0x04, 0x00, 0x00, 0x00, 0x80])],
     ["zero CScriptNum", Buffer.from([0x01, 0x00])],
     ["CSV one above the BIP-68 block-count field (0x10000)", Buffer.from([0x03, 0x00, 0x00, 0x01])],
-    ["CSV 0x7fffffff — the 4-byte maximum the firmware accepted before V-005", Buffer.from([0x04, 0xff, 0xff, 0xff, 0x7f])],
+    ["CSV 0x7fffffff — the 4-byte maximum the firmware accepted before the refund-sequence fix", Buffer.from([0x04, 0xff, 0xff, 0xff, 0x7f])],
     ["5-byte CScriptNum", Buffer.from([0x05, 0x01, 0x00, 0x00, 0x00, 0x00])],
     ["OP_PUSHDATA1 with a 5-byte length", Buffer.from([0x4c, 0x05, 0x01, 0x00, 0x00, 0x00, 0x00])],
     ["push extending past the script end", Buffer.from([0x04, 0x01])],
@@ -288,11 +293,15 @@ describe("assertRefundPsbtSignable", () => {
   });
 
   it("rejects a sequence with the BIP-68 disable flag set", () => {
-    expect(() => assertRefundPsbtSignable(classified({ sequence: 0x80000000 + CSV_2016 }))).toThrow(/sequence/);
+    expect(() => assertRefundPsbtSignable(classified({ sequence: 0x80000000 + CSV_2016 }))).toThrow(
+      /disable\/time flags clear/,
+    );
   });
 
   it("rejects a sequence with the BIP-68 time-based flag set", () => {
-    expect(() => assertRefundPsbtSignable(classified({ sequence: 0x00400000 + CSV_2016 }))).toThrow(/sequence/);
+    expect(() => assertRefundPsbtSignable(classified({ sequence: 0x00400000 + CSV_2016 }))).toThrow(
+      /disable\/time flags clear/,
+    );
   });
 
   it("rejects a sequence that does not encode exactly the leaf CSV", () => {
@@ -300,8 +309,16 @@ describe("assertRefundPsbtSignable", () => {
   });
 
   it("rejects a sequence with a bit above the block-count field even though the low 16 bits match the CSV", () => {
-    // A masked compare accepted this; the device compares unmasked (V-005).
+    // A masked compare accepted this; the device compares unmasked.
     expect(() => assertRefundPsbtSignable(classified({ sequence: 0x00010000 + CSV_2016 }))).toThrow(/sequence/);
+  });
+
+  it("accepts an explicit SIGHASH_DEFAULT on the refund input", () => {
+    expect(() => assertRefundPsbtSignable(classified({ sighashType: 0 }))).not.toThrow();
+  });
+
+  it("rejects an explicit SIGHASH_ALL — the device admits only SIGHASH_DEFAULT on this path", () => {
+    expect(() => assertRefundPsbtSignable(classified({ sighashType: 1 }))).toThrow(/sighash/);
   });
 
   it("rejects an input without a witnessUtxo", () => {

--- a/packages/babylon-ledger-vault-signer/src/deviceCaps.ts
+++ b/packages/babylon-ledger-vault-signer/src/deviceCaps.ts
@@ -41,6 +41,13 @@ export const DEVICE_MAX_VAULTS_PER_INTENT = 10;
  */
 export const DEVICE_MAX_BASE_FEE_RATE_SAT_PER_VB = 10_000n;
 
+/**
+ * Upper bound on `prepegin_max_fee` (`vault_tlv.c:170`; `PREPEGIN_MAX_FEE_LIMIT`
+ * at `vault_constants.h:98`). Firmware-only — no btc-vault counterpart, and
+ * the SDK's sized fee cannot approach it at the contract's 1000 sat/vB cap.
+ */
+export const DEVICE_MAX_PREPEGIN_FEE_SATS = 100_000_000n;
+
 /** Shared lower bound for the CSV/refund timelocks (`vault_constants.h:103`). */
 export const DEVICE_TIMELOCK_MIN_BLOCKS = 72;
 

--- a/packages/babylon-ledger-vault-signer/src/deviceCaps.ts
+++ b/packages/babylon-ledger-vault-signer/src/deviceCaps.ts
@@ -1,6 +1,6 @@
 /**
  * Ledger vault-app intent caps, mirrored from the firmware
- * (`app-babylon-vault` @ `8f99b8b`: `vault_tlv.c`, `vault_intent.h`,
+ * (`app-babylon-vault` @ `b0c0ac4d`: `vault_tlv.c`, `vault_intent.h`,
  * `vault_constants.h`). The device rejects violations with SW_INCORRECT_DATA
  * and a dead session, so we fail comprehensibly BEFORE the ceremony.
  *
@@ -20,7 +20,7 @@ export const DEVICE_MAX_VAULT_CORE_VERSION = 3;
 
 /**
  * Keeper and universal-challenger counts, each `[1, 32]` (`vault_intent.h:8-9`,
- * checked `vault_tlv.c:130,137`). Far below the protocol: the contract allows
+ * checked `vault_tlv.c:148,155`). Far below the protocol: the contract allows
  * 1500 universal challengers and sets no keeper cap at all.
  */
 export const DEVICE_MAX_PARTICIPANTS_PER_ROLE = 32;
@@ -34,23 +34,25 @@ export const DEVICE_MAX_VAULTS_PER_INTENT = 10;
 
 /**
  * Fee-rate bounds (sat/vB): the intent parser rejects rate == 0 AND
- * rate > UINT32_MAX (`vault_tlv.c:73`), so the `>= 1` floor is both a device
- * check and the contract invariant.
+ * rate > 10000 (`vault_tlv.c:75`). The ceiling is vaultd's critical-tx config
+ * default (`btc-vault crates/vaultd/src/config/btc.rs:19` @ d0d139305), not a
+ * protocol constant; the contract caps `feeRate` at 1000 (`ProtocolParams.sol:44`),
+ * so a contract-sourced rate can never reach it.
  */
-export const DEVICE_MAX_BASE_FEE_RATE_SAT_PER_VB = 0xffffffffn;
+export const DEVICE_MAX_BASE_FEE_RATE_SAT_PER_VB = 10_000n;
 
-/** Shared lower bound for the CSV/refund timelocks (`vault_constants.h:100`). */
+/** Shared lower bound for the CSV/refund timelocks (`vault_constants.h:103`). */
 export const DEVICE_TIMELOCK_MIN_BLOCKS = 72;
 
-/** Inclusive upper bound for `pegin_csv_timelock` (`vault_constants.h:103`). */
+/** Inclusive upper bound for `pegin_csv_timelock` (`vault_constants.h:106`). */
 export const DEVICE_PEGIN_CSV_TIMELOCK_MAX_BLOCKS = 1008;
 
-/** Inclusive upper bound for `htlc_refund_timelock` (`vault_constants.h:106`). */
+/** Inclusive upper bound for `htlc_refund_timelock` (`vault_constants.h:109`). */
 export const DEVICE_REFUND_TIMELOCK_MAX_BLOCKS = 4320;
 
 /**
  * Inclusive bounds for `payout_timelock`. The intent parser is EXCLUSIVE
- * `(90, 4032)` (`vault_tlv.c`), so the accepted range is `[91, 4031]`; the
+ * `(90, 4032)` (`vault_tlv.c:94`), so the accepted range is `[91, 4031]`; the
  * exclusive form gates deposits, so it wins over Screen 8's inclusive form.
  */
 export const DEVICE_PAYOUT_TIMELOCK_MIN_BLOCKS = 91;

--- a/packages/babylon-ledger-vault-signer/src/envelope.ts
+++ b/packages/babylon-ledger-vault-signer/src/envelope.ts
@@ -46,7 +46,7 @@ export function assertDepositTermsDeviceCompatible(terms: DepositTerms): void {
   );
 
   // The >= 1 floor is enforced by both the contract and the device
-  // (vault_tlv.c:73 rejects rate == 0).
+  // (vault_tlv.c:75 rejects rate == 0).
   if (terms.protocolFeeRate < 1n || terms.protocolFeeRate > DEVICE_MAX_BASE_FEE_RATE_SAT_PER_VB) {
     throw new DepositTermsRejectedError(
       `${RANGE_MSG}: protocolFeeRate ${terms.protocolFeeRate} not in ` + `[1, ${DEVICE_MAX_BASE_FEE_RATE_SAT_PER_VB}]`,
@@ -85,7 +85,7 @@ export function assertDepositTermsDeviceCompatible(terms: DepositTerms): void {
 
   // Raw u64 validity first, then the semantic floor — same ordering as the
   // per-vault loop. The intent parser rejects prepegin_max_fee == 0
-  // (vault_tlv.c:152).
+  // (vault_tlv.c:170).
   requireU64("prepeginMaxFee", terms.prepeginMaxFee);
   if (terms.prepeginMaxFee < 1n) {
     throw new DepositTermsRejectedError(`${RANGE_MSG}: prepeginMaxFee ${terms.prepeginMaxFee} must be >= 1`);

--- a/packages/babylon-ledger-vault-signer/src/envelope.ts
+++ b/packages/babylon-ledger-vault-signer/src/envelope.ts
@@ -10,6 +10,7 @@
 import {
   DEVICE_MAX_BASE_FEE_RATE_SAT_PER_VB,
   DEVICE_MAX_PARTICIPANTS_PER_ROLE,
+  DEVICE_MAX_PREPEGIN_FEE_SATS,
   DEVICE_MAX_VAULT_CORE_VERSION,
   DEVICE_MAX_VAULTS_PER_INTENT,
   DEVICE_MIN_DEPOSITOR_CLAIM_VALUE_SATS,
@@ -83,12 +84,14 @@ export function assertDepositTermsDeviceCompatible(terms: DepositTerms): void {
   );
   requireIntInRange("vault count", terms.vaults.length, 1, DEVICE_MAX_VAULTS_PER_INTENT);
 
-  // Raw u64 validity first, then the semantic floor — same ordering as the
-  // per-vault loop. The intent parser rejects prepegin_max_fee == 0
-  // (vault_tlv.c:170).
+  // Raw u64 validity first, then the semantic band — same ordering as the
+  // per-vault loop. The intent parser rejects prepegin_max_fee == 0 and
+  // > PREPEGIN_MAX_FEE_LIMIT (vault_tlv.c:170).
   requireU64("prepeginMaxFee", terms.prepeginMaxFee);
-  if (terms.prepeginMaxFee < 1n) {
-    throw new DepositTermsRejectedError(`${RANGE_MSG}: prepeginMaxFee ${terms.prepeginMaxFee} must be >= 1`);
+  if (terms.prepeginMaxFee < 1n || terms.prepeginMaxFee > DEVICE_MAX_PREPEGIN_FEE_SATS) {
+    throw new DepositTermsRejectedError(
+      `${RANGE_MSG}: prepeginMaxFee ${terms.prepeginMaxFee} not in [1, ${DEVICE_MAX_PREPEGIN_FEE_SATS}]`,
+    );
   }
 
   // Strictly ascending htlc_vout, u8 on the wire — out-of-range must fail

--- a/packages/babylon-ledger-vault-signer/src/refundPsbt.ts
+++ b/packages/babylon-ledger-vault-signer/src/refundPsbt.ts
@@ -10,7 +10,7 @@
  *
  * Firmware citations: `fw:` = LedgerHQ/app-babylon-vault @ `b0c0ac4d`
  * (`develop`, 2026-09-04). Leaf grammar: `fw:sign_psbt_validate_helpers.c:77-156`
- * (`parse_refund_leaf_script`); input entry: `fw:sign_psbt_validate.c:920-948`;
+ * (`parse_refund_leaf_script`); input entry: `fw:sign_psbt_validate.c:918-965`;
  * output entry: `fw:sign_psbt_validate.c:1025-1069`; both entries are REQUIRED —
  * a missing lookup rejects with SW_INCORRECT_DATA.
  *
@@ -68,6 +68,10 @@ const BIP68_SEQUENCE_MASK = 0x0000ffff;
 const MIN_REFUND_TX_VERSION = 2;
 const REFUND_TX_LOCKTIME = 0;
 
+/** The only sighash the refund path admits when one is present — explicit
+ * SIGHASH_ALL is rejected too (`fw:sign_psbt_validate.c:829-847`). */
+const SIGHASH_DEFAULT = 0;
+
 /** The terms a refund leaf commits to: signer key and CSV timelock. */
 export interface RefundLeafTerms {
   /** UNTWEAKED x-only key inside the leaf (lowercase hex). */
@@ -120,8 +124,8 @@ export function parseRefundLeafScript(script: Uint8Array): RefundLeafTerms | und
   } else {
     return undefined;
   }
-  // Consensus reads only the low 16 bits of a CSV operand, so the firmware
-  // bounds it to the BIP-68 block-count field (`fw:…helpers.c:136-145`).
+  // Block-count refunds only: the operand must fit the 16-bit field, which also
+  // keeps the BIP-68 disable/time flags unsettable (`fw:…helpers.c:136-145`).
   if (csv === 0 || csv > BIP68_SEQUENCE_MASK) return undefined;
 
   if (pos >= script.length) return undefined;
@@ -140,6 +144,8 @@ export interface RefundPsbtClassification extends RefundLeafTerms {
   readonly inputTxidInternalHex: string;
   /** Input 0's nSequence as encoded in the unsigned transaction. */
   readonly sequence: number;
+  /** Input 0's PSBT_IN_SIGHASH_TYPE, when the map carries one. */
+  readonly sighashType: number | undefined;
   /** Input 0's witnessUtxo terms, when the map carries one. */
   readonly witnessUtxo: { readonly scriptLength: number; readonly value: number } | undefined;
   /** Output 0's scriptPubKey (lowercase hex). */
@@ -183,6 +189,7 @@ export function classifyRefundPsbt(psbtHex: string): RefundPsbtClassification | 
     ...terms,
     inputTxidInternalHex: Buffer.from(psbt.txInputs[0].hash).toString("hex"),
     sequence: psbt.txInputs[0].sequence ?? 0,
+    sighashType: input.sighashType,
     witnessUtxo: input.witnessUtxo
       ? { scriptLength: input.witnessUtxo.script.length, value: input.witnessUtxo.value }
       : undefined,
@@ -194,16 +201,22 @@ export function classifyRefundPsbt(psbtHex: string): RefundPsbtClassification | 
 /**
  * Pure signability pins for a classified refund — every term the device
  * validates that needs NO device data, so a caller can reject before any
- * device I/O (not even a liveness probe). Mirrors, in order: the witnessUtxo
- * requirement (`fw:sign_psbt_validate.c:850-863`), the output-value cap
- * (`:1075`), destination ownership (the device derives, BIP-86-tweaks
- * and compares — `:1025-1069`; host-side the leaf key is the derivation
- * anchor, so the output must pay ITS BIP-86 address), the no-intent CSV floor
- * (`:912`, `vault_constants.h:103`), and the BIP-68 sequence pins
- * (`:972-991` — present, flags clear, equal to the CSV; compared unmasked
- * because the leaf parser already bounds the CSV to the block-count field).
+ * device I/O (not even a liveness probe). Mirrors, in order: the sighash pin
+ * (`fw:sign_psbt_validate.c:829-847` — absent or SIGHASH_DEFAULT), the
+ * witnessUtxo requirement (`:850-863`), the output-value cap (`:1075`),
+ * destination ownership (the device derives, BIP-86-tweaks and compares —
+ * `:1025-1069`; host-side the leaf key is the derivation anchor, so the output
+ * must pay ITS BIP-86 address), the no-intent CSV floor (`:912`,
+ * `vault_constants.h:103`), and the BIP-68 sequence pins (`:972-991` —
+ * present, flags clear, equal to the CSV; compared unmasked because the leaf
+ * parser already bounds the CSV to the block-count field).
  */
 export function assertRefundPsbtSignable(refund: RefundPsbtClassification): void {
+  if (refund.sighashType !== undefined && refund.sighashType !== SIGHASH_DEFAULT) {
+    throw new Error(
+      `refund input sighash type ${refund.sighashType} must be absent or SIGHASH_DEFAULT — the device rejects any other value`,
+    );
+  }
   if (refund.witnessUtxo === undefined || refund.witnessUtxo.scriptLength !== P2TR_SCRIPT_BYTES) {
     throw new Error(
       "refund input must carry a P2TR witnessUtxo — the device rejects a missing or non-34-byte scriptPubKey",

--- a/packages/babylon-ledger-vault-signer/src/refundPsbt.ts
+++ b/packages/babylon-ledger-vault-signer/src/refundPsbt.ts
@@ -8,10 +8,10 @@
  * directly), output 0 by the BIP-86 TWEAKED key — the scriptPubKey's witness
  * program (derived, tweaked, then compared).
  *
- * Firmware citations: `fw:` = LedgerHQ/app-babylon-vault @ `ff1e1ce17`
- * (`fix/feedback`, v0.10.0). Leaf grammar: `fw:sign_psbt_validate_helpers.c:77-148`
- * (`parse_refund_leaf_script`); input entry: `fw:sign_psbt_validate.c:905-950`;
- * output entry: `fw:sign_psbt_validate.c:1005-1057`; both entries are REQUIRED —
+ * Firmware citations: `fw:` = LedgerHQ/app-babylon-vault @ `b0c0ac4d`
+ * (`develop`, 2026-09-04). Leaf grammar: `fw:sign_psbt_validate_helpers.c:77-156`
+ * (`parse_refund_leaf_script`); input entry: `fw:sign_psbt_validate.c:920-948`;
+ * output entry: `fw:sign_psbt_validate.c:1025-1069`; both entries are REQUIRED —
  * a missing lookup rejects with SW_INCORRECT_DATA.
  *
  * @module ledger-vault-signer/refundPsbt
@@ -31,7 +31,7 @@ const TAPSCRIPT_LEAF_VERSION = 0xc0;
 const X_ONLY_KEY_BYTES = 32;
 
 // Script opcodes the firmware parser dispatches on
-// (`fw:sign_psbt_validate_helpers.c:104-139`).
+// (`fw:sign_psbt_validate_helpers.c:101-134`).
 const OP_0 = 0x00;
 const OP_PUSHBYTES_1 = 0x01;
 const OP_PUSHBYTES_32 = 0x20;
@@ -44,27 +44,27 @@ const OP_16 = 0x60;
 const OP_CHECKSIGVERIFY = 0xad;
 const OP_CHECKSEQUENCEVERIFY = 0xb2;
 
-/** CScriptNum caps, per the firmware (`fw:sign_psbt_validate_helpers.c:28-30`). */
+/** CScriptNum caps, per the firmware (`fw:sign_psbt_validate_helpers.c:29-30`). */
 const SCRIPT_NUM_MAX_LEN = 4;
 const SCRIPT_NUM_SIGN_BIT = 0x80;
 
-/** `OP_PUSHBYTES_32 ‖ key(32) ‖ OP_CHECKSIGVERIFY ‖ push(1) ‖ OP_CSV` (`fw:…helpers.c:33-34`). */
+/** `OP_PUSHBYTES_32 ‖ key(32) ‖ OP_CHECKSIGVERIFY ‖ push(1) ‖ OP_CSV` (`fw:…helpers.c:34`). */
 const REFUND_SCRIPT_MIN_LEN = 1 + X_ONLY_KEY_BYTES + 1 + 1 + 1;
 
 /** P2TR scriptPubKey: OP_1 ‖ push-32 ‖ witness program(32); program starts here. */
 const P2TR_WITNESS_PROGRAM_OFFSET = 2;
 /** The device requires the refund's witnessUtxo scriptPubKey to be exactly this
- * long — `VAULT_P2TR_SCRIPTPUBKEY_LEN` (`fw:sign_psbt_validate.c:836-854`). */
+ * long — `VAULT_P2TR_SCRIPTPUBKEY_LEN` (`fw:sign_psbt_validate.c:850-863`). */
 const P2TR_SCRIPT_BYTES = 34;
 
 // BIP-68 sequence semantics the device pins on the refund input
-// (`fw:sign_psbt_validate.c:956-979`; values from `fw:vault_constants.h:126-128`).
+// (`fw:sign_psbt_validate.c:972-991`; values from `fw:vault_constants.h:126-128`).
 const BIP68_DISABLE_FLAG = 0x80000000;
 const BIP68_TIME_BASED_FLAG = 0x00400000;
 const BIP68_SEQUENCE_MASK = 0x0000ffff;
 
-/** Refund transactions are v2 with locktime 0 (`fw:sign_psbt_validate.c:806-809`);
- * version 0 never even reaches refund dispatch — it routes to PoP (`:3551`). */
+/** Refund transactions are v2 with locktime 0 (`fw:sign_psbt_validate.c:819`);
+ * version 0 never even reaches refund dispatch — it routes to PoP (`:3578`). */
 const MIN_REFUND_TX_VERSION = 2;
 const REFUND_TX_LOCKTIME = 0;
 
@@ -77,14 +77,14 @@ export interface RefundLeafTerms {
 
 /**
  * Byte-for-byte mirror of the firmware's refund-leaf parser
- * (`fw:sign_psbt_validate_helpers.c:77-148`) — deliberately EXACTLY as loose:
+ * (`fw:sign_psbt_validate_helpers.c:77-156`) — deliberately EXACTLY as loose:
  * OP_PUSHDATA1 and a non-minimal positive CScriptNum are accepted, because a
  * host grammar stricter than the device's would strand a refund the device
  * would sign. Returns `undefined` where the firmware returns false.
  *
  * NOTE: the device's DISPATCH is looser still — it routes any conforming
  * prefix whose last byte is `OP_CSV` to the refund validator
- * (`fw:sign_psbt_validate.c:3643-3691`) and only then runs this grammar. Using
+ * (`fw:sign_psbt_validate.c:3554-3718`) and only then runs this grammar. Using
  * the full grammar for host classification (see {@link classifyRefundPsbt}) is
  * the deliberate, fail-safe divergence: under-classification falls back to
  * requiring an approved intent.
@@ -120,8 +120,9 @@ export function parseRefundLeafScript(script: Uint8Array): RefundLeafTerms | und
   } else {
     return undefined;
   }
-  // The sign-bit rejections above cap csv at 0x7fffffff — no uint32 wrap.
-  if (csv === 0) return undefined;
+  // Consensus reads only the low 16 bits of a CSV operand, so the firmware
+  // bounds it to the BIP-68 block-count field (`fw:…helpers.c:136-145`).
+  if (csv === 0 || csv > BIP68_SEQUENCE_MASK) return undefined;
 
   if (pos >= script.length) return undefined;
   if (script[pos++] !== OP_CHECKSEQUENCEVERIFY) return undefined;
@@ -135,7 +136,7 @@ export function parseRefundLeafScript(script: Uint8Array): RefundLeafTerms | und
 export interface RefundPsbtClassification extends RefundLeafTerms {
   /** Input 0's previous txid in INTERNAL byte order (lowercase hex) — the
    * order the device compares against the loaded intent's `prepegin_txid`
-   * (`fw:sign_psbt_validate.c:1076-1081`). */
+   * (`fw:sign_psbt_validate.c:1082-1094`). */
   readonly inputTxidInternalHex: string;
   /** Input 0's nSequence as encoded in the unsigned transaction. */
   readonly sequence: number;
@@ -156,7 +157,7 @@ export interface RefundPsbtClassification extends RefundLeafTerms {
  *
  * DELIBERATELY a strict subset of the device's own routing: the firmware
  * dispatches on the leaf's shape prefix and terminal `OP_CSV` byte alone
- * (`fw:sign_psbt_validate.c:3643-3691`) and only then validates the full
+ * (`fw:sign_psbt_validate.c:3554-3718`) and only then validates the full
  * grammar, version and locktime inside the refund validator. Host
  * under-classification is the fail-safe direction — an unrecognised PSBT
  * falls back to requiring an approved intent, so neither the intent gate nor
@@ -194,12 +195,13 @@ export function classifyRefundPsbt(psbtHex: string): RefundPsbtClassification | 
  * Pure signability pins for a classified refund — every term the device
  * validates that needs NO device data, so a caller can reject before any
  * device I/O (not even a liveness probe). Mirrors, in order: the witnessUtxo
- * requirement (`fw:sign_psbt_validate.c:836-854`), the output-value cap
- * (`:1059-1062`), destination ownership (the device derives, BIP-86-tweaks
- * and compares — `:1005-1057`; host-side the leaf key is the derivation
+ * requirement (`fw:sign_psbt_validate.c:850-863`), the output-value cap
+ * (`:1075`), destination ownership (the device derives, BIP-86-tweaks
+ * and compares — `:1025-1069`; host-side the leaf key is the derivation
  * anchor, so the output must pay ITS BIP-86 address), the no-intent CSV floor
- * (`:898-903`, `vault_constants.h:103`), and the BIP-68 sequence pins
- * (`:956-979` — present, flags clear, low bits encoding exactly the CSV).
+ * (`:912`, `vault_constants.h:103`), and the BIP-68 sequence pins
+ * (`:972-991` — present, flags clear, equal to the CSV; compared unmasked
+ * because the leaf parser already bounds the CSV to the block-count field).
  */
 export function assertRefundPsbtSignable(refund: RefundPsbtClassification): void {
   if (refund.witnessUtxo === undefined || refund.witnessUtxo.scriptLength !== P2TR_SCRIPT_BYTES) {
@@ -225,9 +227,9 @@ export function assertRefundPsbtSignable(refund: RefundPsbtClassification): void
       "refund input sequence must be a plain block-count relative timelock (BIP-68 disable/time flags clear)",
     );
   }
-  if ((refund.sequence & BIP68_SEQUENCE_MASK) !== (refund.csv & BIP68_SEQUENCE_MASK)) {
+  if (refund.sequence !== refund.csv) {
     throw new Error(
-      `refund input sequence ${refund.sequence} must encode exactly the leaf CSV ${refund.csv} — a mismatch signs but can never broadcast`,
+      `refund input sequence ${refund.sequence} must equal the leaf CSV ${refund.csv} — the device compares them unmasked and rejects a mismatch`,
     );
   }
 }
@@ -247,7 +249,7 @@ export interface AugmentPsbtForRefundParams {
  * Re-classifies internally and requires the leaf key to be the depositor's —
  * augmenting anything that is not this device's refund is a caller bug, not a
  * shape to paper over. `leafHashes: []` is fine: the device's value parser
- * skips the hashes (`fw:sign_psbt_validate_helpers.c:58-63`). Never touches
+ * skips the hashes (`fw:sign_psbt_validate_helpers.c:59-60`). Never touches
  * the unsigned transaction.
  */
 export function augmentPsbtForRefund(params: AugmentPsbtForRefundParams): string {
@@ -288,7 +290,7 @@ export function augmentPsbtForRefund(params: AugmentPsbtForRefundParams): string
         masterFingerprint,
         // The BIP-86 TWEAKED key, verbatim from the scriptPubKey — the device
         // looks the entry up by these exact bytes, then derives at `path`,
-        // applies the BIP-86 tweak and compares (`fw:sign_psbt_validate.c:1005-1057`).
+        // applies the BIP-86 tweak and compares (`fw:sign_psbt_validate.c:1025-1069`).
         // BIP-371 permits the output key as the map key ("It may be the output
         // key, the internal key, or a key present in a leaf script").
         pubkey: outScript.subarray(P2TR_WITNESS_PROGRAM_OFFSET),


### PR DESCRIPTION
- Refund gate now mirrors firmware `b0c0ac4d` (V-005): `nSequence` must equal the leaf CSV
exactly, and the CSV must fit the BIP-68 block-count field. The old masked compare let
through PSBTs the device rejects. Bound matches btc-vault's `NonZeroU16` refund timelock.
- `deviceCaps.ts` re-pinned to `b0c0ac4d`; fee-rate cap `0xffffffff` → `10_000n` with its
provenance (vaultd config default; contract caps at 1000, so unreachable). Firmware
line citations refreshed.