### PR TITLE
feat(ts-sdk, vault): enforce the on-chain maxFundingInputCount bound on the Pre-Pegin funding path

### DIFF
--- a/packages/babylon-ts-sdk/docs/api/clients.md
+++ b/packages/babylon-ts-sdk/docs/api/clients.md
@@ -391,8 +391,11 @@ from `TBVProtocolParams.maxFundingInputCount`.
 
 `unsupported` means the deployment predates the field, and is returned
 only when the contract answers with the 6- or 7-word tuple of a
-deployment that predates the field; any other length is invalid protocol
-data and throws. `unpublished` means the field decoded as `0`, which
+deployment that predates the field. The struct is append-only, so a
+longer return is read as a governance addition this SDK does not know
+about: only the first 8 words are decoded and the rest ignored. A return
+below 6 words, or one that is not whole 32-byte words, is invalid
+protocol data and throws. `unpublished` means the field decoded as `0`, which
 governance has not set yet — a bound of zero is not a real limit, so
 callers must block rather than treat it as unbounded. `published`
 carries an integer validated into `[1, 255]`. Every other failure —
@@ -3363,8 +3366,11 @@ from `TBVProtocolParams.maxFundingInputCount`.
 
 `unsupported` means the deployment predates the field, and is returned
 only when the contract answers with the 6- or 7-word tuple of a
-deployment that predates the field; any other length is invalid protocol
-data and throws. `unpublished` means the field decoded as `0`, which
+deployment that predates the field. The struct is append-only, so a
+longer return is read as a governance addition this SDK does not know
+about: only the first 8 words are decoded and the rest ignored. A return
+below 6 words, or one that is not whole 32-byte words, is invalid
+protocol data and throws. `unpublished` means the field decoded as `0`, which
 governance has not set yet — a bound of zero is not a real limit, so
 callers must block rather than treat it as unbounded. `published`
 carries an integer validated into `[1, 255]`. Every other failure —

--- a/packages/babylon-ts-sdk/docs/api/clients.md
+++ b/packages/babylon-ts-sdk/docs/api/clients.md
@@ -378,6 +378,44 @@ If the deployment does not expose `peginActivationDelay()`, or
 
 [`ProtocolParamsReader`](#protocolparamsreader).[`getPeginActivationDelay`](#getpeginactivationdelay-2)
 
+##### getMaxFundingInputCount()
+
+```ts
+getMaxFundingInputCount(blockNumber?): Promise<FundingInputBound>;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/protocol-params-reader.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/protocol-params-reader.ts)
+
+Ceiling on the number of funding inputs one Pre-PegIn may spend, read
+from `TBVProtocolParams.maxFundingInputCount`.
+
+`unsupported` means the deployment predates the field, and is returned
+only when the contract answers with the 6- or 7-word tuple of a
+deployment that predates the field; any other length is invalid protocol
+data and throws. `unpublished` means the field decoded as `0`, which
+governance has not set yet — a bound of zero is not a real limit, so
+callers must block rather than treat it as unbounded. `published`
+carries an integer validated into `[1, 255]`. Every other failure —
+a dead RPC, a wrong-length return, an out-of-range value — rethrows.
+
+Pass `blockNumber` when the result will shape a Bitcoin lock, so the
+bound describes the same block as the peg-in config it is enforced
+alongside.
+
+###### Parameters
+
+###### blockNumber?
+
+`bigint`
+
+###### Returns
+
+`Promise`\<[`FundingInputBound`](#fundinginputbound)\>
+
+###### Implementation of
+
+[`ProtocolParamsReader`](#protocolparamsreader).[`getMaxFundingInputCount`](#getmaxfundinginputcount-2)
+
 ##### getPegInConfiguration()
 
 ```ts
@@ -3311,6 +3349,40 @@ protocol-param read fail wherever it is missing.
 
 If the deployment does not expose `peginActivationDelay()`, or
   the decoded payload is not a `bigint`.
+
+##### getMaxFundingInputCount()
+
+```ts
+getMaxFundingInputCount(blockNumber?): Promise<FundingInputBound>;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
+
+Ceiling on the number of funding inputs one Pre-PegIn may spend, read
+from `TBVProtocolParams.maxFundingInputCount`.
+
+`unsupported` means the deployment predates the field, and is returned
+only when the contract answers with the 6- or 7-word tuple of a
+deployment that predates the field; any other length is invalid protocol
+data and throws. `unpublished` means the field decoded as `0`, which
+governance has not set yet — a bound of zero is not a real limit, so
+callers must block rather than treat it as unbounded. `published`
+carries an integer validated into `[1, 255]`. Every other failure —
+a dead RPC, a wrong-length return, an out-of-range value — rethrows.
+
+Pass `blockNumber` when the result will shape a Bitcoin lock, so the
+bound describes the same block as the peg-in config it is enforced
+alongside.
+
+###### Parameters
+
+###### blockNumber?
+
+`bigint`
+
+###### Returns
+
+`Promise`\<[`FundingInputBound`](#fundinginputbound)\>
 
 ##### fetchAllOffchainParams()
 
@@ -6318,6 +6390,26 @@ frozen
 
 ***
 
+### FundingInputBound
+
+```ts
+type FundingInputBound = 
+  | {
+  status: "unsupported";
+}
+  | {
+  status: "unpublished";
+}
+  | {
+  status: "published";
+  maxInputs: number;
+};
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts)
+
+***
+
 ### OnSkippedOffchainParamsVersion()
 
 ```ts
@@ -6566,6 +6658,35 @@ Validate TBV protocol params returned from the contract.
 #### Throws
 
 Error on invalid amounts or out-of-range bounded fields.
+
+***
+
+### validateMaxFundingInputCount()
+
+```ts
+function validateMaxFundingInputCount(value): void;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/clients/eth/protocol-params-validation.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/clients/eth/protocol-params-validation.ts)
+
+Validate a published `maxFundingInputCount`.
+
+`0` is not accepted here: it is the unpublished sentinel and is classified
+by the reader before this runs, never validated into a usable bound.
+
+#### Parameters
+
+##### value
+
+`number`
+
+#### Returns
+
+`void`
+
+#### Throws
+
+Error if the value is not an integer in `[1, 255]`.
 
 ***
 

--- a/packages/babylon-ts-sdk/docs/api/managers.md
+++ b/packages/babylon-ts-sdk/docs/api/managers.md
@@ -1487,6 +1487,21 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](http
 
 Available UTXOs from the depositor's wallet for funding the Pre-PegIn transaction.
 
+##### maxFundingInputCount
+
+```ts
+maxFundingInputCount: number | null;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts)
+
+On-chain `ProtocolParams.maxFundingInputCount` read at this build's
+pinned block — the most inputs one Pre-PegIn may spend. `null` only
+when the deployment predates the field.
+
+Enforced at UTXO selection, before any wallet or device I/O, and
+re-asserted against the funded transaction.
+
 ##### changeAddress
 
 ```ts

--- a/packages/babylon-ts-sdk/docs/api/managers.md
+++ b/packages/babylon-ts-sdk/docs/api/managers.md
@@ -1499,7 +1499,7 @@ On-chain `ProtocolParams.maxFundingInputCount` read at this build's
 pinned block — the most inputs one Pre-PegIn may spend. `null` only
 when the deployment predates the field.
 
-Enforced at UTXO selection, before any wallet or device I/O, and
+Enforced at UTXO selection, before any signing or approval prompt, and
 re-asserted against the funded transaction.
 
 ##### changeAddress

--- a/packages/babylon-ts-sdk/docs/api/utils.md
+++ b/packages/babylon-ts-sdk/docs/api/utils.md
@@ -56,7 +56,7 @@ Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/availability.ts](ht
 
 ### FundingInputCountExceededError
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/selectUtxos.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/utxo/selectUtxos.ts)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/fundingInputCountExceeded.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/utxo/fundingInputCountExceeded.ts)
 
 Thrown when funding a Pre-PegIn would need more inputs than the
 protocol's on-chain `maxFundingInputCount` allows in one transaction.
@@ -73,7 +73,7 @@ protocol's on-chain `maxFundingInputCount` allows in one transaction.
 new FundingInputCountExceededError(maxInputCount): FundingInputCountExceededError;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/selectUtxos.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/utxo/selectUtxos.ts)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/fundingInputCountExceeded.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/utxo/fundingInputCountExceeded.ts)
 
 ###### Parameters
 
