### PR TITLE
test(vault): cover payout addresses on both networks

### DIFF
--- a/services/vault/src/utils/__tests__/scriptPubKeyHexToBtcAddress.test.ts
+++ b/services/vault/src/utils/__tests__/scriptPubKeyHexToBtcAddress.test.ts
@@ -8,8 +8,15 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 vi.unmock("@/config");
 vi.unmock("@/config/network");
 
-// Segwit vectors: https://github.com/bitcoin/bips/blob/master/bip-0350.mediawiki
-// The remaining addresses retain the existing bitcoinjs-lib 6.1.7 results.
+// The four segwit v0 addresses are the BIP-173 examples:
+// https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki#examples
+// BIP-350's valid table also attests bc1qw508...kv8f3t4 and tb1qrp33...q0sl5k7
+// with their scriptPubKeys, and adds bc1p0xlxvlh...vqzk5jj0:
+// https://github.com/bitcoin/bips/blob/master/bip-0350.mediawiki#test-vectors-for-v0-v16-native-segregated-witness-addresses
+// The rest are derived, not BIP vectors. tb1p0xlxvlh...vq47zagq is the same
+// Taproot key under the tb HRP. The four base58 values are base58check of
+// hash160 751e76e8199196d454941c45d1b3a323f1433bd6 under version bytes 0x00,
+// 0x6f, 0x05 and 0xc4. The derived values were recorded from bitcoinjs-lib 6.1.7.
 const P2PKH_SCRIPT = "0x76a914751e76e8199196d454941c45d1b3a323f1433bd688ac";
 const P2SH_SCRIPT = "0xa914751e76e8199196d454941c45d1b3a323f1433bd687";
 const SCRIPT_HEX_PREFIXED = "0x0014751e76e8199196d454941c45d1b3a323f1433bd6";