@@ -99,7 +99,7 @@ Error.constructor
 readonly maxInputCount: number;
 ```
 
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/selectUtxos.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/utxo/selectUtxos.ts)
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/fundingInputCountExceeded.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/utxo/fundingInputCountExceeded.ts)
 
 ## Interfaces
 
@@ -1441,6 +1441,29 @@ Error if validation fails
 
 ***
 
+### isFundingInputCountExceededError()
+
+```ts
+function isFundingInputCountExceededError(err): err is FundingInputCountExceededError;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/fundingInputCountExceeded.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/utxo/fundingInputCountExceeded.ts)
+
+Type guard for [FundingInputCountExceededError](#fundinginputcountexceedederror). Falls back to the
+`name` check so the guard still holds across module/realm boundaries.
+
+#### Parameters
+
+##### err
+
+`unknown`
+
+#### Returns
+
+`err is FundingInputCountExceededError`
+
+***
+
 ### findOverlappingPendingVaults()
 
 ```ts
@@ -1462,29 +1485,6 @@ take precedence over a same-id local pegin entry.
 #### Returns
 
 `string`[]
-
-***
-
-### isFundingInputCountExceededError()
-
-```ts
-function isFundingInputCountExceededError(err): err is FundingInputCountExceededError;
-```
-
-Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/selectUtxos.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/utxo/selectUtxos.ts)
-
-Type guard for [FundingInputCountExceededError](#fundinginputcountexceedederror). Falls back to the
-`name` check so the guard still holds across module/realm boundaries.
-
-#### Parameters
-
-##### err
-
-`unknown`
-
-#### Returns
-
-`err is FundingInputCountExceededError`
 
 ***
 
@@ -1610,7 +1610,10 @@ Error if insufficient funds, no valid UTXOs, or `maxInputCount` is neither null 
 
 #### Throws
 
-FundingInputCountExceededError if funding would need more than `maxInputCount` inputs
+FundingInputCountExceededError if funding would need more than
+  `maxInputCount` inputs and the full valid set could have covered the
+  target; a wallet whose whole valid set falls short throws insufficient
+  funds instead
 
 ***
 

--- a/packages/babylon-ts-sdk/docs/api/utils.md
+++ b/packages/babylon-ts-sdk/docs/api/utils.md
@@ -52,6 +52,55 @@ readonly missingUtxos: MissingUtxoInfo[];
 
 Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/availability.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/utxo/availability.ts)
 
+***
+
+### FundingInputCountExceededError
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/selectUtxos.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/utxo/selectUtxos.ts)
+
+Thrown when funding a Pre-PegIn would need more inputs than the
+protocol's on-chain `maxFundingInputCount` allows in one transaction.
+
+#### Extends
+
+- `Error`
+
+#### Constructors
+
+##### Constructor
+
+```ts
+new FundingInputCountExceededError(maxInputCount): FundingInputCountExceededError;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/selectUtxos.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/utxo/selectUtxos.ts)
+
+###### Parameters
+
+###### maxInputCount
+
+`number`
+
+###### Returns
+
+[`FundingInputCountExceededError`](#fundinginputcountexceedederror)
+
+###### Overrides
+
+```ts
+Error.constructor
+```
+
+#### Properties
+
+##### maxInputCount
+
+```ts
+readonly maxInputCount: number;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/selectUtxos.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/utxo/selectUtxos.ts)
+
 ## Interfaces
 
 ### CombinedAbortSignal
@@ -1416,6 +1465,79 @@ take precedence over a same-id local pegin entry.
 
 ***
 
+### isFundingInputCountExceededError()
+
+```ts
+function isFundingInputCountExceededError(err): err is FundingInputCountExceededError;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/selectUtxos.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/utxo/selectUtxos.ts)
+
+Type guard for [FundingInputCountExceededError](#fundinginputcountexceedederror). Falls back to the
+`name` check so the guard still holds across module/realm boundaries.
+
+#### Parameters
+
+##### err
+
+`unknown`
+
+#### Returns
+
+`err is FundingInputCountExceededError`
+
+***
+
+### computeFundingBudget()
+
+```ts
+function computeFundingBudget(availableUTXOs, maxInputCount): object;
+```
+
+Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/selectUtxos.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/utxo/selectUtxos.ts)
+
+The inputs and balance a Pre-PegIn may actually spend under the
+protocol's funding-input bound: the largest `maxInputCount` valid UTXOs
+(all of them when `maxInputCount` is null).
+
+#### Parameters
+
+##### availableUTXOs
+
+[`UTXO`](#utxo)[]
+
+All available UTXOs from wallet
+
+##### maxInputCount
+
+Protocol `maxFundingInputCount`, or null when the deployment publishes no bound
+
+`number` | `null`
+
+#### Returns
+
+`object`
+
+Number of spendable inputs and their summed value (satoshis)
+
+##### numInputs
+
+```ts
+numInputs: number;
+```
+
+##### totalBalance
+
+```ts
+totalBalance: bigint;
+```
+
+#### Throws
+
+Error if `maxInputCount` is neither null nor a positive integer
+
+***
+
 ### selectUtxosForPegin()
 
 ```ts
@@ -1423,7 +1545,8 @@ function selectUtxosForPegin(
    availableUTXOs, 
    peginAmount, 
    feeRate, 
-   numOutputs): UTXOSelectionResult;
+   numOutputs, 
+   maxInputCount): UTXOSelectionResult;
 ```
 
 Defined in: [packages/babylon-ts-sdk/src/tbv/core/utils/utxo/selectUtxos.ts](https://github.com/babylonlabs-io/babylon-toolkit/blob/main/packages/babylon-ts-sdk/src/tbv/core/utils/utxo/selectUtxos.ts)
@@ -1466,6 +1589,15 @@ Fee rate (sat/vbyte)
 
 Number of outputs in the unfunded transaction (HTLC + CPFP anchor, before change)
 
+##### maxInputCount
+
+Protocol `maxFundingInputCount`: the most inputs one
+  Pre-PegIn may spend, or null when the deployment publishes no bound. The
+  bound is exclusive in the same sense as the registry's `>` check —
+  exactly `maxInputCount` inputs is accepted, needing one more is rejected.
+
+`number` | `null`
+
 #### Returns
 
 [`UTXOSelectionResult`](#utxoselectionresult)
@@ -1474,7 +1606,11 @@ Selected UTXOs, total value, calculated fee, and change amount
 
 #### Throws
 
-Error if insufficient funds or no valid UTXOs
+Error if insufficient funds, no valid UTXOs, or `maxInputCount` is neither null nor a positive integer
+
+#### Throws
+
+FundingInputCountExceededError if funding would need more than `maxInputCount` inputs
 
 ***
 

--- a/packages/babylon-ts-sdk/docs/quickstart/managers-advanced.md
+++ b/packages/babylon-ts-sdk/docs/quickstart/managers-advanced.md
@@ -148,7 +148,7 @@ declare const expectedFingerprint: Hex;
 
 // Every non-array param is the same as the single-vault happy path —
 // vault provider pubkey, keepers, challengers, timelocks, fee rate,
-// council params, UTXO set, change address.
+// council params, `maxFundingInputCount`, UTXO set, change address.
 declare const sharedBatchParams: Omit<
   Parameters<typeof peginManager.preparePegin>[0],
   "amounts"

--- a/packages/babylon-ts-sdk/docs/quickstart/managers.md
+++ b/packages/babylon-ts-sdk/docs/quickstart/managers.md
@@ -165,6 +165,7 @@ const result = await peginManager.preparePegin({
   mempoolFeeRate,
   councilQuorum,
   councilSize,
+  maxFundingInputCount,             // on-chain bound, read at the pinned block
   availableUTXOs,
   changeAddress,
 });

--- a/packages/babylon-ts-sdk/docs/quickstart/primitives.md
+++ b/packages/babylon-ts-sdk/docs/quickstart/primitives.md
@@ -216,6 +216,7 @@ const { selectedUTXOs, fee, changeAmount } = selectUtxosForPegin(
   amount, // Target amount (satoshis)
   feeRate, // sat/vB
   peginOutputCount(vaultCount), // N HTLCs + CPFP anchor
+  maxFundingInputCount, // on-chain bound; null only pre-deployment of the field
 );
 ```
 

--- a/packages/babylon-ts-sdk/src/tbv/core/clients/eth/__tests__/protocol-params-reader.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/eth/__tests__/protocol-params-reader.test.ts
@@ -1,6 +1,13 @@
-import { describe, expect, it, vi } from "vitest";
 import type { Address, Hex } from "viem";
+import {
+  concat,
+  encodeFunctionData,
+  encodeFunctionResult,
+  numberToHex,
+} from "viem";
+import { describe, expect, it, vi } from "vitest";
 
+import { ProtocolParamsFundingInputBoundABI } from "../../../contracts/abis/ProtocolParams.abi";
 import { ViemProtocolParamsReader } from "../protocol-params-reader";
 
 const MOCK_ADDRESS = "0x1234567890abcdef1234567890abcdef12345678" as Address;
@@ -34,6 +41,32 @@ const MOCK_OFFCHAIN_PARAMS = {
   minPrepeginDepth: 6,
 };
 
+/** An 8-component `TBVProtocolParams` as viem decodes it: a named object. */
+const MOCK_FUNDING_INPUT_BOUND_PARAMS = {
+  ...MOCK_TBV_PARAMS,
+  peginActivationDelay: 200n,
+  maxFundingInputCount: 20,
+};
+
+const FUNDING_INPUT_BOUND_CALLDATA = encodeFunctionData({
+  abi: ProtocolParamsFundingInputBoundABI,
+  functionName: "getTBVProtocolParams",
+});
+
+/** ABI-encode a static tuple by hand, one 32-byte word per value. */
+function words(...values: Array<bigint | number>): Hex {
+  return concat(values.map((v) => numberToHex(v, { size: 32 })));
+}
+
+/** The 8-word return of a deployment carrying `maxFundingInputCount`. */
+function fundingInputBoundReturn(maxFundingInputCount: number): Hex {
+  return encodeFunctionResult({
+    abi: ProtocolParamsFundingInputBoundABI,
+    functionName: "getTBVProtocolParams",
+    result: { ...MOCK_FUNDING_INPUT_BOUND_PARAMS, maxFundingInputCount },
+  });
+}
+
 function createMockPublicClient(overrides?: {
   tbvParams?: unknown;
   offchainParams?: unknown;
@@ -41,6 +74,7 @@ function createMockPublicClient(overrides?: {
   activeVaultCoreVersion?: unknown;
   perVersionOffchainParams?: Map<number, unknown>;
   peginActivationDelay?: unknown;
+  fundingInputBoundData?: Hex | Error;
 }) {
   return {
     readContract: vi.fn(
@@ -84,6 +118,14 @@ function createMockPublicClient(overrides?: {
         throw new Error(`Unknown function: ${functionName}`);
       },
     ),
+    call: vi.fn(async () => {
+      const data =
+        overrides?.fundingInputBoundData ?? fundingInputBoundReturn(20);
+      if (data instanceof Error) {
+        throw data;
+      }
+      return { data };
+    }),
     multicall: vi.fn(
       async ({
         contracts,
@@ -379,6 +421,139 @@ describe("ViemProtocolParamsReader", () => {
     await expect(reader.getPeginActivationDelay()).rejects.toThrow(
       /Invalid peginActivationDelay from contract: must be a bigint/,
     );
+  });
+
+  it("getMaxFundingInputCount returns the published bound", async () => {
+    const publicClient = createMockPublicClient();
+    const reader = new ViemProtocolParamsReader(
+      publicClient as never,
+      MOCK_ADDRESS,
+    );
+
+    await expect(reader.getMaxFundingInputCount()).resolves.toEqual({
+      status: "published",
+      maxInputs: 20,
+    });
+  });
+
+  it("getMaxFundingInputCount reports 0 as unpublished, never as unbounded", async () => {
+    const publicClient = createMockPublicClient({
+      fundingInputBoundData: fundingInputBoundReturn(0),
+    });
+    const reader = new ViemProtocolParamsReader(
+      publicClient as never,
+      MOCK_ADDRESS,
+    );
+
+    await expect(reader.getMaxFundingInputCount()).resolves.toEqual({
+      status: "unpublished",
+    });
+  });
+
+  it("getMaxFundingInputCount reports a 6-word legacy tuple as unsupported", async () => {
+    const publicClient = createMockPublicClient({
+      fundingInputBoundData: words(100000n, 10000000n, 7200n, 14400n, 5, 100n),
+    });
+    const reader = new ViemProtocolParamsReader(
+      publicClient as never,
+      MOCK_ADDRESS,
+    );
+
+    await expect(reader.getMaxFundingInputCount()).resolves.toEqual({
+      status: "unsupported",
+    });
+  });
+
+  it("getMaxFundingInputCount reports a 7-word legacy tuple as unsupported", async () => {
+    const publicClient = createMockPublicClient({
+      fundingInputBoundData: words(
+        100000n,
+        10000000n,
+        7200n,
+        14400n,
+        5,
+        100n,
+        200n,
+      ),
+    });
+    const reader = new ViemProtocolParamsReader(
+      publicClient as never,
+      MOCK_ADDRESS,
+    );
+
+    await expect(reader.getMaxFundingInputCount()).resolves.toEqual({
+      status: "unsupported",
+    });
+  });
+
+  it("getMaxFundingInputCount rejects a truncated tuple instead of reporting unsupported", async () => {
+    // A one-word return is malformed protocol data, not an older deployment.
+    // Folding it into `unsupported` would fail open — the caller would skip
+    // the input-count check rather than surface the bad response.
+    const publicClient = createMockPublicClient({
+      fundingInputBoundData: words(20),
+    });
+    const reader = new ViemProtocolParamsReader(
+      publicClient as never,
+      MOCK_ADDRESS,
+    );
+
+    await expect(reader.getMaxFundingInputCount()).rejects.toThrow(
+      "Invalid getTBVProtocolParams return: expected 8 words (or a legacy 6/7-word tuple), got 32 bytes",
+    );
+  });
+
+  it("getMaxFundingInputCount rethrows a transport failure instead of reporting unsupported", async () => {
+    const publicClient = createMockPublicClient({
+      fundingInputBoundData: new Error("rpc down"),
+    });
+    const reader = new ViemProtocolParamsReader(
+      publicClient as never,
+      MOCK_ADDRESS,
+    );
+
+    await expect(reader.getMaxFundingInputCount()).rejects.toThrow("rpc down");
+  });
+
+  it("getMaxFundingInputCount rejects an out-of-range bound", async () => {
+    // Hand-built: viem's `uint8` encoder rejects 300, so this shape can only
+    // arrive from a contract, not from `encodeFunctionResult`.
+    const publicClient = createMockPublicClient({
+      fundingInputBoundData: words(
+        100000n,
+        10000000n,
+        7200n,
+        14400n,
+        5,
+        100n,
+        200n,
+        300,
+      ),
+    });
+    const reader = new ViemProtocolParamsReader(
+      publicClient as never,
+      MOCK_ADDRESS,
+    );
+
+    await expect(reader.getMaxFundingInputCount()).rejects.toThrow(
+      "maxFundingInputCount must be an integer in [1, 255], got 300",
+    );
+  });
+
+  it("getMaxFundingInputCount calls the 8-component selector and forwards blockNumber", async () => {
+    const publicClient = createMockPublicClient();
+    const reader = new ViemProtocolParamsReader(
+      publicClient as never,
+      MOCK_ADDRESS,
+    );
+
+    await reader.getMaxFundingInputCount(1234n);
+
+    expect(publicClient.call).toHaveBeenCalledWith({
+      to: MOCK_ADDRESS,
+      data: FUNDING_INPUT_BOUND_CALLDATA,
+      blockNumber: 1234n,
+    });
   });
 
   it("getTBVProtocolParams throws on invalid params via the auto-validator", async () => {

--- a/packages/babylon-ts-sdk/src/tbv/core/clients/eth/__tests__/protocol-params-reader.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/eth/__tests__/protocol-params-reader.test.ts
@@ -499,8 +499,50 @@ describe("ViemProtocolParamsReader", () => {
     );
 
     await expect(reader.getMaxFundingInputCount()).rejects.toThrow(
-      "Invalid getTBVProtocolParams return: expected 8 words (or a legacy 6/7-word tuple), got 32 bytes",
+      "Invalid getTBVProtocolParams return: expected at least 8 words (or a legacy 6/7-word tuple), got 32 bytes",
     );
+  });
+
+  it("getMaxFundingInputCount rejects a return that is not whole 32-byte words", async () => {
+    const publicClient = createMockPublicClient({
+      fundingInputBoundData: `${words(20)}ff` as Hex,
+    });
+    const reader = new ViemProtocolParamsReader(
+      publicClient as never,
+      MOCK_ADDRESS,
+    );
+
+    await expect(reader.getMaxFundingInputCount()).rejects.toThrow(
+      "Invalid getTBVProtocolParams return: expected whole 32-byte words, got 33 bytes",
+    );
+  });
+
+  it("getMaxFundingInputCount decodes the first 8 words of a longer append-only tuple", async () => {
+    // Governance appending a 9th field must not halt every deposit until the
+    // next SDK release: the struct is append-only, so the first 8 words still
+    // mean what this SDK thinks they mean.
+    const publicClient = createMockPublicClient({
+      fundingInputBoundData: words(
+        100000n,
+        10000000n,
+        7200n,
+        14400n,
+        5,
+        100n,
+        200n,
+        20,
+        999n,
+      ),
+    });
+    const reader = new ViemProtocolParamsReader(
+      publicClient as never,
+      MOCK_ADDRESS,
+    );
+
+    await expect(reader.getMaxFundingInputCount()).resolves.toEqual({
+      status: "published",
+      maxInputs: 20,
+    });
   });
 
   it("getMaxFundingInputCount rethrows a transport failure instead of reporting unsupported", async () => {

--- a/packages/babylon-ts-sdk/src/tbv/core/clients/eth/index.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/eth/index.ts
@@ -21,6 +21,7 @@ export type {
 export { calculateBtcTxHash, derivePeginVaultId } from "./pegin-transaction";
 export { ViemProtocolParamsReader } from "./protocol-params-reader";
 export {
+  validateMaxFundingInputCount,
   validateOffchainParams,
   validatePegInConfiguration,
   validateTBVProtocolParams,
@@ -40,6 +41,7 @@ export { OnChainBtcVaultStatus } from "./types";
 export type {
   AddressBTCKeyPair,
   AllOffchainParamsData,
+  FundingInputBound,
   KeyEpochs,
   OnChainBtcPubkey,
   OnSkippedOffchainParamsVersion,

--- a/packages/babylon-ts-sdk/src/tbv/core/clients/eth/protocol-params-reader.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/eth/protocol-params-reader.ts
@@ -6,7 +6,7 @@
  */
 
 import type { Abi, Address, Hex, PublicClient } from "viem";
-import { decodeFunctionResult, encodeFunctionData, size } from "viem";
+import { decodeFunctionResult, encodeFunctionData, size, slice } from "viem";
 
 import {
   ProtocolParamsABI,
@@ -241,6 +241,11 @@ export class ViemProtocolParamsReader implements ProtocolParamsReader {
       throw new Error("getTBVProtocolParams returned no data");
     }
 
+    if (size(data) % ABI_WORD_BYTES !== 0) {
+      throw new Error(
+        `Invalid getTBVProtocolParams return: expected whole 32-byte words, got ${size(data)} bytes`,
+      );
+    }
     const words = size(data) / ABI_WORD_BYTES;
     if (
       (TBV_PROTOCOL_PARAMS_LEGACY_WORD_COUNTS as readonly number[]).includes(
@@ -249,16 +254,21 @@ export class ViemProtocolParamsReader implements ProtocolParamsReader {
     ) {
       return { status: "unsupported" };
     }
-    if (words !== TBV_PROTOCOL_PARAMS_WORD_COUNT) {
+    if (words < TBV_PROTOCOL_PARAMS_WORD_COUNT) {
       throw new Error(
-        `Invalid getTBVProtocolParams return: expected ${TBV_PROTOCOL_PARAMS_WORD_COUNT} words (or a legacy 6/7-word tuple), got ${size(data)} bytes`,
+        `Invalid getTBVProtocolParams return: expected at least ${TBV_PROTOCOL_PARAMS_WORD_COUNT} words (or a legacy 6/7-word tuple), got ${size(data)} bytes`,
       );
     }
 
+    // `TBVProtocolParams` is append-only — it has grown twice, and
+    // `IProtocolParams.sol` documents each new field as appended last. A 9th
+    // word is therefore a field this SDK does not know about, not a corrupt
+    // payload, so decode the prefix this SDK does know and ignore the rest
+    // rather than halting every deposit until the next SDK release.
     const result = decodeFunctionResult({
       abi: ProtocolParamsFundingInputBoundABI,
       functionName: "getTBVProtocolParams",
-      data,
+      data: slice(data, 0, TBV_PROTOCOL_PARAMS_WORD_COUNT * ABI_WORD_BYTES),
     });
 
     const raw = result.maxFundingInputCount;

--- a/packages/babylon-ts-sdk/src/tbv/core/clients/eth/protocol-params-reader.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/eth/protocol-params-reader.ts
@@ -6,16 +6,22 @@
  */
 
 import type { Abi, Address, Hex, PublicClient } from "viem";
+import { decodeFunctionResult, encodeFunctionData, size } from "viem";
 
-import { ProtocolParamsABI } from "../../contracts/abis/ProtocolParams.abi";
+import {
+  ProtocolParamsABI,
+  ProtocolParamsFundingInputBoundABI,
+} from "../../contracts/abis/ProtocolParams.abi";
 import {
   assertValidOffchainParamsVersion,
+  validateMaxFundingInputCount,
   validateOffchainParams,
   validatePegInConfiguration,
   validateTBVProtocolParams,
 } from "./protocol-params-validation";
 import type {
   AllOffchainParamsData,
+  FundingInputBound,
   OnSkippedOffchainParamsVersion,
   PegInConfiguration,
   ProtocolParamsReader,
@@ -29,6 +35,18 @@ import type {
  */
 const UINT16_MAX = 65535;
 
+/** Width of one ABI-encoded word, in bytes. */
+const ABI_WORD_BYTES = 32;
+
+/**
+ * Return lengths of the two `TBVProtocolParams` struct generations that
+ * predate `maxFundingInputCount`: the original 6-component struct, and the
+ * 7-component one that appended `peginActivationDelay`.
+ */
+const TBV_PROTOCOL_PARAMS_LEGACY_WORD_COUNTS = [6, 7] as const;
+
+/** Word count of the current 8-component `TBVProtocolParams` struct. */
+const TBV_PROTOCOL_PARAMS_WORD_COUNT = 8;
 
 /**
  * Raw shape viem returns for VersionedOffchainParams struct.
@@ -206,6 +224,49 @@ export class ViemProtocolParamsReader implements ProtocolParamsReader {
       );
     }
     return raw;
+  }
+
+  async getMaxFundingInputCount(
+    blockNumber?: bigint,
+  ): Promise<FundingInputBound> {
+    const { data } = await this.publicClient.call({
+      to: this.contractAddress,
+      data: encodeFunctionData({
+        abi: ProtocolParamsFundingInputBoundABI,
+        functionName: "getTBVProtocolParams",
+      }),
+      blockNumber,
+    });
+    if (data === undefined) {
+      throw new Error("getTBVProtocolParams returned no data");
+    }
+
+    const words = size(data) / ABI_WORD_BYTES;
+    if (
+      (TBV_PROTOCOL_PARAMS_LEGACY_WORD_COUNTS as readonly number[]).includes(
+        words,
+      )
+    ) {
+      return { status: "unsupported" };
+    }
+    if (words !== TBV_PROTOCOL_PARAMS_WORD_COUNT) {
+      throw new Error(
+        `Invalid getTBVProtocolParams return: expected ${TBV_PROTOCOL_PARAMS_WORD_COUNT} words (or a legacy 6/7-word tuple), got ${size(data)} bytes`,
+      );
+    }
+
+    const result = decodeFunctionResult({
+      abi: ProtocolParamsFundingInputBoundABI,
+      functionName: "getTBVProtocolParams",
+      data,
+    });
+
+    const raw = result.maxFundingInputCount;
+    if (raw === 0) {
+      return { status: "unpublished" };
+    }
+    validateMaxFundingInputCount(raw);
+    return { status: "published", maxInputs: raw };
   }
 
   /**

--- a/packages/babylon-ts-sdk/src/tbv/core/clients/eth/protocol-params-validation.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/eth/protocol-params-validation.ts
@@ -40,11 +40,7 @@ const UINT8_MAX = 255;
  * map key. Used by reader entry points that surface the version to JS.
  */
 export function assertValidOffchainParamsVersion(version: number): void {
-  if (
-    !Number.isInteger(version) ||
-    version < 0 ||
-    version > UINT32_MAX
-  ) {
+  if (!Number.isInteger(version) || version < 0 || version > UINT32_MAX) {
     throw new Error(
       `Invalid offchainParamsVersion from contract: must be a uint32, got ${version}`,
     );
@@ -210,6 +206,22 @@ export function validateTBVProtocolParams(params: TBVProtocolParams): void {
 
   if (errors.length > 0) {
     throw new Error(`Invalid TBV protocol parameters: ${errors.join("; ")}`);
+  }
+}
+
+/**
+ * Validate a published `maxFundingInputCount`.
+ *
+ * `0` is not accepted here: it is the unpublished sentinel and is classified
+ * by the reader before this runs, never validated into a usable bound.
+ *
+ * @throws Error if the value is not an integer in `[1, 255]`.
+ */
+export function validateMaxFundingInputCount(value: number): void {
+  if (!Number.isInteger(value) || value <= 0 || value > UINT8_MAX) {
+    throw new Error(
+      `maxFundingInputCount must be an integer in [1, ${UINT8_MAX}], got ${value}`,
+    );
   }
 }
 

--- a/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts
@@ -213,6 +213,11 @@ export interface TBVProtocolParams {
   expiredPegInGraceBlocks: bigint;
 }
 
+export type FundingInputBound =
+  | { status: "unsupported" }
+  | { status: "unpublished" }
+  | { status: "published"; maxInputs: number };
+
 /**
  * Versioned offchain parameters from the ProtocolParams contract.
  * Matches Solidity struct `IProtocolParams.VersionedOffchainParams` exactly.
@@ -315,6 +320,24 @@ export interface ProtocolParamsReader {
    *   the decoded payload is not a `bigint`.
    */
   getPeginActivationDelay(): Promise<bigint>;
+  /**
+   * Ceiling on the number of funding inputs one Pre-PegIn may spend, read
+   * from `TBVProtocolParams.maxFundingInputCount`.
+   *
+   * `unsupported` means the deployment predates the field, and is returned
+   * only when the contract answers with the 6- or 7-word tuple of a
+   * deployment that predates the field; any other length is invalid protocol
+   * data and throws. `unpublished` means the field decoded as `0`, which
+   * governance has not set yet — a bound of zero is not a real limit, so
+   * callers must block rather than treat it as unbounded. `published`
+   * carries an integer validated into `[1, 255]`. Every other failure —
+   * a dead RPC, a wrong-length return, an out-of-range value — rethrows.
+   *
+   * Pass `blockNumber` when the result will shape a Bitcoin lock, so the
+   * bound describes the same block as the peg-in config it is enforced
+   * alongside.
+   */
+  getMaxFundingInputCount(blockNumber?: bigint): Promise<FundingInputBound>;
   fetchAllOffchainParams(
     onSkippedVersion?: OnSkippedOffchainParamsVersion,
   ): Promise<AllOffchainParamsData>;

--- a/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/clients/eth/types.ts
@@ -326,8 +326,11 @@ export interface ProtocolParamsReader {
    *
    * `unsupported` means the deployment predates the field, and is returned
    * only when the contract answers with the 6- or 7-word tuple of a
-   * deployment that predates the field; any other length is invalid protocol
-   * data and throws. `unpublished` means the field decoded as `0`, which
+   * deployment that predates the field. The struct is append-only, so a
+   * longer return is read as a governance addition this SDK does not know
+   * about: only the first 8 words are decoded and the rest ignored. A return
+   * below 6 words, or one that is not whole 32-byte words, is invalid
+   * protocol data and throws. `unpublished` means the field decoded as `0`, which
    * governance has not set yet — a bound of zero is not a real limit, so
    * callers must block rather than treat it as unbounded. `published`
    * carries an integer validated into `[1, 255]`. Every other failure —

--- a/packages/babylon-ts-sdk/src/tbv/core/contracts/__tests__/errors.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/contracts/__tests__/errors.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
 
+import { isFundingInputCountExceededError } from "../../utils/utxo/fundingInputCountExceeded";
 import {
   CONTRACT_ERRORS,
   PEGIN_FINGERPRINT_CHANGED_SELECTOR,
   PeginFingerprintChangedError,
+  TOO_MANY_FUNDING_INPUTS_SELECTOR,
   extractErrorData,
   getContractErrorMessage,
   handleContractError,
@@ -17,9 +19,7 @@ const INVALID_PEGIN_FEE_SELECTOR = "0x979f4518";
 const EXPECTED_FINGERPRINT = `0x${"11".repeat(32)}`;
 const ACTUAL_FINGERPRINT = `0x${"22".repeat(32)}`;
 const FINGERPRINT_REVERT_DATA =
-  PEGIN_FINGERPRINT_CHANGED_SELECTOR +
-  "11".repeat(32) +
-  "22".repeat(32);
+  PEGIN_FINGERPRINT_CHANGED_SELECTOR + "11".repeat(32) + "22".repeat(32);
 
 describe("extractErrorData", () => {
   it("returns undefined for null", () => {
@@ -217,9 +217,7 @@ describe("CONTRACT_ERRORS table", () => {
     // The consuming app branches on the typed error rather than rendering a
     // string, so an entry here would be a second, unused representation that
     // could silently drift from the copy the depositor actually sees.
-    expect(
-      CONTRACT_ERRORS[PEGIN_FINGERPRINT_CHANGED_SELECTOR],
-    ).toBeUndefined();
+    expect(CONTRACT_ERRORS[PEGIN_FINGERPRINT_CHANGED_SELECTOR]).toBeUndefined();
   });
 });
 
@@ -253,6 +251,42 @@ describe("PeginFingerprintChanged", () => {
     const err = caught as PeginFingerprintChangedError;
     expect(err.expected).toBeUndefined();
     expect(err.actual).toBeUndefined();
+  });
+
+  it("throws a typed funding-input error carrying the registry's maxAllowed", () => {
+    // `maxAllowed` is the second word, so a swap with `inputCount` would
+    // report the depositor's own count back at them as the protocol limit.
+    const revertData =
+      TOO_MANY_FUNDING_INPUTS_SELECTOR +
+      (25).toString(16).padStart(64, "0") +
+      (20).toString(16).padStart(64, "0");
+
+    let caught: unknown;
+    try {
+      handleContractError({ data: revertData });
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(isFundingInputCountExceededError(caught)).toBe(true);
+    expect((caught as { maxInputCount: number }).maxInputCount).toBe(20);
+  });
+
+  it("falls back to the tabled message when the funding-input revert carries only the selector", () => {
+    // The common shape in practice: viem exposes a decoded `signature`, not
+    // raw data, so there is no `maxAllowed` to build the typed error from.
+    // The depositor must still get the consolidate-your-UTXOs copy.
+    let caught: unknown;
+    try {
+      handleContractError({ data: TOO_MANY_FUNDING_INPUTS_SELECTOR });
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(isFundingInputCountExceededError(caught)).toBe(false);
+    expect((caught as Error).message).toBe(
+      CONTRACT_ERRORS[TOO_MANY_FUNDING_INPUTS_SELECTOR],
+    );
   });
 
   it("does not classify a different selector as a fingerprint change", () => {

--- a/packages/babylon-ts-sdk/src/tbv/core/contracts/__tests__/peginFingerprintAbi.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/contracts/__tests__/peginFingerprintAbi.test.ts
@@ -27,7 +27,10 @@ import { describe, expect, it } from "vitest";
 import { ApplicationRegistryABI } from "../abis/ApplicationRegistry.abi";
 import { BTCVaultRegistryABI } from "../abis/BTCVaultRegistry.abi";
 import { ProtocolParamsABI } from "../abis/ProtocolParams.abi";
-import { PEGIN_FINGERPRINT_CHANGED_SELECTOR } from "../errors";
+import {
+  PEGIN_FINGERPRINT_CHANGED_SELECTOR,
+  TOO_MANY_FUNDING_INPUTS_SELECTOR,
+} from "../errors";
 
 /**
  * `toFunctionSignature` prefixes an error item with the `error ` keyword,
@@ -93,18 +96,25 @@ describe("peg-in submit selectors", () => {
     expect(PEGIN_FINGERPRINT_CHANGED_SELECTOR).toBe("0x846c25bb");
   });
 
+  it("declares TooManyFundingInputs so viem can decode the revert", () => {
+    const [error, ...extras] = itemsNamed("TooManyFundingInputs");
+    expect(extras).toHaveLength(0);
+    expect(error.type).toBe("error");
+    expect(error.inputs.map((input) => input.type)).toEqual([
+      "uint256",
+      "uint256",
+    ]);
+    expect(selectorOf(error)).toBe(TOO_MANY_FUNDING_INPUTS_SELECTOR);
+    expect(TOO_MANY_FUNDING_INPUTS_SELECTOR).toBe("0xf14dcc9f");
+  });
+
   // The two epoch getters feed fingerprint words 5 and 6. Neither is a compile
   // error if it drifts: a wrong name or arity reverts the read at build time
   // for every depositor, and a wrong output WIDTH is worse — `uint256` where
   // the contract declares `uint64` decodes to a value that encodes differently
   // and fails the on-chain comparison with two opaque hashes and no hint.
   it.each([
-    [
-      "appKeeperKeyEpochCurrent",
-      ApplicationRegistryABI,
-      ["address"],
-      "uint64",
-    ],
+    ["appKeeperKeyEpochCurrent", ApplicationRegistryABI, ["address"], "uint64"],
     ["ucKeyEpochCurrent", ProtocolParamsABI, [], "uint64"],
   ])(
     "declares %s with the width the fingerprint encodes",
@@ -123,9 +133,9 @@ describe("peg-in submit selectors", () => {
   );
 
   it("exposes getVaultProviderApplication, which resolves the keeper roster", () => {
-    const [getter, ...extras] = itemsNamed("getVaultProviderApplication").filter(
-      (item) => item.type === "function",
-    );
+    const [getter, ...extras] = itemsNamed(
+      "getVaultProviderApplication",
+    ).filter((item) => item.type === "function");
     expect(extras).toHaveLength(0);
     expect(getter.inputs.map((input) => input.type)).toEqual(["address"]);
     expect(getter.outputs.map((output) => output.type)).toEqual(["address"]);

--- a/packages/babylon-ts-sdk/src/tbv/core/contracts/abis/BTCVaultRegistry.abi.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/contracts/abis/BTCVaultRegistry.abi.ts
@@ -626,6 +626,14 @@ export const BTCVaultRegistryABI = [
   },
   {
     type: "error",
+    name: "TooManyFundingInputs",
+    inputs: [
+      { name: "inputCount", type: "uint256", internalType: "uint256" },
+      { name: "maxAllowed", type: "uint256", internalType: "uint256" },
+    ],
+  },
+  {
+    type: "error",
     name: "VaultBelowMinimum",
     inputs: [
       { name: "actual", type: "uint256", internalType: "uint256" },

--- a/packages/babylon-ts-sdk/src/tbv/core/contracts/abis/ProtocolParams.abi.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/contracts/abis/ProtocolParams.abi.ts
@@ -373,3 +373,71 @@ export const ProtocolParamsABI = [
     stateMutability: "view",
   },
 ] as const;
+
+// The full 8-component `TBVProtocolParams` tuple, ending in the
+// `maxFundingInputCount` bound the registry enforces on a Pre-PegIn's input
+// count. It lives in its own ABI rather than as a second `getTBVProtocolParams`
+// entry in `ProtocolParamsABI` for two reasons: viem's `getAbiItem` picks the
+// first entry of a given name, so a duplicate would shadow the 6-component one
+// every other read depends on; and an 8-component decode cannot be run
+// against the 6- or 7-word return of deployments that predate the field.
+// Read it only through `getMaxFundingInputCount`, which classifies the raw
+// return by word count before decoding and reports those shorter tuples as
+// an `unsupported` bound.
+export const ProtocolParamsFundingInputBoundABI = [
+  {
+    type: "function",
+    name: "getTBVProtocolParams",
+    inputs: [],
+    outputs: [
+      {
+        name: "",
+        type: "tuple",
+        internalType: "struct IProtocolParams.TBVProtocolParams",
+        components: [
+          {
+            name: "minimumPegInAmount",
+            type: "uint64",
+            internalType: "uint64",
+          },
+          {
+            name: "maxPegInAmount",
+            type: "uint64",
+            internalType: "uint64",
+          },
+          {
+            name: "pegInAckTimeout",
+            type: "uint64",
+            internalType: "uint64",
+          },
+          {
+            name: "pegInActivationTimeout",
+            type: "uint64",
+            internalType: "uint64",
+          },
+          {
+            name: "maxHtlcOutputCount",
+            type: "uint8",
+            internalType: "uint8",
+          },
+          {
+            name: "expiredPegInGraceBlocks",
+            type: "uint64",
+            internalType: "uint64",
+          },
+          {
+            name: "peginActivationDelay",
+            type: "uint64",
+            internalType: "uint64",
+          },
+          {
+            name: "maxFundingInputCount",
+            type: "uint8",
+            internalType: "uint8",
+          },
+        ],
+      },
+    ],
+    stateMutability: "view",
+  },
+] as const;

--- a/packages/babylon-ts-sdk/src/tbv/core/contracts/errors.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/contracts/errors.ts
@@ -9,6 +9,8 @@
 
 import { decodeAbiParameters, type Hex } from "viem";
 
+import { FundingInputCountExceededError } from "../utils/utxo/fundingInputCountExceeded";
+
 /**
  * `PeginFingerprintChanged(bytes32 expected, bytes32 actual)`.
  *
@@ -20,6 +22,42 @@ import { decodeAbiParameters, type Hex } from "viem";
  * test asserts the two agree.
  */
 export const PEGIN_FINGERPRINT_CHANGED_SELECTOR = "0x846c25bb";
+
+/**
+ * `TooManyFundingInputs(uint256 inputCount, uint256 maxAllowed)` — the
+ * registry's own enforcement of `maxFundingInputCount`.
+ *
+ * Re-derived rather than copied: `keccak256("TooManyFundingInputs(uint256,uint256)")`
+ * begins `0xf14dcc9f`. `BTCVaultRegistry.abi.ts` carries the matching error
+ * entry, and a test asserts the two agree.
+ */
+export const TOO_MANY_FUNDING_INPUTS_SELECTOR = "0xf14dcc9f";
+
+/** `"0x"` + 4-byte selector + two abi-encoded `uint256` words. */
+const TOO_MANY_FUNDING_INPUTS_REVERT_DATA_LENGTH = 2 + 8 + 64 * 2;
+
+/**
+ * Recover the registry's `maxAllowed` from the revert payload, when there is
+ * one. Selector-only payloads are normal here for the same reason they are for
+ * the fingerprint revert, so the caller must have a path that does not need
+ * this number.
+ */
+function decodeMaxFundingInputsAllowed(errorData: string): number | undefined {
+  if (errorData.length !== TOO_MANY_FUNDING_INPUTS_REVERT_DATA_LENGTH) {
+    return undefined;
+  }
+  try {
+    const [, maxAllowed] = decodeAbiParameters(
+      [{ type: "uint256" }, { type: "uint256" }],
+      `0x${errorData.slice(10)}` as Hex,
+    );
+    return maxAllowed <= BigInt(Number.MAX_SAFE_INTEGER)
+      ? Number(maxAllowed)
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
 
 /** `"0x"` + 4-byte selector + two abi-encoded `bytes32` words. */
 const FINGERPRINT_REVERT_DATA_LENGTH = 2 + 8 + 64 * 2;
@@ -139,6 +177,12 @@ export const CONTRACT_ERRORS: Record<string, string> = {
   "0x979f4518":
     "Invalid pegin fee: The ETH fee sent does not match the required amount. " +
     "This may indicate a fee rate change during the transaction.",
+  // TooManyFundingInputs(uint256,uint256). Also thrown typed by
+  // `handleContractError`; this entry is the fallback for a revert that
+  // reached us as a bare selector, with no `maxAllowed` to carry.
+  "0xf14dcc9f":
+    "Too many funding inputs: This deposit spends more Bitcoin UTXOs than the protocol " +
+    "allows in one Pre-Pegin transaction. Consolidate your UTXOs and try again.",
   // PrePeginOutputAlreadyUsed()
   "0x5fad9694":
     "This pre-pegin output has already been used to activate another vault.",
@@ -180,10 +224,7 @@ export function extractErrorData(error: unknown): string | undefined {
  *
  * Depth-limited (10) and walk-result-deduplicated so a cycle can't loop.
  */
-function walkForErrorData(
-  error: unknown,
-  depth: number,
-): string | undefined {
+function walkForErrorData(error: unknown, depth: number): string | undefined {
   if (depth > 10 || !error || typeof error !== "object") return undefined;
 
   const err = error as Record<string, unknown>;
@@ -320,6 +361,19 @@ export function handleContractError(error: unknown): never {
           "at inclusion differs from the state this deposit was built against.",
         decodeFingerprints(errorData),
       );
+    }
+
+    // Typed ahead of the message map for the same reason as the fingerprint
+    // revert: the app already branches on this error class to reach the
+    // "Too many UTXOs" copy, via `isFundingInputCountExceededError`. Only
+    // when the payload carried `maxAllowed` — the error class has no
+    // meaningful message without it, and the table entry below covers the
+    // selector-only case.
+    if (selector.toLowerCase() === TOO_MANY_FUNDING_INPUTS_SELECTOR) {
+      const maxAllowed = decodeMaxFundingInputsAllowed(errorData);
+      if (maxAllowed !== undefined) {
+        throw new FundingInputCountExceededError(maxAllowed);
+      }
     }
 
     const knownError = CONTRACT_ERRORS[errorData] ?? CONTRACT_ERRORS[selector];

--- a/packages/babylon-ts-sdk/src/tbv/core/contracts/index.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/contracts/index.ts
@@ -10,7 +10,10 @@
 export { ApplicationRegistryABI } from "./abis/ApplicationRegistry.abi";
 export { BTCVaultRegistryABI } from "./abis/BTCVaultRegistry.abi";
 export { BTCVaultRegistryKeyEpochsABI } from "./abis/BTCVaultRegistryKeyEpochs.abi";
-export { ProtocolParamsABI } from "./abis/ProtocolParams.abi";
+export {
+  ProtocolParamsABI,
+  ProtocolParamsFundingInputBoundABI,
+} from "./abis/ProtocolParams.abi";
 
 export {
   CONTRACT_ERRORS,

--- a/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts
@@ -79,6 +79,7 @@ import {
 } from "../primitives/utils/bitcoin";
 import {
   calculateBtcTxHash,
+  FundingInputCountExceededError,
   fundPeginTransaction,
   getNetwork,
   getPsbtInputFields,
@@ -284,7 +285,7 @@ export interface PreparePeginParams {
    * pinned block — the most inputs one Pre-PegIn may spend. `null` only
    * when the deployment predates the field.
    *
-   * Enforced at UTXO selection, before any wallet or device I/O, and
+   * Enforced at UTXO selection, before any signing or approval prompt, and
    * re-asserted against the funded transaction.
    */
   maxFundingInputCount: number | null;
@@ -1055,15 +1056,14 @@ export class PeginManager {
           `spend exactly the selected inputs.`,
       );
     }
+    // Typed, not a plain Error: the consuming app routes this class to the
+    // "Too many UTXOs" copy, and a generic failure here would look like a
+    // bug in the app rather than a bound the depositor can act on.
     if (
       params.maxFundingInputCount !== null &&
       fundedInputCount > params.maxFundingInputCount
     ) {
-      throw new Error(
-        `Pre-PegIn declares ${fundedInputCount} inputs, above the on-chain ` +
-          `maxFundingInputCount of ${params.maxFundingInputCount}; refusing to ` +
-          `submit a transaction the registry will reject.`,
-      );
+      throw new FundingInputCountExceededError(params.maxFundingInputCount);
     }
 
     const prePeginTxid = stripHexPrefix(

--- a/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/PeginManager.ts
@@ -280,6 +280,16 @@ export interface PreparePeginParams {
   availableUTXOs: readonly UTXO[];
 
   /**
+   * On-chain `ProtocolParams.maxFundingInputCount` read at this build's
+   * pinned block — the most inputs one Pre-PegIn may spend. `null` only
+   * when the deployment predates the field.
+   *
+   * Enforced at UTXO selection, before any wallet or device I/O, and
+   * re-asserted against the funded transaction.
+   */
+  maxFundingInputCount: number | null;
+
+  /**
    * Bitcoin address for receiving change from the Pre-PegIn transaction.
    */
   changeAddress: string;
@@ -874,6 +884,7 @@ export class PeginManager {
       prePegin.totalOutputValue,
       params.mempoolFeeRate,
       peginOutputCount(prePegin.htlcValues.length, true),
+      params.maxFundingInputCount,
     );
 
     return {
@@ -1029,6 +1040,29 @@ export class PeginManager {
         `Pre-PegIn funded fee ${fundedFee} does not match the sizing-pass fee ` +
           `${sizing.fee}; refusing to publish a deposit-terms fee bound the ` +
           `funded transaction does not pay.`,
+      );
+    }
+
+    // The registry rejects `inputCount > maxFundingInputCount`, so re-read
+    // the input count off the funded tx rather than trusting the selection
+    // the funder was handed.
+    const fundedInputCount =
+      Transaction.fromHex(fundedPrePeginTxHex).ins.length;
+    if (fundedInputCount !== sizing.selectedUTXOs.length) {
+      throw new Error(
+        `Pre-PegIn declares ${fundedInputCount} inputs but ${sizing.selectedUTXOs.length} ` +
+          `UTXOs were selected; refusing to submit a transaction that does not ` +
+          `spend exactly the selected inputs.`,
+      );
+    }
+    if (
+      params.maxFundingInputCount !== null &&
+      fundedInputCount > params.maxFundingInputCount
+    ) {
+      throw new Error(
+        `Pre-PegIn declares ${fundedInputCount} inputs, above the on-chain ` +
+          `maxFundingInputCount of ${params.maxFundingInputCount}; refusing to ` +
+          `submit a transaction the registry will reject.`,
       );
     }
 

--- a/packages/babylon-ts-sdk/src/tbv/core/managers/__tests__/PeginManager.rebuildDepositTerms.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/__tests__/PeginManager.rebuildDepositTerms.test.ts
@@ -138,6 +138,7 @@ const PARAMS = {
   availableUTXOs: TEST_UTXOS,
   changeAddress: deriveTaprootAddress(TEST_KEYS.DEPOSITOR, "signet"),
   commissionBps: 250,
+  maxFundingInputCount: null,
 } as const;
 
 // Fresh path applies `capMaxAcceptableCommissionBps`: quote + 25 bps headroom.

--- a/packages/babylon-ts-sdk/src/tbv/core/managers/__tests__/PeginManager.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/__tests__/PeginManager.test.ts
@@ -38,13 +38,40 @@ import {
   initializeWasmForTests,
 } from "../../primitives/psbt/__tests__/helpers";
 import { FundingInputCountExceededError, type UTXO } from "../../utils";
-import { parseUnfundedWasmTransaction } from "../../utils/transaction/fundPeginTransaction";
+import {
+  fundPeginTransaction,
+  parseUnfundedWasmTransaction,
+} from "../../utils/transaction/fundPeginTransaction";
+import { selectUtxosForPegin } from "../../utils/utxo/selectUtxos";
 import { PeginManager, type PeginManagerConfig } from "../PeginManager";
 
 // Mock calculateBtcTxHash to avoid parsing funded pre-pegin tx in tests
 vi.mock("../../utils/transaction/btcTxHash", () => ({
   calculateBtcTxHash: vi.fn(() => `0x${"a".repeat(64)}`),
 }));
+
+// Pass-through spies. The post-funding cross-checks assert that the funder
+// spent exactly the selected inputs and stayed within the bound, and neither
+// is reachable while both halves behave — one test overrides each.
+vi.mock(
+  "../../utils/transaction/fundPeginTransaction",
+  async (importOriginal) => {
+    const actual =
+      await importOriginal<
+        typeof import("../../utils/transaction/fundPeginTransaction")
+      >();
+    return {
+      ...actual,
+      fundPeginTransaction: vi.fn(actual.fundPeginTransaction),
+    };
+  },
+);
+
+vi.mock("../../utils/utxo/selectUtxos", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../../utils/utxo/selectUtxos")>();
+  return { ...actual, selectUtxosForPegin: vi.fn(actual.selectUtxosForPegin) };
+});
 
 // Mock buildPeginInputPsbt, extractPeginInputSignature, and finalizePeginInputPsbt —
 // the mock wallet cannot produce a valid signed PSBT, so we mock these primitives
@@ -760,6 +787,75 @@ describe("PeginManager", () => {
       expect(deriveContextHashSpy).not.toHaveBeenCalled();
       expect(signPsbtSpy).not.toHaveBeenCalled();
       expect(signPsbtsSpy).not.toHaveBeenCalled();
+    });
+
+    it("refuses to submit when the funder spends an input the selection did not include", async () => {
+      const manager = new PeginManager({
+        btcNetwork: "signet",
+        btcWallet: new MockBitcoinWallet({ publicKeyHex: TEST_KEYS.DEPOSITOR }),
+        ethWallet: new MockEthereumWallet() as never,
+        ethChain: TEST_CHAIN,
+        publicClient: TEST_PUBLIC_CLIENT,
+        vaultContracts: { btcVaultRegistry: TEST_CONTRACT_ADDRESS },
+        mempoolApiUrl: MEMPOOL_API_URLS.signet,
+      });
+
+      const actualFund = await vi.importActual<
+        typeof import("../../utils/transaction/fundPeginTransaction")
+      >("../../utils/transaction/fundPeginTransaction");
+      vi.mocked(fundPeginTransaction).mockImplementationOnce((args) => {
+        const funded = bitcoin.Transaction.fromHex(
+          actualFund.fundPeginTransaction(args),
+        );
+        // The input the selection never authorised. Its value never entered
+        // the fee math, so a depositor would silently overpay by it.
+        funded.addInput(Buffer.alloc(32, 7), 0);
+        return funded.toHex();
+      });
+
+      await expect(
+        manager.preparePegin({
+          amounts: [TEST_AMOUNTS.PEGIN_LARGE],
+          ...BASE_PREPARE_PEGIN_PARAMS,
+        }),
+      ).rejects.toThrow(/does not\s+spend exactly the selected inputs/);
+    });
+
+    it("refuses to submit a funded transaction above maxFundingInputCount", async () => {
+      const manager = new PeginManager({
+        btcNetwork: "signet",
+        btcWallet: new MockBitcoinWallet({ publicKeyHex: TEST_KEYS.DEPOSITOR }),
+        ethWallet: new MockEthereumWallet() as never,
+        ethChain: TEST_CHAIN,
+        publicClient: TEST_PUBLIC_CLIENT,
+        vaultContracts: { btcVaultRegistry: TEST_CONTRACT_ADDRESS },
+        mempoolApiUrl: MEMPOOL_API_URLS.signet,
+      });
+
+      // Only a selector that ignored the bound can reach the broadcast-site
+      // check, so this stands in for that bug: select as if unbounded, then
+      // let the manager re-read the count off the funded transaction.
+      const actualSelect = await vi.importActual<
+        typeof import("../../utils/utxo/selectUtxos")
+      >("../../utils/utxo/selectUtxos");
+      vi.mocked(selectUtxosForPegin).mockImplementationOnce(
+        (utxos, amount, feeRate, numOutputs) =>
+          actualSelect.selectUtxosForPegin(
+            utxos,
+            amount,
+            feeRate,
+            numOutputs,
+            null,
+          ),
+      );
+
+      await expect(
+        manager.preparePegin({
+          amounts: [TEST_AMOUNTS.PEGIN_LARGE, TEST_AMOUNTS.PEGIN_LARGE],
+          ...BASE_PREPARE_PEGIN_PARAMS,
+          maxFundingInputCount: 1,
+        }),
+      ).rejects.toBeInstanceOf(FundingInputCountExceededError);
     });
 
     it("should throw error for empty UTXOs", async () => {

--- a/packages/babylon-ts-sdk/src/tbv/core/managers/__tests__/PeginManager.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/managers/__tests__/PeginManager.test.ts
@@ -37,7 +37,7 @@ import {
   TEST_KEYS,
   initializeWasmForTests,
 } from "../../primitives/psbt/__tests__/helpers";
-import type { UTXO } from "../../utils";
+import { FundingInputCountExceededError, type UTXO } from "../../utils";
 import { parseUnfundedWasmTransaction } from "../../utils/transaction/fundPeginTransaction";
 import { PeginManager, type PeginManagerConfig } from "../PeginManager";
 
@@ -273,6 +273,7 @@ const BASE_PREPARE_PEGIN_PARAMS = {
   availableUTXOs: TEST_UTXOS,
   changeAddress: TEST_CHANGE_ADDRESS,
   commissionBps: 250,
+  maxFundingInputCount: null,
 } as const;
 
 function appendUnexpectedPrePeginOutput(
@@ -726,6 +727,39 @@ describe("PeginManager", () => {
           ...BASE_PREPARE_PEGIN_PARAMS,
         }),
       ).rejects.toThrow(/Insufficient funds/);
+    });
+
+    it("rejects with FundingInputCountExceededError before deriving or signing when the deposit needs more inputs than maxFundingInputCount", async () => {
+      const btcWallet = new MockBitcoinWallet({
+        publicKeyHex: TEST_KEYS.DEPOSITOR,
+      });
+      const ethWallet = new MockEthereumWallet();
+      const deriveContextHashSpy = vi.spyOn(btcWallet, "deriveContextHash");
+      const signPsbtSpy = vi.spyOn(btcWallet, "signPsbt");
+      const signPsbtsSpy = vi.spyOn(btcWallet, "signPsbts");
+
+      const manager = new PeginManager({
+        btcNetwork: "signet",
+        btcWallet,
+        ethWallet: ethWallet as never,
+        ethChain: TEST_CHAIN,
+        publicClient: TEST_PUBLIC_CLIENT,
+        vaultContracts: { btcVaultRegistry: TEST_CONTRACT_ADDRESS },
+        mempoolApiUrl: MEMPOOL_API_URLS.signet,
+      });
+
+      // Two 500_000-sat vaults need two of the 800_000-sat TEST_UTXOS.
+      await expect(
+        manager.preparePegin({
+          amounts: [TEST_AMOUNTS.PEGIN_LARGE, TEST_AMOUNTS.PEGIN_LARGE],
+          ...BASE_PREPARE_PEGIN_PARAMS,
+          maxFundingInputCount: 1,
+        }),
+      ).rejects.toBeInstanceOf(FundingInputCountExceededError);
+
+      expect(deriveContextHashSpy).not.toHaveBeenCalled();
+      expect(signPsbtSpy).not.toHaveBeenCalled();
+      expect(signPsbtsSpy).not.toHaveBeenCalled();
     });
 
     it("should throw error for empty UTXOs", async () => {

--- a/packages/babylon-ts-sdk/src/tbv/core/utils/fee/__tests__/peginFeeMath.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/utils/fee/__tests__/peginFeeMath.test.ts
@@ -19,6 +19,12 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  computeFundingBudget,
+  FundingInputCountExceededError,
+  selectUtxosForPegin,
+  type UTXO,
+} from "../../utxo/selectUtxos";
+import {
   applyChangeOutputPolicy,
   computeChangeOutputFeeSats,
   computeMaxDeposit,
@@ -251,8 +257,7 @@ describe("applyChangeOutputPolicy", () => {
     const totalInputValue = 100_000n;
 
     // Just-above-dust → emit change.
-    const peginAbove =
-      totalInputValue - baseFee - changeOutputFee - 547n;
+    const peginAbove = totalInputValue - baseFee - changeOutputFee - 547n;
     const above = applyChangeOutputPolicy({
       totalInputValue,
       peginAmount: peginAbove,
@@ -338,5 +343,82 @@ describe("computeMaxDeposit", () => {
       feeRate: 5,
     });
     expect(max).toBe(10_000n - baseFee);
+  });
+});
+
+describe("estimator-vs-selection agreement under maxFundingInputCount", () => {
+  // 25 UTXOs, deliberately out of value order so the shared largest-first
+  // sort is what makes the budget and the selection agree. Every value is
+  // far above the per-input fee (58 × 5 = 290 sats), so the selector cannot
+  // terminate on fewer inputs than the budget assumed.
+  const UTXO_VALUES = [
+    47_000, 120_000, 8_000, 88_000, 33_000, 61_000, 15_000, 95_000, 25_000,
+    70_000, 39_000, 5_000, 77_500, 51_000, 19_000, 66_000, 30_000, 11_000,
+    58_000, 44_000, 22_000, 54_000, 36_000, 28_000, 41_000,
+  ];
+  const FIXTURE_UTXOS: UTXO[] = UTXO_VALUES.map((value, index) => ({
+    txid: index.toString(16).padStart(64, "0"),
+    vout: 0,
+    value,
+    scriptPubKey:
+      "5120abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+  }));
+  const MAX_INPUT_COUNT = 20;
+  const FEE_RATE = 5;
+  const NUM_OUTPUTS = 3;
+
+  it("selects exactly maxFundingInputCount inputs at the Max the budget advertises", () => {
+    const budget = computeFundingBudget(FIXTURE_UTXOS, MAX_INPUT_COUNT);
+    expect(budget.numInputs).toBe(MAX_INPUT_COUNT);
+
+    const max = computeMaxDeposit({
+      numInputs: budget.numInputs,
+      numOutputs: NUM_OUTPUTS,
+      totalBalance: budget.totalBalance,
+      feeRate: FEE_RATE,
+    });
+    expect(max).not.toBeNull();
+
+    const result = selectUtxosForPegin(
+      FIXTURE_UTXOS,
+      max!,
+      FEE_RATE,
+      NUM_OUTPUTS,
+      MAX_INPUT_COUNT,
+    );
+
+    expect(result.selectedUTXOs).toHaveLength(MAX_INPUT_COUNT);
+    expect(result.totalValue).toBe(budget.totalBalance);
+    expect(result.changeAmount).toBe(0n);
+    // The estimator subtracted exactly this fee to reach `max`; the
+    // selector must charge exactly it back.
+    expect(result.fee).toBe(
+      computePeginBaseFeeSats({
+        numInputs: MAX_INPUT_COUNT,
+        numOutputs: NUM_OUTPUTS,
+        feeRate: FEE_RATE,
+      }),
+    );
+  });
+
+  it("throws FundingInputCountExceededError one satoshi above that Max", () => {
+    const budget = computeFundingBudget(FIXTURE_UTXOS, MAX_INPUT_COUNT);
+    const max = computeMaxDeposit({
+      numInputs: budget.numInputs,
+      numOutputs: NUM_OUTPUTS,
+      totalBalance: budget.totalBalance,
+      feeRate: FEE_RATE,
+    });
+    expect(max).not.toBeNull();
+
+    expect(() =>
+      selectUtxosForPegin(
+        FIXTURE_UTXOS,
+        max! + 1n,
+        FEE_RATE,
+        NUM_OUTPUTS,
+        MAX_INPUT_COUNT,
+      ),
+    ).toThrow(FundingInputCountExceededError);
   });
 });

--- a/packages/babylon-ts-sdk/src/tbv/core/utils/utxo/__tests__/selectUtxos.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/utils/utxo/__tests__/selectUtxos.test.ts
@@ -261,6 +261,26 @@ describe("selectUtxosForPegin", () => {
     expect((thrown as FundingInputCountExceededError).maxInputCount).toBe(1);
   });
 
+  it("reports insufficient funds, not the input bound, when the whole valid set falls short", () => {
+    const smallUTXOs: UTXO[] = Array.from({ length: 25 }, (_, index) => ({
+      txid: index.toString(16).padStart(64, "0"),
+      vout: 0,
+      value: 1_000,
+      scriptPubKey:
+        "5120abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+    }));
+
+    let thrown: unknown;
+    try {
+      selectUtxosForPegin(smallUTXOs, 100_000n, 5, 2, 20);
+    } catch (err) {
+      thrown = err;
+    }
+
+    expect(isFundingInputCountExceededError(thrown)).toBe(false);
+    expect((thrown as Error).message).toMatch(/^Insufficient funds: need /);
+  });
+
   it("selects more inputs than any bound would allow when maxInputCount is null", () => {
     // 150000 + fee exceeds the two largest, so all three are needed.
     const result = selectUtxosForPegin(mockUTXOs, 150000n, 10, 2, null);

--- a/packages/babylon-ts-sdk/src/tbv/core/utils/utxo/__tests__/selectUtxos.test.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/utils/utxo/__tests__/selectUtxos.test.ts
@@ -5,7 +5,10 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  computeFundingBudget,
+  FundingInputCountExceededError,
   getDustThreshold,
+  isFundingInputCountExceededError,
   selectUtxosForPegin,
   shouldAddChangeOutput,
   type UTXO,
@@ -37,7 +40,7 @@ describe("selectUtxosForPegin", () => {
   ];
 
   it("should select single UTXO when sufficient", () => {
-    const result = selectUtxosForPegin(mockUTXOs, 50000n, 10, 2);
+    const result = selectUtxosForPegin(mockUTXOs, 50000n, 10, 2, null);
 
     expect(result.selectedUTXOs).toHaveLength(1);
     expect(result.selectedUTXOs[0].txid).toBe("tx1"); // Largest UTXO selected first
@@ -47,7 +50,7 @@ describe("selectUtxosForPegin", () => {
   });
 
   it("should select multiple UTXOs when needed", () => {
-    const result = selectUtxosForPegin(mockUTXOs, 120000n, 10, 2);
+    const result = selectUtxosForPegin(mockUTXOs, 120000n, 10, 2, null);
 
     expect(result.selectedUTXOs.length).toBeGreaterThan(1);
     expect(result.totalValue).toBeGreaterThanOrEqual(120000n);
@@ -55,26 +58,24 @@ describe("selectUtxosForPegin", () => {
   });
 
   it("should sort UTXOs by value (largest first)", () => {
-    const result = selectUtxosForPegin(mockUTXOs, 30000n, 10, 2);
+    const result = selectUtxosForPegin(mockUTXOs, 30000n, 10, 2, null);
 
     // Should select the largest UTXO first (100000)
     expect(result.selectedUTXOs[0].value).toBe(100000);
   });
 
   it("should calculate fee with change output if change > dust", () => {
-    const result = selectUtxosForPegin(mockUTXOs, 50000n, 10, 2);
+    const result = selectUtxosForPegin(mockUTXOs, 50000n, 10, 2, null);
 
     // Change should be above dust threshold
     expect(result.changeAmount).toBeGreaterThan(546n);
 
     // Total should equal: peginAmount + fee + change
-    expect(result.totalValue).toBe(
-      50000n + result.fee + result.changeAmount,
-    );
+    expect(result.totalValue).toBe(50000n + result.fee + result.changeAmount);
   });
 
   it("should throw error when no UTXOs available", () => {
-    expect(() => selectUtxosForPegin([], 10000n, 10, 2)).toThrow(
+    expect(() => selectUtxosForPegin([], 10000n, 10, 2, null)).toThrow(
       "Insufficient funds: no UTXOs available",
     );
   });
@@ -90,7 +91,7 @@ describe("selectUtxosForPegin", () => {
       },
     ];
 
-    expect(() => selectUtxosForPegin(smallUTXOs, 500000n, 10, 2)).toThrow(
+    expect(() => selectUtxosForPegin(smallUTXOs, 500000n, 10, 2, null)).toThrow(
       /Insufficient funds/,
     );
   });
@@ -100,14 +101,14 @@ describe("selectUtxosForPegin", () => {
   // during transaction signing. Real wallets filter UTXOs before passing to SDK.
 
   it("should handle low fee rates with buffer", () => {
-    const result = selectUtxosForPegin(mockUTXOs, 50000n, 1, 2);
+    const result = selectUtxosForPegin(mockUTXOs, 50000n, 1, 2, null);
 
     // Fee should include LOW_RATE_ESTIMATION_ACCURACY_BUFFER (30 sats)
     expect(result.fee).toBeGreaterThan(30n);
   });
 
   it("should handle high fee rates without extra buffer", () => {
-    const result = selectUtxosForPegin(mockUTXOs, 50000n, 50, 2);
+    const result = selectUtxosForPegin(mockUTXOs, 50000n, 50, 2, null);
 
     // Fee should be proportional to fee rate
     expect(result.fee).toBeGreaterThan(100n);
@@ -115,15 +116,13 @@ describe("selectUtxosForPegin", () => {
 
   it("should iterate until sufficient funds including fees", () => {
     // Test that it keeps adding UTXOs until total >= peginAmount + fee
-    const result = selectUtxosForPegin(mockUTXOs, 150000n, 10, 2);
+    const result = selectUtxosForPegin(mockUTXOs, 150000n, 10, 2, null);
 
     // Should select at least 2 UTXOs
     expect(result.selectedUTXOs.length).toBeGreaterThanOrEqual(2);
 
     // Total should cover everything
-    expect(result.totalValue).toBeGreaterThanOrEqual(
-      150000n + result.fee,
-    );
+    expect(result.totalValue).toBeGreaterThanOrEqual(150000n + result.fee);
   });
 
   it("should throw when availableUTXOs contains duplicate txid:vout entries", () => {
@@ -144,9 +143,9 @@ describe("selectUtxosForPegin", () => {
       },
     ];
 
-    expect(() => selectUtxosForPegin(duplicateUTXOs, 50000n, 10, 2)).toThrow(
-      /Duplicate UTXO detected/,
-    );
+    expect(() =>
+      selectUtxosForPegin(duplicateUTXOs, 50000n, 10, 2, null),
+    ).toThrow(/Duplicate UTXO detected/);
   });
 
   it("should treat UTXOs with same txid but different vout as distinct", () => {
@@ -168,7 +167,7 @@ describe("selectUtxosForPegin", () => {
     ];
 
     expect(() =>
-      selectUtxosForPegin(sameHashDifferentVout, 50000n, 10, 2),
+      selectUtxosForPegin(sameHashDifferentVout, 50000n, 10, 2, null),
     ).not.toThrow();
   });
 
@@ -191,13 +190,25 @@ describe("selectUtxosForPegin", () => {
     ];
 
     expect(() =>
-      selectUtxosForPegin(mixedCaseDuplicates, 50000n, 10, 2),
+      selectUtxosForPegin(mixedCaseDuplicates, 50000n, 10, 2, null),
     ).toThrow(/Duplicate UTXO detected/);
   });
 
   it("should charge higher fee for more outputs", () => {
-    const feeWith2Outputs = selectUtxosForPegin(mockUTXOs, 50000n, 10, 2).fee;
-    const feeWith5Outputs = selectUtxosForPegin(mockUTXOs, 50000n, 10, 5).fee;
+    const feeWith2Outputs = selectUtxosForPegin(
+      mockUTXOs,
+      50000n,
+      10,
+      2,
+      null,
+    ).fee;
+    const feeWith5Outputs = selectUtxosForPegin(
+      mockUTXOs,
+      50000n,
+      10,
+      5,
+      null,
+    ).fee;
 
     // More outputs → larger tx → higher fee
     expect(feeWith5Outputs).toBeGreaterThan(feeWith2Outputs);
@@ -214,8 +225,7 @@ describe("selectUtxosForPegin", () => {
     // (baseFee + the absorbed 750 sats).
     const single: UTXO[] = [
       {
-        txid:
-          "0000000000000000000000000000000000000000000000000000000000000001",
+        txid: "0000000000000000000000000000000000000000000000000000000000000001",
         vout: 0,
         value: 100_000,
         scriptPubKey:
@@ -225,10 +235,113 @@ describe("selectUtxosForPegin", () => {
     const baseFee = 775n;
     const peginAmount = 100_000n - baseFee - 750n;
 
-    const result = selectUtxosForPegin(single, peginAmount, 5, 2);
+    const result = selectUtxosForPegin(single, peginAmount, 5, 2, null);
 
     expect(result.fee).toBe(baseFee + 750n);
     expect(result.changeAmount).toBe(0n);
+  });
+
+  it("accepts a selection that needs exactly maxInputCount inputs", () => {
+    // 120000 needs the two largest UTXOs (100000 + 50000).
+    const result = selectUtxosForPegin(mockUTXOs, 120000n, 10, 2, 2);
+
+    expect(result.selectedUTXOs).toHaveLength(2);
+  });
+
+  it("throws FundingInputCountExceededError when one more input than maxInputCount is needed", () => {
+    let thrown: unknown;
+    try {
+      selectUtxosForPegin(mockUTXOs, 120000n, 10, 2, 1);
+    } catch (err) {
+      thrown = err;
+    }
+
+    expect(thrown).toBeInstanceOf(FundingInputCountExceededError);
+    expect(isFundingInputCountExceededError(thrown)).toBe(true);
+    expect((thrown as FundingInputCountExceededError).maxInputCount).toBe(1);
+  });
+
+  it("selects more inputs than any bound would allow when maxInputCount is null", () => {
+    // 150000 + fee exceeds the two largest, so all three are needed.
+    const result = selectUtxosForPegin(mockUTXOs, 150000n, 10, 2, null);
+
+    expect(result.selectedUTXOs).toHaveLength(3);
+  });
+
+  it("rejects a maxInputCount that is not a positive integer", () => {
+    expect(() => selectUtxosForPegin(mockUTXOs, 50000n, 10, 2, 0)).toThrow(
+      "Invalid maxInputCount: expected a positive integer or null, got 0",
+    );
+    expect(() => selectUtxosForPegin(mockUTXOs, 50000n, 10, 2, 1.5)).toThrow(
+      "Invalid maxInputCount: expected a positive integer or null, got 1.5",
+    );
+  });
+});
+
+describe("computeFundingBudget", () => {
+  const invalidScriptUTXO: UTXO = {
+    txid: "0000000000000000000000000000000000000000000000000000000000000009",
+    vout: 0,
+    value: 999999,
+    // OP_PUSHDATA1 declaring 255 bytes that are not there — decompiles to null.
+    scriptPubKey: "4cff",
+  };
+
+  const budgetUTXOs: UTXO[] = [
+    {
+      txid: "0000000000000000000000000000000000000000000000000000000000000001",
+      vout: 0,
+      value: 30000,
+      scriptPubKey:
+        "5120abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+    },
+    {
+      txid: "0000000000000000000000000000000000000000000000000000000000000002",
+      vout: 0,
+      value: 70000,
+      scriptPubKey:
+        "5120fedcba0987654321fedcba0987654321fedcba0987654321fedcba0987654321",
+    },
+    {
+      txid: "0000000000000000000000000000000000000000000000000000000000000003",
+      vout: 0,
+      value: 50000,
+      scriptPubKey:
+        "51201111111111111111111111111111111111111111111111111111111111111111",
+    },
+  ];
+
+  it("returns the top-N UTXOs by value when a bound is given", () => {
+    expect(computeFundingBudget(budgetUTXOs, 2)).toEqual({
+      numInputs: 2,
+      totalBalance: 120000n,
+    });
+  });
+
+  it("returns every valid UTXO when maxInputCount is null", () => {
+    expect(computeFundingBudget(budgetUTXOs, null)).toEqual({
+      numInputs: 3,
+      totalBalance: 150000n,
+    });
+  });
+
+  it("ignores UTXOs with undecodable scripts", () => {
+    expect(
+      computeFundingBudget([invalidScriptUTXO, ...budgetUTXOs], 2),
+    ).toEqual({ numInputs: 2, totalBalance: 120000n });
+  });
+
+  it("returns an empty budget for an empty UTXO set", () => {
+    expect(computeFundingBudget([], 5)).toEqual({
+      numInputs: 0,
+      totalBalance: 0n,
+    });
+  });
+
+  it("rejects a maxInputCount that is not a positive integer", () => {
+    expect(() => computeFundingBudget(budgetUTXOs, 0)).toThrow(
+      "Invalid maxInputCount: expected a positive integer or null, got 0",
+    );
   });
 });
 

--- a/packages/babylon-ts-sdk/src/tbv/core/utils/utxo/fundingInputCountExceeded.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/utils/utxo/fundingInputCountExceeded.ts
@@ -1,0 +1,36 @@
+/**
+ * The funding-input bound error, in its own module so the ETH-only
+ * `tbv/core/contracts` subpath can throw it without pulling `bitcoinjs-lib`
+ * in through the selector. `scripts/check-eth-build.js` enforces that.
+ *
+ * @module utils/utxo/fundingInputCountExceeded
+ */
+
+/**
+ * Thrown when funding a Pre-PegIn would need more inputs than the
+ * protocol's on-chain `maxFundingInputCount` allows in one transaction.
+ */
+export class FundingInputCountExceededError extends Error {
+  public readonly maxInputCount: number;
+
+  constructor(maxInputCount: number) {
+    super(
+      `Funding this deposit needs more than ${maxInputCount} UTXOs, the most one Pre-PegIn may spend`,
+    );
+    this.name = "FundingInputCountExceededError";
+    this.maxInputCount = maxInputCount;
+  }
+}
+
+/**
+ * Type guard for {@link FundingInputCountExceededError}. Falls back to the
+ * `name` check so the guard still holds across module/realm boundaries.
+ */
+export function isFundingInputCountExceededError(
+  err: unknown,
+): err is FundingInputCountExceededError {
+  return (
+    err instanceof FundingInputCountExceededError ||
+    (err instanceof Error && err.name === "FundingInputCountExceededError")
+  );
+}

--- a/packages/babylon-ts-sdk/src/tbv/core/utils/utxo/selectUtxos.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/utils/utxo/selectUtxos.ts
@@ -46,6 +46,95 @@ export interface UTXOSelectionResult {
 }
 
 /**
+ * Thrown when funding a Pre-PegIn would need more inputs than the
+ * protocol's on-chain `maxFundingInputCount` allows in one transaction.
+ */
+export class FundingInputCountExceededError extends Error {
+  public readonly maxInputCount: number;
+
+  constructor(maxInputCount: number) {
+    super(
+      `Funding this deposit needs more than ${maxInputCount} UTXOs, the most one Pre-PegIn may spend`,
+    );
+    this.name = "FundingInputCountExceededError";
+    this.maxInputCount = maxInputCount;
+  }
+}
+
+/**
+ * Type guard for {@link FundingInputCountExceededError}. Falls back to the
+ * `name` check so the guard still holds across module/realm boundaries.
+ */
+export function isFundingInputCountExceededError(
+  err: unknown,
+): err is FundingInputCountExceededError {
+  return (
+    err instanceof FundingInputCountExceededError ||
+    (err instanceof Error && err.name === "FundingInputCountExceededError")
+  );
+}
+
+/**
+ * Validate the caller-stated funding-input bound. `null` means the
+ * deployment publishes no bound; any other value must be a usable count.
+ */
+function assertMaxInputCount(maxInputCount: number | null): void {
+  if (
+    maxInputCount !== null &&
+    (!Number.isInteger(maxInputCount) || maxInputCount < 1)
+  ) {
+    throw new Error(
+      `Invalid maxInputCount: expected a positive integer or null, got ${maxInputCount}`,
+    );
+  }
+}
+
+/**
+ * Filter for script validity ONLY (matching btc-staking-ts approach) and
+ * sort by value, highest first. No minimum value filter — any UTXO with a
+ * decodable script is spendable here.
+ *
+ * Shared by the selector and {@link computeFundingBudget} so the maximum
+ * a depositor is offered is computed over exactly the UTXOs the selector
+ * would reach for, in the same order.
+ */
+function selectableUtxosLargestFirst(availableUTXOs: UTXO[]): UTXO[] {
+  const validUTXOs = availableUTXOs.filter((utxo) => {
+    const script = Buffer.from(utxo.scriptPubKey, "hex");
+    const decompiledScript = bitcoinScript.decompile(script);
+    return !!decompiledScript;
+  });
+  // Use spread to avoid mutating the original array
+  return [...validUTXOs].sort((a, b) => b.value - a.value);
+}
+
+/**
+ * The inputs and balance a Pre-PegIn may actually spend under the
+ * protocol's funding-input bound: the largest `maxInputCount` valid UTXOs
+ * (all of them when `maxInputCount` is null).
+ *
+ * @param availableUTXOs - All available UTXOs from wallet
+ * @param maxInputCount - Protocol `maxFundingInputCount`, or null when the deployment publishes no bound
+ * @returns Number of spendable inputs and their summed value (satoshis)
+ * @throws Error if `maxInputCount` is neither null nor a positive integer
+ */
+export function computeFundingBudget(
+  availableUTXOs: UTXO[],
+  maxInputCount: number | null,
+): { numInputs: number; totalBalance: bigint } {
+  assertMaxInputCount(maxInputCount);
+
+  const sortedUTXOs = selectableUtxosLargestFirst(availableUTXOs);
+  const spendable =
+    maxInputCount === null ? sortedUTXOs : sortedUTXOs.slice(0, maxInputCount);
+
+  return {
+    numInputs: spendable.length,
+    totalBalance: spendable.reduce((sum, u) => sum + BigInt(u.value), 0n),
+  };
+}
+
+/**
  * Assert that no two UTXOs share the same txid:vout outpoint.
  * Duplicates from a buggy or compromised UTXO source would produce
  * an invalid Bitcoin transaction that double-spends the same outpoint.
@@ -81,14 +170,20 @@ function assertNoDuplicateUtxos(utxos: UTXO[]): void {
  * @param peginAmount - Amount to peg in (satoshis)
  * @param feeRate - Fee rate (sat/vbyte)
  * @param numOutputs - Number of outputs in the unfunded transaction (HTLC + CPFP anchor, before change)
+ * @param maxInputCount - Protocol `maxFundingInputCount`: the most inputs one
+ *   Pre-PegIn may spend, or null when the deployment publishes no bound. The
+ *   bound is exclusive in the same sense as the registry's `>` check —
+ *   exactly `maxInputCount` inputs is accepted, needing one more is rejected.
  * @returns Selected UTXOs, total value, calculated fee, and change amount
- * @throws Error if insufficient funds or no valid UTXOs
+ * @throws Error if insufficient funds, no valid UTXOs, or `maxInputCount` is neither null nor a positive integer
+ * @throws FundingInputCountExceededError if funding would need more than `maxInputCount` inputs
  */
 export function selectUtxosForPegin(
   availableUTXOs: UTXO[],
   peginAmount: bigint,
   feeRate: number,
   numOutputs: number,
+  maxInputCount: number | null,
 ): UTXOSelectionResult {
   if (!Number.isInteger(numOutputs) || numOutputs < 1) {
     throw new Error(
@@ -96,29 +191,21 @@ export function selectUtxosForPegin(
     );
   }
 
+  assertMaxInputCount(maxInputCount);
+
   if (availableUTXOs.length === 0) {
     throw new Error("Insufficient funds: no UTXOs available");
   }
 
   assertNoDuplicateUtxos(availableUTXOs);
 
-  // Filter for script validity ONLY (matching btc-staking-ts approach)
-  // No minimum value filter - we accept any UTXO with valid script
-  const validUTXOs = availableUTXOs.filter((utxo) => {
-    const script = Buffer.from(utxo.scriptPubKey, "hex");
-    const decompiledScript = bitcoinScript.decompile(script);
-    return !!decompiledScript;
-  });
+  const sortedUTXOs = selectableUtxosLargestFirst(availableUTXOs);
 
-  if (validUTXOs.length === 0) {
+  if (sortedUTXOs.length === 0) {
     throw new Error(
       "Insufficient funds: no valid UTXOs available (all have invalid scripts)",
     );
   }
-
-  // Sort by value: HIGHEST to LOWEST (use big UTXOs first)
-  // Use spread to avoid mutating the original array
-  const sortedUTXOs = [...validUTXOs].sort((a, b) => b.value - a.value);
 
   const selectedUTXOs: UTXO[] = [];
   let accumulatedValue = 0n;
@@ -131,6 +218,12 @@ export function selectUtxosForPegin(
   // selector charged for — silent depositor overpayment at the dust
   // boundary.
   for (const utxo of sortedUTXOs) {
+    // Reject before the push, so a selection that would need input
+    // `maxInputCount + 1` never reaches the fee math or the caller — the
+    // registry rejects `inputCount > maxFundingInputCount`.
+    if (maxInputCount !== null && selectedUTXOs.length >= maxInputCount) {
+      throw new FundingInputCountExceededError(maxInputCount);
+    }
     selectedUTXOs.push(utxo);
     accumulatedValue += BigInt(utxo.value);
 

--- a/packages/babylon-ts-sdk/src/tbv/core/utils/utxo/selectUtxos.ts
+++ b/packages/babylon-ts-sdk/src/tbv/core/utils/utxo/selectUtxos.ts
@@ -12,6 +12,12 @@ import {
   computeChangeOutputFeeSats,
   computePeginBaseFeeSats,
 } from "../fee/peginFeeMath";
+import { FundingInputCountExceededError } from "./fundingInputCountExceeded";
+
+export {
+  FundingInputCountExceededError,
+  isFundingInputCountExceededError,
+} from "./fundingInputCountExceeded";
 
 /**
  * Unspent Transaction Output (UTXO) for funding peg-in transactions.
@@ -43,35 +49,6 @@ export interface UTXOSelectionResult {
   totalValue: bigint;
   fee: bigint;
   changeAmount: bigint;
-}
-
-/**
- * Thrown when funding a Pre-PegIn would need more inputs than the
- * protocol's on-chain `maxFundingInputCount` allows in one transaction.
- */
-export class FundingInputCountExceededError extends Error {
-  public readonly maxInputCount: number;
-
-  constructor(maxInputCount: number) {
-    super(
-      `Funding this deposit needs more than ${maxInputCount} UTXOs, the most one Pre-PegIn may spend`,
-    );
-    this.name = "FundingInputCountExceededError";
-    this.maxInputCount = maxInputCount;
-  }
-}
-
-/**
- * Type guard for {@link FundingInputCountExceededError}. Falls back to the
- * `name` check so the guard still holds across module/realm boundaries.
- */
-export function isFundingInputCountExceededError(
-  err: unknown,
-): err is FundingInputCountExceededError {
-  return (
-    err instanceof FundingInputCountExceededError ||
-    (err instanceof Error && err.name === "FundingInputCountExceededError")
-  );
 }
 
 /**
@@ -176,7 +153,10 @@ function assertNoDuplicateUtxos(utxos: UTXO[]): void {
  *   exactly `maxInputCount` inputs is accepted, needing one more is rejected.
  * @returns Selected UTXOs, total value, calculated fee, and change amount
  * @throws Error if insufficient funds, no valid UTXOs, or `maxInputCount` is neither null nor a positive integer
- * @throws FundingInputCountExceededError if funding would need more than `maxInputCount` inputs
+ * @throws FundingInputCountExceededError if funding would need more than
+ *   `maxInputCount` inputs and the full valid set could have covered the
+ *   target; a wallet whose whole valid set falls short throws insufficient
+ *   funds instead
  */
 export function selectUtxosForPegin(
   availableUTXOs: UTXO[],
@@ -218,12 +198,6 @@ export function selectUtxosForPegin(
   // selector charged for — silent depositor overpayment at the dust
   // boundary.
   for (const utxo of sortedUTXOs) {
-    // Reject before the push, so a selection that would need input
-    // `maxInputCount + 1` never reaches the fee math or the caller — the
-    // registry rejects `inputCount > maxFundingInputCount`.
-    if (maxInputCount !== null && selectedUTXOs.length >= maxInputCount) {
-      throw new FundingInputCountExceededError(maxInputCount);
-    }
     selectedUTXOs.push(utxo);
     accumulatedValue += BigInt(utxo.value);
 
@@ -237,6 +211,18 @@ export function selectUtxosForPegin(
     if (accumulatedValue < peginAmount + baseFee) {
       estimatedFee = baseFee;
       continue;
+    }
+
+    // Only once this prefix can actually fund the deposit: a wallet whose
+    // whole valid set falls short is short of funds, not over the input
+    // bound, and "consolidate your UTXOs" cannot fix a shortfall. Largest-
+    // first prefixes are the best k-input subsets for every k and the fee
+    // depends only on k, so reaching this line at all means no selection
+    // within the bound could have funded it either. The fee math above is
+    // pure integer arithmetic, so running it for the rejected input costs
+    // nothing.
+    if (maxInputCount !== null && selectedUTXOs.length > maxInputCount) {
+      throw new FundingInputCountExceededError(maxInputCount);
     }
 
     const policy = applyChangeOutputPolicy({

--- a/services/vault/src/components/simple/DepositForm.tsx
+++ b/services/vault/src/components/simple/DepositForm.tsx
@@ -162,6 +162,21 @@ export interface DepositGatingState {
    */
   vaultCountCapUnavailable?: boolean;
   /**
+   * True when the chain publishes no funding-input bound — fail closed (block
+   * the CTA), since the registry would reject a Pre-PegIn built without one.
+   */
+  fundingInputBoundUnpublished?: boolean;
+  /**
+   * True when the funding-input bound read terminally failed — fail closed, so
+   * a deposit can't be built against an unverified UTXO limit.
+   */
+  fundingInputBoundUnavailable?: boolean;
+  /**
+   * True when the funding-input bound, not the balance, caps the depositable
+   * maximum. Advisory only: shows an inline notice, never blocks.
+   */
+  fundingInputCapBites?: boolean;
+  /**
    * True when a single vault still fits but a 2-vault split would exceed the
    * cap — the deposit proceeds as a single vault and we surface the inline
    * "split unavailable" hint. The reason picks which hint: only the
@@ -245,6 +260,9 @@ export function DepositForm({
     ordinalsCheckPending = false,
     isVaultCapReached = false,
     vaultCountCapUnavailable = false,
+    fundingInputBoundUnpublished = false,
+    fundingInputBoundUnavailable = false,
+    fundingInputCapBites = false,
     splitUnavailableReason = null,
     vaultCapUsage,
   } = gatingState;
@@ -334,6 +352,24 @@ export function DepositForm({
     !!selectedProvider && selectedProviderCommissionBps === undefined;
 
   const hasAmount = !!amount && amount !== "0";
+
+  // Explains a Max that reads lower than the wallet balance: the depositor
+  // holds more UTXOs than one Pre-Pegin may spend. Withheld until there is a
+  // resolved max and a chosen provider, so it never appears beside a "--".
+  const fundingInputCapNotice =
+    fundingInputCapBites && hasAmount && !!selectedProvider && isMaxResolved ? (
+      <span className="inline-flex items-center gap-1 text-accent-secondary">
+        {COPY.deposit.form.fundingInputCapNotice(maxDepositLabel)}
+        {/* A bare Hint renders a div, which is invalid inside the p container. */}
+        <Hint
+          tooltip={COPY.deposit.form.fundingInputCapTooltip}
+          attachToChildren
+        >
+          <InfoIcon size={16} className="text-accent-secondary" />
+        </Hint>
+      </span>
+    ) : null;
+
   const isFeeError = hasAmount && !isLoadingFee && !!feeError;
   const feeDisabled =
     isLoadingFee ||
@@ -416,11 +452,16 @@ export function DepositForm({
           inputClassName="h-10 w-auto rounded-lg bg-primary-contrast px-4 [field-sizing:content]"
         />
         <p
-          className={pendingConfirmationNotice ? "text-sm" : "sr-only"}
+          className={
+            pendingConfirmationNotice || fundingInputCapNotice
+              ? "text-sm"
+              : "sr-only"
+          }
           role="status"
           aria-live="polite"
         >
           {pendingConfirmationNotice}
+          {fundingInputCapNotice}
         </p>
         <CollateralFactorRow
           collateralFactor={collateralFactor}
@@ -496,17 +537,23 @@ export function DepositForm({
           cta.disabled ||
           isVerifyingWallet ||
           isVaultCapReached ||
-          vaultCountCapUnavailable
+          vaultCountCapUnavailable ||
+          fundingInputBoundUnpublished ||
+          fundingInputBoundUnavailable
         }
         onClick={onDeposit}
       >
-        {isVaultCapReached
-          ? COPY.deposit.maxVaultsReached.cta
-          : vaultCountCapUnavailable
-            ? COPY.deposit.maxVaultsReached.unavailableCta
-            : isVerifyingWallet
-              ? "Checking wallet..."
-              : ctaLabel}
+        {fundingInputBoundUnpublished
+          ? COPY.deposit.fundingInputBound.pausedCta
+          : fundingInputBoundUnavailable
+            ? COPY.deposit.fundingInputBound.unavailableCta
+            : isVaultCapReached
+              ? COPY.deposit.maxVaultsReached.cta
+              : vaultCountCapUnavailable
+                ? COPY.deposit.maxVaultsReached.unavailableCta
+                : isVerifyingWallet
+                  ? "Checking wallet..."
+                  : ctaLabel}
       </DepositButton>
 
       {/* Fee breakdown */}

--- a/services/vault/src/components/simple/DepositProgressView/FeeRateSelector.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/FeeRateSelector.tsx
@@ -18,6 +18,10 @@ import { MIN_RELAY_FEE_RATE_SATS_VB } from "@/constants";
 import { useBTCWallet } from "@/context/wallet";
 import { COPY } from "@/copy";
 import { useEstimatedBtcFee } from "@/hooks/deposit/useEstimatedBtcFee";
+import {
+  resolveMaxInputCount,
+  useFundingInputBound,
+} from "@/hooks/deposit/useFundingInputBound";
 import { useNetworkFees } from "@/hooks/useNetworkFees";
 import { useUTXOs } from "@/hooks/useUTXOs";
 import { satoshiToBtcNumber } from "@/utils/btcConversion";
@@ -69,10 +73,12 @@ export function FeeRateSelector({
     [vaultAmounts],
   );
   const numOutputs = peginOutputCount(vaultAmounts.length, true);
+  const { bound: fundingInputBound } = useFundingInputBound();
   const estimatedFee = useEstimatedBtcFee(
     totalAmountSats,
     spendableMempoolUTXOs,
     numOutputs,
+    resolveMaxInputCount(fundingInputBound),
     feeRate,
   );
 

--- a/services/vault/src/components/simple/DepositProgressView/__tests__/FeeRateSelector.test.tsx
+++ b/services/vault/src/components/simple/DepositProgressView/__tests__/FeeRateSelector.test.tsx
@@ -23,6 +23,15 @@ vi.mock("@/hooks/deposit/useEstimatedBtcFee", () => ({
   useEstimatedBtcFee: vi.fn(),
 }));
 
+// The bound is a React Query read; stubbed so these tests need no QueryClient.
+vi.mock("@/hooks/deposit/useFundingInputBound", () => ({
+  useFundingInputBound: vi.fn(() => ({
+    bound: { status: "published", maxInputs: 20 },
+    isError: false,
+  })),
+  resolveMaxInputCount: vi.fn(() => 20),
+}));
+
 // Slow=2, Avg=5, Fast=10 — kept low so nextPowerOfTwo(fastest) < 128 and the
 // custom-input cap is pinned at the LEAST_MAX_FEE_RATE floor for every test.
 const FEE_TIERS = {

--- a/services/vault/src/components/simple/SimpleDeposit.tsx
+++ b/services/vault/src/components/simple/SimpleDeposit.tsx
@@ -142,6 +142,10 @@ function SimpleDepositContent({
     btcPublicKeyError,
     refetchBtcPublicKey,
     ordinalsCheckPending,
+    maxInputCount,
+    fundingInputBoundUnpublished,
+    fundingInputBoundUnavailable,
+    fundingInputCapBites,
     validateForm,
     resetForm,
   } = useDepositPageForm();
@@ -297,6 +301,7 @@ function SimpleDepositContent({
     estimatedFeeRate,
     depositorClaimValue,
     minPeginFee,
+    maxInputCount,
   });
   const [overlappingPendingVaultCount, setOverlappingPendingVaultCount] =
     useState<number | null>(null);
@@ -356,6 +361,11 @@ function SimpleDepositContent({
     // position past the on-chain cap, or when the cap couldn't be read (fail
     // closed) — defense-in-depth behind the disabled CTA.
     if (isVaultCapReached || vaultCountCapUnavailable) return;
+
+    // Same fail-closed shape for the on-chain funding-input bound: the registry
+    // rejects a Pre-PegIn built without one, and an unreadable bound means we
+    // cannot know how many UTXOs the selector may spend.
+    if (fundingInputBoundUnpublished || fundingInputBoundUnavailable) return;
 
     // The CTA doubles as the recovery action when the wallet-liveness probe
     // has failed OR the proactive lock poll has flagged a silently-locked
@@ -522,6 +532,9 @@ function SimpleDepositContent({
                   ordinalsCheckPending,
                   isVaultCapReached,
                   vaultCountCapUnavailable,
+                  fundingInputBoundUnpublished,
+                  fundingInputBoundUnavailable,
+                  fundingInputCapBites,
                   splitUnavailableReason,
                   // Usage figures only make sense for the per-position cap; the
                   // protocol cap can bite with an empty position and an unknown

--- a/services/vault/src/components/simple/__tests__/DepositForm.fundingInputBound.test.tsx
+++ b/services/vault/src/components/simple/__tests__/DepositForm.fundingInputBound.test.tsx
@@ -1,0 +1,160 @@
+/**
+ * The CTA gate for the on-chain funding-input bound.
+ *
+ * Both blocked states fail closed: a Pre-PegIn built against no bound, or
+ * against a bound that could not be read, is one the registry rejects after
+ * the depositor has already signed. A regression here would not produce an
+ * over-limit transaction — `useDepositFlow` still aborts — it would let a
+ * depositor start a deposit that cannot finish.
+ */
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { COPY } from "@/copy";
+
+import {
+  DepositForm,
+  type DepositAmountState,
+  type DepositFeeState,
+  type DepositGatingState,
+  type DepositProviderState,
+  type DepositWalletState,
+} from "../DepositForm";
+
+vi.mock("@/config", () => ({
+  getNetworkConfigBTC: () => ({
+    coinSymbol: "BTC",
+    name: "Bitcoin",
+    icon: "bitcoin.svg",
+  }),
+}));
+
+vi.mock("@/services/deposit", async () => {
+  const actual =
+    await vi.importActual<typeof import("@/services/deposit")>(
+      "@/services/deposit",
+    );
+  return {
+    ...actual,
+    depositService: {
+      ...actual.depositService,
+      getDepositCtaState: () => ({ disabled: false, label: "Deposit" }),
+    },
+  };
+});
+
+vi.mock("../DepositFeesBreakdown", () => ({
+  DepositFeesBreakdown: () => null,
+}));
+vi.mock("../VaultProviderSelectorV3", () => ({
+  VaultProviderSelectorV3: () => null,
+}));
+// Forwards `disabled`, unlike the sibling suites' stub — the gate under test
+// is exactly that prop.
+vi.mock("@/components/shared", () => ({
+  DepositButton: ({
+    children,
+    disabled,
+  }: {
+    children: React.ReactNode;
+    disabled?: boolean;
+  }) => (
+    <button type="button" disabled={disabled}>
+      {children}
+    </button>
+  ),
+}));
+
+const amountState: DepositAmountState = {
+  amount: "",
+  amountSats: 0n,
+  btcBalance: 100_000_000n,
+  unconfirmedBalance: 0n,
+  minDeposit: 10_000n,
+  maxDeposit: 100_000_000n,
+  maxDepositSats: 100_000_000n,
+  effectiveRemaining: null,
+  capUnavailable: false,
+  suggestedAmountSats: null,
+};
+
+const feeState: DepositFeeState = {
+  minPeginFee: 0n,
+  minPeginFeeError: null,
+  btcPrice: 60_000,
+  hasPriceFetchError: false,
+  estimatedFeeSats: 0n,
+  estimatedFeeRate: 1,
+  isLoadingFee: false,
+  feeError: null,
+  depositorClaimValue: 0n,
+  commissionBaseValues: undefined,
+  appVersionUnsupported: false,
+  p2aAnchorValueSats: 0n,
+  depositorClaimValueError: null,
+  protocolFeeAmount: "--",
+  protocolFeePrice: "",
+  protocolFeeIsError: false,
+  feeRows: [],
+};
+
+const providerState: DepositProviderState = {
+  providers: [],
+  isLoadingProviders: false,
+  selectedProvider: "",
+  onProviderSelect: vi.fn(),
+};
+
+const walletState: DepositWalletState = {
+  isWalletConnected: true,
+};
+
+function renderForm(gatingOverrides: Partial<DepositGatingState>) {
+  const gatingState: DepositGatingState = {
+    isDepositDisabled: false,
+    isGeoBlocked: false,
+    isAddressBlocked: false,
+    ...gatingOverrides,
+  };
+  render(
+    <DepositForm
+      amountState={amountState}
+      feeState={feeState}
+      providerState={providerState}
+      walletState={walletState}
+      gatingState={gatingState}
+      collateralFactor={null}
+      twoVaultSplit={undefined}
+      onAmountChange={vi.fn()}
+      onMaxClick={vi.fn()}
+      onDeposit={vi.fn()}
+    />,
+  );
+}
+
+describe("DepositForm funding-input bound gate", () => {
+  it("disables the CTA when the chain publishes no bound", () => {
+    renderForm({ fundingInputBoundUnpublished: true });
+
+    const cta = screen.getByRole("button", {
+      name: COPY.deposit.fundingInputBound.pausedCta,
+    });
+    expect(cta).toBeDisabled();
+  });
+
+  it("disables the CTA when the bound read failed", () => {
+    renderForm({ fundingInputBoundUnavailable: true });
+
+    const cta = screen.getByRole("button", {
+      name: COPY.deposit.fundingInputBound.unavailableCta,
+    });
+    expect(cta).toBeDisabled();
+  });
+
+  it("leaves the CTA enabled once the bound resolves", () => {
+    renderForm({});
+
+    expect(screen.getByRole("button", { name: "Deposit" })).toBeEnabled();
+  });
+});

--- a/services/vault/src/components/simple/__tests__/ResumeDepositContent.test.tsx
+++ b/services/vault/src/components/simple/__tests__/ResumeDepositContent.test.tsx
@@ -50,6 +50,7 @@ vi.mock("@babylonlabs-io/ts-sdk/tbv/core", () => ({
   expandWotsSeed: vi.fn(() => new Uint8Array(32)),
   hexToUint8Array: vi.fn(() => new Uint8Array(32)),
   isDepositTermsRejectedError: vi.fn(() => false),
+  isFundingInputCountExceededError: vi.fn(() => false),
   isWotsMismatchError: vi.fn(() => false),
   isRegisteredVaultVersionMismatchError: vi.fn(() => false),
   isApplicationEntryPointMismatchError: vi.fn(() => false),

--- a/services/vault/src/copy.ts
+++ b/services/vault/src/copy.ts
@@ -305,6 +305,14 @@ export const COPY = {
       splitUnavailableProtocolLimit:
         "The protocol currently allows one BTCVault per transaction. BTCVault split unavailable.",
     },
+    // CTA labels for the on-chain funding-input bound. `pausedCta` is the
+    // chain publishing no bound at all (fail closed: a Pre-PegIn built without
+    // one would be rejected by the registry); `unavailableCta` is the read
+    // itself failing, which is recoverable by retrying.
+    fundingInputBound: {
+      pausedCta: "Peg-ins temporarily unavailable",
+      unavailableCta: "Unable to verify UTXO limit — please try again",
+    },
     steps: {
       generateSecret: "Generate secret for the deposit",
       signPeginBtc: "Sign the peg-in BTC transaction",
@@ -707,6 +715,13 @@ export const COPY = {
         `${amount} pending confirmation`,
       pendingConfirmationTooltip:
         "Only balances confirmed in a Bitcoin block are shown here. This amount is still waiting to confirm.",
+      // Shown when the on-chain funding-input bound, not the balance, is what
+      // caps the depositable maximum. Names the maximum rather than the UTXO
+      // count: the count is the cause, the amount is what the depositor acts on.
+      fundingInputCapNotice: (maxWithSymbol: string) =>
+        `You can deposit up to ${maxWithSymbol} with your current Bitcoin UTXOs`,
+      fundingInputCapTooltip:
+        "One deposit can spend at most a limited number of Bitcoin UTXOs. To deposit more, consolidate your UTXOs in your wallet first.",
       doNotSplit: "Do not split",
       selectVaultProvider: "Select vault provider",
       providerSelectDescription: "Choose a vault provider to secure your BTC",
@@ -1007,6 +1022,22 @@ export const COPY = {
       vaultCountLimitChanged: {
         title: "BTCVault limit changed",
         body: `The number of BTCVaults allowed in a single transaction changed while we were preparing your deposit, and this deposit asks for more than the new limit. ${NOTHING_SIGNED_OR_SPENT} — please start the deposit again without splitting across BTCVaults.`,
+      },
+      // Pre-signing, and the chain stopped publishing its funding-input bound.
+      // Nothing the depositor chose can fix it, so the copy offers no action
+      // beyond waiting — unlike the two above, which send them back to the form.
+      peginsPaused: {
+        title: "Peg-ins temporarily unavailable",
+        body: `The protocol stopped publishing its UTXO limit while we were preparing your deposit, so new deposits are paused. ${NOTHING_SIGNED_OR_SPENT} — please try again later.`,
+      },
+      // Pre-signing, and funding this deposit needs more Bitcoin UTXOs than one
+      // Pre-Pegin may spend. The fix is in the wallet, not the form, so the
+      // copy names consolidation rather than a different amount. `title`
+      // doubles as the fee estimator's error string, which becomes the CTA
+      // label — the same sentence in both places, held in one.
+      tooManyFundingInputs: {
+        title: "Too many UTXOs for one deposit",
+        body: `This deposit would spend more Bitcoin UTXOs than the protocol allows in a single transaction. ${NOTHING_SIGNED_OR_SPENT} — consolidate your UTXOs in your wallet and start the deposit again.`,
       },
       participantKeyDrift: {
         title: "Vault operator keys changed",

--- a/services/vault/src/hooks/deposit/__tests__/useDepositFlow.test.tsx
+++ b/services/vault/src/hooks/deposit/__tests__/useDepositFlow.test.tsx
@@ -9,6 +9,7 @@ import type { BitcoinWallet } from "@babylonlabs-io/ts-sdk/shared";
 import type {
   DepositTerms,
   DepositTermsApprover,
+  FundingInputBound,
 } from "@babylonlabs-io/ts-sdk/tbv/core";
 import { act, renderHook, waitFor } from "@testing-library/react";
 import type { Address, Hex } from "viem";
@@ -25,6 +26,7 @@ import { COPY } from "@/copy";
 
 import { DepositFlowStep } from "../depositFlowSteps";
 import { useDepositFlow } from "../useDepositFlow";
+import { FUNDING_INPUT_BOUND_QUERY_KEY } from "../useFundingInputBound";
 
 const DEPOSIT_ERRORS = COPY.deposit.errors;
 
@@ -107,6 +109,12 @@ const chainMocks = vi.hoisted(() => {
     /** Block the flow pins its protocol-state reads to. */
     pinnedBlock: 4_242_042n,
     getPegInConfiguration: vi.fn(async () => peginConfig),
+    getMaxFundingInputCount: vi.fn(
+      async (): Promise<FundingInputBound> => ({
+        status: "published",
+        maxInputs: 20,
+      }),
+    ),
   };
 });
 
@@ -123,6 +131,7 @@ vi.mock("@/clients/eth-contract/sdk-readers", () => ({
   getOperationKeyReader: vi.fn(async () => ({})),
   getProtocolParamsReader: vi.fn(async () => ({
     getPegInConfiguration: chainMocks.getPegInConfiguration,
+    getMaxFundingInputCount: chainMocks.getMaxFundingInputCount,
   })),
 }));
 
@@ -149,9 +158,10 @@ vi.mock("@/hooks/useProtocolGate", () => ({
 }));
 
 // Avoid threading a real QueryClientProvider through every renderHook —
-// `useDepositFlow` uses the client for two things: invalidating the UTXO query
-// after broadcast, and seeding the peg-in config cache when a drift guard
-// aborts. Hoisted rather than inline so the seed can be asserted.
+// `useDepositFlow` uses the client for three things: invalidating the UTXO
+// query after broadcast, seeding the peg-in config cache when a drift guard
+// aborts, and refreshing the funding-input bound cache from every pinned build
+// read. Hoisted rather than inline so those writes can be asserted.
 const queryClientMocks = vi.hoisted(() => ({
   invalidateQueries: vi.fn(),
   setQueryData: vi.fn(),
@@ -1170,6 +1180,63 @@ describe("useDepositFlow", () => {
       );
     });
 
+    it("aborts before building and seeds the bound cache when the chain publishes no funding-input bound", async () => {
+      const { preparePeginTransaction } = vi.mocked(
+        await import("@/services/vault/vaultTransactionService"),
+      );
+
+      const unpublished: FundingInputBound = { status: "unpublished" };
+      chainMocks.getMaxFundingInputCount.mockResolvedValueOnce(unpublished);
+
+      const { result } = renderHook(() => useDepositFlow(MOCK_PARAMS));
+
+      await executeDepositFlow(result);
+
+      await waitFor(() => {
+        // Its own callout: nothing the depositor chose can fix an unpublished
+        // bound, so it must not share the "start again" copy of its siblings.
+        expect(result.current.error).toEqual(DEPOSIT_ERRORS.peginsPaused);
+      });
+      expect(preparePeginTransaction).not.toHaveBeenCalled();
+      // The bound has its own key, so the config seed above cannot repair it —
+      // without this a reopened form re-reads the stale published bound and
+      // fails here identically.
+      expect(queryClientMocks.setQueryData).toHaveBeenCalledWith(
+        FUNDING_INPUT_BOUND_QUERY_KEY,
+        unpublished,
+      );
+    });
+
+    it("refreshes the cached bound from the pinned read before building", async () => {
+      const { preparePeginTransaction } = vi.mocked(
+        await import("@/services/vault/vaultTransactionService"),
+      );
+
+      // Governance lowered the bound below the 20 the form sized its Max
+      // against. Nothing aborts here — the SDK would reject the selection
+      // outside the drift guard — so only the unconditional refresh stops a
+      // restarted form offering the same unfundable Max again.
+      const lowered: FundingInputBound = { status: "published", maxInputs: 10 };
+      chainMocks.getMaxFundingInputCount.mockResolvedValueOnce(lowered);
+
+      const { result } = renderHook(() => useDepositFlow(MOCK_PARAMS));
+
+      await executeDepositFlow(result);
+
+      await waitFor(() => {
+        expect(preparePeginTransaction).toHaveBeenCalled();
+      });
+      expect(queryClientMocks.setQueryData).toHaveBeenCalledWith(
+        FUNDING_INPUT_BOUND_QUERY_KEY,
+        lowered,
+      );
+      expect(preparePeginTransaction).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        expect.objectContaining({ maxFundingInputCount: 10 }),
+      );
+    });
+
     it("does not touch the config cache when the abort is not drift", async () => {
       // The seed overwrites a key the blocking ProtocolParamsProvider and the
       // polling hook both read. A TypeError from the guard establishes nothing
@@ -1188,7 +1255,16 @@ describe("useDepositFlow", () => {
       await waitFor(() => {
         expect(result.current.error).not.toBeNull();
       });
-      expect(queryClientMocks.setQueryData).not.toHaveBeenCalled();
+      // Scoped to the config key: the bound cache is refreshed unconditionally
+      // from the pinned read, which succeeded, so it is legitimately written on
+      // this path too.
+      const { pegInConfigQueryOptions } = await vi.importActual<
+        typeof import("@/context/ProtocolParamsContext")
+      >("@/context/ProtocolParamsContext");
+      expect(queryClientMocks.setQueryData).not.toHaveBeenCalledWith(
+        pegInConfigQueryOptions().queryKey,
+        expect.anything(),
+      );
     });
 
     it("leaves the config cache alone when the build succeeds", async () => {
@@ -1201,7 +1277,13 @@ describe("useDepositFlow", () => {
       await waitFor(() => {
         expect(chainMocks.getPegInConfiguration).toHaveBeenCalled();
       });
-      expect(queryClientMocks.setQueryData).not.toHaveBeenCalled();
+      const { pegInConfigQueryOptions } = await vi.importActual<
+        typeof import("@/context/ProtocolParamsContext")
+      >("@/context/ProtocolParamsContext");
+      expect(queryClientMocks.setQueryData).not.toHaveBeenCalledWith(
+        pegInConfigQueryOptions().queryKey,
+        expect.anything(),
+      );
     });
 
     it("aborts before building when the pinned HTLC output cap is below the vault count", async () => {

--- a/services/vault/src/hooks/deposit/__tests__/useDepositFlow.test.tsx
+++ b/services/vault/src/hooks/deposit/__tests__/useDepositFlow.test.tsx
@@ -1205,6 +1205,16 @@ describe("useDepositFlow", () => {
         FUNDING_INPUT_BOUND_QUERY_KEY,
         unpublished,
       );
+      // The peg-in configuration did not drift on this path, so the drift
+      // catch's overwrite must not reach it — that cache is also read by the
+      // blocking ProtocolParamsProvider.
+      const { pegInConfigQueryOptions } = await vi.importActual<
+        typeof import("@/context/ProtocolParamsContext")
+      >("@/context/ProtocolParamsContext");
+      expect(queryClientMocks.setQueryData).not.toHaveBeenCalledWith(
+        pegInConfigQueryOptions().queryKey,
+        expect.anything(),
+      );
     });
 
     it("refreshes the cached bound from the pinned read before building", async () => {
@@ -1229,6 +1239,11 @@ describe("useDepositFlow", () => {
       expect(queryClientMocks.setQueryData).toHaveBeenCalledWith(
         FUNDING_INPUT_BOUND_QUERY_KEY,
         lowered,
+      );
+      // The bound has to describe the same block as the config and the
+      // participant keys, or the Pre-PegIn is built from mixed chain states.
+      expect(chainMocks.getMaxFundingInputCount).toHaveBeenCalledWith(
+        chainMocks.pinnedBlock,
       );
       expect(preparePeginTransaction).toHaveBeenCalledWith(
         expect.anything(),

--- a/services/vault/src/hooks/deposit/__tests__/useDepositPageForm.test.tsx
+++ b/services/vault/src/hooks/deposit/__tests__/useDepositPageForm.test.tsx
@@ -71,15 +71,36 @@ vi.mock("../../../applications/aave/context", () => ({
   })),
 }));
 
+import { useApplicationCap } from "../../useApplicationCap";
 import { useApplications } from "../../useApplications";
 import { useBtcPublicKey } from "../../useBtcPublicKey";
 import { useUTXOs } from "../../useUTXOs";
 import { useAllocationPlanning } from "../useAllocationPlanning";
 import { useDepositPageForm } from "../useDepositPageForm";
 import { useEstimatedBtcFee } from "../useEstimatedBtcFee";
+import { resolveMaxInputCount } from "../useFundingInputBound";
 import { useVaultProviders } from "../useVaultProviders";
 
 vi.mock("@babylonlabs-io/ts-sdk/tbv/core", () => ({
+  // Stands in for the real budget: drop UTXOs whose script does not decode,
+  // take the largest `maxInputCount`, sum them. `scriptPubKey: null` marks the
+  // undecodable ones here; the real filter is covered in the SDK's own tests.
+  computeFundingBudget: vi.fn(
+    (
+      utxos: Array<{ value: number; scriptPubKey: string | null }>,
+      maxInputCount: number | null,
+    ) => {
+      const sorted = utxos
+        .filter((u) => u.scriptPubKey !== null)
+        .sort((a, b) => b.value - a.value);
+      const spendable =
+        maxInputCount === null ? sorted : sorted.slice(0, maxInputCount);
+      return {
+        numInputs: spendable.length,
+        totalBalance: spendable.reduce((sum, u) => sum + BigInt(u.value), 0n),
+      };
+    },
+  ),
   computeNumLocalChallengers: vi.fn(() => 2),
   computeMinClaimValue: vi.fn().mockResolvedValue(35_000n),
   // Mocked to a deterministic, realistic-shape value (~vsize × low rate).
@@ -1177,6 +1198,97 @@ describe("useDepositPageForm", () => {
       const { result } = renderHook(() => useDepositPageForm(), { wrapper });
 
       expect(result.current.btcPublicKeyError).toBe(walletError);
+    });
+  });
+
+  describe("fundingInputCapBites", () => {
+    // `clearAllMocks` keeps implementations, so restore the module defaults
+    // these tests override rather than leaking them into later suites.
+    beforeEach(() => {
+      vi.mocked(resolveMaxInputCount).mockReturnValue(20);
+      vi.mocked(useApplicationCap).mockReturnValue({
+        snapshot: {
+          totalCapBTC: 0n,
+          perAddressCapBTC: 0n,
+          totalBTC: 0n,
+          userBTC: null,
+          hasTotalCap: false,
+          hasPerAddressCap: false,
+          remainingTotal: null,
+          remainingForUser: null,
+          effectiveRemaining: null,
+        },
+        isLoading: false,
+        error: null,
+        refetch: vi.fn(),
+      } as unknown as ReturnType<typeof useApplicationCap>);
+    });
+
+    const utxo = (value: number, scriptPubKey: string | null = "0xabc") => ({
+      txid: `0x${value}`,
+      vout: 0,
+      value,
+      scriptPubKey,
+      confirmed: true,
+    });
+
+    function mockSpendable(utxos: ReturnType<typeof utxo>[]) {
+      vi.mocked(useUTXOs).mockReturnValue({
+        allUTXOs: utxos,
+        confirmedUTXOs: utxos,
+        availableUTXOs: utxos,
+        inscriptionUTXOs: [],
+        spendableUTXOs: utxos,
+        spendableMempoolUTXOs: utxos,
+        ordinalsCheckPending: false,
+        unconfirmedBalance: 0n,
+      } as unknown as ReturnType<typeof useUTXOs>);
+    }
+
+    it("is set when the bound, not the balance, caps the maximum", () => {
+      mockSpendable([utxo(500_000), utxo(300_000), utxo(100_000)]);
+      vi.mocked(resolveMaxInputCount).mockReturnValue(2);
+
+      const { result } = renderHook(() => useDepositPageForm(), { wrapper });
+
+      expect(result.current.fundingInputCapBites).toBe(true);
+    });
+
+    it("is not set when the inputs past the bound are the ones with undecodable scripts", () => {
+      // The selector and the Max both discard these, so the depositor's
+      // selectable set is inside the bound and consolidating buys nothing.
+      mockSpendable([utxo(500_000), utxo(300_000), utxo(900_000, null)]);
+      vi.mocked(resolveMaxInputCount).mockReturnValue(2);
+
+      const { result } = renderHook(() => useDepositPageForm(), { wrapper });
+
+      expect(result.current.fundingInputCapBites).toBe(false);
+    });
+
+    it("is not set when the supply cap, not the bound, is the binding ceiling", () => {
+      mockSpendable([utxo(500_000), utxo(300_000), utxo(100_000)]);
+      vi.mocked(resolveMaxInputCount).mockReturnValue(2);
+      vi.mocked(useApplicationCap).mockReturnValue({
+        snapshot: {
+          totalCapBTC: 0n,
+          perAddressCapBTC: 0n,
+          totalBTC: 0n,
+          userBTC: null,
+          hasTotalCap: true,
+          hasPerAddressCap: false,
+          remainingTotal: 50_000n,
+          remainingForUser: null,
+          effectiveRemaining: 50_000n,
+        },
+        isLoading: false,
+        error: null,
+        refetch: vi.fn(),
+      } as unknown as ReturnType<typeof useApplicationCap>);
+
+      const { result } = renderHook(() => useDepositPageForm(), { wrapper });
+
+      expect(result.current.maxDepositSats).toBe(50_000n);
+      expect(result.current.fundingInputCapBites).toBe(false);
     });
   });
 });

--- a/services/vault/src/hooks/deposit/__tests__/useDepositPageForm.test.tsx
+++ b/services/vault/src/hooks/deposit/__tests__/useDepositPageForm.test.tsx
@@ -370,6 +370,14 @@ vi.mock("../useEstimatedBtcFee", () => ({
   })),
 }));
 
+vi.mock("../useFundingInputBound", () => ({
+  useFundingInputBound: vi.fn(() => ({
+    bound: { status: "published", maxInputs: 20 },
+    isError: false,
+  })),
+  resolveMaxInputCount: vi.fn(() => 20),
+}));
+
 vi.mock("../useDepositValidation", () => ({
   useDepositValidation: vi.fn(() => ({
     validateAmount: mockValidateAmount,

--- a/services/vault/src/hooks/deposit/__tests__/useEstimatedBtcFee.test.tsx
+++ b/services/vault/src/hooks/deposit/__tests__/useEstimatedBtcFee.test.tsx
@@ -1,6 +1,12 @@
 import type { MempoolUTXO } from "@babylonlabs-io/ts-sdk";
+import {
+  computeMaxDeposit,
+  selectUtxosForPegin,
+} from "@babylonlabs-io/ts-sdk/tbv/core";
 import { renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { COPY } from "@/copy";
 
 import { useEstimatedBtcFee } from "../useEstimatedBtcFee";
 
@@ -18,8 +24,10 @@ vi.mock("../../useNetworkFees", () => ({
   useNetworkFees: () => networkFees,
 }));
 
-// Both SDK helpers are linear in the fee rate, which is all these tests need:
-// they assert which rate reaches the SDK, not the SDK's own vsize model.
+// The fee helpers are linear in the fee rate, which is all these tests need:
+// they assert which rate reaches the SDK, not the SDK's own vsize model. The
+// budget helper caps the input set the way the real one does so the maxDeposit
+// assertions see a bound that actually bites.
 vi.mock("@babylonlabs-io/ts-sdk/tbv/core", () => ({
   selectUtxosForPegin: vi.fn((_utxos, _amount, feeRate: number) => ({
     fee: BigInt(Math.round(feeRate * 100)),
@@ -27,6 +35,20 @@ vi.mock("@babylonlabs-io/ts-sdk/tbv/core", () => ({
   computeMaxDeposit: vi.fn(
     ({ totalBalance, feeRate }: { totalBalance: bigint; feeRate: number }) =>
       totalBalance - BigInt(Math.round(feeRate * 100)),
+  ),
+  computeFundingBudget: vi.fn(
+    (utxos: Array<{ value: number }>, maxInputCount: number | null) => {
+      const capped =
+        maxInputCount === null ? utxos : utxos.slice(0, maxInputCount);
+      return {
+        numInputs: capped.length,
+        totalBalance: capped.reduce((sum, u) => sum + BigInt(u.value), 0n),
+      };
+    },
+  ),
+  isFundingInputCountExceededError: vi.fn(
+    (err: unknown) =>
+      err instanceof Error && err.name === "FundingInputCountExceededError",
   ),
 }));
 
@@ -36,11 +58,21 @@ const UTXOS = [
 
 const AMOUNT = 100_000n;
 const NUM_OUTPUTS = 2;
+const MAX_INPUTS = 20;
 
 const render = (override?: number) =>
-  renderHook(() => useEstimatedBtcFee(AMOUNT, UTXOS, NUM_OUTPUTS, override));
+  renderHook(() =>
+    useEstimatedBtcFee(AMOUNT, UTXOS, NUM_OUTPUTS, MAX_INPUTS, override),
+  );
 
 beforeEach(() => {
+  vi.mocked(selectUtxosForPegin).mockImplementation(((
+    _utxos: unknown,
+    _amount: bigint,
+    feeRate: number,
+  ) => ({
+    fee: BigInt(Math.round(feeRate * 100)),
+  })) as unknown as typeof selectUtxosForPegin);
   networkFees.defaultFeeRate = 10;
   networkFees.isLoading = false;
   networkFees.error = null;
@@ -84,7 +116,7 @@ describe("useEstimatedBtcFee fee-rate override", () => {
   it("keeps the override when the mempool rate changes underneath it", () => {
     const { result, rerender } = renderHook(
       ({ override }) =>
-        useEstimatedBtcFee(AMOUNT, UTXOS, NUM_OUTPUTS, override),
+        useEstimatedBtcFee(AMOUNT, UTXOS, NUM_OUTPUTS, MAX_INPUTS, override),
       { initialProps: { override: 25 } },
     );
 
@@ -115,5 +147,52 @@ describe("useEstimatedBtcFee fee-rate override", () => {
 
     expect(result.current.isLoading).toBe(true);
     expect(result.current.fee).toBeNull();
+  });
+});
+
+describe("useEstimatedBtcFee funding-input bound", () => {
+  it("reports loading with no max while the bound is unresolved", () => {
+    const { result } = renderHook(() =>
+      useEstimatedBtcFee(AMOUNT, UTXOS, NUM_OUTPUTS, undefined),
+    );
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.maxDeposit).toBeNull();
+    expect(result.current.fee).toBeNull();
+    expect(result.current.error).toBeNull();
+  });
+
+  it("shows the copy string, not the SDK message, when the bound is exceeded", () => {
+    const exceeded = new Error("Funding this deposit needs more than 2 UTXOs");
+    exceeded.name = "FundingInputCountExceededError";
+    vi.mocked(selectUtxosForPegin).mockImplementation(() => {
+      throw exceeded;
+    });
+
+    const { result } = renderHook(() =>
+      useEstimatedBtcFee(AMOUNT, UTXOS, NUM_OUTPUTS, 2),
+    );
+
+    expect(result.current.error).toBe(
+      COPY.deposit.errors.tooManyFundingInputs.title,
+    );
+    expect(result.current.error).not.toBe(exceeded.message);
+  });
+
+  it("sizes maxDeposit from the capped budget, not the whole UTXO set", () => {
+    const utxos = [
+      { txid: "a".repeat(64), vout: 0, value: 600_000, scriptPubKey: "00" },
+      { txid: "b".repeat(64), vout: 0, value: 400_000, scriptPubKey: "00" },
+      { txid: "c".repeat(64), vout: 0, value: 300_000, scriptPubKey: "00" },
+    ] as unknown as MempoolUTXO[];
+
+    renderHook(() => useEstimatedBtcFee(AMOUNT, utxos, NUM_OUTPUTS, 2));
+
+    expect(computeMaxDeposit).toHaveBeenCalledWith({
+      numInputs: 2,
+      numOutputs: NUM_OUTPUTS,
+      totalBalance: 1_000_000n,
+      feeRate: 10,
+    });
   });
 });

--- a/services/vault/src/hooks/deposit/__tests__/useFundingInputBound.test.ts
+++ b/services/vault/src/hooks/deposit/__tests__/useFundingInputBound.test.ts
@@ -1,0 +1,34 @@
+/**
+ * `resolveMaxInputCount` is the seam that keeps the UTXO selector from running
+ * uncapped. Three of its four cases mean "do not select yet" or "no bound
+ * exists", and only one carries a number — collapsing any of them into the
+ * wrong neighbour either blocks every deposit or selects without a cap at all.
+ * Both consumer suites mock this function, so nothing else covers it.
+ */
+
+import type { FundingInputBound } from "@babylonlabs-io/ts-sdk/tbv/core";
+import { describe, expect, it } from "vitest";
+
+import { resolveMaxInputCount } from "../useFundingInputBound";
+
+describe("resolveMaxInputCount", () => {
+  it("passes a published bound through as its integer", () => {
+    const bound: FundingInputBound = { status: "published", maxInputs: 20 };
+    expect(resolveMaxInputCount(bound)).toBe(20);
+  });
+
+  it("resolves an unpublished bound to undefined, never null", () => {
+    // `null` is "this deployment has no bound" and selects uncapped. A chain
+    // that publishes a zero bound rejects every Pre-PegIn instead, so this has
+    // to read as unresolved and block.
+    expect(resolveMaxInputCount({ status: "unpublished" })).toBeUndefined();
+  });
+
+  it("resolves an in-flight read to undefined", () => {
+    expect(resolveMaxInputCount(undefined)).toBeUndefined();
+  });
+
+  it("resolves a deployment that predates the field to null", () => {
+    expect(resolveMaxInputCount({ status: "unsupported" })).toBeNull();
+  });
+});

--- a/services/vault/src/hooks/deposit/useDepositFlow.ts
+++ b/services/vault/src/hooks/deposit/useDepositFlow.ts
@@ -79,6 +79,7 @@ import {
 import { computeBuildPeginFingerprint } from "@/services/vault/peginFingerprintInput";
 import {
   assertBuildWithinPinnedLimits,
+  BuildLimitsDriftError,
   isBuildLimitsDriftError,
 } from "@/services/vault/pinnedBuildLimits";
 import type { PayoutSigningProgress } from "@/services/vault/vaultPayoutSignatureService";
@@ -133,6 +134,7 @@ import {
 } from "./depositFlowSteps";
 import type { DepositWarning } from "./depositWarnings";
 import { useBtcWalletState } from "./useBtcWalletState";
+import { FUNDING_INPUT_BOUND_QUERY_KEY } from "./useFundingInputBound";
 import { useVaultProviders } from "./useVaultProviders";
 
 // ============================================================================
@@ -669,6 +671,17 @@ export function useDepositFlow(
         const pinnedBlock = await resolvePinnedReadBlock();
         const buildConfig =
           await protocolParamsReader.getPegInConfiguration(pinnedBlock);
+        const fundingInputBound =
+          await protocolParamsReader.getMaxFundingInputCount(pinnedBlock);
+        // The form sized its Max against the cached bound. If governance
+        // lowered it, the SDK rejects the selection below with
+        // `FundingInputCountExceededError` — outside the drift try/catch — and
+        // a restarted form must see the lowered bound or it will offer the same
+        // unfundable Max again.
+        queryClient.setQueryData(
+          FUNDING_INPUT_BOUND_QUERY_KEY,
+          fundingInputBound,
+        );
 
         // The page gated the "update the app" check and sized the amount
         // against the cached snapshot; the lock is about to be built from this
@@ -685,6 +698,17 @@ export function useDepositFlow(
           // Re-check what the depositor actually approved against the pinned
           // numbers.
           assertBuildWithinPinnedLimits(vaultAmounts, buildConfig);
+
+          // A chain that publishes no funding-input bound rejects every
+          // Pre-PegIn built against it, so there is nothing to build. Raised as
+          // drift because the form gated on a bound that has since gone away,
+          // and the recovery is the same: stop before anything is signed.
+          if (fundingInputBound.status === "unpublished") {
+            throw new BuildLimitsDriftError(
+              "Deposit limits changed while preparing this deposit: the chain no longer publishes a funding-input bound, so peg-ins are paused.",
+              "funding-inputs",
+            );
+          }
         } catch (driftError) {
           // Both aborts tell the depositor to start again, and the only way to
           // do that is to close and reopen the form, which reads the cached
@@ -789,6 +813,10 @@ export function useDepositFlow(
             timelockRefund: buildConfig.timelockRefund,
             councilQuorum: buildConfig.offchainParams.councilQuorum,
             councilSize: buildConfig.offchainParams.securityCouncilKeys.length,
+            maxFundingInputCount:
+              fundingInputBound.status === "published"
+                ? fundingInputBound.maxInputs
+                : null,
             availableUTXOs: spendableUTXOs,
           },
         );

--- a/services/vault/src/hooks/deposit/useDepositFlow.ts
+++ b/services/vault/src/hooks/deposit/useDepositFlow.ts
@@ -698,17 +698,6 @@ export function useDepositFlow(
           // Re-check what the depositor actually approved against the pinned
           // numbers.
           assertBuildWithinPinnedLimits(vaultAmounts, buildConfig);
-
-          // A chain that publishes no funding-input bound rejects every
-          // Pre-PegIn built against it, so there is nothing to build. Raised as
-          // drift because the form gated on a bound that has since gone away,
-          // and the recovery is the same: stop before anything is signed.
-          if (fundingInputBound.status === "unpublished") {
-            throw new BuildLimitsDriftError(
-              "Deposit limits changed while preparing this deposit: the chain no longer publishes a funding-input bound, so peg-ins are paused.",
-              "funding-inputs",
-            );
-          }
         } catch (driftError) {
           // Both aborts tell the depositor to start again, and the only way to
           // do that is to close and reopen the form, which reads the cached
@@ -738,6 +727,40 @@ export function useDepositFlow(
           }
           throw driftError;
         }
+
+        // A chain that publishes no funding-input bound rejects every Pre-PegIn
+        // built against it, so there is nothing to build. Raised as drift
+        // because the form gated on a bound that has since gone away, and the
+        // recovery is the same: stop before anything is signed.
+        //
+        // Outside the try/catch above on purpose: the peg-in configuration did
+        // not drift here, and the catch's cache overwrite is justified only on
+        // the axis that failed. The bound has its own cache key, already
+        // refreshed from the pinned read above.
+        if (fundingInputBound.status === "unpublished") {
+          throw new BuildLimitsDriftError(
+            "Deposit limits changed while preparing this deposit: the chain no longer publishes a funding-input bound, so peg-ins are paused.",
+            "funding-inputs",
+          );
+        }
+
+        // `unpublished` threw above, so the union left here is
+        // `published | unsupported` and this switch is exhaustive over it. That
+        // is the point: a new bound status becomes a compile error instead of
+        // silently falling through to `null`, which the selector reads as "no
+        // cap at all".
+        const pinnedMaxFundingInputCount = ((): number | null => {
+          switch (fundingInputBound.status) {
+            case "published":
+              return fundingInputBound.maxInputs;
+            case "unsupported":
+              return null;
+            default: {
+              const exhaustive: never = fundingInputBound;
+              return exhaustive;
+            }
+          }
+        })();
 
         const validatedKeys = await validateOnChainParticipantKeys({
           vaultRegistryReader: getVaultRegistryReader(),
@@ -813,10 +836,7 @@ export function useDepositFlow(
             timelockRefund: buildConfig.timelockRefund,
             councilQuorum: buildConfig.offchainParams.councilQuorum,
             councilSize: buildConfig.offchainParams.securityCouncilKeys.length,
-            maxFundingInputCount:
-              fundingInputBound.status === "published"
-                ? fundingInputBound.maxInputs
-                : null,
+            maxFundingInputCount: pinnedMaxFundingInputCount,
             availableUTXOs: spendableUTXOs,
           },
         );

--- a/services/vault/src/hooks/deposit/useDepositPageForm.ts
+++ b/services/vault/src/hooks/deposit/useDepositPageForm.ts
@@ -41,6 +41,10 @@ import { useAllocationPlanning } from "./useAllocationPlanning";
 import { useDepositFormErrors } from "./useDepositFormErrors";
 import { useDepositValidation } from "./useDepositValidation";
 import { useEstimatedBtcFee } from "./useEstimatedBtcFee";
+import {
+  resolveMaxInputCount,
+  useFundingInputBound,
+} from "./useFundingInputBound";
 import { useVaultProviders } from "./useVaultProviders";
 
 const STALE_TIME_MS = 5 * 60 * 1000;
@@ -181,6 +185,29 @@ export interface UseDepositPageFormResult {
    * the check resolves.
    */
   ordinalsCheckPending: boolean;
+
+  /**
+   * On-chain `maxFundingInputCount` as the SDK's UTXO selector wants it —
+   * `null` for a deployment without the field, `undefined` while unresolved.
+   */
+  maxInputCount: number | null | undefined;
+  /**
+   * True when the chain publishes no funding-input bound (reads 0). Terminal:
+   * the registry would reject any Pre-PegIn built without one, so consumers
+   * must block the CTA rather than select against an uncapped budget.
+   */
+  fundingInputBoundUnpublished: boolean;
+  /**
+   * True when the funding-input bound read terminally failed — fail closed,
+   * same as the vault-count cap.
+   */
+  fundingInputBoundUnavailable: boolean;
+  /**
+   * True when the bound, not the wallet balance, is what caps the depositable
+   * maximum — the depositor holds more spendable UTXOs than one Pre-PegIn may
+   * spend. Advisory: the Max already accounts for it.
+   */
+  fundingInputCapBites: boolean;
 
   // Two-vault split (multi-vault) intent
   isTwoVaultSplit: boolean;
@@ -416,13 +443,22 @@ export function useDepositPageForm(): UseDepositPageFormResult {
   const vaultCount = isTwoVaultSplit && canSplit ? 2 : 1;
   const numPeginOutputs = peginOutputCount(vaultCount, true);
 
+  const { bound: fundingInputBound, isError: fundingInputBoundUnavailable } =
+    useFundingInputBound();
+  const maxInputCount = resolveMaxInputCount(fundingInputBound);
+
   const {
     fee: estimatedFeeSats,
     feeRate: estimatedFeeRate,
     isLoading: isLoadingFee,
     error: feeError,
     maxDeposit: maxDepositSats,
-  } = useEstimatedBtcFee(amountSats, spendableMempoolUTXOs, numPeginOutputs);
+  } = useEstimatedBtcFee(
+    amountSats,
+    spendableMempoolUTXOs,
+    numPeginOutputs,
+    maxInputCount,
+  );
 
   // Compute depositorClaimValue for UI validation (min deposit check).
   // Uses {VP} ∪ {VKs} − {depositor} which is >= the transaction builder's
@@ -751,6 +787,12 @@ export function useDepositPageForm(): UseDepositPageFormResult {
     appVersionUnsupported,
     p2aAnchorValueSats: p2aAnchorValueSats ?? null,
     ordinalsCheckPending,
+    maxInputCount,
+    fundingInputBoundUnpublished: fundingInputBound?.status === "unpublished",
+    fundingInputBoundUnavailable,
+    fundingInputCapBites:
+      fundingInputBound?.status === "published" &&
+      (spendableMempoolUTXOs?.length ?? 0) > fundingInputBound.maxInputs,
     isTwoVaultSplit,
     setIsTwoVaultSplit,
     canSplit,

--- a/services/vault/src/hooks/deposit/useDepositPageForm.ts
+++ b/services/vault/src/hooks/deposit/useDepositPageForm.ts
@@ -1,4 +1,5 @@
 import {
+  computeFundingBudget,
   computeMinClaimValue,
   computeMinPeginFee,
   computeNumLocalChallengers,
@@ -204,8 +205,9 @@ export interface UseDepositPageFormResult {
   fundingInputBoundUnavailable: boolean;
   /**
    * True when the bound, not the wallet balance, is what caps the depositable
-   * maximum — the depositor holds more spendable UTXOs than one Pre-PegIn may
-   * spend. Advisory: the Max already accounts for it.
+   * maximum: the UTXOs the selector would actually reach for sum to less under
+   * the bound than without it, and the supply cap is not the binding ceiling.
+   * Advisory — the Max already accounts for it.
    */
   fundingInputCapBites: boolean;
 
@@ -744,6 +746,36 @@ export function useDepositPageForm(): UseDepositPageFormResult {
     resetErrors();
   }, [resetErrors]);
 
+  // The notice tells the depositor to consolidate, so it must only fire when
+  // consolidating would actually raise their Max. A count comparison does not
+  // establish that: the SDK's budget discards UTXOs with undecodable scripts,
+  // so counting raw entries can claim the bound binds when the selectable set
+  // is within it. Compare the two budgets instead — the same filter, sort and
+  // cap the Max itself was computed from.
+  //
+  // Suppressed when the supply cap is the real ceiling: there, the Max would
+  // not move even with one UTXO, and "consolidate your UTXOs" is wrong advice.
+  const fundingInputCapBites = useMemo(() => {
+    if (maxInputCount == null) return false;
+    const utxos = spendableMempoolUTXOs ?? [];
+    const effectiveRemaining = capSnapshot?.effectiveRemaining ?? null;
+    if (
+      effectiveRemaining !== null &&
+      adjustedMaxDepositSats === effectiveRemaining
+    ) {
+      return false;
+    }
+    return (
+      computeFundingBudget(utxos, maxInputCount).totalBalance <
+      computeFundingBudget(utxos, null).totalBalance
+    );
+  }, [
+    spendableMempoolUTXOs,
+    maxInputCount,
+    capSnapshot,
+    adjustedMaxDepositSats,
+  ]);
+
   return {
     formData,
     setFormData,
@@ -790,9 +822,7 @@ export function useDepositPageForm(): UseDepositPageFormResult {
     maxInputCount,
     fundingInputBoundUnpublished: fundingInputBound?.status === "unpublished",
     fundingInputBoundUnavailable,
-    fundingInputCapBites:
-      fundingInputBound?.status === "published" &&
-      (spendableMempoolUTXOs?.length ?? 0) > fundingInputBound.maxInputs,
+    fundingInputCapBites,
     isTwoVaultSplit,
     setIsTwoVaultSplit,
     canSplit,

--- a/services/vault/src/hooks/deposit/useEstimatedBtcFee.ts
+++ b/services/vault/src/hooks/deposit/useEstimatedBtcFee.ts
@@ -13,16 +13,23 @@
  * @param amount - Amount to peg in (in satoshis)
  * @param utxos - Available UTXOs for fee calculation
  * @param numOutputs - Number of outputs before change (e.g. N HTLCs + 1 CPFP anchor)
+ * @param maxInputCount - On-chain `maxFundingInputCount`; `null` when the
+ *   deployment predates the field, `undefined` while the bound is unresolved
+ *   (treated as loading — selecting without it would fail open)
  * @param feeRateOverride - Optional sat/vB rate; when > 0, replaces mempool default
  * @returns Estimated fee, fee rate, loading state, and error
  */
 
 import type { MempoolUTXO } from "@babylonlabs-io/ts-sdk";
 import {
+  computeFundingBudget,
   computeMaxDeposit,
+  isFundingInputCountExceededError,
   selectUtxosForPegin,
 } from "@babylonlabs-io/ts-sdk/tbv/core";
 import { useMemo } from "react";
+
+import { COPY } from "@/copy";
 
 import { useNetworkFees } from "../useNetworkFees";
 
@@ -43,6 +50,7 @@ export function useEstimatedBtcFee(
   amount: bigint,
   utxos: MempoolUTXO[] | undefined,
   numOutputs: number,
+  maxInputCount: number | null | undefined,
   feeRateOverride?: number,
 ): EstimatedBtcFeeResult {
   const { defaultFeeRate, isLoading, error: feeError } = useNetworkFees();
@@ -55,19 +63,32 @@ export function useEstimatedBtcFee(
       ? feeRateOverride
       : defaultFeeRate;
 
-  // Max deposit only depends on UTXOs + fee rate, not the user's amount
+  // Max deposit only depends on the fundable UTXOs + fee rate, not the user's
+  // amount. The budget is the same filter, sort and cap the selector applies,
+  // so the Max stays fundable once the bound binds rather than quoting a
+  // balance the selector would then refuse to reach.
   const maxDeposit = useMemo(() => {
-    if (isLoading || feeRate === 0 || !utxos?.length) return null;
-    const totalBalance = utxos.reduce((sum, u) => sum + BigInt(u.value), 0n);
+    if (isLoading || feeRate === 0 || maxInputCount === undefined) return null;
+    const budget = computeFundingBudget(utxos ?? [], maxInputCount);
     return computeMaxDeposit({
-      numInputs: utxos.length,
+      numInputs: budget.numInputs,
       numOutputs,
-      totalBalance,
+      totalBalance: budget.totalBalance,
       feeRate,
     });
-  }, [utxos, feeRate, numOutputs, isLoading]);
+  }, [utxos, feeRate, numOutputs, isLoading, maxInputCount]);
 
   const result = useMemo((): EstimatedBtcFeeResult => {
+    if (maxInputCount === undefined) {
+      return {
+        fee: null,
+        feeRate,
+        isLoading: true,
+        error: null,
+        maxDeposit: null,
+      };
+    }
+
     // Still loading fee rates — and no usable override yet
     if (isLoading && feeRate === 0) {
       return {
@@ -113,7 +134,13 @@ export function useEstimatedBtcFee(
     }
 
     try {
-      const { fee } = selectUtxosForPegin(utxos, amount, feeRate, numOutputs);
+      const { fee } = selectUtxosForPegin(
+        utxos,
+        amount,
+        feeRate,
+        numOutputs,
+        maxInputCount,
+      );
 
       return {
         fee,
@@ -123,8 +150,14 @@ export function useEstimatedBtcFee(
         maxDeposit,
       };
     } catch (err) {
-      const errorMessage =
-        err instanceof Error ? err.message : "Failed to estimate fee";
+      // The SDK message names an input count, which is not what the depositor
+      // acts on. Map it to the copy surface by guard so the raw message can
+      // never reach the CTA label.
+      const errorMessage = isFundingInputCountExceededError(err)
+        ? COPY.deposit.errors.tooManyFundingInputs.title
+        : err instanceof Error
+          ? err.message
+          : "Failed to estimate fee";
 
       return {
         fee: null,
@@ -134,7 +167,16 @@ export function useEstimatedBtcFee(
         maxDeposit,
       };
     }
-  }, [amount, utxos, feeRate, numOutputs, isLoading, feeError, maxDeposit]);
+  }, [
+    amount,
+    utxos,
+    feeRate,
+    numOutputs,
+    maxInputCount,
+    isLoading,
+    feeError,
+    maxDeposit,
+  ]);
 
   return result;
 }

--- a/services/vault/src/hooks/deposit/useFundingInputBound.ts
+++ b/services/vault/src/hooks/deposit/useFundingInputBound.ts
@@ -1,0 +1,69 @@
+/**
+ * On-chain `ProtocolParams.maxFundingInputCount` — the most Bitcoin UTXOs one
+ * Pre-PegIn may spend. Read on its own React Query key rather than folded into
+ * the peg-in configuration multicall: `useDepositFlow` overwrites this entry
+ * from every pinned build read, and sharing a key would make that overwrite
+ * rewrite a configuration snapshot the blocking provider also reads.
+ *
+ * @module hooks/deposit/useFundingInputBound
+ */
+
+import type { FundingInputBound } from "@babylonlabs-io/ts-sdk/tbv/core";
+import { useQuery } from "@tanstack/react-query";
+
+import { getProtocolParamsReader } from "@/clients/eth-contract/sdk-readers";
+
+const STALE_TIME_MS = 5 * 60 * 1000;
+const RETRY_COUNT = 3;
+const BLOCKED_REFETCH_INTERVAL_MS = 60 * 1000;
+
+export const FUNDING_INPUT_BOUND_QUERY_KEY = [
+  "protocolParams",
+  "fundingInputBound",
+] as const;
+
+export interface UseFundingInputBoundResult {
+  /** The chain's bound, or undefined while the read is in flight. */
+  bound: FundingInputBound | undefined;
+  /** True when the read terminally failed — consumers must fail closed. */
+  isError: boolean;
+}
+
+export function useFundingInputBound(): UseFundingInputBoundResult {
+  const { data, isError } = useQuery({
+    queryKey: FUNDING_INPUT_BOUND_QUERY_KEY,
+    queryFn: async (): Promise<FundingInputBound> => {
+      const reader = await getProtocolParamsReader();
+      return reader.getMaxFundingInputCount();
+    },
+    staleTime: STALE_TIME_MS,
+    refetchOnWindowFocus: false,
+    retry: RETRY_COUNT,
+    // A failed read (including a failed refetch that kept older data) and an
+    // unpublished bound both block the deposit CTA and both can be lifted by
+    // the chain, so they must keep polling or a mounted page stays blocked
+    // forever. `unsupported` and `published` are terminal and must not poll.
+    refetchInterval: (query) =>
+      query.state.status === "error" ||
+      query.state.data?.status === "unpublished"
+        ? BLOCKED_REFETCH_INTERVAL_MS
+        : false,
+  });
+
+  return { bound: data, isError };
+}
+
+/**
+ * The bound as the UTXO selector wants it: a positive integer, or `null` for a
+ * deployment that predates the field. `unpublished` deliberately resolves to
+ * `undefined`, not `null` — the form blocks that state on its own, and handing
+ * the estimator `null` would fail open by selecting without any cap.
+ */
+export function resolveMaxInputCount(
+  bound: FundingInputBound | undefined,
+): number | null | undefined {
+  if (bound === undefined) return undefined;
+  if (bound.status === "unsupported") return null;
+  if (bound.status === "published") return bound.maxInputs;
+  return undefined;
+}

--- a/services/vault/src/hooks/deposit/usePendingVaultOverlapCheck.ts
+++ b/services/vault/src/hooks/deposit/usePendingVaultOverlapCheck.ts
@@ -23,6 +23,11 @@ interface UsePendingVaultOverlapCheckParams {
   depositorClaimValue: bigint | undefined;
   /** Per-vault minimum peg-in fee (sats) — must match the signing-path target. */
   minPeginFee: bigint | null;
+  /**
+   * On-chain `maxFundingInputCount` — must match the signing-path cap so the
+   * prediction selects the same inputs. `undefined` while unresolved.
+   */
+  maxInputCount: number | null | undefined;
 }
 
 export function usePendingVaultOverlapCheck({
@@ -31,11 +36,16 @@ export function usePendingVaultOverlapCheck({
   estimatedFeeRate,
   depositorClaimValue,
   minPeginFee,
+  maxInputCount,
 }: UsePendingVaultOverlapCheckParams) {
   const { data: depositorVaults } = useVaults(ethAddress);
 
   return useCallback(
     (vaultAmounts: readonly bigint[]): number | null => {
+      // Without the bound the prediction would select a different input set
+      // than signing will. Skip rather than advise on the wrong outpoints.
+      if (maxInputCount === undefined) return null;
+
       const sumPeginAmounts = vaultAmounts.reduce((s, a) => s + a, 0n);
       const perVaultExtras = (depositorClaimValue ?? 0n) + (minPeginFee ?? 0n);
       // Mirrors `prePegin.totalOutputValue`: HTLC values + CPFP anchor.
@@ -53,6 +63,7 @@ export function usePendingVaultOverlapCheck({
           predictedTarget,
           estimatedFeeRate,
           numOutputs,
+          maxInputCount,
         );
       } catch {
         // Let the real signing path surface insufficient-funds errors.
@@ -76,6 +87,7 @@ export function usePendingVaultOverlapCheck({
       estimatedFeeRate,
       depositorClaimValue,
       minPeginFee,
+      maxInputCount,
       depositorVaults,
     ],
   );

--- a/services/vault/src/services/vault/__tests__/vaultTransactionService.test.ts
+++ b/services/vault/src/services/vault/__tests__/vaultTransactionService.test.ts
@@ -100,6 +100,7 @@ describe("vaultTransactionService - preparePeginTransaction", () => {
     timelockRefund: 50,
     councilQuorum: 2,
     councilSize: 3,
+    maxFundingInputCount: 20,
     availableUTXOs: mockUTXOs,
   };
 

--- a/services/vault/src/services/vault/pinnedBuildLimits.ts
+++ b/services/vault/src/services/vault/pinnedBuildLimits.ts
@@ -46,8 +46,14 @@ import { validateVaultAmounts } from "@babylonlabs-io/ts-sdk/tbv/core/services";
  * copy: an amount outside the bounds is fixed by entering a different amount,
  * a vault count over the cap by not splitting. One message covering both would
  * give the wrong instruction for whichever case it was not written for.
+ *
+ * `funding-inputs` is the third: the chain stopped publishing a funding-input
+ * bound, which the depositor can do nothing about — its copy offers no fix.
  */
-export type BuildLimitsDriftReason = "amount-bounds" | "vault-count";
+export type BuildLimitsDriftReason =
+  | "amount-bounds"
+  | "vault-count"
+  | "funding-inputs";
 
 /**
  * The depositor's amounts or vault count fall outside the protocol limits read

--- a/services/vault/src/services/vault/vaultTransactionService.ts
+++ b/services/vault/src/services/vault/vaultTransactionService.ts
@@ -63,6 +63,13 @@ export interface PreparePeginParams {
   councilQuorum: number;
   /** N in M-of-N council multisig */
   councilSize: number;
+  /**
+   * On-chain `ProtocolParams.maxFundingInputCount` read at the build's pinned
+   * block; `null` only when the deployment predates the field. Enforced at UTXO
+   * selection before any wallet or device I/O, and re-asserted against the
+   * funded transaction.
+   */
+  maxFundingInputCount: number | null;
   availableUTXOs: UTXO[];
 }
 
@@ -226,6 +233,7 @@ export async function preparePeginTransaction(
       mempoolFeeRate: params.mempoolFeeRate,
       councilQuorum: params.councilQuorum,
       councilSize: params.councilSize,
+      maxFundingInputCount: params.maxFundingInputCount,
       availableUTXOs: params.availableUTXOs,
       changeAddress: params.changeAddress,
     });

--- a/services/vault/src/services/vault/vaultTransactionService.ts
+++ b/services/vault/src/services/vault/vaultTransactionService.ts
@@ -66,8 +66,8 @@ export interface PreparePeginParams {
   /**
    * On-chain `ProtocolParams.maxFundingInputCount` read at the build's pinned
    * block; `null` only when the deployment predates the field. Enforced at UTXO
-   * selection before any wallet or device I/O, and re-asserted against the
-   * funded transaction.
+   * selection before any signing or approval prompt, and re-asserted against
+   * the funded transaction.
    */
   maxFundingInputCount: number | null;
   availableUTXOs: UTXO[];

--- a/services/vault/src/utils/errors/__tests__/depositErrors.test.ts
+++ b/services/vault/src/utils/errors/__tests__/depositErrors.test.ts
@@ -197,6 +197,22 @@ describe("mapDepositError", () => {
     expect(mapDepositError(err)).toEqual(ERRORS.vaultCountLimitChanged);
   });
 
+  it("maps a funding-inputs drift to the peg-ins-paused callout", () => {
+    // Nothing the depositor chose can fix an unpublished bound, so this must
+    // not share the two callouts above, which both send them back to the form.
+    const err = Object.assign(new Error("Deposit limits changed"), {
+      name: "BuildLimitsDriftError",
+      reason: "funding-inputs",
+    });
+    expect(mapDepositError(err)).toEqual(ERRORS.peginsPaused);
+  });
+
+  it("maps an exceeded funding-input count to the too-many-UTXOs callout", () => {
+    const err = new Error("Funding this deposit needs more than 20 UTXOs");
+    err.name = "FundingInputCountExceededError";
+    expect(mapDepositError(err)).toEqual(ERRORS.tooManyFundingInputs);
+  });
+
   it("falls back to the amount-bounds callout when the reason did not survive", () => {
     // A structurally-cloned error matches by name but loses its fields. Both
     // callouts send the depositor back to the form, so the common case is the

--- a/services/vault/src/utils/errors/depositErrors.ts
+++ b/services/vault/src/utils/errors/depositErrors.ts
@@ -53,6 +53,7 @@
 import {
   isApplicationEntryPointMismatchError,
   isDepositTermsRejectedError,
+  isFundingInputCountExceededError,
   isParticipantKeyDriftError,
   isPeginFingerprintChangedError,
   isPeginFingerprintInputError,
@@ -236,9 +237,16 @@ export function mapDepositError(err: unknown): DepositErrorContent {
   // is both the far likelier case and the safe thing to show when the tag is
   // unreadable — it sends the depositor back to the form either way.
   if (isBuildLimitsDriftError(err)) {
-    return err.reason === "vault-count"
-      ? ERRORS.vaultCountLimitChanged
-      : ERRORS.depositLimitsChanged;
+    if (err.reason === "vault-count") return ERRORS.vaultCountLimitChanged;
+    if (err.reason === "funding-inputs") return ERRORS.peginsPaused;
+    return ERRORS.depositLimitsChanged;
+  }
+
+  // Same pre-signing point, from the UTXO selector rather than a limit guard:
+  // funding the approved amount would spend more inputs than one Pre-Pegin may
+  // carry. The fix is in the wallet, so it needs its own callout.
+  if (isFundingInputCountExceededError(err)) {
+    return ERRORS.tooManyFundingInputs;
   }
 
   // 3b. RFC-006 participant key drift. Distinct from the version mismatch

--- a/services/vault/src/utils/errors/errorMessages.ts
+++ b/services/vault/src/utils/errors/errorMessages.ts
@@ -65,6 +65,10 @@ export const CONTRACT_ERROR_MESSAGES: Record<string, string> = {
     "This Pre-Pegin output has already been used to activate another BTCVault.",
   PeginTransactionAlreadyUsed:
     "This peg-in transaction has already been used to activate another BTCVault.",
+  TooManyFundingInputs:
+    "This deposit spends more Bitcoin UTXOs than the protocol allows in one Pre-Pegin transaction. Consolidate your UTXOs and try again.",
+  TooManyHtlcOutputs:
+    "This deposit creates more BTCVaults than the protocol allows in one Pre-Pegin transaction. Try again without splitting.",
 
   // ============================================================================
   // Vault Provider errors


### PR DESCRIPTION
## Summary

Enforces the new on-chain `maxFundingInputCount` bound on the Pre-Pegin funding path so a depositor with a fragmented wallet is stopped before the signing ceremony instead of at an undecodable revert.

Decision from the #tbv-protocol and #web threads: no consolidation transaction, the frontend caps UTXO selection at the contract's bound (20 on devnet), tells the user passively once amount and vault provider are filled, and blocks the deposit when it cannot fit.

## SDK (`@babylonlabs-io/ts-sdk`)

- `ProtocolParamsReader.getMaxFundingInputCount(blockNumber?)` reads the 8-component `getTBVProtocolParams` through its own ABI const and its own call, never through the 6-component tuple that feeds the blocking `ProtocolParamsContext`. It classifies the raw return by word count: 6 or 7 words is a deployment that predates the field (`unsupported`), 8 or more words decodes the first 8, so a field appended later by governance does not halt deposits. Fewer than 6 words or a length that is not whole 32-byte words throws. A value of `0` is `unpublished` and never becomes "no bound". Published values are validated into `[1, 255]`.
- `selectUtxosForPegin` takes a required `maxInputCount: number | null`. The cap check runs only once a prefix of the sorted valid set could fund `peginAmount + fee`; a wallet whose whole valid set falls short reaches the insufficient-funds throw, so the depositor is told to add funds rather than to consolidate. At the cap it throws the typed `FundingInputCountExceededError` before pushing input `max + 1`. Exactly `max` inputs is accepted, matching the registry's exclusive `>` check.
- `FundingInputCountExceededError` lives in its own dependency-free module, `utils/utxo/fundingInputCountExceeded.ts`, and is re-exported from `selectUtxos.ts`. The registry ABI adds `TooManyFundingInputs(uint256,uint256)`, `CONTRACT_ERRORS` carries its selector, and `handleContractError` throws the typed error when the revert payload decodes, so the registration path maps it to the same copy as the selection path. The split keeps `bitcoinjs-lib` out of the ETH-only `contracts` subpath.
- `computeFundingBudget` returns the top-N spendable UTXOs with the selector's own filter and ordering, so the Max the form offers is always fundable under the bound.
- `PeginManager.preparePegin` takes `maxFundingInputCount`, enforces it at selection (before `deriveVaultRoot` and any signing or approval prompt), and re-asserts the funded transaction's declared input count against both the selection and the bound, throwing the typed error in both cases.

## Vault app

- New `useFundingInputBound` query on its own key. Blocked states (`unpublished`, read error) poll every 60 s so the CTA recovers without a reload. A failed background refetch sets `status: "error"` in query-core, so polling continues and the form fails closed.
- `useEstimatedBtcFee` sizes Max from the capped budget and passes the bound to selection. The SDK error is mapped to copy by type guard; the raw message never reaches the CTA label.
- CTA: `unpublished` blocks with "Peg-ins temporarily unavailable", a failed read blocks with "Unable to verify UTXO limit — please try again". A deployment without the field behaves exactly as today.
- Passive notice once amount and vault provider are filled, shown only when the capped budget's balance is below the uncapped budget's balance and the Max is not clamped by the supply cap: "You can deposit up to X BTC with your current Bitcoin UTXOs". Invalid-script UTXOs never trigger it because both budgets use the selector's filter.
- `useDepositFlow` reads the bound at the pinned block, refreshes the form cache from that read, and aborts with a "Peg-ins temporarily unavailable" callout if it is `unpublished`. The abort sits outside the drift `try/catch`, so it never overwrites the peg-in config cache; the `unpublished`/`unsupported`/`published` mapping into the build is an exhaustive switch.
- Contract error messages for `TooManyFundingInputs` and `TooManyHtlcOutputs`.

## Critical path review

`selectUtxos.ts`, `peginFeeMath` tests and `PeginManager.ts` are on the fee-calculation-consistency critical path (CLAUDE.md section 2). This needs two reviewers and an author line-walk. The estimator-versus-selection agreement test in `peginFeeMath.test.ts` pins that the capped Max is fundable with exactly `max` inputs and that one satoshi more throws the typed error.

The issue's scoped plan put the pinned-block re-check in `pinnedBuildLimits.ts`. It lives in `PeginManager.preparePegin` instead (selection throw plus the funded-transaction assert, both fed by the bound read at the pinned block), so there is one enforcement site rather than two that must agree.

## Out of scope

- UTXO consolidation UX.
- `SPLIT_TX_FEE_SAFETY_MULTIPLIER` deletion (dead constant, separate change).
- Excluding dust past the top N from the cap notice. The two-budget comparison still counts dust as consolidatable; a `computeMaxDeposit` comparison would be needed to drop it.

## Testing

- SDK: selection at bound / one over / null bound / 25 small UTXOs below the amount → insufficient funds; budget helper; estimator-vs-selection agreement; reader `published` / `unpublished` / `unsupported` (6 and 7 words) / 9 words decodes / non-whole-word length throws / RPC error propagates / `blockNumber` forwarded; manager rejects before derive and sign, and throws the typed error when the funder returns an extra input; `handleContractError` on both revert branches; ABI selector agreement.
- App: estimator loading while unresolved, copy label not SDK message, Max from capped budget; the bound is read at the pinned block; drift path seeds the bound cache, aborts, and leaves the peg-in config cache untouched; `resolveMaxInputCount` four cases; CTA disabled in `unpublished`; cap notice on/off for the supply-cap and invalid-script cases; error mapping for both new callouts.
- `pnpm --filter @babylonlabs-io/ts-sdk run test` — 118 files, 2029 tests. `pnpm --filter vault run test` — 317 files, 3874 tests. Lint and `tsc --noEmit` clean on both.

Refs #2402