@@ -30,7 +37,7 @@ beforeEach(async () => {
   configureBabylonConfig({
     btcNetwork: "signet",
     ethChainId: 11155111,
-    ethRpcUrl: process.env.NEXT_PUBLIC_ETH_RPC_URL!,
+    ethRpcUrl: "https://test.example/eth",
   });
   ({ btcAddressToScriptPubKeyHex, scriptPubKeyHexToBtcAddress } = await import(
     "../btc"
@@ -42,51 +49,77 @@ beforeEach(async () => {
 afterEach(() => bitcoin.initEccLib(undefined));
 
 describe("scriptPubKeyHexToBtcAddress", () => {
-  it("decodes supported payout scripts on the configured signet network", () => {
+  it("decodes a P2PKH scriptPubKey to its signet address", () => {
     expect(scriptPubKeyHexToBtcAddress(P2PKH_SCRIPT)).toBe(
       "mrCDrCybB6J1vRfbwM5hemdJz73FwDBC8r",
     );
+  });
+
+  it("decodes a P2SH scriptPubKey to its signet address", () => {
     expect(scriptPubKeyHexToBtcAddress(P2SH_SCRIPT)).toBe(
       "2N3vVYSK5XRgVSGWy21PnsRmBUywSQNdCsf",
     );
+  });
+
+  it("decodes a P2WPKH scriptPubKey to its signet address", () => {
     expect(scriptPubKeyHexToBtcAddress(SCRIPT_HEX_PREFIXED)).toBe(
       EXPECTED_TESTNET_ADDRESS,
     );
+  });
+
+  it("decodes a P2WSH scriptPubKey to its signet address", () => {
     expect(scriptPubKeyHexToBtcAddress(P2WSH_SCRIPT)).toBe(
       "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sl5k7",
     );
+  });
+
+  it("decodes a P2TR scriptPubKey to its signet address", () => {
     expect(scriptPubKeyHexToBtcAddress(P2TR_SCRIPT)).toBe(
       "tb1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vq47zagq",
     );
   });
 
-  it("decodes supported payout scripts on the configured mainnet network", async () => {
-    vi.resetModules();
-    const { configureBabylonConfig } = await import(
-      "../../config/network/runtime"
-    );
-    configureBabylonConfig({
-      btcNetwork: "mainnet",
-      ethChainId: 1,
-      ethRpcUrl: process.env.NEXT_PUBLIC_ETH_RPC_URL!,
-    });
-    const { scriptPubKeyHexToBtcAddress } = await import("../btc");
+  describe("on the configured mainnet network", () => {
+    let decode: typeof import("../btc").scriptPubKeyHexToBtcAddress;
 
-    expect(scriptPubKeyHexToBtcAddress(P2PKH_SCRIPT)).toBe(
-      "1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH",
-    );
-    expect(scriptPubKeyHexToBtcAddress(P2SH_SCRIPT)).toBe(
-      "3CNHUhP3uyB9EUtRLsmvFUmvGdjGdkTxJw",
-    );
-    expect(scriptPubKeyHexToBtcAddress(SCRIPT_HEX_PREFIXED)).toBe(
-      "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4",
-    );
-    expect(scriptPubKeyHexToBtcAddress(P2WSH_SCRIPT)).toBe(
-      "bc1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qccfmv3",
-    );
-    expect(scriptPubKeyHexToBtcAddress(P2TR_SCRIPT)).toBe(
-      "bc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vqzk5jj0",
-    );
+    beforeEach(async () => {
+      vi.resetModules();
+      const { configureBabylonConfig } = await import(
+        "../../config/network/runtime"
+      );
+      configureBabylonConfig({
+        btcNetwork: "mainnet",
+        ethChainId: 1,
+        ethRpcUrl: "https://test.example/eth",
+      });
+      ({ scriptPubKeyHexToBtcAddress: decode } = await import("../btc"));
+    });
+
+    it("decodes a P2PKH scriptPubKey to its mainnet address", () => {
+      expect(decode(P2PKH_SCRIPT)).toBe("1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH");
+    });
+
+    it("decodes a P2SH scriptPubKey to its mainnet address", () => {
+      expect(decode(P2SH_SCRIPT)).toBe("3CNHUhP3uyB9EUtRLsmvFUmvGdjGdkTxJw");
+    });
+
+    it("decodes a P2WPKH scriptPubKey to its mainnet address", () => {
+      expect(decode(SCRIPT_HEX_PREFIXED)).toBe(
+        "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4",
+      );
+    });
+
+    it("decodes a P2WSH scriptPubKey to its mainnet address", () => {
+      expect(decode(P2WSH_SCRIPT)).toBe(
+        "bc1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qccfmv3",
+      );
+    });
+
+    it("decodes a P2TR scriptPubKey to its mainnet address", () => {
+      expect(decode(P2TR_SCRIPT)).toBe(
+        "bc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vqzk5jj0",
+      );
+    });
   });
 
   it("accepts unprefixed hex (no leading 0x)", () => {
@@ -113,11 +146,12 @@ describe("scriptPubKeyHexToBtcAddress", () => {
     );
   });
 
-  it("rejects a Taproot script whose output key is not on the curve", () => {
+  it("rejects a Taproot output key that is not a valid x-only point", () => {
+    expect(scriptPubKeyHexToBtcAddress(P2TR_SCRIPT)).toBe(
+      "tb1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vq47zagq",
+    );
     expect(() =>
-      scriptPubKeyHexToBtcAddress(
-        "0x5120ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-      ),
+      scriptPubKeyHexToBtcAddress(`0x5120${"ff".repeat(32)}`),
     ).toThrow("has no matching Address");
   });
 

--- a/services/vault/src/utils/__tests__/scriptPubKeyHexToBtcAddress.test.ts
+++ b/services/vault/src/utils/__tests__/scriptPubKeyHexToBtcAddress.test.ts
@@ -1,38 +1,91 @@
+// @vitest-environment node
+// The curve library needs Node's typed arrays for these non-DOM checks.
+
+import * as ecc from "@bitcoin-js/tiny-secp256k1-asmjs";
 import * as bitcoin from "bitcoinjs-lib";
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import {
-  btcAddressToScriptPubKeyHex,
-  scriptPubKeyHexToBtcAddress,
-} from "../btc";
+vi.unmock("@/config");
+vi.unmock("@/config/network");
 
-/**
- * Build the test fixture via bitcoinjs-lib's own payment helper so the script
- * bytes are guaranteed valid.
- *
- * Test config mocks the BTC network as signet (treated as testnet by btcUtils),
- * so the expected address is bech32-encoded with the `tb1` HRP.
- */
-const PUBKEY_HASH_BYTES = new Uint8Array([
-  0x75, 0x1e, 0x76, 0xe8, 0x19, 0x91, 0x96, 0xd4, 0x54, 0x94, 0x1c, 0x45, 0xd1,
-  0xb3, 0xa3, 0x23, 0xf1, 0x43, 0x3b, 0xd6,
-]);
+// Segwit vectors: https://github.com/bitcoin/bips/blob/master/bip-0350.mediawiki
+// The remaining addresses retain the existing bitcoinjs-lib 6.1.7 results.
+const P2PKH_SCRIPT = "0x76a914751e76e8199196d454941c45d1b3a323f1433bd688ac";
+const P2SH_SCRIPT = "0xa914751e76e8199196d454941c45d1b3a323f1433bd687";
+const SCRIPT_HEX_PREFIXED = "0x0014751e76e8199196d454941c45d1b3a323f1433bd6";
+const P2WSH_SCRIPT =
+  "0x00201863143c14c5166804bd19203356da136c985678cd4d27a1b8c6329604903262";
+const P2TR_SCRIPT =
+  "0x512079be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798";
+const EXPECTED_TESTNET_ADDRESS = "tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx";
 
-const { output, address: EXPECTED_TESTNET_ADDRESS } = bitcoin.payments.p2wpkh({
-  hash: Buffer.from(PUBKEY_HASH_BYTES),
-  network: bitcoin.networks.testnet,
+let btcAddressToScriptPubKeyHex: typeof import("../btc").btcAddressToScriptPubKeyHex;
+let scriptPubKeyHexToBtcAddress: typeof import("../btc").scriptPubKeyHexToBtcAddress;
+
+beforeEach(async () => {
+  vi.resetModules();
+  const { configureBabylonConfig } = await import(
+    "../../config/network/runtime"
+  );
+  configureBabylonConfig({
+    btcNetwork: "signet",
+    ethChainId: 11155111,
+    ethRpcUrl: process.env.NEXT_PUBLIC_ETH_RPC_URL!,
+  });
+  ({ btcAddressToScriptPubKeyHex, scriptPubKeyHexToBtcAddress } = await import(
+    "../btc"
+  ));
+  // Match the curve setup in the application's main.tsx.
+  bitcoin.initEccLib(ecc);
 });
 
-if (!output || !EXPECTED_TESTNET_ADDRESS) {
-  throw new Error("Test fixture setup failed: could not derive p2wpkh");
-}
-
-const SCRIPT_HEX_PREFIXED = `0x${Buffer.from(output).toString("hex")}`;
+afterEach(() => bitcoin.initEccLib(undefined));
 
 describe("scriptPubKeyHexToBtcAddress", () => {
-  it("decodes a P2WPKH scriptPubKey hex back to its testnet address", () => {
+  it("decodes supported payout scripts on the configured signet network", () => {
+    expect(scriptPubKeyHexToBtcAddress(P2PKH_SCRIPT)).toBe(
+      "mrCDrCybB6J1vRfbwM5hemdJz73FwDBC8r",
+    );
+    expect(scriptPubKeyHexToBtcAddress(P2SH_SCRIPT)).toBe(
+      "2N3vVYSK5XRgVSGWy21PnsRmBUywSQNdCsf",
+    );
     expect(scriptPubKeyHexToBtcAddress(SCRIPT_HEX_PREFIXED)).toBe(
       EXPECTED_TESTNET_ADDRESS,
+    );
+    expect(scriptPubKeyHexToBtcAddress(P2WSH_SCRIPT)).toBe(
+      "tb1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3q0sl5k7",
+    );
+    expect(scriptPubKeyHexToBtcAddress(P2TR_SCRIPT)).toBe(
+      "tb1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vq47zagq",
+    );
+  });
+
+  it("decodes supported payout scripts on the configured mainnet network", async () => {
+    vi.resetModules();
+    const { configureBabylonConfig } = await import(
+      "../../config/network/runtime"
+    );
+    configureBabylonConfig({
+      btcNetwork: "mainnet",
+      ethChainId: 1,
+      ethRpcUrl: process.env.NEXT_PUBLIC_ETH_RPC_URL!,
+    });
+    const { scriptPubKeyHexToBtcAddress } = await import("../btc");
+
+    expect(scriptPubKeyHexToBtcAddress(P2PKH_SCRIPT)).toBe(
+      "1BgGZ9tcN4rm9KBzDn7KprQz87SZ26SAMH",
+    );
+    expect(scriptPubKeyHexToBtcAddress(P2SH_SCRIPT)).toBe(
+      "3CNHUhP3uyB9EUtRLsmvFUmvGdjGdkTxJw",
+    );
+    expect(scriptPubKeyHexToBtcAddress(SCRIPT_HEX_PREFIXED)).toBe(
+      "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4",
+    );
+    expect(scriptPubKeyHexToBtcAddress(P2WSH_SCRIPT)).toBe(
+      "bc1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qccfmv3",
+    );
+    expect(scriptPubKeyHexToBtcAddress(P2TR_SCRIPT)).toBe(
+      "bc1p0xlxvlhemja6c4dqv22uapctqupfhlxm9h8z3k2e72q4k9hcz7vqzk5jj0",
     );
   });
 
@@ -40,6 +93,32 @@ describe("scriptPubKeyHexToBtcAddress", () => {
     expect(scriptPubKeyHexToBtcAddress(SCRIPT_HEX_PREFIXED.slice(2))).toBe(
       EXPECTED_TESTNET_ADDRESS,
     );
+  });
+
+  it("accepts uppercase hex and its prefix", () => {
+    expect(scriptPubKeyHexToBtcAddress(SCRIPT_HEX_PREFIXED.toUpperCase())).toBe(
+      EXPECTED_TESTNET_ADDRESS,
+    );
+  });
+
+  it("rejects an odd number of hex digits", () => {
+    expect(() => scriptPubKeyHexToBtcAddress("0x001")).toThrow(
+      "must be non-empty and even",
+    );
+  });
+
+  it("rejects a script without a destination address", () => {
+    expect(() => scriptPubKeyHexToBtcAddress("0x6a")).toThrow(
+      "has no matching Address",
+    );
+  });
+
+  it("rejects a Taproot script whose output key is not on the curve", () => {
+    expect(() =>
+      scriptPubKeyHexToBtcAddress(
+        "0x5120ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+      ),
+    ).toThrow("has no matching Address");
   });
 
   it("throws on a non-hex string rather than silently returning a fallback", () => {

--- a/services/vault/vitest.config.ts
+++ b/services/vault/vitest.config.ts
@@ -117,6 +117,8 @@ export default defineConfig({
     },
     server: {
       deps: {
+        // Use Node for the built wallet entry. Vite corrupts a label in this bundle.
+        external: [/\/babylon-wallet-connector\/dist\/index\.es\.js$/],
         inline: ["@babylonlabs-io/wallet-connector", "@noble/hashes"],
       },
     },

--- a/services/vault/vitest.config.ts
+++ b/services/vault/vitest.config.ts
@@ -117,7 +117,16 @@ export default defineConfig({
     },
     server: {
       deps: {
-        // Use Node for the built wallet entry. Vite corrupts a label in this bundle.
+        // Load the built wallet entry through Node, not Vite's SSR transform.
+        // A statement label in the bundle collides with the "@keystonehq/sdk"
+        // default-import binding. Vite 6.4.1 rewrites that label to
+        // `__vite_ssr_import_N__.default:`, so
+        // scriptPubKeyHexToBtcAddress.test.ts, which loads the bundle through
+        // the real `@/config`, fails with "SyntaxError: Unexpected token ':'".
+        // Fixed upstream in https://github.com/vitejs/vite/pull/22451, which is
+        // not in the Vite 6 line this package uses. The `inline` string entry
+        // below never matches the pnpm-realpathed id, so this regex is the one
+        // entry that decides how the bundle loads.
         external: [/\/babylon-wallet-connector\/dist\/index\.es\.js$/],
         inline: ["@babylonlabs-io/wallet-connector", "@noble/hashes"],
       },


### PR DESCRIPTION
## Outcome

Status: all 12 GitHub checks pass for `c578deb0`. The fresh Greptile review gives 5/5. Required human reviews remain.

Payout-address checks cover mainnet and signet for Ethereum-only Vault access. This supplies address-regression evidence for #2232 step 4.

## Change

- Check P2PKH, P2SH, P2WPKH, P2WSH, and Taproot with fixed expected addresses and the real network configuration.
- Check uppercase hex, odd-length hex, unsupported scripts, and an invalid Taproot output key. Keep the existing prefix and round-trip checks.
- Load the built wallet entry through Node in tests. Vite's test transform otherwise changes a valid JavaScript label into invalid syntax.

## Safety

The existing converter supplies every result. No production code changes. The expected Segwit values include [BIP350 vectors](https://github.com/bitcoin/bips/blob/master/bip-0350.mediawiki#test-vectors-for-v0-v16-native-segregated-witness-addresses). The other values are derived from bitcoinjs-lib 6.1.7.

Scope decision in #2228: download-size improvements are optional. Keep the current converter and Taproot validation. This PR does not require a new encoder or a loading refactor. The loading observations below are background evidence, not completion gates.

## Verification

Current commit `c578deb0`: [all 12 GitHub checks pass](https://github.com/babylonlabs-io/babylon-toolkit/actions/runs/34716737151). [Greptile gives 5/5](https://github.com/babylonlabs-io/babylon-toolkit/pull/2500#issuecomment-5617646646), reviewed on 2026-09-13. All seven earlier review threads are resolved. The current focused address suite passes all 18 tests.

Earlier evidence at `1a272544177934ef84be24b3412b9c80eb6ff5ab`: [Verify PR](https://github.com/babylonlabs-io/babylon-toolkit/actions/runs/34468982808/job/102844176213) and [Visual regression](https://github.com/babylonlabs-io/babylon-toolkit/actions/runs/34468982859/job/102844176542) pass. Both visual versions contain all 329 Storybook screens and 58 Vault screens. No images are missing or changed. [Greptile gives 5/5](https://github.com/babylonlabs-io/babylon-toolkit/pull/2500#issuecomment-5617646646).

- Full Vault suite: 3,824 tests pass; two tests are skipped.
- Vault lint and production build pass.
- A deliberate mainnet-to-testnet conversion error fails the new mainnet check. The original converter is restored.
- Parsed the built JavaScript import edges and source maps at main `05f60bf9`. The app entry, address decoder, withdrawal address helper, and redeemed-vault hook each have zero Rust-engine source modules in their static import closures. Each still includes 30 Bitcoin library modules and five curve modules. The two HTML modulepreloads also contain no Rust-engine sources.
- The 3,118,058-byte Rust WASM asset remains behind dynamic loading. This is build evidence. It does not prove a browser journey or exclude imports called during rendering.

## Links

Tracks #2232. #2232 stays open. Epic: #2228. Final browser journey: #2233.